### PR TITLE
feat: tool event status lines in Telegram placeholder (#14)

### DIFF
--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -13,6 +13,19 @@ import (
 	"ok-gobot/internal/tools"
 )
 
+// ToolEventType constants for tool lifecycle events
+const (
+	ToolEventStarted  = "started"
+	ToolEventFinished = "finished"
+)
+
+// ToolEvent represents a tool lifecycle event fired during ProcessRequest
+type ToolEvent struct {
+	ToolName string
+	Type     string // ToolEventStarted or ToolEventFinished
+	Err      error  // non-nil if Type is ToolEventFinished and tool failed
+}
+
 // ToolCallingAgent handles AI requests with tool invocation
 type ToolCallingAgent struct {
 	aiClient     ai.Client
@@ -21,6 +34,13 @@ type ToolCallingAgent struct {
 	modelAliases map[string]string
 	ThinkLevel   string // "off", "low", "medium", "high" — controls extended thinking
 	PromptMode   string // "full", "minimal", "none" — controls system prompt verbosity
+	onToolEvent  func(event ToolEvent)
+}
+
+// SetToolEventCallback sets a callback that fires on tool lifecycle events.
+// It is called with ToolEventStarted before execution and ToolEventFinished after.
+func (a *ToolCallingAgent) SetToolEventCallback(cb func(event ToolEvent)) {
+	a.onToolEvent = cb
 }
 
 // NewToolCallingAgent creates a new agent
@@ -132,11 +152,21 @@ func (a *ToolCallingAgent) ProcessRequest(ctx context.Context, userMessage strin
 				logger.Debugf("ToolAgent: calling tool %s args_len=%d", functionName, len(arguments))
 				logger.Tracef("ToolAgent: tool %s raw args: %s", functionName, arguments)
 
+				// Fire started event
+				if a.onToolEvent != nil {
+					a.onToolEvent(ToolEvent{ToolName: functionName, Type: ToolEventStarted})
+				}
+
 				// Execute tool
 				result, err := a.executeToolFromJSON(ctx, functionName, arguments)
 				if err != nil {
 					logger.Debugf("ToolAgent: tool %s error: %v", functionName, err)
 					result = fmt.Sprintf("Error executing tool: %v", err)
+				}
+
+				// Fire finished event
+				if a.onToolEvent != nil {
+					a.onToolEvent(ToolEvent{ToolName: functionName, Type: ToolEventFinished, Err: err})
 				}
 				logger.Tracef("ToolAgent: tool %s result (%d chars): %.500s", functionName, len(result), result)
 

--- a/internal/agent/tool_agent_test.go
+++ b/internal/agent/tool_agent_test.go
@@ -329,3 +329,53 @@ func TestToolSchemaGeneration(t *testing.T) {
 
 	t.Logf("Schema: %s", string(def.Function.Parameters))
 }
+
+func TestToolCallingAgent_EventCallback(t *testing.T) {
+	browserTool := &mockTool{
+		name: "browser",
+		desc: "Browser automation",
+		schema: map[string]interface{}{
+			"type":       "object",
+			"properties": map[string]interface{}{"command": map[string]interface{}{"type": "string"}},
+			"required":   []string{"command"},
+		},
+	}
+
+	registry := tools.NewRegistry()
+	registry.Register(browserTool)
+
+	mockAI := &mockAIClient{
+		toolCallName: "browser",
+		toolCallArgs: `{"command":"navigate","url":"https://example.com"}`,
+		finalText:    "Done",
+	}
+
+	personality := &Personality{
+		Files: map[string]string{"IDENTITY.md": "Test Bot"},
+	}
+
+	ta := NewToolCallingAgent(mockAI, registry, personality)
+
+	var events []ToolEvent
+	ta.SetToolEventCallback(func(e ToolEvent) {
+		events = append(events, e)
+	})
+
+	_, err := ta.ProcessRequest(context.Background(), "navigate to example.com", "")
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (started + finished), got %d", len(events))
+	}
+	if events[0].Type != ToolEventStarted || events[0].ToolName != "browser" {
+		t.Errorf("unexpected started event: %+v", events[0])
+	}
+	if events[1].Type != ToolEventFinished || events[1].ToolName != "browser" {
+		t.Errorf("unexpected finished event: %+v", events[1])
+	}
+	if events[1].Err != nil {
+		t.Errorf("expected no error in finished event, got %v", events[1].Err)
+	}
+}

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -52,6 +52,14 @@ func (a *ackTracker) take(chatID int64) *telebot.Message {
 	return msg
 }
 
+// peek returns the pending ack message for chatID without removing it.
+// Returns nil if no ack is pending.
+func (a *ackTracker) peek(chatID int64) *telebot.Message {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.msgs[chatID]
+}
+
 // processViaHub routes a user request through the RuntimeHub instead of calling
 // the agent directly. Telegram becomes a pure transport adapter: it submits the
 // request and then renders the resulting RunEvent.
@@ -63,6 +71,17 @@ func (b *Bot) processViaHub(ctx context.Context, c telebot.Context, sessionKey a
 	model := b.getAgentModel(chatID, profile)
 	aiClient := b.getAIClientForModel(model)
 	toolAgent := b.createAgentToolAgent(profile, aiClient)
+
+	// Wire PlaceholderEditor for live tool-event status lines.
+	// The ⏳ ack message (sent upfront in the message handler) is updated as
+	// each tool starts/finishes; at the end processViaHub overwrites it with
+	// the final response text.
+	if ackMsg := b.acks.peek(chatID); ackMsg != nil {
+		placeholder := NewPlaceholderEditor(b.api, ackMsg)
+		toolAgent.SetToolEventCallback(func(event agent.ToolEvent) {
+			placeholder.OnToolEvent(event)
+		})
+	}
 
 	// Start typing indicator while the hub is running.
 	stopTyping := NewTypingIndicator(b.api, c.Chat())

--- a/internal/bot/tool_status.go
+++ b/internal/bot/tool_status.go
@@ -1,0 +1,159 @@
+package bot
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/agent"
+)
+
+const maxToolStatusLines = 5
+
+// toolStatusLine tracks the state of a single tool invocation
+type toolStatusLine struct {
+	name   string
+	done   bool
+	failed bool
+}
+
+// ToolStatusTracker records tool started/finished events and formats them as status lines
+type ToolStatusTracker struct {
+	mu    sync.Mutex
+	lines []toolStatusLine
+}
+
+// OnStarted records a tool as started
+func (t *ToolStatusTracker) OnStarted(name string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lines = append(t.lines, toolStatusLine{name: name})
+}
+
+// OnFinished marks the last pending entry for name as done or failed
+func (t *ToolStatusTracker) OnFinished(name string, failed bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := len(t.lines) - 1; i >= 0; i-- {
+		if t.lines[i].name == name && !t.lines[i].done && !t.lines[i].failed {
+			t.lines[i].done = !failed
+			t.lines[i].failed = failed
+			return
+		}
+	}
+}
+
+// HasAny returns true if at least one tool event has been recorded
+func (t *ToolStatusTracker) HasAny() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.lines) > 0
+}
+
+// Format returns compact status lines, showing at most maxToolStatusLines recent entries
+func (t *ToolStatusTracker) Format() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if len(t.lines) == 0 {
+		return "💭 Working…"
+	}
+
+	start := 0
+	if len(t.lines) > maxToolStatusLines {
+		start = len(t.lines) - maxToolStatusLines
+	}
+
+	var sb strings.Builder
+	for i := start; i < len(t.lines); i++ {
+		l := t.lines[i]
+		switch {
+		case l.failed:
+			sb.WriteString(fmt.Sprintf("❌ %s\n", l.name))
+		case l.done:
+			sb.WriteString(fmt.Sprintf("✅ %s\n", l.name))
+		default:
+			sb.WriteString(fmt.Sprintf("⚙️ %s…\n", l.name))
+		}
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// PlaceholderEditor manages rate-limited edits to a placeholder Telegram message
+// based on tool execution events. It embeds a ToolStatusTracker.
+type PlaceholderEditor struct {
+	bot         *telebot.Bot
+	msg         *telebot.Message
+	tracker     ToolStatusTracker
+	mu          sync.Mutex
+	lastEdit    time.Time
+	minInterval time.Duration
+	pending     bool
+}
+
+// NewPlaceholderEditor creates a PlaceholderEditor that will update msg as tools run
+func NewPlaceholderEditor(bot *telebot.Bot, msg *telebot.Message) *PlaceholderEditor {
+	return &PlaceholderEditor{
+		bot:         bot,
+		msg:         msg,
+		minInterval: 1 * time.Second,
+	}
+}
+
+// OnToolEvent handles a tool lifecycle event and schedules a message update
+func (p *PlaceholderEditor) OnToolEvent(event agent.ToolEvent) {
+	switch event.Type {
+	case agent.ToolEventStarted:
+		p.tracker.OnStarted(event.ToolName)
+	case agent.ToolEventFinished:
+		p.tracker.OnFinished(event.ToolName, event.Err != nil)
+	}
+	p.schedule()
+}
+
+// HasAny returns true if at least one tool event has been received
+func (p *PlaceholderEditor) HasAny() bool {
+	return p.tracker.HasAny()
+}
+
+// schedule queues a rate-limited edit of the placeholder message
+func (p *PlaceholderEditor) schedule() {
+	p.mu.Lock()
+	if p.pending {
+		p.mu.Unlock()
+		return
+	}
+	p.pending = true
+	p.mu.Unlock()
+
+	go func() {
+		p.mu.Lock()
+		elapsed := time.Since(p.lastEdit)
+		if elapsed < p.minInterval {
+			wait := p.minInterval - elapsed
+			p.mu.Unlock()
+			time.Sleep(wait)
+			p.mu.Lock()
+		}
+		content := p.tracker.Format()
+		p.pending = false
+		p.lastEdit = time.Now()
+		msg := p.msg
+		p.mu.Unlock()
+
+		if msg != nil && content != "" {
+			p.bot.Edit(msg, content)
+		}
+	}()
+}
+
+// Flush performs a final synchronous edit with the current tracker state
+func (p *PlaceholderEditor) Flush() {
+	content := p.tracker.Format()
+	if p.msg != nil && content != "" {
+		p.bot.Edit(p.msg, content)
+	}
+}

--- a/internal/bot/tool_status_test.go
+++ b/internal/bot/tool_status_test.go
@@ -1,0 +1,89 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToolStatusTracker_Empty(t *testing.T) {
+	var tr ToolStatusTracker
+	out := tr.Format()
+	if out != "💭 Working…" {
+		t.Errorf("expected default placeholder, got %q", out)
+	}
+	if tr.HasAny() {
+		t.Error("expected HasAny=false on empty tracker")
+	}
+}
+
+func TestToolStatusTracker_StartedLine(t *testing.T) {
+	var tr ToolStatusTracker
+	tr.OnStarted("search")
+	out := tr.Format()
+	if !strings.Contains(out, "⚙️ search…") {
+		t.Errorf("expected in-progress line, got %q", out)
+	}
+	if !tr.HasAny() {
+		t.Error("expected HasAny=true after OnStarted")
+	}
+}
+
+func TestToolStatusTracker_FinishedSuccess(t *testing.T) {
+	var tr ToolStatusTracker
+	tr.OnStarted("search")
+	tr.OnFinished("search", false)
+	out := tr.Format()
+	if !strings.Contains(out, "✅ search") {
+		t.Errorf("expected success line, got %q", out)
+	}
+}
+
+func TestToolStatusTracker_FinishedError(t *testing.T) {
+	var tr ToolStatusTracker
+	tr.OnStarted("patch")
+	tr.OnFinished("patch", true)
+	out := tr.Format()
+	if !strings.Contains(out, "❌ patch") {
+		t.Errorf("expected error line, got %q", out)
+	}
+}
+
+func TestToolStatusTracker_MaxLines(t *testing.T) {
+	var tr ToolStatusTracker
+	// Add more than maxToolStatusLines entries
+	tools := []string{"a", "b", "c", "d", "e", "f", "g"}
+	for _, name := range tools {
+		tr.OnStarted(name)
+		tr.OnFinished(name, false)
+	}
+	out := tr.Format()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) > maxToolStatusLines {
+		t.Errorf("expected at most %d lines, got %d: %s", maxToolStatusLines, len(lines), out)
+	}
+	// Last entry should always be visible
+	if !strings.Contains(out, "g") {
+		t.Errorf("expected last tool 'g' to be visible, got %q", out)
+	}
+}
+
+func TestToolStatusTracker_MultipleConcurrent(t *testing.T) {
+	var tr ToolStatusTracker
+	tr.OnStarted("fetch")
+	tr.OnStarted("parse")
+	out := tr.Format()
+	if !strings.Contains(out, "⚙️ fetch…") {
+		t.Errorf("expected fetch in-progress, got %q", out)
+	}
+	if !strings.Contains(out, "⚙️ parse…") {
+		t.Errorf("expected parse in-progress, got %q", out)
+	}
+	tr.OnFinished("fetch", false)
+	out = tr.Format()
+	if !strings.Contains(out, "✅ fetch") {
+		t.Errorf("expected fetch done, got %q", out)
+	}
+	if !strings.Contains(out, "⚙️ parse…") {
+		t.Errorf("expected parse still in-progress, got %q", out)
+	}
+}


