### PR TITLE
fix: honor session model override on normal tool path (#3)

### DIFF
--- a/internal/bot/agent_handler.go
+++ b/internal/bot/agent_handler.go
@@ -60,10 +60,10 @@ func (b *Bot) getFilteredToolRegistry(profile *agent.AgentProfile) *tools.Regist
 	return filteredRegistry
 }
 
-// createAgentToolAgent creates a ToolCallingAgent for the active agent profile
-func (b *Bot) createAgentToolAgent(profile *agent.AgentProfile) *agent.ToolCallingAgent {
+// createAgentToolAgent creates a ToolCallingAgent for the active agent profile using the provided AI client.
+func (b *Bot) createAgentToolAgent(profile *agent.AgentProfile, aiClient ai.Client) *agent.ToolCallingAgent {
 	filteredTools := b.getFilteredToolRegistry(profile)
-	return newToolAgentWithAliases(b.ai, filteredTools, profile.Personality, b.aiConfig.ModelAliases)
+	return newToolAgentWithAliases(aiClient, filteredTools, profile.Personality, b.aiConfig.ModelAliases)
 }
 
 // getAgentModel returns the model to use for the active agent, considering overrides
@@ -102,11 +102,14 @@ func (b *Bot) handleAgentRequestWithProfile(ctx context.Context, c telebot.Conte
 	// Get active agent profile
 	profile := b.getActiveAgentProfile(chatID)
 
-	// Create tool agent for this profile
-	toolAgent := b.createAgentToolAgent(profile)
-
-	// Get effective model
+	// Get effective model (session override > agent model > global default)
 	model := b.getAgentModel(chatID, profile)
+
+	// Get AI client configured for the effective model
+	aiClient := b.getAIClientForModel(model)
+
+	// Create tool agent for this profile with the effective model's client
+	toolAgent := b.createAgentToolAgent(profile, aiClient)
 
 	// Start typing indicator
 	stopTyping := NewTypingIndicator(b.api, c.Chat())

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -411,8 +411,13 @@ func (b *Bot) handleAgentRequest(ctx context.Context, c telebot.Context, content
 	stopTyping := NewTypingIndicator(b.api, c.Chat())
 	defer stopTyping()
 
+	// Get effective model (session override takes precedence over global default)
+	model := b.getEffectiveModel(chatID)
+	aiClient := b.getAIClientForModel(model)
+	toolAgent := newToolAgentWithAliases(aiClient, b.toolRegistry, b.personality, b.aiConfig.ModelAliases)
+
 	// Always use tool-calling path — streaming doesn't support tools
-	response, err := b.toolAgent.ProcessRequest(ctx, content, session)
+	response, err := toolAgent.ProcessRequest(ctx, content, session)
 	if err != nil {
 		log.Printf("Agent error: %v", err)
 		return c.Send("❌ Sorry, I encountered an error processing your request.")
@@ -512,6 +517,29 @@ func (b *Bot) handleStreamingRequest(ctx context.Context, c telebot.Context, con
 	}
 
 	return nil
+}
+
+// getAIClientForModel returns an AI client configured for the given model.
+// Returns the default client if model matches the configured default.
+func (b *Bot) getAIClientForModel(model string) ai.Client {
+	if model == b.aiConfig.Model {
+		return b.ai
+	}
+
+	cfg := ai.ProviderConfig{
+		Name:    b.aiConfig.Provider,
+		APIKey:  b.aiConfig.APIKey,
+		Model:   model,
+		BaseURL: b.aiConfig.BaseURL,
+	}
+
+	client, err := ai.NewClient(cfg)
+	if err != nil {
+		log.Printf("Failed to create AI client with model %s: %v", model, err)
+		return b.ai // Fallback to default
+	}
+
+	return client
 }
 
 // getEffectiveModel returns the model to use for a chat session


### PR DESCRIPTION
Implements #3

## Changes

**Root cause:** Session model overrides (set via `/model <name>` or TUI) were stored in the DB but never applied on the normal (non-streaming) tool-calling path. Both `handleAgentRequestWithProfile` and the legacy `handleAgentRequest` always created the `ToolCallingAgent` with `b.ai` — the global default client — ignoring the per-session and per-agent model configuration.

**Fix:**

1. **`getAIClientForModel(model string) ai.Client`** (new helper in `bot.go`) — constructs an `ai.Client` configured for the given model, reusing the global default client when the model matches the default (zero overhead for the common case).

2. **`handleAgentRequestWithProfile`** — now calls `getAgentModel()` first (which already implements the correct priority: session override → agent model → global default), then feeds the resolved model into `getAIClientForModel()` and passes the result to `createAgentToolAgent()`.

3. **`createAgentToolAgent`** — signature changed to accept an explicit `aiClient ai.Client` parameter instead of always closing over `b.ai`. This removes the implicit coupling to the global default.

4. **Legacy `handleAgentRequest`** — reads the session override via `getEffectiveModel()` and builds a fresh `ToolCallingAgent` with the appropriate client before each run. Previously it always used `b.toolAgent` (the global-default agent created at startup).

## Testing

- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass
- `go build ./cmd/ok-gobot/` — binary builds successfully

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes the issue where session model overrides (set via `/model <name>`) were being ignored on the non-streaming tool-calling path.

**Key Changes:**
- Added `getAIClientForModel(model)` helper that efficiently reuses the default client when possible and creates model-specific clients when needed
- Modified `createAgentToolAgent` to accept an explicit AI client parameter, removing implicit coupling to the global default
- Updated `handleAgentRequestWithProfile` to properly resolve model priority (session override → agent model → global default) and create agents with the correct client
- Fixed legacy `handleAgentRequest` path to respect session overrides by creating fresh tool agents with appropriate clients

**Implementation Quality:**
- Clean separation of concerns with the new helper method
- Proper fallback handling when client creation fails
- Efficient optimization: reuses default client when model matches (zero overhead for common case)
- Consistent with the existing `getAIClientForSession` pattern used in streaming path
- All tests pass and code is properly formatted

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a focused bug fix with clean implementation and no side effects
- The changes are straightforward, well-tested, and directly address the stated issue. The implementation follows existing patterns in the codebase, includes proper error handling with fallbacks, and maintains backward compatibility. No breaking changes or risky operations introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/agent_handler.go | Updated `createAgentToolAgent` to accept explicit AI client parameter and modified `handleAgentRequestWithProfile` to resolve and use session/agent-specific model correctly |
| internal/bot/bot.go | Added `getAIClientForModel` helper and updated legacy `handleAgentRequest` to respect session model overrides by creating fresh tool agent with appropriate client |

</details>



<sub>Last reviewed commit: 7435952</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->