### PR TITLE
feat: wire config watcher in app.Start (#2)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sync"
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/ai"
@@ -17,6 +18,7 @@ import (
 
 // App orchestrates all components
 type App struct {
+	mu          sync.RWMutex
 	config      *config.Config
 	store       *storage.Store
 	bot         *bot.Bot
@@ -25,6 +27,7 @@ type App struct {
 	memory      *agent.Memory
 	scheduler   *cron.Scheduler
 	apiServer   *api.APIServer
+	watcher     *config.ConfigWatcher
 }
 
 // New creates a new application instance
@@ -37,6 +40,23 @@ func New(cfg *config.Config, store *storage.Store) *App {
 
 // Start initializes and runs all components
 func (a *App) Start(ctx context.Context) error {
+	// Start config watcher if a config file path is known
+	if a.config.ConfigPath != "" {
+		watcher, err := config.NewConfigWatcher(a.config.ConfigPath, func(cfg *config.Config) {
+			a.mu.Lock()
+			a.config = cfg
+			a.mu.Unlock()
+			log.Printf("[config] Configuration reloaded from %s", cfg.ConfigPath)
+		})
+		if err != nil {
+			log.Printf("[config] Failed to start config watcher: %v", err)
+		} else {
+			a.watcher = watcher
+		}
+	} else {
+		log.Println("[config] No config file path set; config watcher disabled")
+	}
+
 	// Set log level from config
 	logger.SetLevel(a.config.LogLevel)
 
@@ -155,6 +175,9 @@ func (a *App) GetScheduler() *cron.Scheduler {
 
 // Stop gracefully shuts down all components
 func (a *App) Stop() error {
+	if a.watcher != nil {
+		a.watcher.Stop()
+	}
 	if a.scheduler != nil {
 		a.scheduler.Stop()
 	}


### PR DESCRIPTION
Implements #2

## Changes

- Added `watcher *config.ConfigWatcher` field to `App` struct
- Added `sync.RWMutex` to `App` for safe concurrent config updates
- In `app.Start()`: if `config.ConfigPath` is set, a `ConfigWatcher` is created and started with an `onChange` callback that atomically replaces `a.config` under the write lock
- If the config path is empty (e.g. env-only config), the watcher is skipped with a log message
- In `app.Stop()`: watcher is stopped before other components
- Parse errors and validation failures are already handled inside `ConfigWatcher.reload()` — the callback is only called on a valid config, so the previous config is retained on error

## Testing

- Existing `internal/config` watcher tests cover file-change detection, debouncing, invalid-config retention, and manual reload — all pass
- `go fmt ./...`, `go vet ./...`, `go test ./...`, `go build ./cmd/ok-gobot/` all pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds configuration hot-reloading by integrating a `ConfigWatcher` that monitors the config file for changes and atomically updates the `App.config` field using a `sync.RWMutex`. The watcher is started in `app.Start()` if a config file path is present, and gracefully stopped in `app.Stop()`.

**Key changes:**
- Added `sync.RWMutex` and `watcher *config.ConfigWatcher` fields to `App` struct
- Config watcher initialization with atomic config updates via mutex-protected callback
- Proper cleanup in `Stop()` method

**Issues found:**
- **Race condition during initialization**: The watcher starts immediately when created (line 45), launching a background goroutine that can modify `a.config` while the rest of `Start()` (lines 61-168) reads from it without holding the read lock. This creates a data race that would be caught by Go's race detector and could cause inconsistent initialization state if the config file changes during startup.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the race condition in initialization sequence
- The implementation is sound with proper mutex protection and cleanup, but has a race condition where the config watcher can update `a.config` concurrently with unprotected reads during `Start()`. Fix by moving watcher initialization to end of `Start()`.
- internal/app/app.go requires attention for the initialization race condition

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/app/app.go | Added config watcher with mutex protection, but potential race condition exists during initialization where config reads are unprotected after watcher starts |

</details>



<sub>Last reviewed commit: c9608df</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->