### PR TITLE
feat: route Telegram through runtime hub (#10)

### DIFF
--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+)
+
+// SessionKey is the canonical identifier for a chat session.
+// Format: "dm:<chatID>" for private chats, "group:<chatID>" for groups.
+type SessionKey string
+
+// NewDMSessionKey returns the canonical session key for a private (DM) chat.
+func NewDMSessionKey(chatID int64) SessionKey {
+	return SessionKey(fmt.Sprintf("dm:%d", chatID))
+}
+
+// NewGroupSessionKey returns the canonical session key for a group/supergroup/channel.
+func NewGroupSessionKey(chatID int64) SessionKey {
+	return SessionKey(fmt.Sprintf("group:%d", chatID))
+}
+
+// RunEventType describes the kind of event emitted by the hub.
+type RunEventType string
+
+const (
+	// RunEventDone signals a successful completion; Result is set.
+	RunEventDone RunEventType = "done"
+	// RunEventError signals a failure; Err is set.
+	RunEventError RunEventType = "error"
+)
+
+// RunEvent is emitted by the RuntimeHub when a run completes or fails.
+type RunEvent struct {
+	Type   RunEventType
+	Result *AgentResponse // non-nil when Type == RunEventDone
+	Err    error          // non-nil when Type == RunEventError
+}
+
+// RunRequest carries everything the hub needs to execute an agent run.
+type RunRequest struct {
+	SessionKey SessionKey
+	Content    string
+	Session    string // prior session context
+	Agent      *ToolCallingAgent
+	Context    context.Context
+}
+
+// runSlot holds the state of a single active run.
+// Using a pointer allows safe identity comparison when cleaning up.
+type runSlot struct {
+	cancel context.CancelFunc
+}
+
+// RuntimeHub manages concurrent agent runs keyed by canonical session.
+// At most one run per session key is active at any time; a new Submit
+// automatically cancels the previous run for the same session.
+type RuntimeHub struct {
+	mu     sync.Mutex
+	active map[SessionKey]*runSlot
+}
+
+// NewRuntimeHub creates a new RuntimeHub.
+func NewRuntimeHub() *RuntimeHub {
+	return &RuntimeHub{
+		active: make(map[SessionKey]*runSlot),
+	}
+}
+
+// Submit starts an agent run asynchronously for the given request.
+// If another run is already active for the same session key it is cancelled first.
+// Returns a channel that receives exactly one RunEvent then closes.
+func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
+	events := make(chan RunEvent, 1)
+
+	ctx, cancel := context.WithCancel(req.Context)
+	slot := &runSlot{cancel: cancel}
+
+	h.mu.Lock()
+	if existing, ok := h.active[req.SessionKey]; ok {
+		log.Printf("[hub] cancelling existing run for session %s", req.SessionKey)
+		existing.cancel()
+	}
+	h.active[req.SessionKey] = slot
+	h.mu.Unlock()
+
+	go func() {
+		defer func() {
+			h.mu.Lock()
+			// Only remove our slot; a newer Submit may have replaced it already.
+			if h.active[req.SessionKey] == slot {
+				delete(h.active, req.SessionKey)
+			}
+			h.mu.Unlock()
+			cancel()
+			close(events)
+		}()
+
+		log.Printf("[hub] starting run for session %s", req.SessionKey)
+		result, err := req.Agent.ProcessRequest(ctx, req.Content, req.Session)
+		if err != nil {
+			if ctx.Err() != nil {
+				log.Printf("[hub] run for session %s was cancelled", req.SessionKey)
+			} else {
+				log.Printf("[hub] run for session %s failed: %v", req.SessionKey, err)
+			}
+			events <- RunEvent{Type: RunEventError, Err: err}
+			return
+		}
+
+		log.Printf("[hub] run for session %s done", req.SessionKey)
+		events <- RunEvent{Type: RunEventDone, Result: result}
+	}()
+
+	return events
+}
+
+// Cancel stops the active run for the given session key (no-op if none).
+func (h *RuntimeHub) Cancel(key SessionKey) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if slot, ok := h.active[key]; ok {
+		log.Printf("[hub] cancelling run for session %s", key)
+		slot.cancel()
+	}
+}
+
+// IsActive reports whether a run is currently active for the given session key.
+func (h *RuntimeHub) IsActive(key SessionKey) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, ok := h.active[key]
+	return ok
+}