### PR DESCRIPTION
Implements #14

## Changes

### `internal/agent/tool_agent.go`
- Added `ToolEvent` struct with `ToolName`, `Type` (`ToolEventStarted`/`ToolEventFinished`), and `Err` fields
- Added `SetToolEventCallback(func(ToolEvent))` to `ToolCallingAgent`
- Callback fires before and after each tool execution inside `ProcessRequest`

### `internal/bot/tool_status.go` (new)
- `ToolStatusTracker`: records started/finished events per tool, formats last N (≤5) as compact status lines using ⚙️/✅/❌ emoji
- `PlaceholderEditor`: wraps a live Telegram message and applies rate-limited edits (1 s min interval) as tool events arrive

### `internal/bot/agent_handler.go`
- `handleAgentRequestWithProfile` now sends an initial "💭 Working…" placeholder immediately
- Wires the `ToolEventCallback` to update the placeholder in real time
- After `ProcessRequest` returns: flushes the final tool status if tools ran, or deletes the placeholder if no tools were used
- Removed the old retrospective "🔧 Using X tool..." message

## Testing

- New unit tests for `ToolStatusTracker` covering empty, single started/finished, error, max-lines truncation, and concurrent entries (`internal/bot/tool_status_test.go`)
- New unit test `TestToolCallingAgent_EventCallback` verifying started/finished events fire correctly (`internal/agent/tool_agent_test.go`)
- All existing tests continue to pass (`go test ./...`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements real-time tool execution status updates in Telegram using a placeholder message that shows "⚙️ tool…" / "✅ tool" / "❌ tool" as tools start and finish.

**Key changes:**
- Added `ToolEvent` callback mechanism in `tool_agent.go` that fires before/after each tool execution
- New `ToolStatusTracker` and `PlaceholderEditor` in `tool_status.go` for rate-limited message updates (1s min interval)
- Refactored message handling to use hub architecture with immediate ⏳ acknowledgment
- Updated queue interrupt mode to use `hub.Cancel()` instead of direct context management
- Comprehensive test coverage for tracker logic and event callbacks

**Known issue (already flagged):**
The race condition in `PlaceholderEditor.schedule()` where background goroutines can overwrite the final response with stale tool status remains unresolved.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with the known race condition documented; the issue is timing-dependent and may not occur frequently in practice
- Core functionality is well-implemented with good test coverage, clean callback mechanism, and proper event lifecycle. The known race condition in `PlaceholderEditor.schedule()` (where background goroutines can overwrite the final response) is already flagged in previous review comments and is the primary concern. The issue occurs when scheduled message edits execute after the final response has been sent, but this is timing-dependent and requires tools to execute within ~1 second of completion.
- Pay close attention to `internal/bot/tool_status.go` due to the race condition in the `schedule()` method

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/tool_status.go | New file implementing tool status tracking with live Telegram message updates; contains known race condition where scheduled edits can overwrite final response |
| internal/bot/hub_handler.go | New hub-based request processing that integrates PlaceholderEditor for real-time tool status; placeholder lifecycle is correct but doesn't wait for pending edits before final response |
| internal/agent/tool_agent.go | Added ToolEvent callback mechanism; clean implementation with proper started/finished events around tool execution |
| internal/bot/bot.go | Refactored message handling to use hub architecture; added ack tracker for ⏳ placeholders and immediate message acknowledgment |

</details>



<sub>Last reviewed commit: f2c8ed4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->