### PR TITLE
fix: resolve file/path tools against agent workspace, not process cwd (#6)

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -79,13 +79,16 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		return nil, fmt.Errorf("failed to create bot: %w", err)
 	}
 
-	// Create tool registry with TTS configuration
+	// Create tool registry with TTS configuration.
+	// Use personality.BasePath as the workspace root so that file/path tools
+	// resolve relative paths against the configured soul directory instead of
+	// the process working directory.
 	toolsConfig := &tools.ToolsConfig{
 		OpenAIAPIKey: aiCfg.APIKey,
 		TTSProvider:  ttsCfg.Provider,
 		TTSVoice:     ttsCfg.DefaultVoice,
 	}
-	toolRegistry, _ := tools.LoadFromConfigWithOptions("", toolsConfig)
+	toolRegistry, _ := tools.LoadFromConfigWithOptions(personality.BasePath, toolsConfig)
 
 	// Try to cast aiClient to streaming client
 	streamingClient, _ := aiClient.(*ai.OpenAICompatibleClient)
@@ -97,22 +100,22 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 	groupManager := NewGroupManager(store, groupsCfg.DefaultMode, api.Me.Username)
 
 	return &Bot{
-		api:           api,
-		store:         store,
-		ai:            aiClient,
-		streamingAI:   streamingClient,
-		aiConfig:      aiCfg,
-		personality:   personality,
-		agentRegistry: agentRegistry,
-		toolRegistry:  toolRegistry,
-		safety:        agent.NewSafety(),
-		memory:        agent.NewMemory(""),
-		toolAgent:     newToolAgentWithAliases(aiClient, toolRegistry, personality, aiCfg.ModelAliases),
-		authManager:   authManager,
-		groupManager:  groupManager,
-		enableStream:  streamingClient != nil,
-		debouncer:     NewDebouncer(1500 * time.Millisecond),
-		rateLimiter:   NewRateLimiter(10, 1*time.Minute),
+		api:            api,
+		store:          store,
+		ai:             aiClient,
+		streamingAI:    streamingClient,
+		aiConfig:       aiCfg,
+		personality:    personality,
+		agentRegistry:  agentRegistry,
+		toolRegistry:   toolRegistry,
+		safety:         agent.NewSafety(),
+		memory:         agent.NewMemory(""),
+		toolAgent:      newToolAgentWithAliases(aiClient, toolRegistry, personality, aiCfg.ModelAliases),
+		authManager:    authManager,
+		groupManager:   groupManager,
+		enableStream:   streamingClient != nil,
+		debouncer:      NewDebouncer(1500 * time.Millisecond),
+		rateLimiter:    NewRateLimiter(10, 1*time.Minute),
 		usageTracker:   NewUsageTracker(),
 		activeRuns:     make(map[int64]context.CancelFunc),
 		fragmentBuffer: NewFragmentBuffer(),
@@ -243,7 +246,6 @@ func (b *Bot) Start(ctx context.Context) error {
 	b.api.Handle("/model", func(c telebot.Context) error {
 		return b.handleModelCommand(c)
 	})
-
 
 	b.api.Handle("/activate", func(c telebot.Context) error {
 		return b.handleActivateCommand(c)
@@ -788,34 +790,34 @@ func (b *Bot) handlePairCommand(c telebot.Context) error {
 // handleActivateCommand handles the /activate command
 func (b *Bot) handleActivateCommand(c telebot.Context) error {
 	chatID := c.Chat().ID
-	
+
 	// Only works in group chats
 	if c.Chat().Type == telebot.ChatPrivate {
 		return c.Send("This command only works in group chats.")
 	}
-	
+
 	if err := b.groupManager.SetMode(chatID, ModeActive); err != nil {
 		log.Printf("Failed to set active mode: %v", err)
 		return c.Send("❌ Failed to activate bot")
 	}
-	
+
 	return c.Send("✅ Bot activated! I'll respond to all messages in this group.")
 }
 
 // handleStandbyCommand handles the /standby command
 func (b *Bot) handleStandbyCommand(c telebot.Context) error {
 	chatID := c.Chat().ID
-	
+
 	// Only works in group chats
 	if c.Chat().Type == telebot.ChatPrivate {
 		return c.Send("This command only works in group chats.")
 	}
-	
+
 	if err := b.groupManager.SetMode(chatID, ModeStandby); err != nil {
 		log.Printf("Failed to set standby mode: %v", err)
 		return c.Send("❌ Failed to set standby mode")
 	}
-	
+
 	return c.Send("✅ Bot in standby mode. Mention me or reply to my messages to talk.")
 }
 

--- a/internal/tools/patch.go
+++ b/internal/tools/patch.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -46,10 +45,9 @@ func (p *PatchTool) Execute(ctx context.Context, args ...string) (string, error)
 
 // applyPatch parses a unified diff and applies it to the target file
 func (p *PatchTool) applyPatch(targetPath, patchContent string) error {
-	// Ensure path is within base path (security)
-	fullPath := filepath.Join(p.BasePath, targetPath)
-	if p.BasePath != "" && !strings.HasPrefix(fullPath, p.BasePath) {
-		return fmt.Errorf("path outside allowed directory")
+	fullPath, err := resolvePath(p.BasePath, targetPath)
+	if err != nil {
+		return err
 	}
 
 	// Read current file content

--- a/internal/tools/search_file.go
+++ b/internal/tools/search_file.go
@@ -52,14 +52,15 @@ func (s *SearchFileTool) Execute(ctx context.Context, args ...string) (string, e
 	}
 
 	pattern := args[0]
-	searchDir := s.BasePath
+	var searchDir string
 	if len(args) > 1 {
-		searchDir = filepath.Join(s.BasePath, args[1])
-	}
-
-	// Ensure search directory is within base path (security)
-	if s.BasePath != "" && !strings.HasPrefix(searchDir, s.BasePath) {
-		return "", fmt.Errorf("search path outside allowed directory")
+		resolved, err := resolvePath(s.BasePath, args[1])
+		if err != nil {
+			return "", err
+		}
+		searchDir = resolved
+	} else {
+		searchDir = s.BasePath
 	}
 
 	// Compile regex pattern

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -131,10 +131,9 @@ func (f *FileTool) Description() string {
 }
 
 func (f *FileTool) Read(path string) (string, error) {
-	// Ensure path is within base path (security)
-	fullPath := filepath.Join(f.BasePath, path)
-	if !strings.HasPrefix(fullPath, f.BasePath) {
-		return "", fmt.Errorf("path outside allowed directory")
+	fullPath, err := resolvePath(f.BasePath, path)
+	if err != nil {
+		return "", err
 	}
 
 	content, err := os.ReadFile(fullPath)
@@ -145,9 +144,9 @@ func (f *FileTool) Read(path string) (string, error) {
 }
 
 func (f *FileTool) Write(path string, content string) error {
-	fullPath := filepath.Join(f.BasePath, path)
-	if !strings.HasPrefix(fullPath, f.BasePath) {
-		return fmt.Errorf("path outside allowed directory")
+	fullPath, err := resolvePath(f.BasePath, path)
+	if err != nil {
+		return err
 	}
 
 	// Ensure directory exists
@@ -157,6 +156,34 @@ func (f *FileTool) Write(path string, content string) error {
 	}
 
 	return os.WriteFile(fullPath, []byte(content), 0644)
+}
+
+// resolvePath resolves a path against the workspace root with traversal protection.
+// Relative paths are joined with workspaceRoot. Absolute paths are validated to
+// be within workspaceRoot. Returns the cleaned absolute path, or an error if the
+// path escapes the workspace.
+func resolvePath(workspaceRoot, path string) (string, error) {
+	var fullPath string
+	if filepath.IsAbs(path) {
+		fullPath = filepath.Clean(path)
+	} else {
+		if workspaceRoot == "" {
+			return path, nil
+		}
+		fullPath = filepath.Join(workspaceRoot, path)
+	}
+
+	if workspaceRoot == "" {
+		return fullPath, nil
+	}
+
+	cleanRoot := filepath.Clean(workspaceRoot)
+	rootWithSep := cleanRoot + string(os.PathSeparator)
+	if fullPath != cleanRoot && !strings.HasPrefix(fullPath, rootWithSep) {
+		return "", fmt.Errorf("path %q is outside allowed directory %q", path, workspaceRoot)
+	}
+
+	return fullPath, nil
 }
 
 func (f *FileTool) Execute(ctx context.Context, args ...string) (string, error) {
@@ -214,17 +241,17 @@ func (r *Registry) List() []Tool {
 
 // ToolsConfig holds configuration for optional tools
 type ToolsConfig struct {
-	OpenAIAPIKey   string
-	OpenAIBaseURL  string
-	BraveAPIKey    string
-	ExaAPIKey      string
-	SearchEngine   string // "brave" or "exa"
-	TTSProvider    string // "openai" or "edge"
-	TTSVoice       string // Default TTS voice
-	CronScheduler  CronScheduler
-	MessageSender  MessageSender
-	CurrentChatID  int64
-	MemoryManager  *memory.MemoryManager
+	OpenAIAPIKey  string
+	OpenAIBaseURL string
+	BraveAPIKey   string
+	ExaAPIKey     string
+	SearchEngine  string // "brave" or "exa"
+	TTSProvider   string // "openai" or "edge"
+	TTSVoice      string // Default TTS voice
+	CronScheduler CronScheduler
+	MessageSender MessageSender
+	CurrentChatID int64
+	MemoryManager *memory.MemoryManager
 }
 
 // LoadFromConfig loads tools from TOOLS.md

--- a/internal/tools/workspace_test.go
+++ b/internal/tools/workspace_test.go
@@ -1,0 +1,195 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolvePath verifies that resolvePath correctly joins relative paths,
+// validates absolute paths, and rejects traversal attempts.
+func TestResolvePath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name          string
+		workspaceRoot string
+		path          string
+		wantSuffix    string // expected suffix of returned path
+		wantErr       bool
+		errContains   string
+	}{
+		{
+			name:          "relative path joined with root",
+			workspaceRoot: tmpDir,
+			path:          "subdir/file.txt",
+			wantSuffix:    filepath.Join(tmpDir, "subdir/file.txt"),
+		},
+		{
+			name:          "absolute path inside root",
+			workspaceRoot: tmpDir,
+			path:          filepath.Join(tmpDir, "file.txt"),
+			wantSuffix:    filepath.Join(tmpDir, "file.txt"),
+		},
+		{
+			name:          "traversal via relative path blocked",
+			workspaceRoot: tmpDir,
+			path:          "../escape.txt",
+			wantErr:       true,
+			errContains:   "outside allowed directory",
+		},
+		{
+			name:          "absolute path outside root blocked",
+			workspaceRoot: tmpDir,
+			path:          "/etc/passwd",
+			wantErr:       true,
+			errContains:   "outside allowed directory",
+		},
+		{
+			name:          "empty root returns path as-is (relative)",
+			workspaceRoot: "",
+			path:          "relative.txt",
+			wantSuffix:    "relative.txt",
+		},
+		{
+			name:          "root itself is allowed",
+			workspaceRoot: tmpDir,
+			path:          ".",
+			wantSuffix:    filepath.Clean(tmpDir),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolvePath(tt.workspaceRoot, tt.path)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("resolvePath() expected error, got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("resolvePath() error = %q, want to contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("resolvePath() unexpected error: %v", err)
+				return
+			}
+			if got != tt.wantSuffix {
+				t.Errorf("resolvePath() = %q, want %q", got, tt.wantSuffix)
+			}
+		})
+	}
+}
+
+// TestFileTool_WorkspaceResolution verifies that FileTool reads and writes
+// correctly when the process is not started from the workspace directory.
+// This simulates the case where the binary is started from /tmp but the
+// workspace is elsewhere.
+func TestFileTool_WorkspaceResolution(t *testing.T) {
+	// Create workspace in a temp dir (simulates soul_path)
+	workspace := t.TempDir()
+
+	// Write a file into the workspace
+	content := "hello workspace\n"
+	if err := os.WriteFile(filepath.Join(workspace, "hello.txt"), []byte(content), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	tool := &FileTool{BasePath: workspace}
+
+	// Read with a relative path — must resolve against workspace, not process cwd
+	got, err := tool.Read("hello.txt")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got != content {
+		t.Errorf("Read() = %q, want %q", got, content)
+	}
+
+	// Write with a relative path
+	if err := tool.Write("out.txt", "written"); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	written, err := os.ReadFile(filepath.Join(workspace, "out.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile after Write: %v", err)
+	}
+	if string(written) != "written" {
+		t.Errorf("Write() wrote %q, want %q", string(written), "written")
+	}
+
+	// Traversal attempt must be blocked
+	_, err = tool.Read("../secret.txt")
+	if err == nil {
+		t.Error("Read() expected error for traversal path, got nil")
+	}
+}
+
+// TestPatchTool_WorkspaceResolution verifies that PatchTool resolves relative
+// paths against the configured workspace root.
+func TestPatchTool_WorkspaceResolution(t *testing.T) {
+	workspace := t.TempDir()
+
+	original := "line1\nline2\nline3\n"
+	if err := os.WriteFile(filepath.Join(workspace, "target.txt"), []byte(original), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	tool := NewPatchTool(workspace)
+
+	patch := `--- a/target.txt
++++ b/target.txt
+@@ -1,3 +1,3 @@
+ line1
+-line2
++LINE2
+ line3
+`
+	_, err := tool.Execute(context.Background(), "target.txt", patch)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	result, err := os.ReadFile(filepath.Join(workspace, "target.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(result), "LINE2") {
+		t.Errorf("patch not applied, content: %q", string(result))
+	}
+}
+
+// TestSearchFileTool_WorkspaceResolution verifies that SearchFileTool resolves
+// relative subdirectory paths against the configured workspace root.
+func TestSearchFileTool_WorkspaceResolution(t *testing.T) {
+	workspace := t.TempDir()
+
+	// Create a file inside the workspace
+	if err := os.WriteFile(filepath.Join(workspace, "find_me.txt"), []byte("needle\n"), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	tool := NewSearchFileTool(workspace)
+
+	// Search without a subdirectory — should find file in workspace
+	result, err := tool.Execute(context.Background(), "needle")
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(result, "find_me.txt") {
+		t.Errorf("expected find_me.txt in results, got: %s", result)
+	}
+
+	// Traversal attempt must be blocked
+	_, err = tool.Execute(context.Background(), "needle", "../outside")
+	if err == nil {
+		t.Error("Execute() expected error for traversal path, got nil")
+	}
+	if !strings.Contains(err.Error(), "outside allowed directory") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Implements #6

## Changes

### Root cause
`bot.go` called `tools.LoadFromConfigWithOptions("", toolsConfig)` with an empty `basePath`, which caused `FileTool`, `PatchTool`, and `SearchFileTool` to never register (they're guarded by `if basePath != ""`). Even when BasePath was set manually, the traversal-protection check used `strings.HasPrefix(fullPath, basePath)` which is incorrect — `/foo` is a prefix of `/foobar`, so paths could escape the intended directory.

### Fix

- **`internal/tools/tools.go`**: Added `resolvePath(workspaceRoot, path string)` helper that:
  - Joins relative paths with `workspaceRoot` using `filepath.Join`
  - For absolute paths, validates they're within `workspaceRoot`
  - Uses `filepath.Clean` + separator-terminated prefix check to prevent traversal
  - Updated `FileTool.Read` and `FileTool.Write` to use it

- **`internal/tools/patch.go`**: Updated `applyPatch` to use `resolvePath` instead of the broken inline check

- **`internal/tools/search_file.go`**: Updated `Execute` to use `resolvePath` for the optional subdirectory argument

- **`internal/bot/bot.go`**: Changed tool registry initialization from `LoadFromConfigWithOptions("", ...)` to `LoadFromConfigWithOptions(personality.BasePath, ...)` so file tools resolve against the configured `soul_path`

### New test file

`internal/tools/workspace_test.go` covers:
- `TestResolvePath`: relative paths, absolute inside/outside root, traversal via `..`, empty root passthrough
- `TestFileTool_WorkspaceResolution`: read/write with relative paths resolve against workspace, traversal blocked
- `TestPatchTool_WorkspaceResolution`: patch applied via relative path
- `TestSearchFileTool_WorkspaceResolution`: search uses workspace root, traversal blocked

## Testing

```
go fmt ./...
go vet ./...
go test ./...    # all packages pass
go build ./cmd/ok-gobot/
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical security vulnerability and a functionality bug in file/path tool resolution. The previous implementation had two issues: (1) passing an empty `basePath` prevented file tools from being registered, and (2) the traversal protection used a vulnerable string prefix check that could be bypassed (e.g., `/foo` is a prefix of `/foobar`).

The fix introduces a robust `resolvePath()` helper that:
- Properly joins relative paths with the workspace root using `filepath.Join`
- Validates absolute paths stay within the workspace boundary
- Uses a separator-terminated prefix check to prevent directory traversal attacks
- Handles edge cases like empty workspace roots and root directory access

All affected tools (`FileTool`, `PatchTool`, `SearchFileTool`) now use this secure helper, and comprehensive tests verify the implementation blocks traversal attempts while allowing legitimate access patterns.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The implementation is security-focused with proper path validation, comprehensive test coverage verifies all edge cases including traversal attacks, and the changes fix both a critical security vulnerability and functionality bug without introducing new risks
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tools/tools.go | Added secure `resolvePath()` helper with proper traversal protection using separator-terminated prefix checks |
| internal/bot/bot.go | Fixed tool registration by passing `personality.BasePath` instead of empty string, enabling file tools |
| internal/tools/patch.go | Replaced vulnerable inline path check with secure `resolvePath()` helper |
| internal/tools/search_file.go | Updated subdirectory resolution to use secure `resolvePath()` helper |
| internal/tools/workspace_test.go | Comprehensive test coverage for path resolution, traversal prevention, and all affected tools |

</details>



<sub>Last reviewed commit: 6802b03</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->