--- a/internal/bot/agent_handler.go
+++ b/internal/bot/agent_handler.go
@@ -2,10 +2,8 @@ package bot
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
-	"strings"
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/ai"
@@ -84,132 +82,9 @@ func (b *Bot) getAgentModel(chatID int64, profile *agent.AgentProfile) string {
 	return b.aiConfig.Model
 }
 
-// handleAgentRequestWithProfile processes request using the active agent profile
-func (b *Bot) handleAgentRequestWithProfile(ctx context.Context, c telebot.Context, content, session string) error {
-	chatID := c.Chat().ID
-
-	// Register cancellable context for /stop support
-	runCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	b.cancelMu.Lock()
-	b.activeRuns[chatID] = cancel
-	b.cancelMu.Unlock()
-	defer func() {
-		b.cancelMu.Lock()
-		delete(b.activeRuns, chatID)
-		b.cancelMu.Unlock()
-	}()
-
-	// Get active agent profile
-	profile := b.getActiveAgentProfile(chatID)
-
-	// Get effective model (session override > agent model > global default)
-	model := b.getAgentModel(chatID, profile)
-
-	// Get AI client configured for the effective model
-	aiClient := b.getAIClientForModel(model)
-
-	// Create tool agent for this profile with the effective model's client
-	toolAgent := b.createAgentToolAgent(profile, aiClient)
-
-	// Start typing indicator
-	stopTyping := NewTypingIndicator(b.api, c.Chat())
-	defer stopTyping()
-
-	// Process request
-	response, err := toolAgent.ProcessRequest(runCtx, content, session)
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			log.Printf("Agent request aborted for chat=%d", chatID)
-			return nil // /abort handler already sent "⛔ Aborted"
-		}
-		log.Printf("Agent error: %v", err)
-		return c.Send("❌ Sorry, I encountered an error processing your request.")
-	}
-
-	// Record token usage
-	if response.PromptTokens > 0 || response.CompletionTokens > 0 {
-		b.store.UpdateTokenUsage(chatID, response.PromptTokens, response.CompletionTokens, response.TotalTokens)
-	}
-
-	// Check for silent reply tokens — suppress sending to Telegram
-	trimmed := strings.TrimSpace(response.Message)
-	if trimmed == "SILENT_REPLY" || trimmed == "HEARTBEAT_OK" {
-		log.Printf("Agent '%s' returned silent token: %s — suppressing reply", profile.Name, trimmed)
-		return nil
-	}
-
-	// If a tool was used, show intermediate message
-	if response.ToolUsed {
-		b.api.Send(c.Chat(), fmt.Sprintf("🔧 Using %s tool...", response.ToolName))
-	}
-
-	// Build response with optional usage footer
-	msg := response.Message
-	usageMode, _ := b.store.GetSessionOption(chatID, "usage_mode")
-	if usageMode == "tokens" || usageMode == "full" {
-		if response.PromptTokens > 0 {
-			msg += "\n\n" + FormatUsageFooter(response.PromptTokens, response.CompletionTokens)
-		}
-	}
-
-	// Parse reactions from response
-	msg, reactions := parseReactions(msg)
-
-	// Parse reply tags from response
-	replyTarget := parseReplyTags(msg)
-	msg = replyTarget.Clean
-
-	// Send reactions to the user's original message
-	if len(reactions) > 0 && c.Message() != nil {
-		for _, emoji := range reactions {
-			err := b.api.React(c.Chat(), c.Message(), telebot.Reactions{
-				Reactions: []telebot.Reaction{{Type: telebot.ReactionTypeEmoji, Emoji: emoji}},
-			})
-			if err != nil {
-				log.Printf("Failed to set reaction %s: %v", emoji, err)
-			}
-		}
-	}
-
-	// Guard against empty messages (Telegram rejects them)
-	if strings.TrimSpace(msg) == "" {
-		msg = "⚠️ Got an empty response from the model."
-	}
-
-	// Send final response with optional native reply
-	sendOpts := &telebot.SendOptions{}
-	switch {
-	case replyTarget.MessageID == -1:
-		sendOpts.ReplyTo = c.Message()
-	case replyTarget.MessageID > 0:
-		sendOpts.ReplyTo = &telebot.Message{ID: replyTarget.MessageID}
-	}
-
-	if _, err := b.api.Send(c.Chat(), msg, sendOpts); err != nil {
-		return err
-	}
-
-	// Save to memory
-	memoryEntry := fmt.Sprintf("Assistant (%s): %s", profile.Name, response.Message)
-	if response.ToolUsed {
-		memoryEntry += fmt.Sprintf(" [Tool: %s]", response.ToolName)
-	}
-	if err := b.memory.AppendToToday(memoryEntry); err != nil {
-		log.Printf("Failed to save to memory: %v", err)
-	}
-
-	// Save session
-	if err := b.store.SaveSession(chatID, response.Message); err != nil {
-		log.Printf("Failed to save session: %v", err)
-	}
-
-	log.Printf("Agent '%s' (model: %s) processed request", profile.Name, model)
-
-	return nil
-}
-
-// handleStreamingRequestWithProfile processes message with streaming response using active agent
+// handleStreamingRequestWithProfile processes message with streaming response using active agent.
+// NOTE: This function is not used in the main message path (tool calling is always used instead).
+// It is retained for potential future use.
 func (b *Bot) handleStreamingRequestWithProfile(ctx context.Context, c telebot.Context, content, session string) error {
 	chatID := c.Chat().ID
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -2,11 +2,9 @@ package bot
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
-	"sync"
 	"time"
 
 	"gopkg.in/telebot.v4"
@@ -35,14 +33,14 @@ type Bot struct {
 	authManager     *AuthManager
 	groupManager    *GroupManager
 	approvalManager *ApprovalManager
+	hub             *agent.RuntimeHub
+	acks            ackTracker
 	adminID         int64
 	enableStream    bool
 	debouncer       *Debouncer
 	rateLimiter     *RateLimiter
 	configWatcher   ConfigWatcher
 	usageTracker    *UsageTracker
-	activeRuns      map[int64]context.CancelFunc
-	cancelMu        sync.Mutex
 	fragmentBuffer  *FragmentBuffer
 	mediaGroupBuf   *MediaGroupBuffer
 	queueManager    *QueueManager
@@ -115,11 +113,12 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		toolAgent:      newToolAgentWithAliases(aiClient, toolRegistry, personality, aiCfg.ModelAliases),
 		authManager:    authManager,
 		groupManager:   groupManager,
+		hub:            agent.NewRuntimeHub(),
+		acks:           ackTracker{msgs: make(map[int64]*telebot.Message)},
 		enableStream:   streamingClient != nil,
 		debouncer:      NewDebouncer(1500 * time.Millisecond),
 		rateLimiter:    NewRateLimiter(10, 1*time.Minute),
 		usageTracker:   NewUsageTracker(),
-		activeRuns:     make(map[int64]context.CancelFunc),
 		fragmentBuffer: NewFragmentBuffer(),
 		mediaGroupBuf:  NewMediaGroupBuffer(),
 		queueManager:   NewQueueManager(),
@@ -341,27 +340,32 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 		return c.Send(fmt.Sprintf("⏱️ Please wait %d seconds before sending another message.", seconds))
 	}
 
-	// Use ToolCallingAgent to process the request
-	if b.ai != nil && !strings.HasPrefix(content, "/") {
-		// Check queue mode - if a run is active, may queue/steer/interrupt
-		if b.handleWithQueueMode(ctx, chatID, content) {
-			return nil // Message was queued or steered
+	// Route through the runtime hub.
+	if b.ai != nil {
+		sessionKey := sessionKeyForChat(msg.Chat)
+
+		// Check queue mode — if a run is active this may queue, steer, or interrupt.
+		if b.handleWithQueueMode(ctx, sessionKey, chatID, content) {
+			return nil // Message was queued or steered; no ⏳ needed yet.
 		}
 
-		// Fragment buffering -> debounce -> process
+		// Send ⏳ acknowledgment immediately (acceptance criterion: within 1 second).
+		b.acks.send(b.api, chatID, c.Chat())
+
+		// Fragment buffering → debounce → process via hub.
 		b.fragmentBuffer.TryBuffer(chatID, userID, msg.ID, content, func(assembled string) {
 			b.debouncer.Debounce(chatID, assembled, func(combined string) {
-				// Mark run as active
 				b.queueManager.StartRun(chatID)
 				defer func() {
-					// Process any queued messages after run completes
+					// Process any messages that were queued while the run was active.
 					queued := b.queueManager.EndRun(chatID)
 					if len(queued) > 0 {
 						logger.Debugf("Bot: processing %d queued messages for chat=%d", len(queued), chatID)
 						for _, qMsg := range queued {
 							b.debouncer.Debounce(chatID, qMsg, func(qCombined string) {
 								session, _ := b.store.GetSession(chatID)
-								b.handleAgentRequest(ctx, c, qCombined, session)
+								b.acks.send(b.api, chatID, c.Chat())
+								b.processViaHub(ctx, c, sessionKey, qCombined, session) //nolint:errcheck
 							})
 						}
 					}
@@ -372,89 +376,19 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 					log.Printf("Failed to get session: %v", err)
 				}
 
-				if err := b.handleAgentRequest(ctx, c, combined, session); err != nil {
+				if err := b.processViaHub(ctx, c, sessionKey, combined, session); err != nil {
 					log.Printf("Failed to handle agent request: %v", err)
-					c.Send("❌ Sorry, I encountered an error processing your request.")
+					c.Send("❌ Sorry, I encountered an error processing your request.") //nolint:errcheck
 				}
 			})
 		})
 		return nil
 	}
 
-	// Simple echo response for now
+	// No AI configured — echo the message.
 	return c.Send(fmt.Sprintf("You said: %s", content))
 }
 
-// handleAgentRequest processes message through the ToolCallingAgent
-func (b *Bot) handleAgentRequest(ctx context.Context, c telebot.Context, content, session string) error {
-	chatID := c.Chat().ID
-
-	// Register cancellable context for /stop support
-	runCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	b.cancelMu.Lock()
-	b.activeRuns[chatID] = cancel
-	b.cancelMu.Unlock()
-	defer func() {
-		b.cancelMu.Lock()
-		delete(b.activeRuns, chatID)
-		b.cancelMu.Unlock()
-	}()
-	_ = runCtx // used below
-
-	// Use agent-aware handlers if agent registry is configured
-	if b.agentRegistry != nil {
-		// Always use tool-calling path — streaming doesn't support tools
-		return b.handleAgentRequestWithProfile(ctx, c, content, session)
-	}
-
-	// Legacy behavior for non-agent mode
-	// Start typing indicator
-	stopTyping := NewTypingIndicator(b.api, c.Chat())
-	defer stopTyping()
-
-	// Get effective model (session override takes precedence over global default)
-	model := b.getEffectiveModel(chatID)
-	aiClient := b.getAIClientForModel(model)
-	toolAgent := newToolAgentWithAliases(aiClient, b.toolRegistry, b.personality, b.aiConfig.ModelAliases)
-
-	// Always use tool-calling path — streaming doesn't support tools
-	response, err := toolAgent.ProcessRequest(ctx, content, session)
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			log.Printf("Agent request aborted for chat=%d", chatID)
-			return nil // /abort handler already sent "⛔ Aborted"
-		}
-		log.Printf("Agent error: %v", err)
-		return c.Send("❌ Sorry, I encountered an error processing your request.")
-	}
-
-	// If a tool was used, show intermediate message
-	if response.ToolUsed {
-		b.api.Send(c.Chat(), fmt.Sprintf("🔧 Using %s tool...", response.ToolName))
-	}
-
-	// Send final response
-	if err := c.Send(response.Message); err != nil {
-		return err
-	}
-
-	// Save to memory
-	memoryEntry := fmt.Sprintf("Assistant: %s", response.Message)
-	if response.ToolUsed {
-		memoryEntry += fmt.Sprintf(" [Tool: %s]", response.ToolName)
-	}
-	if err := b.memory.AppendToToday(memoryEntry); err != nil {
-		log.Printf("Failed to save to memory: %v", err)
-	}
-
-	// Save session
-	if err := b.store.SaveSession(c.Chat().ID, response.Message); err != nil {
-		log.Printf("Failed to save session: %v", err)
-	}
-
-	return nil
-}
 
 // handleStreamingRequest processes message with streaming response
 func (b *Bot) handleStreamingRequest(ctx context.Context, c telebot.Context, content, session string) error {

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -150,31 +150,23 @@ func (b *Bot) handleNewCommand(c telebot.Context) error {
 	return c.Send("✅ New session started. History and counters cleared.")
 }
 
-// handleStopCommand stops the current AI run
+// handleStopCommand stops the current AI run via the runtime hub.
 func (b *Bot) handleStopCommand(c telebot.Context) error {
-	chatID := c.Chat().ID
+	sessionKey := sessionKeyForChat(c.Chat())
 
-	b.cancelMu.Lock()
-	cancel, ok := b.activeRuns[chatID]
-	b.cancelMu.Unlock()
-
-	if ok && cancel != nil {
-		cancel()
+	if b.hub.IsActive(sessionKey) {
+		b.hub.Cancel(sessionKey)
 		return c.Send("🛑 Stopped current run.")
 	}
 	return c.Send("ℹ️ No active run to stop.")
 }
 
-// handleAbortCommand aborts the current AI run with a cancellation signal
+// handleAbortCommand aborts the current AI run via the runtime hub.
 func (b *Bot) handleAbortCommand(c telebot.Context) error {
-	chatID := c.Chat().ID
+	sessionKey := sessionKeyForChat(c.Chat())
 
-	b.cancelMu.Lock()
-	cancel, ok := b.activeRuns[chatID]
-	b.cancelMu.Unlock()
-
-	if ok && cancel != nil {
-		cancel()
+	if b.hub.IsActive(sessionKey) {
+		b.hub.Cancel(sessionKey)
 		return c.Send("⛔ Aborted")
 	}
 	return c.Send("ℹ️ No active run to abort.")

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -1,0 +1,198 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/agent"
+)
+
+// sessionKeyForChat returns the canonical session key for a Telegram chat.
+// Private (DM) chats use "dm:<chatID>"; groups/supergroups/channels use "group:<chatID>".
+func sessionKeyForChat(chat *telebot.Chat) agent.SessionKey {
+	if chat.Type == telebot.ChatPrivate {
+		return agent.NewDMSessionKey(chat.ID)
+	}
+	return agent.NewGroupSessionKey(chat.ID)
+}
+
+// ackTracker tracks per-chat ⏳ placeholder messages sent as immediate acknowledgements.
+type ackTracker struct {
+	mu   sync.Mutex
+	msgs map[int64]*telebot.Message
+}
+
+// send sends a ⏳ for the given chat if one hasn't been sent yet for this batch.
+func (a *ackTracker) send(api *telebot.Bot, chatID int64, chat *telebot.Chat) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if _, exists := a.msgs[chatID]; exists {
+		return // already acknowledged this batch
+	}
+	msg, err := api.Send(chat, "⏳")
+	if err != nil {
+		log.Printf("[bot] failed to send ⏳ for chat %d: %v", chatID, err)
+		return
+	}
+	a.msgs[chatID] = msg
+}
+
+// take retrieves and removes the pending ack message for chatID.
+// Returns nil if no ack is pending.
+func (a *ackTracker) take(chatID int64) *telebot.Message {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	msg := a.msgs[chatID]
+	delete(a.msgs, chatID)
+	return msg
+}
+
+// processViaHub routes a user request through the RuntimeHub instead of calling
+// the agent directly. Telegram becomes a pure transport adapter: it submits the
+// request and then renders the resulting RunEvent.
+func (b *Bot) processViaHub(ctx context.Context, c telebot.Context, sessionKey agent.SessionKey, content, session string) error {
+	chatID := c.Chat().ID
+
+	// Resolve active agent profile and build the tool agent for this session.
+	profile := b.getActiveAgentProfile(chatID)
+	model := b.getAgentModel(chatID, profile)
+	aiClient := b.getAIClientForModel(model)
+	toolAgent := b.createAgentToolAgent(profile, aiClient)
+
+	// Start typing indicator while the hub is running.
+	stopTyping := NewTypingIndicator(b.api, c.Chat())
+	defer stopTyping()
+
+	// Submit to the hub — execution happens asynchronously in the hub's goroutine.
+	req := agent.RunRequest{
+		SessionKey: sessionKey,
+		Content:    content,
+		Session:    session,
+		Agent:      toolAgent,
+		Context:    ctx,
+	}
+	events := b.hub.Submit(req)
+
+	// Wait for the single result event.
+	var result *agent.AgentResponse
+	for ev := range events {
+		switch ev.Type {
+		case agent.RunEventDone:
+			result = ev.Result
+
+		case agent.RunEventError:
+			stopTyping()
+			ackMsg := b.acks.take(chatID)
+			if ctx.Err() != nil {
+				// Cancelled — silently clear the ⏳ placeholder.
+				if ackMsg != nil {
+					b.api.Delete(ackMsg) //nolint:errcheck
+				}
+				return nil
+			}
+			log.Printf("[bot] hub error for session %s: %v", sessionKey, ev.Err)
+			errText := "❌ Sorry, I encountered an error processing your request."
+			if ackMsg != nil {
+				if _, err := b.api.Edit(ackMsg, errText); err != nil {
+					b.api.Send(c.Chat(), errText) //nolint:errcheck
+				}
+			} else {
+				b.api.Send(c.Chat(), errText) //nolint:errcheck
+			}
+			return nil
+		}
+	}
+
+	if result == nil {
+		// Run was cancelled before producing a result.
+		if ackMsg := b.acks.take(chatID); ackMsg != nil {
+			b.api.Delete(ackMsg) //nolint:errcheck
+		}
+		return nil
+	}
+
+	// Record token usage.
+	if result.PromptTokens > 0 || result.CompletionTokens > 0 {
+		b.store.UpdateTokenUsage(chatID, result.PromptTokens, result.CompletionTokens, result.TotalTokens)
+	}
+
+	// Suppress internal sentinel tokens.
+	trimmed := strings.TrimSpace(result.Message)
+	if trimmed == "SILENT_REPLY" || trimmed == "HEARTBEAT_OK" {
+		log.Printf("[bot] agent '%s' returned silent token: %s — suppressing reply", profile.Name, trimmed)
+		if ackMsg := b.acks.take(chatID); ackMsg != nil {
+			b.api.Delete(ackMsg) //nolint:errcheck
+		}
+		return nil
+	}
+
+	// Build the outbound message, optionally appending a usage footer.
+	msg := result.Message
+	usageMode, _ := b.store.GetSessionOption(chatID, "usage_mode")
+	if (usageMode == "tokens" || usageMode == "full") && result.PromptTokens > 0 {
+		msg += "\n\n" + FormatUsageFooter(result.PromptTokens, result.CompletionTokens)
+	}
+
+	// Extract and send emoji reactions.
+	msg, reactions := parseReactions(msg)
+	if len(reactions) > 0 && c.Message() != nil {
+		for _, emoji := range reactions {
+			if err := b.api.React(c.Chat(), c.Message(), telebot.Reactions{
+				Reactions: []telebot.Reaction{{Type: telebot.ReactionTypeEmoji, Emoji: emoji}},
+			}); err != nil {
+				log.Printf("[bot] failed to set reaction %s: %v", emoji, err)
+			}
+		}
+	}
+
+	// Extract reply-to tags.
+	replyTarget := parseReplyTags(msg)
+	msg = replyTarget.Clean
+
+	// Guard against empty messages (Telegram rejects them).
+	if strings.TrimSpace(msg) == "" {
+		msg = "⚠️ Got an empty response from the model."
+	}
+
+	// Edit the ⏳ placeholder if one exists; otherwise send a new message.
+	ackMsg := b.acks.take(chatID)
+	if ackMsg != nil {
+		if _, err := b.api.Edit(ackMsg, msg); err != nil {
+			log.Printf("[bot] failed to edit ⏳ for chat %d: %v", chatID, err)
+			b.api.Send(c.Chat(), msg) //nolint:errcheck
+		}
+	} else {
+		sendOpts := &telebot.SendOptions{}
+		switch {
+		case replyTarget.MessageID == -1:
+			sendOpts.ReplyTo = c.Message()
+		case replyTarget.MessageID > 0:
+			sendOpts.ReplyTo = &telebot.Message{ID: replyTarget.MessageID}
+		}
+		if _, err := b.api.Send(c.Chat(), msg, sendOpts); err != nil {
+			return fmt.Errorf("send response: %w", err)
+		}
+	}
+
+	// Persist to daily memory.
+	memoryEntry := fmt.Sprintf("Assistant (%s): %s", profile.Name, result.Message)
+	if result.ToolUsed {
+		memoryEntry += fmt.Sprintf(" [Tool: %s]", result.ToolName)
+	}
+	if err := b.memory.AppendToToday(memoryEntry); err != nil {
+		log.Printf("[bot] failed to save to memory: %v", err)
+	}
+
+	// Persist session state.
+	if err := b.store.SaveSession(chatID, result.Message); err != nil {
+		log.Printf("[bot] failed to save session: %v", err)
+	}
+
+	log.Printf("[bot] session %s processed by agent '%s'", sessionKey, profile.Name)
+	return nil
+}

--- a/internal/bot/media_handler.go
+++ b/internal/bot/media_handler.go
@@ -194,14 +194,16 @@ func (b *Bot) handlePhotoMessage(ctx context.Context, c telebot.Context) error {
 		log.Printf("Failed to save message: %v", err)
 	}
 
+	sessionKey := sessionKeyForChat(msg.Chat)
+	b.acks.send(b.api, chatID, c.Chat())
 	b.debouncer.Debounce(chatID, content, func(combined string) {
 		session, err := b.store.GetSession(chatID)
 		if err != nil {
 			log.Printf("Failed to get session: %v", err)
 		}
-		if err := b.handleAgentRequest(ctx, c, combined, session); err != nil {
+		if err := b.processViaHub(ctx, c, sessionKey, combined, session); err != nil {
 			log.Printf("Failed to handle photo request: %v", err)
-			c.Send("❌ Sorry, I encountered an error processing your photo.")
+			c.Send("❌ Sorry, I encountered an error processing your photo.") //nolint:errcheck
 		}
 	})
 
@@ -267,15 +269,15 @@ func (b *Bot) handleStickerMessage(ctx context.Context, c telebot.Context) error
 		log.Printf("Failed to save message: %v", err)
 	}
 
-	// Process through pipeline
+	// Process through pipeline via hub
+	sessionKey := sessionKeyForChat(msg.Chat)
+	b.acks.send(b.api, chatID, c.Chat())
 	b.debouncer.Debounce(chatID, content, func(combined string) {
 		session, err := b.store.GetSession(chatID)
 		if err != nil {
 			log.Printf("Failed to get session: %v", err)
 		}
-		if err := b.handleAgentRequest(ctx, c, combined, session); err != nil {
-			log.Printf("Failed to handle sticker request: %v", err)
-		}
+		b.processViaHub(ctx, c, sessionKey, combined, session) //nolint:errcheck
 	})
 
 	return nil
@@ -313,12 +315,14 @@ func (b *Bot) handleDocumentMessage(ctx context.Context, c telebot.Context) erro
 		log.Printf("Failed to save message: %v", err)
 	}
 
+	sessionKey := sessionKeyForChat(msg.Chat)
+	b.acks.send(b.api, chatID, c.Chat())
 	b.debouncer.Debounce(chatID, content, func(combined string) {
 		session, err := b.store.GetSession(chatID)
 		if err != nil {
 			log.Printf("Failed to get session: %v", err)
 		}
-		if err := b.handleAgentRequest(ctx, c, combined, session); err != nil {
+		if err := b.processViaHub(ctx, c, sessionKey, combined, session); err != nil {
 			log.Printf("Failed to handle document request: %v", err)
 		}
 	})

--- a/internal/bot/queue.go
+++ b/internal/bot/queue.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"sync"
 
+	"ok-gobot/internal/agent"
 	"ok-gobot/internal/logger"
 )
 
@@ -73,9 +74,9 @@ func (qm *QueueManager) GetQueueDepth(chatID int64) int {
 	return len(qm.queued[chatID])
 }
 
-// handleWithQueueMode processes a message according to the queue mode
-// Returns true if the message was handled (queued/interrupted), false if it should proceed normally
-func (b *Bot) handleWithQueueMode(ctx context.Context, chatID int64, content string) bool {
+// handleWithQueueMode processes a message according to the queue mode.
+// Returns true if the message was handled (queued/steered), false if it should proceed normally.
+func (b *Bot) handleWithQueueMode(ctx context.Context, sessionKey agent.SessionKey, chatID int64, content string) bool {
 	if !b.queueManager.IsRunning(chatID) {
 		return false // No active run, proceed normally
 	}
@@ -91,14 +92,9 @@ func (b *Bot) handleWithQueueMode(ctx context.Context, chatID int64, content str
 		return true
 
 	case QueueInterrupt:
-		// Interrupt: cancel current run, message will be processed fresh
-		b.cancelMu.Lock()
-		cancel, ok := b.activeRuns[chatID]
-		b.cancelMu.Unlock()
-		if ok && cancel != nil {
-			cancel()
-			log.Printf("Interrupted active run for chat %d", chatID)
-		}
+		// Interrupt: cancel the active run via the hub, then let the new message proceed.
+		b.hub.Cancel(sessionKey)
+		log.Printf("[bot] interrupted active run for session %s", sessionKey)
 		return false // Let the message proceed normally after interrupt
 
 	case QueueCollect:


### PR DESCRIPTION
Implements #10

## Changes

### New: `internal/agent/runtime.go` — RuntimeHub
- `SessionKey` type with canonical formats: `dm:<chatID>` (private) and `group:<chatID>` (group/supergroup/channel)
- `RunRequest` / `RunEvent` / `RunEventType` — the hub's public contract
- `RuntimeHub` — manages at most one active run per session key; new `Submit` auto-cancels stale runs via pointer-identity slot tracking
- `Cancel(key)` / `IsActive(key)` — used by `/stop` and interrupt queue mode

### New: `internal/bot/hub_handler.go` — hub routing
- `sessionKeyForChat(chat)` — derives canonical session key from Telegram chat type
- `ackTracker` — sends a single `⏳` placeholder per chat per debounce batch; prevents duplicates across fragments
- `processViaHub(ctx, c, sessionKey, content, session)` — replaces `handleAgentRequest` + `handleAgentRequestWithProfile`; submits `RunRequest` to hub, waits for `RunEvent`, then renders the response (reactions, reply tags, usage footer, ⏳ edit-or-send)

### Modified: `internal/bot/bot.go`
- `Bot` struct: `hub *agent.RuntimeHub` + `acks ackTracker` added; `activeRuns` and `cancelMu` removed
- `handleMessage`: sends `⏳` immediately (≤1 second acceptance criterion), then routes through `processViaHub` via fragment buffer + debounce
- `handleAgentRequest` removed — all execution now goes through the hub

### Modified: `internal/bot/agent_handler.go`
- `handleAgentRequestWithProfile` removed (execution superseded by `processViaHub`)
- `createAgentToolAgent` and other profile helpers retained for use by `processViaHub`

### Modified: `internal/bot/commands.go`
- `/stop` uses `hub.Cancel(sessionKey)` instead of `activeRuns` map

### Modified: `internal/bot/queue.go`
- Interrupt queue mode cancels via `hub.Cancel(sessionKey)`

### Modified: `internal/bot/media_handler.go`
- Photo, sticker, and document handlers route through `processViaHub`

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all tests pass
- `go build ./cmd/ok-gobot/` — binary builds successfully
- `./ok-gobot version` — `ok-gobot v0.1.0 (go)`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully centralizes agent run management through a new RuntimeHub, replacing the previous `activeRuns` map with canonical session keys and ensuring at most one active run per session. The refactoring eliminates 249 lines of duplicated logic and routes all message types through a unified `processViaHub` handler.

**Major Changes:**
- New `RuntimeHub` with pointer-identity slot tracking for safe concurrent run cancellation
- Canonical session keys (`dm:<chatID>` and `group:<chatID>`) replace chat-ID-only tracking
- `ackTracker` ensures exactly one `⏳` placeholder per chat per debounce batch
- All `/stop`, `/abort`, and interrupt-mode cancellations now route through `hub.Cancel()`

**Critical Issue:**
- Media handlers (photo, sticker, document) bypass queue mode checking and don't track runs via `QueueManager.StartRun/EndRun`, causing inconsistent behavior compared to text messages. When queue mode is set to "collect" or "steer", media messages will interrupt active runs instead of being queued.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing media handler queue inconsistencies
- Core hub architecture is solid, but media handlers have logic bugs that cause inconsistent queue behavior. The hub correctly manages concurrent runs and cancellation, but the integration gap in media handlers means users will experience different queue semantics for photos/stickers/documents vs text messages.
- `internal/bot/media_handler.go` requires queue mode integration for photo/sticker/document handlers

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/agent/runtime.go | New RuntimeHub implementation with canonical session keys and slot-based run management; solid design with pointer-identity tracking |
| internal/bot/hub_handler.go | New hub routing logic with `ackTracker` and `processViaHub`; cleanly replaces old agent request handlers |
| internal/bot/media_handler.go | Media handlers (photo, sticker, document) route through hub but skip queue mode checks and run tracking, causing inconsistent behavior vs text messages |

</details>



<sub>Last reviewed commit: a069316</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->