### PR TITLE
feat: queued acknowledgment when session is busy (#12)

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -342,7 +342,7 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 	// Use ToolCallingAgent to process the request
 	if b.ai != nil && !strings.HasPrefix(content, "/") {
 		// Check queue mode - if a run is active, may queue/steer/interrupt
-		if b.handleWithQueueMode(ctx, chatID, content) {
+		if b.handleWithQueueMode(ctx, c, content) {
 			return nil // Message was queued or steered
 		}
 
@@ -357,7 +357,14 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 					if len(queued) > 0 {
 						logger.Debugf("Bot: processing %d queued messages for chat=%d", len(queued), chatID)
 						for _, qMsg := range queued {
-							b.debouncer.Debounce(chatID, qMsg, func(qCombined string) {
+							// Transition the acknowledgment placeholder to active state
+							if qMsg.AckMsgID != 0 {
+								ackRef := &telebot.Message{ID: qMsg.AckMsgID, Chat: c.Chat()}
+								if _, err := b.api.Edit(ackRef, "💭 processing queued message..."); err != nil {
+									logger.Debugf("Bot: failed to update queue ack msg: %v", err)
+								}
+							}
+							b.debouncer.Debounce(chatID, qMsg.Content, func(qCombined string) {
 								session, _ := b.store.GetSession(chatID)
 								b.handleAgentRequest(ctx, c, qCombined, session)
 							})

--- a/internal/bot/queue.go
+++ b/internal/bot/queue.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 
 	"ok-gobot/internal/logger"
+
+	"gopkg.in/telebot.v4"
 )
 
 // QueueMode defines how incoming messages are handled during an active AI run
@@ -20,18 +22,24 @@ const (
 	QueueInterrupt QueueMode = "interrupt"
 )
 
+// QueuedMessage holds a buffered message and the ID of its acknowledgment message
+type QueuedMessage struct {
+	Content  string
+	AckMsgID int
+}
+
 // QueueManager manages per-chat message queuing with different modes
 type QueueManager struct {
 	mu         sync.Mutex
 	activeRuns map[int64]bool
-	queued     map[int64][]string
+	queued     map[int64][]QueuedMessage
 }
 
 // NewQueueManager creates a new queue manager
 func NewQueueManager() *QueueManager {
 	return &QueueManager{
 		activeRuns: make(map[int64]bool),
-		queued:     make(map[int64][]string),
+		queued:     make(map[int64][]QueuedMessage),
 	}
 }
 
@@ -50,7 +58,7 @@ func (qm *QueueManager) StartRun(chatID int64) {
 }
 
 // EndRun marks a chat's run as complete and returns any queued messages
-func (qm *QueueManager) EndRun(chatID int64) []string {
+func (qm *QueueManager) EndRun(chatID int64) []QueuedMessage {
 	qm.mu.Lock()
 	defer qm.mu.Unlock()
 	qm.activeRuns[chatID] = false
@@ -59,11 +67,11 @@ func (qm *QueueManager) EndRun(chatID int64) []string {
 	return queued
 }
 
-// Enqueue adds a message to the chat's queue
-func (qm *QueueManager) Enqueue(chatID int64, msg string) {
+// Enqueue adds a message to the chat's queue along with the ID of the sent acknowledgment message
+func (qm *QueueManager) Enqueue(chatID int64, content string, ackMsgID int) {
 	qm.mu.Lock()
 	defer qm.mu.Unlock()
-	qm.queued[chatID] = append(qm.queued[chatID], msg)
+	qm.queued[chatID] = append(qm.queued[chatID], QueuedMessage{Content: content, AckMsgID: ackMsgID})
 }
 
 // GetQueueDepth returns the number of queued messages for a chat
@@ -73,9 +81,11 @@ func (qm *QueueManager) GetQueueDepth(chatID int64) int {
 	return len(qm.queued[chatID])
 }
 
-// handleWithQueueMode processes a message according to the queue mode
-// Returns true if the message was handled (queued/interrupted), false if it should proceed normally
-func (b *Bot) handleWithQueueMode(ctx context.Context, chatID int64, content string) bool {
+// handleWithQueueMode processes a message according to the queue mode.
+// Returns true if the message was handled (queued/steered), false if it should proceed normally.
+// When the message is queued, an immediate acknowledgment is sent to the user.
+func (b *Bot) handleWithQueueMode(ctx context.Context, c telebot.Context, content string) bool {
+	chatID := c.Chat().ID
 	if !b.queueManager.IsRunning(chatID) {
 		return false // No active run, proceed normally
 	}
@@ -85,8 +95,9 @@ func (b *Bot) handleWithQueueMode(ctx context.Context, chatID int64, content str
 
 	switch mode {
 	case QueueSteer:
-		// Steer: add to queue, the active run will pick it up
-		b.queueManager.Enqueue(chatID, content)
+		// Steer: add to queue; send immediate acknowledgment
+		ackMsgID := b.sendQueuedAck(c)
+		b.queueManager.Enqueue(chatID, content, ackMsgID)
 		logger.Debugf("Bot: steered message to active run, queue depth=%d", b.queueManager.GetQueueDepth(chatID))
 		return true
 
@@ -102,14 +113,33 @@ func (b *Bot) handleWithQueueMode(ctx context.Context, chatID int64, content str
 		return false // Let the message proceed normally after interrupt
 
 	case QueueCollect:
-		// Collect: buffer the message silently
-		b.queueManager.Enqueue(chatID, content)
+		// Collect: buffer the message and send immediate acknowledgment
+		ackMsgID := b.sendQueuedAck(c)
+		b.queueManager.Enqueue(chatID, content, ackMsgID)
 		logger.Debugf("Bot: collected message, queue depth=%d", b.queueManager.GetQueueDepth(chatID))
 		return true
 
 	default:
 		return false
 	}
+}
+
+// sendQueuedAck sends an immediate "queued" acknowledgment to the user and returns
+// the sent message ID (0 on failure).
+func (b *Bot) sendQueuedAck(c telebot.Context) int {
+	depth := b.queueManager.GetQueueDepth(c.Chat().ID)
+	var text string
+	if depth == 0 {
+		text = "⏳ queued — previous run in progress"
+	} else {
+		text = "⏳ queued — previous run in progress"
+	}
+	msg, err := b.api.Send(c.Chat(), text)
+	if err != nil {
+		log.Printf("Bot: failed to send queue ack: %v", err)
+		return 0
+	}
+	return msg.ID
 }
 
 func (b *Bot) getQueueMode(chatID int64) QueueMode {


### PR DESCRIPTION
Implements #12

## Changes

**`internal/bot/queue.go`**
- Added `QueuedMessage` struct pairing `Content string` with `AckMsgID int` — the ID of the Telegram message sent as the immediate acknowledgment
- Changed `QueueManager.queued` map to store `[]QueuedMessage` instead of `[]string`
- Changed `QueueManager.Enqueue` to accept `ackMsgID int` alongside the content
- Changed `QueueManager.EndRun` to return `[]QueuedMessage` so callers can access both the message text and its ack placeholder ID
- Added `sendQueuedAck` helper that sends "⏳ queued — previous run in progress" to the user immediately and returns the sent message ID

**`internal/bot/bot.go`**
- Updated `handleWithQueueMode` call site to pass `telebot.Context` instead of bare `chatID` (the function now sends the ack itself)
- Updated the defer block that drains the queue after a run finishes: for each `QueuedMessage`, first edits the ack placeholder to "💭 processing queued message..." before passing it to the agent — satisfying AC3 (transition to active state)

## Testing

- `go test ./...` — all tests pass
- `go build ./cmd/ok-gobot/` — binary builds cleanly
- Logic verified: when `QueueManager.IsRunning(chatID)` is true and mode is `QueueCollect` (the default), `sendQueuedAck` fires immediately in the handler goroutine, well within the 1-second window; the ack message ID is stored and edited when the queued run begins

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements immediate queued acknowledgments when a session is busy, as specified in issue #12.

**Key changes:**
- Added `QueuedMessage` struct to pair message content with acknowledgment message IDs
- Modified `QueueManager` to store acknowledgment IDs alongside queued messages  
- Implemented `sendQueuedAck` helper that sends "⏳ queued" messages immediately
- Added logic to edit acknowledgment messages to "💭 processing..." when queued messages begin processing

**Issues found:**
- The `sendQueuedAck` function has identical text in both if/else branches (lines 132-136), meaning queue position is never shown to users
- Minor logging inconsistency using `log.Printf` instead of `logger.Debugf`

The overall architecture is sound and properly handles acknowledgment message IDs through the queue lifecycle.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the if/else logic error in sendQueuedAck
- The implementation follows good practices with proper mutex usage and error handling. However, there's a clear logic bug where both branches of an if/else statement set identical text, preventing queue position from being displayed. This won't cause crashes but reduces user experience. Once fixed, the PR would be solid.
- Pay close attention to `internal/bot/queue.go` lines 132-136 where the if/else branches need to be differentiated

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/queue.go | Added `QueuedMessage` struct and updated queue handling to send immediate acknowledgments. Contains a logic error where if/else branches set identical text (lines 132-136). |
| internal/bot/bot.go | Updated to pass `telebot.Context` to queue handler and added logic to edit acknowledgment messages when processing queued messages. Implementation looks correct. |

</details>



<sub>Last reviewed commit: 1d6ce48</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->