### PR TITLE
feat: implement per-session worker mailbox model (#9)

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,0 +1,303 @@
+// Package runtime implements the per-session worker mailbox model.
+// It is the sole owner of agent execution scheduling.
+//
+// Each unique session key gets one SessionWorker goroutine that processes
+// requests one at a time from a buffered queue. Different session keys run
+// fully concurrently. On every inbound request, the caller receives
+// immediate acknowledgment via AckHandle (idle → active, busy → queued),
+// and all state transitions are broadcast as RuntimeEvents to subscribers.
+package runtime
+
+import (
+	"context"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// EventType describes the kind of a RuntimeEvent.
+type EventType string
+
+const (
+	// EventQueued is emitted when a request is accepted but the session is busy.
+	EventQueued EventType = "queued"
+	// EventActive is emitted when a request starts executing.
+	EventActive EventType = "active"
+	// EventUpdate is emitted by the RunFunc during execution for progress updates.
+	EventUpdate EventType = "update"
+	// EventDone is emitted when a request completes successfully.
+	EventDone EventType = "done"
+	// EventError is emitted when a request completes with an error.
+	EventError EventType = "error"
+)
+
+// RuntimeEvent is broadcast to all Hub subscribers on every state change.
+type RuntimeEvent struct {
+	Type       EventType
+	SessionKey string
+	RequestID  string
+	Payload    any
+	Err        error
+	Timestamp  time.Time
+}
+
+// AckHandle is returned by Hub.Submit. The Hub and the RunFunc call its
+// methods to signal run state transitions to the caller.
+type AckHandle interface {
+	// AcceptQueued signals that the session was busy; request is enqueued.
+	AcceptQueued()
+	// AcceptActive signals that the request is now executing.
+	AcceptActive()
+	// Update sends an in-flight progress payload.
+	Update(payload any)
+	// Close marks the request done. nil err means success.
+	Close(err error)
+}
+
+// RunFunc is the work to be executed for a session request.
+// It receives a cancellable context and an AckHandle for signalling progress.
+// Implementations must call ack.Close when done (typically deferred).
+type RunFunc func(ctx context.Context, ack AckHandle)
+
+// Hub manages one SessionWorker per session key.
+type Hub struct {
+	mu         sync.Mutex
+	workers    map[string]*SessionWorker
+	subsMu     sync.Mutex
+	subs       []chan<- RuntimeEvent
+	ctx        context.Context
+	queueDepth int
+}
+
+// NewHub creates a Hub. queueDepth controls the per-session inbound buffer size.
+func NewHub(ctx context.Context, queueDepth int) *Hub {
+	if queueDepth <= 0 {
+		queueDepth = 64
+	}
+	return &Hub{
+		workers:    make(map[string]*SessionWorker),
+		ctx:        ctx,
+		queueDepth: queueDepth,
+	}
+}
+
+// Subscribe adds ch to receive all RuntimeEvents. ch must be buffered to
+// avoid blocking the hub; events are dropped (with a log warning) if full.
+func (h *Hub) Subscribe(ch chan<- RuntimeEvent) {
+	h.subsMu.Lock()
+	defer h.subsMu.Unlock()
+	h.subs = append(h.subs, ch)
+}
+
+// Unsubscribe removes ch from the subscriber list.
+func (h *Hub) Unsubscribe(ch chan<- RuntimeEvent) {
+	h.subsMu.Lock()
+	defer h.subsMu.Unlock()
+	out := h.subs[:0]
+	for _, s := range h.subs {
+		if s != ch {
+			out = append(out, s)
+		}
+	}
+	h.subs = out
+}
+
+// emit broadcasts ev to all subscribers, dropping events to full channels.
+func (h *Hub) emit(ev RuntimeEvent) {
+	h.subsMu.Lock()
+	subs := make([]chan<- RuntimeEvent, len(h.subs))
+	copy(subs, h.subs)
+	h.subsMu.Unlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- ev:
+		default:
+			log.Printf("[runtime] subscriber full, dropping event %s for session %s", ev.Type, ev.SessionKey)
+		}
+	}
+}
+
+// Submit enqueues run under sessionKey. It returns an AckHandle immediately;
+// AcceptQueued or AcceptActive is called synchronously before Submit returns.
+func (h *Hub) Submit(sessionKey, requestID string, run RunFunc) AckHandle {
+	h.mu.Lock()
+	w, ok := h.workers[sessionKey]
+	if !ok {
+		w = newSessionWorker(h.ctx, sessionKey, h.queueDepth, h)
+		h.workers[sessionKey] = w
+	}
+	h.mu.Unlock()
+
+	ack := &handle{
+		sessionKey: sessionKey,
+		requestID:  requestID,
+		hub:        h,
+	}
+
+	req := runRequest{id: requestID, run: run, ack: ack}
+
+	// Signal immediately: queued if the worker has an active run, active otherwise.
+	if w.isRunning() {
+		ack.wasQueued.Store(true)
+		ack.AcceptQueued()
+	} else {
+		ack.AcceptActive()
+	}
+
+	w.queue <- req
+	return ack
+}
+
+// CancelSession cancels the currently executing request for sessionKey.
+// Has no effect if the session is idle.
+func (h *Hub) CancelSession(sessionKey string) {
+	h.mu.Lock()
+	w, ok := h.workers[sessionKey]
+	h.mu.Unlock()
+	if ok {
+		w.cancelCurrent()
+	}
+}
+
+// ── runRequest ───────────────────────────────────────────────────────────────
+
+type runRequest struct {
+	id  string
+	run RunFunc
+	ack *handle
+}
+
+// ── SessionWorker ────────────────────────────────────────────────────────────
+
+// SessionWorker processes one request at a time from a buffered queue.
+// A single goroutine runs the loop; different SessionWorkers run concurrently.
+type SessionWorker struct {
+	sessionKey string
+	queue      chan runRequest
+	hub        *Hub
+	running    atomic.Bool
+
+	cancelMu sync.Mutex
+	cancelFn context.CancelFunc
+}
+
+func newSessionWorker(ctx context.Context, key string, depth int, hub *Hub) *SessionWorker {
+	sw := &SessionWorker{
+		sessionKey: key,
+		queue:      make(chan runRequest, depth),
+		hub:        hub,
+	}
+	go sw.loop(ctx)
+	return sw
+}
+
+// isRunning reports whether a run is currently active in this worker.
+func (sw *SessionWorker) isRunning() bool {
+	return sw.running.Load()
+}
+
+// cancelCurrent cancels the active run context, if any.
+func (sw *SessionWorker) cancelCurrent() {
+	sw.cancelMu.Lock()
+	defer sw.cancelMu.Unlock()
+	if sw.cancelFn != nil {
+		sw.cancelFn()
+	}
+}
+
+func (sw *SessionWorker) loop(ctx context.Context) {
+	log.Printf("[runtime] session worker started: %s", sw.sessionKey)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("[runtime] session worker stopped: %s", sw.sessionKey)
+			return
+		case req := <-sw.queue:
+			sw.execute(ctx, req)
+		}
+	}
+}
+
+func (sw *SessionWorker) execute(ctx context.Context, req runRequest) {
+	runCtx, cancel := context.WithCancel(ctx)
+	sw.cancelMu.Lock()
+	sw.cancelFn = cancel
+	sw.cancelMu.Unlock()
+
+	sw.running.Store(true)
+
+	// If the request was initially queued, signal it is now active.
+	if req.ack.wasQueued.Load() {
+		req.ack.AcceptActive()
+	}
+
+	log.Printf("[runtime] session %s: executing request %s", sw.sessionKey, req.id)
+
+	defer func() {
+		cancel()
+		sw.cancelMu.Lock()
+		sw.cancelFn = nil
+		sw.cancelMu.Unlock()
+		sw.running.Store(false)
+		log.Printf("[runtime] session %s: request %s completed", sw.sessionKey, req.id)
+	}()
+
+	req.run(runCtx, req.ack)
+}
+
+// ── handle ───────────────────────────────────────────────────────────────────
+
+// handle is the concrete AckHandle returned by Hub.Submit.
+type handle struct {
+	sessionKey string
+	requestID  string
+	hub        *Hub
+	wasQueued  atomic.Bool
+	closeOnce  sync.Once
+}
+
+func (h *handle) AcceptQueued() {
+	h.hub.emit(RuntimeEvent{
+		Type:       EventQueued,
+		SessionKey: h.sessionKey,
+		RequestID:  h.requestID,
+		Timestamp:  time.Now(),
+	})
+}
+
+func (h *handle) AcceptActive() {
+	h.hub.emit(RuntimeEvent{
+		Type:       EventActive,
+		SessionKey: h.sessionKey,
+		RequestID:  h.requestID,
+		Timestamp:  time.Now(),
+	})
+}
+
+func (h *handle) Update(payload any) {
+	h.hub.emit(RuntimeEvent{
+		Type:       EventUpdate,
+		SessionKey: h.sessionKey,
+		RequestID:  h.requestID,
+		Payload:    payload,
+		Timestamp:  time.Now(),
+	})
+}
+
+func (h *handle) Close(err error) {
+	h.closeOnce.Do(func() {
+		evType := EventDone
+		if err != nil {
+			evType = EventError
+		}
+		h.hub.emit(RuntimeEvent{
+			Type:       evType,
+			SessionKey: h.sessionKey,
+			RequestID:  h.requestID,
+			Err:        err,
+			Timestamp:  time.Now(),
+		})
+	})
+}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1,0 +1,269 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// collectEvents drains events from ch until it is closed or the deadline passes.
+func collectEvents(ch <-chan RuntimeEvent, timeout time.Duration) []RuntimeEvent {
+	var events []RuntimeEvent
+	deadline := time.After(timeout)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return events
+			}
+			events = append(events, ev)
+		case <-deadline:
+			return events
+		}
+	}
+}
+
+// TestSessionWorkerOneRunAtATime verifies that a single session key never
+// executes more than one run concurrently.
+func TestSessionWorkerOneRunAtATime(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	hub := NewHub(ctx, 10)
+
+	var mu sync.Mutex
+	var concurrent, maxConcurrent int
+	var wg sync.WaitGroup
+
+	const numRequests = 5
+	wg.Add(numRequests)
+
+	for i := 0; i < numRequests; i++ {
+		id := fmt.Sprintf("req-%d", i)
+		hub.Submit("session-A", id, func(ctx context.Context, ack AckHandle) {
+			defer wg.Done()
+			defer ack.Close(nil)
+
+			mu.Lock()
+			concurrent++
+			if concurrent > maxConcurrent {
+				maxConcurrent = concurrent
+			}
+			mu.Unlock()
+
+			time.Sleep(20 * time.Millisecond)
+
+			mu.Lock()
+			concurrent--
+			mu.Unlock()
+		})
+	}
+
+	wg.Wait()
+
+	if maxConcurrent > 1 {
+		t.Errorf("same session: expected max 1 concurrent run, got %d", maxConcurrent)
+	}
+}
+
+// TestDifferentSessionsConcurrent verifies that two different session keys
+// execute their runs concurrently without blocking each other.
+func TestDifferentSessionsConcurrent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	hub := NewHub(ctx, 10)
+
+	var mu sync.Mutex
+	var concurrent, maxConcurrent int
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	for i := 0; i < 2; i++ {
+		key := fmt.Sprintf("session-%d", i)
+		hub.Submit(key, "req-1", func(ctx context.Context, ack AckHandle) {
+			defer wg.Done()
+			defer ack.Close(nil)
+
+			mu.Lock()
+			concurrent++
+			if concurrent > maxConcurrent {
+				maxConcurrent = concurrent
+			}
+			mu.Unlock()
+
+			time.Sleep(100 * time.Millisecond)
+
+			mu.Lock()
+			concurrent--
+			mu.Unlock()
+		})
+	}
+
+	wg.Wait()
+
+	if maxConcurrent < 2 {
+		t.Errorf("different sessions: expected both to run concurrently, max concurrent was %d", maxConcurrent)
+	}
+}
+
+// TestAckHandleEvents verifies that the correct RuntimeEvents are emitted
+// in the expected order for a simple run.
+func TestAckHandleEvents(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	hub := NewHub(ctx, 10)
+	subCh := make(chan RuntimeEvent, 50)
+	hub.Subscribe(subCh)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	hub.Submit("session-X", "req-1", func(ctx context.Context, ack AckHandle) {
+		defer wg.Done()
+		ack.Update("progress")
+		ack.Close(nil)
+	})
+
+	wg.Wait()
+	// Give the hub a moment to deliver all events.
+	time.Sleep(10 * time.Millisecond)
+
+	events := collectEvents(subCh, 100*time.Millisecond)
+
+	want := []EventType{EventActive, EventUpdate, EventDone}
+	if len(events) < len(want) {
+		t.Fatalf("expected at least %d events, got %d: %v", len(want), len(events), events)
+	}
+
+	for i, w := range want {
+		if events[i].Type != w {
+			t.Errorf("event[%d]: want %s, got %s", i, w, events[i].Type)
+		}
+	}
+}
+
+// TestQueuedThenActive verifies that when a session is busy, additional
+// requests get EventQueued followed by EventActive when they start.
+func TestQueuedThenActive(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	hub := NewHub(ctx, 10)
+	subCh := make(chan RuntimeEvent, 100)
+	hub.Subscribe(subCh)
+
+	startFirst := make(chan struct{})
+	releaseFirst := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// First request: holds the worker until released.
+	hub.Submit("session-Q", "req-1", func(ctx context.Context, ack AckHandle) {
+		defer wg.Done()
+		close(startFirst)
+		<-releaseFirst
+		ack.Close(nil)
+	})
+
+	// Wait until the first request is running so the second will be queued.
+	<-startFirst
+
+	hub.Submit("session-Q", "req-2", func(ctx context.Context, ack AckHandle) {
+		defer wg.Done()
+		ack.Close(nil)
+	})
+
+	// Release the first request.
+	close(releaseFirst)
+	wg.Wait()
+	time.Sleep(10 * time.Millisecond)
+
+	events := collectEvents(subCh, 100*time.Millisecond)
+
+	// Count event types.
+	counts := make(map[EventType]int)
+	for _, ev := range events {
+		counts[ev.Type]++
+	}
+
+	if counts[EventQueued] < 1 {
+		t.Errorf("expected at least 1 EventQueued, got %d; events: %v", counts[EventQueued], events)
+	}
+	if counts[EventActive] < 2 {
+		t.Errorf("expected at least 2 EventActive (one per request), got %d; events: %v", counts[EventActive], events)
+	}
+}
+
+// TestCancelSession verifies that CancelSession interrupts the active run.
+func TestCancelSession(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	hub := NewHub(ctx, 10)
+
+	started := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	hub.Submit("session-C", "req-1", func(runCtx context.Context, ack AckHandle) {
+		defer wg.Done()
+		close(started)
+		<-runCtx.Done() // block until cancelled
+		ack.Close(runCtx.Err())
+	})
+
+	<-started
+	hub.CancelSession("session-C")
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(2 * time.Second):
+		t.Error("CancelSession did not cancel the active run in time")
+	}
+}
+
+// TestAckHandleErrorClose verifies that Close with a non-nil error emits EventError.
+func TestAckHandleErrorClose(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	hub := NewHub(ctx, 10)
+	subCh := make(chan RuntimeEvent, 20)
+	hub.Subscribe(subCh)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	hub.Submit("session-E", "req-err", func(ctx context.Context, ack AckHandle) {
+		defer wg.Done()
+		ack.Close(fmt.Errorf("something went wrong"))
+	})
+
+	wg.Wait()
+	time.Sleep(10 * time.Millisecond)
+
+	events := collectEvents(subCh, 100*time.Millisecond)
+
+	var gotError bool
+	for _, ev := range events {
+		if ev.Type == EventError {
+			gotError = true
+			if ev.Err == nil {
+				t.Error("EventError has nil Err field")
+			}
+		}
+	}
+	if !gotError {
+		t.Errorf("expected EventError, got: %v", events)
+	}
+}


