### PR TITLE
feat: wire cron/message/semantic memory tools through real runtime deps (#5)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,6 +14,7 @@ import (
 	"ok-gobot/internal/control"
 	"ok-gobot/internal/cron"
 	"ok-gobot/internal/logger"
+	"ok-gobot/internal/memory"
 	"ok-gobot/internal/storage"
 )
 
@@ -27,6 +28,7 @@ type App struct {
 	personality   *agent.Personality
 	memory        *agent.Memory
 	scheduler     *cron.Scheduler
+	memoryManager *memory.MemoryManager
 	apiServer     *api.APIServer
 	watcher       *config.ConfigWatcher
 	controlServer *control.Server
@@ -182,6 +184,22 @@ func (a *App) Start(ctx context.Context) error {
 		log.Println("📅 Cron scheduler started")
 	}
 
+	// Initialize semantic memory when enabled
+	if a.config.Memory.Enabled {
+		embClient := memory.NewEmbeddingClient(
+			a.config.Memory.EmbeddingsBaseURL,
+			a.config.Memory.EmbeddingsAPIKey,
+			a.config.Memory.EmbeddingsModel,
+		)
+		memStore, err := memory.NewMemoryStore(a.store.DB())
+		if err != nil {
+			log.Printf("⚠️ Failed to initialize memory store: %v", err)
+		} else {
+			a.memoryManager = memory.NewMemoryManager(embClient, memStore)
+			log.Println("🧠 Semantic memory initialized")
+		}
+	}
+
 	// Initialize bot
 	aiCfg := bot.AIConfig{
 		Provider:       a.config.AI.Provider,
@@ -191,7 +209,7 @@ func (a *App) Start(ctx context.Context) error {
 		FallbackModels: a.config.AI.FallbackModels,
 		ModelAliases:   a.config.ModelAliases,
 	}
-	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS)
+	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.scheduler, a.memoryManager)
 	if err != nil {
 		return fmt.Errorf("failed to create bot: %w", err)
 	}

--- a/internal/bot/agent_handler.go
+++ b/internal/bot/agent_handler.go
@@ -59,9 +59,32 @@ func (b *Bot) getFilteredToolRegistry(profile *agent.AgentProfile) *tools.Regist
 	return filteredRegistry
 }
 