### PR DESCRIPTION
Implements #9

## Changes

- Added `internal/runtime` package as the sole owner of agent execution scheduling
- **`Hub`** — manages one `SessionWorker` per session key; fan-outs `RuntimeEvent` to subscribers
- **`SessionWorker`** — per-session goroutine; processes one run at a time from a buffered inbound queue; parallel across different session keys
- **`AckHandle` interface** — `AcceptQueued`, `AcceptActive`, `Update`, `Close`; concrete implementation (`handle`) emits `RuntimeEvent` on every call
- **`RuntimeEvent`** — structured event with `EventType` (queued / active / update / done / error), session key, request ID, payload, error, timestamp
- **`Hub.Submit`** — immediate acknowledgment: if session is idle → `AcceptActive`; if busy → `AcceptQueued`; when dequeued → `AcceptActive` again
- **`Hub.CancelSession`** — cancels the currently active run context for a session

## Testing

Six tests covering all acceptance criteria:
- `TestSessionWorkerOneRunAtATime` — 5 requests on the same session key; max concurrent never exceeds 1
- `TestDifferentSessionsConcurrent` — 2 sessions run fully in parallel (max concurrent = 2)
- `TestAckHandleEvents` — event sequence is active → update → done
- `TestQueuedThenActive` — second request gets EventQueued then EventActive when dequeued
- `TestCancelSession` — `CancelSession` interrupts the active run via context cancellation
- `TestAckHandleErrorClose` — `Close(err)` emits `EventError` with non-nil `Err`