-// createAgentToolAgent creates a ToolCallingAgent for the active agent profile using the provided AI client.
-func (b *Bot) createAgentToolAgent(profile *agent.AgentProfile, aiClient ai.Client) *agent.ToolCallingAgent {
-	filteredTools := b.getFilteredToolRegistry(profile)
+// getFilteredToolRegistryForChat returns a tool registry for a specific chat,
+// replacing the global cron tool with a chat-specific instance so scheduled
+// jobs are associated with the correct chatID.
+func (b *Bot) getFilteredToolRegistryForChat(chatID int64, profile *agent.AgentProfile) *tools.Registry {
+	if b.scheduler == nil {
+		return b.getFilteredToolRegistry(profile)
+	}
+
+	// Copy all tools from the filtered registry, skipping the global cron tool.
+	// We'll inject a fresh per-chat cron tool instead.
+	base := b.getFilteredToolRegistry(profile)
+	chatRegistry := tools.NewRegistry()
+	for _, tool := range base.List() {
+		if tool.Name() != "cron" {
+			chatRegistry.Register(tool)
+		}
+	}
+	chatRegistry.Register(tools.NewCronTool(b.scheduler, chatID))
+	return chatRegistry
+}
+
+// createAgentToolAgent creates a ToolCallingAgent for the active agent profile
+// using a per-chat tool registry so the cron tool carries the correct chatID,
+// and the provided AI client so model overrides are respected.
+func (b *Bot) createAgentToolAgent(chatID int64, profile *agent.AgentProfile, aiClient ai.Client) *agent.ToolCallingAgent {
+	filteredTools := b.getFilteredToolRegistryForChat(chatID, profile)
 	return newToolAgentWithAliases(aiClient, filteredTools, profile.Personality, b.aiConfig.ModelAliases)
 }
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -13,6 +13,7 @@ import (
 	"ok-gobot/internal/ai"
 	"ok-gobot/internal/config"
 	"ok-gobot/internal/logger"
+	"ok-gobot/internal/memory"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 	"ok-gobot/internal/tools"
@@ -47,6 +48,7 @@ type Bot struct {
 	fragmentBuffer   *FragmentBuffer
 	mediaGroupBuf    *MediaGroupBuffer
 	queueManager     *QueueManager
+	scheduler        tools.CronScheduler
 }
 
 // AIConfig holds AI configuration for status display
@@ -71,7 +73,7 @@ func newToolAgentWithAliases(aiClient ai.Client, toolRegistry *tools.Registry, p
 }
 
 // New creates a new bot instance
-func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig) (*Bot, error) {
+func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager) (*Bot, error) {
 	pref := telebot.Settings{
 		Token:  token,
 		Poller: &telebot.LongPoller{Timeout: 10 * time.Second},
@@ -82,14 +84,16 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		return nil, fmt.Errorf("failed to create bot: %w", err)
 	}
 
-	// Create tool registry with TTS configuration.
-	// Use personality.BasePath as the workspace root so that file/path tools
-	// resolve relative paths against the configured soul directory instead of
-	// the process working directory.
+	// Create tool registry with optional dependencies.
+	// Cron tool is NOT registered here — it is created per-chat in the agent handler
+	// so each job gets the correct chatID. Use personality.BasePath as the workspace
+	// root so that file/path tools resolve relative paths against the configured soul
+	// directory instead of the process working directory.
 	toolsConfig := &tools.ToolsConfig{
-		OpenAIAPIKey: aiCfg.APIKey,
-		TTSProvider:  ttsCfg.Provider,
-		TTSVoice:     ttsCfg.DefaultVoice,
+		OpenAIAPIKey:  aiCfg.APIKey,
+		TTSProvider:   ttsCfg.Provider,
+		TTSVoice:      ttsCfg.DefaultVoice,
+		MemoryManager: memoryManager,
 	}
 	toolRegistry, _ := tools.LoadFromConfigWithOptions(personality.BasePath, toolsConfig)
 
@@ -102,7 +106,7 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 	// Create group manager
 	groupManager := NewGroupManager(store, groupsCfg.DefaultMode, api.Me.Username)
 
-	return &Bot{
+	b := &Bot{
 		api:              api,
 		store:            store,
 		ai:               aiClient,
@@ -113,7 +117,6 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		toolRegistry:     toolRegistry,
 		safety:           agent.NewSafety(),
 		memory:           agent.NewMemory(""),
-		toolAgent:        newToolAgentWithAliases(aiClient, toolRegistry, personality, aiCfg.ModelAliases),
 		authManager:      authManager,
 		groupManager:     groupManager,
 		hub:              agent.NewRuntimeHub(),
@@ -126,7 +129,28 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		fragmentBuffer:   NewFragmentBuffer(),
 		mediaGroupBuf:    NewMediaGroupBuffer(),
 		queueManager:     NewQueueManager(),
-	}, nil
+		scheduler:        scheduler,
+	}
+
+	// Register message tool: bot itself is the sender (self-reference is safe post-creation)
+	toolRegistry.Register(tools.NewMessageTool(b))
+
+	// Register cron tool with chatID=0 for the legacy single-agent path.
+	// The per-profile agent path creates a chat-specific cron tool per request.
+	if scheduler != nil {
+		toolRegistry.Register(tools.NewCronTool(scheduler, 0))
+	}
+
+	// Build the shared tool agent for the legacy (non-agent-registry) path
+	b.toolAgent = newToolAgentWithAliases(aiClient, toolRegistry, personality, aiCfg.ModelAliases)
+
+	return b, nil
+}
+
+// SendToChat implements tools.MessageSender, allowing the message tool to send
+// Telegram messages through the live bot instance.
+func (b *Bot) SendToChat(chatID int64, text string) error {
+	return b.SendMessage(chatID, text)
 }
 
 // EnableStreaming enables or disables streaming mode

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -62,7 +62,7 @@ func (b *Bot) processViaHub(ctx context.Context, c telebot.Context, sessionKey a
 	profile := b.getActiveAgentProfile(chatID)
 	model := b.getAgentModel(chatID, profile)
 	aiClient := b.getAIClientForModel(model)
-	toolAgent := b.createAgentToolAgent(profile, aiClient)
+	toolAgent := b.createAgentToolAgent(chatID, profile, aiClient)
 
 	// Start typing indicator while the hub is running.
 	stopTyping := NewTypingIndicator(b.api, c.Chat())

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -49,6 +49,11 @@ func (s *Store) Close() error {
 	return s.db.Close()
 }
 
+// DB returns the underlying database connection
+func (s *Store) DB() *sql.DB {
+	return s.db
+}
+
 // migrate runs database migrations
 func (s *Store) migrate() error {
 	migrations := []string{


### PR DESCRIPTION
Implements #5

## Changes

### `internal/storage/sqlite.go`
- Added `DB() *sql.DB` method to expose the underlying database connection so the memory package can share the same SQLite file.

### `internal/app/app.go`
- Added `memoryManager *memory.MemoryManager` to `App` struct.
- When `memory.enabled` is set in config, initializes `EmbeddingClient` + `MemoryStore` + `MemoryManager` at startup.
- Passes the live cron scheduler and memory manager to `bot.New`.

### `internal/bot/bot.go`
- Updated `New` signature to accept `scheduler tools.CronScheduler` and `memoryManager *memory.MemoryManager`.
- Stores `scheduler` in `Bot` struct for per-chat cron tool injection.
- Registers **message tool** immediately after bot creation using the bot itself as `MessageSender` (`SendToChat` wraps `SendMessage`).
- Registers **memory tool** via `ToolsConfig.MemoryManager` (nil-safe: only registered when memory is configured).
- Registers **cron tool** with `chatID=0` in the shared registry for the legacy single-agent path.
- Added `SendToChat(chatID int64, text string) error` to implement `tools.MessageSender`.

### `internal/bot/agent_handler.go`
- Added `getFilteredToolRegistryForChat(chatID, profile)`: copies the filtered tool set and replaces the shared cron tool (chatID=0) with a fresh per-chat instance so scheduled jobs are correctly associated with the originating chat.
- Updated `createAgentToolAgent` to accept `chatID` and delegate to the per-chat registry builder.
- Updated the `handleAgentRequestWithProfile` call site accordingly.

## Testing

- `go fmt ./...` — clean
- `go vet ./...` — no issues
- `go test ./...` — all packages pass
- `go build ./cmd/ok-gobot/` — binary builds successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wires cron, message, and semantic memory tools through proper runtime dependencies. Exposes SQLite connection for memory store sharing, initializes memory components when configured, and creates per-chat cron tool instances to correctly associate scheduled jobs with their originating chat.

**Key changes:**
- Added `DB()` method to expose SQLite connection for memory package
- Initialized `EmbeddingClient`, `MemoryStore`, and `MemoryManager` when `memory.enabled` config is set
- Updated `bot.New` signature to accept scheduler and memory manager
- Registered message tool (bot implements `MessageSender`) and memory tool (via `ToolsConfig`)
- Registered cron tool with `chatID=0` for legacy path, and per-chat instances for profile-based path

**Issues:**
- The cron tool permission bypass issue from the previous review thread remains unresolved in `internal/bot/agent_handler.go:79`

<h3>Confidence Score: 3/5</h3>

- Safe to merge with moderate risk due to unresolved permission bypass
- The implementation is technically sound with proper error handling, nil-safety checks, and passing tests. However, the cron tool permission bypass in `agent_handler.go:79` (noted in previous review) remains unresolved, allowing agents to access the cron tool even when explicitly disallowed by their profile.
- Pay attention to `internal/bot/agent_handler.go` - the cron tool permission bypass must be fixed before or immediately after merge

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/storage/sqlite.go | Added `DB()` method to expose underlying database connection for memory package integration |
| internal/app/app.go | Initialized memory manager with proper error handling and passed dependencies to bot constructor |
| internal/bot/bot.go | Wired scheduler and memory manager through constructor, registered message and cron tools with nil-safety |
| internal/bot/agent_handler.go | Added per-chat cron tool registry, but cron tool bypasses permission filtering (known issue from previous thread) |
| internal/bot/hub_handler.go | Updated to pass `chatID` parameter to `createAgentToolAgent` for per-chat tool registry |

</details>



<sub>Last reviewed commit: 43d7d01</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->