All existing tests continue to pass; build succeeds.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a per-session worker mailbox model for agent execution scheduling. The architecture is well-designed with clear separation of concerns between Hub, SessionWorker, and event handling.

**Key changes:**
- Added Hub to manage one SessionWorker per session key with fan-out event broadcasting
- SessionWorker processes requests serially per session while different sessions run concurrently
- AckHandle interface provides immediate feedback and progress updates via RuntimeEvent emissions

**Critical issue:**
- Race condition in `Hub.Submit` between checking worker state and enqueueing requests can cause incorrect event sequences when multiple requests arrive concurrently for the same session

**Additional considerations:**
- SessionWorkers accumulate indefinitely without cleanup mechanism for idle sessions
- Tests are comprehensive for serial scenarios but lack coverage for concurrent submissions to the same session

The implementation demonstrates good concurrency patterns overall (atomic operations, proper mutex usage, context handling) but needs the race condition fixed before merge.

<h3>Confidence Score: 2/5</h3>

- This PR has a race condition that will cause incorrect behavior under concurrent load
- Score reflects critical race condition in Submit that breaks correctness guarantees when concurrent requests arrive for same session - both could receive AcceptActive when only first should. While tests pass, they don't exercise concurrent submission paths where bug manifests. Additional concern about unbounded goroutine growth over time.
- Pay close attention to `internal/runtime/runtime.go` lines 141-149 where the race condition exists

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/runtime/runtime.go | implements per-session worker mailbox with solid structure, but has race condition in Submit causing incorrect event sequences under concurrent submissions, and potential goroutine leak from never cleaning up idle workers |
| internal/runtime/runtime_test.go | comprehensive test coverage for serial scenarios, but missing tests for concurrent submissions to same session which would expose the race condition |

</details>



<sub>Last reviewed commit: 9890cd6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->