### PR TITLE
feat: implement TUI with Bubble Tea + control server (#17)

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,7 +32,7 @@ Supports Telegram bot integration with personality and memory.`,
 	root.AddCommand(newVersionCommand())
 	root.AddCommand(newDoctorCommand(cfg))
 	root.AddCommand(newDaemonCommand(cfg))
-	root.AddCommand(newTUICommand())
+	root.AddCommand(newTUICommand(cfg))
 
 	return root
 }

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -1,21 +1,99 @@
 package cli
 
 import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
 	"github.com/spf13/cobra"
 
+	"ok-gobot/internal/ai"
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/controlserver"
 	"ok-gobot/internal/tui"
 )
 
-func newTUICommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "tui",
-		Short: "Launch the terminal user interface",
-		Long: `Launch the interactive terminal UI.
+const defaultControlServerAddr = "127.0.0.1:9099"
 
-The session picker lists all active agent sessions.
-Press 'n' to open the sub-agent spawn dialog.`,
+func newTUICommand(cfg *config.Config) *cobra.Command {
+	var (
+		serverAddr string
+		noServer   bool
+		modelList  []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "tui",
+		Short: "Launch the interactive terminal UI",
+		Long: `Launch the Bubble Tea terminal UI for ok-gobot.
+
+By default this command starts a local control server and connects
+the TUI to it. You can point the TUI at an existing control server
+with --server.
+
+Key bindings:
+  Enter       Send message
+  Alt+Enter   Insert newline
+  Ctrl+P      Open session picker
+  Ctrl+M      Open model picker
+  Ctrl+A      Abort active run
+  Ctrl+C      Quit
+
+In-chat commands:
+  /abort            Cancel the active AI run
+  /new [name]       Open a new session
+  /model <name>     Switch to a named model
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return tui.Run(nil)
+			ctx := cmd.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+
+			if serverAddr == "" {
+				serverAddr = defaultControlServerAddr
+			}
+
+			if !noServer {
+				// Start an embedded control server
+				aiCfg := ai.ProviderConfig{
+					Name:    cfg.AI.Provider,
+					APIKey:  cfg.AI.APIKey,
+					Model:   cfg.AI.Model,
+					BaseURL: cfg.AI.BaseURL,
+				}
+
+				srv := controlserver.New(controlserver.Config{
+					Addr:  serverAddr,
+					AICfg: aiCfg,
+				})
+
+				srvCtx, srvCancel := context.WithCancel(ctx)
+				defer srvCancel()
+
+				go func() {
+					if err := srv.Start(srvCtx); err != nil && srvCtx.Err() == nil {
+						log.Printf("[tui] control server error: %v", err)
+					}
+				}()
+
+				// Wait for the server to be ready (up to 3 s)
+				if err := controlserver.WaitReady(serverAddr, 3*time.Second); err != nil {
+					return fmt.Errorf("control server did not start: %w", err)
+				}
+			}
+
+			return tui.Run(tui.Options{
+				ServerAddr: serverAddr,
+				ModelList:  modelList,
+			})
 		},
 	}
+
+	cmd.Flags().StringVar(&serverAddr, "server", "", fmt.Sprintf("control server address (default %s)", defaultControlServerAddr))
+	cmd.Flags().BoolVar(&noServer, "no-server", false, "do not start an embedded control server (use --server to point at one)")
+	cmd.Flags().StringSliceVar(&modelList, "models", nil, "comma-separated list of models for the model picker")
+
+	return cmd
 }

--- a/internal/controlserver/hub.go
+++ b/internal/controlserver/hub.go
@@ -1,0 +1,74 @@
+package controlserver
+
+import (
+	"encoding/json"
+	"log"
+	"net"
+	"sync"
+
+	"github.com/gobwas/ws/wsutil"
+)
+
+// wsClient represents a connected WebSocket TUI client.
+type wsClient struct {
+	conn net.Conn
+	mu   sync.Mutex
+}
+
+func (c *wsClient) send(msg ServerMsg) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return wsutil.WriteServerText(c.conn, data)
+}
+
+// Hub manages connected WebSocket clients and broadcasts events.
+type Hub struct {
+	mu      sync.RWMutex
+	clients map[*wsClient]struct{}
+}
+
+// NewHub creates a new Hub.
+func NewHub() *Hub {
+	return &Hub{
+		clients: make(map[*wsClient]struct{}),
+	}
+}
+
+func (h *Hub) add(c *wsClient) {
+	h.mu.Lock()
+	h.clients[c] = struct{}{}
+	h.mu.Unlock()
+}
+
+func (h *Hub) remove(c *wsClient) {
+	h.mu.Lock()
+	delete(h.clients, c)
+	h.mu.Unlock()
+}
+
+// Broadcast sends a message to all connected clients.
+func (h *Hub) Broadcast(msg ServerMsg) {
+	h.mu.RLock()
+	clients := make([]*wsClient, 0, len(h.clients))
+	for c := range h.clients {
+		clients = append(clients, c)
+	}
+	h.mu.RUnlock()
+
+	for _, c := range clients {
+		if err := c.send(msg); err != nil {
+			log.Printf("[hub] send error: %v", err)
+		}
+	}
+}
+
+// Count returns the number of connected clients.
+func (h *Hub) Count() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.clients)
+}

--- a/internal/controlserver/server.go
+++ b/internal/controlserver/server.go
@@ -1,0 +1,233 @@
+// Package controlserver provides a WebSocket control server for the TUI client.
+// It manages AI sessions and broadcasts events to connected clients.
+package controlserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+
+	"ok-gobot/internal/ai"
+)
+
+// Config holds control server configuration.
+type Config struct {
+	Addr  string // e.g. "127.0.0.1:9099"
+	AICfg ai.ProviderConfig
+}
+
+// Server is the control server.
+type Server struct {
+	cfg     Config
+	hub     *Hub
+	manager *Manager
+	http    *http.Server
+}
+
+// New creates a new control server.
+func New(cfg Config) *Server {
+	hub := NewHub()
+	return &Server{
+		cfg:     cfg,
+		hub:     hub,
+		manager: NewManager(hub, cfg.AICfg),
+	}
+}
+
+// Manager returns the session manager (for external inspection).
+func (s *Server) Manager() *Manager {
+	return s.manager
+}
+
+// Hub returns the event hub.
+func (s *Server) Hub() *Hub {
+	return s.hub
+}
+
+// Start begins listening on the configured address.
+func (s *Server) Start(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws", s.handleWS)
+	mux.HandleFunc("/health", s.handleHealth)
+
+	s.http = &http.Server{
+		Addr:    s.cfg.Addr,
+		Handler: mux,
+	}
+
+	// Ensure a default session exists
+	if _, err := s.manager.NewSession("Chat", ""); err != nil {
+		log.Printf("[controlserver] warning: could not create default session: %v", err)
+	}
+
+	log.Printf("[controlserver] listening on %s", s.cfg.Addr)
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := s.http.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("control server: %w", err)
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		return s.http.Shutdown(shutCtx)
+	}
+}
+
+// handleHealth is a simple health check endpoint.
+func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, `{"status":"ok","clients":%d}`, s.hub.Count())
+}
+
+// handleWS upgrades the connection to WebSocket and handles client messages.
+func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
+	conn, _, _, err := ws.UpgradeHTTP(r, w)
+	if err != nil {
+		log.Printf("[controlserver] ws upgrade error: %v", err)
+		return
+	}
+
+	client := &wsClient{conn: conn}
+	s.hub.add(client)
+	defer func() {
+		s.hub.remove(client)
+		conn.Close()
+	}()
+
+	log.Printf("[controlserver] client connected from %s", conn.RemoteAddr())
+
+	// Send the current session list on connect
+	sessions := s.manager.List()
+	activeID := ""
+	if len(sessions) > 0 {
+		activeID = sessions[0].ID
+	}
+	_ = client.send(ServerMsg{
+		Type:      MsgTypeConnected,
+		SessionID: activeID,
+		Sessions:  sessions,
+	})
+
+	// Read loop
+	for {
+		data, op, err := wsutil.ReadClientData(conn)
+		if err != nil {
+			break
+		}
+		if op != ws.OpText {
+			continue
+		}
+
+		var cmd ClientMsg
+		if err := json.Unmarshal(data, &cmd); err != nil {
+			log.Printf("[controlserver] bad client message: %v", err)
+			continue
+		}
+
+		s.handleClientMsg(r.Context(), client, cmd)
+	}
+}
+
+// handleClientMsg dispatches a client command.
+func (s *Server) handleClientMsg(ctx context.Context, client *wsClient, cmd ClientMsg) {
+	switch cmd.Type {
+	case CmdSend:
+		sess := s.getOrFirst(cmd.SessionID)
+		if sess == nil {
+			_ = client.send(ServerMsg{Type: MsgTypeError, Message: "no active session"})
+			return
+		}
+		sess.Send(ctx, cmd.Text)
+
+	case CmdAbort:
+		sess := s.getOrFirst(cmd.SessionID)
+		if sess != nil {
+			sess.Abort()
+		}
+
+	case CmdApprove:
+		sess := s.getOrFirst(cmd.SessionID)
+		if sess != nil {
+			sess.Approve(cmd.ApprovalID, cmd.Approved)
+		}
+
+	case CmdSetModel:
+		if err := s.manager.SetModel(cmd.SessionID, cmd.Model); err != nil {
+			_ = client.send(ServerMsg{Type: MsgTypeError, Message: err.Error()})
+			return
+		}
+		_ = client.send(ServerMsg{
+			Type:     MsgTypeSessions,
+			Sessions: s.manager.List(),
+		})
+
+	case CmdListSessions:
+		_ = client.send(ServerMsg{
+			Type:     MsgTypeSessions,
+			Sessions: s.manager.List(),
+		})
+
+	case CmdNewSession:
+		sess, err := s.manager.NewSession(cmd.Name, cmd.Model)
+		if err != nil {
+			_ = client.send(ServerMsg{Type: MsgTypeError, Message: err.Error()})
+			return
+		}
+		_ = client.send(ServerMsg{
+			Type:      MsgTypeConnected,
+			SessionID: sess.ID,
+			Sessions:  s.manager.List(),
+		})
+
+	case CmdSwitch:
+		sess := s.manager.Get(cmd.SessionID)
+		if sess == nil {
+			_ = client.send(ServerMsg{Type: MsgTypeError, Message: "session not found"})
+			return
+		}
+		_ = client.send(ServerMsg{
+			Type:      MsgTypeConnected,
+			SessionID: sess.ID,
+			Sessions:  s.manager.List(),
+		})
+	}
+}
+
+// getOrFirst returns the named session or the first available one.
+func (s *Server) getOrFirst(id string) *Session {
+	if id != "" {
+		return s.manager.Get(id)
+	}
+	list := s.manager.List()
+	if len(list) == 0 {
+		return nil
+	}
+	return s.manager.Get(list[0].ID)
+}
+
+// WaitReady polls until the server is accepting connections.
+func WaitReady(addr string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("control server at %s not ready after %s", addr, timeout)
+}

--- a/internal/controlserver/session.go
+++ b/internal/controlserver/session.go
@@ -1,0 +1,373 @@
+package controlserver
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"ok-gobot/internal/ai"
+)
+
+// Session holds one conversation with the AI.
+type Session struct {
+	ID       string
+	Name     string
+	Model    string
+	Messages []ai.ChatMessage
+
+	mu          sync.Mutex
+	cancelFn    context.CancelFunc
+	running     bool
+	hub         *Hub
+	aiClient    ai.Client
+	aiCfg       ai.ProviderConfig
+	approvals   map[string]*ApprovalRequest
+	approvalsMu sync.Mutex
+}
+
+// Manager manages multiple sessions.
+type Manager struct {
+	mu       sync.RWMutex
+	sessions map[string]*Session
+	hub      *Hub
+	aiCfg    ai.ProviderConfig
+}
+
+// NewManager creates a new session manager.
+func NewManager(hub *Hub, aiCfg ai.ProviderConfig) *Manager {
+	return &Manager{
+		sessions: make(map[string]*Session),
+		hub:      hub,
+		aiCfg:    aiCfg,
+	}
+}
+
+// NewSession creates and registers a new session.
+func (m *Manager) NewSession(name, model string) (*Session, error) {
+	cfg := m.aiCfg
+	if model != "" {
+		cfg.Model = model
+	}
+
+	aiClient, err := ai.NewClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create ai client: %w", err)
+	}
+
+	id := fmt.Sprintf("sess-%d", time.Now().UnixMilli())
+	if name == "" {
+		name = "Chat"
+	}
+
+	s := &Session{
+		ID:        id,
+		Name:      name,
+		Model:     cfg.Model,
+		hub:       m.hub,
+		aiClient:  aiClient,
+		aiCfg:     cfg,
+		approvals: make(map[string]*ApprovalRequest),
+	}
+
+	m.mu.Lock()
+	m.sessions[id] = s
+	m.mu.Unlock()
+
+	return s, nil
+}
+
+// Get returns a session by ID.
+func (m *Manager) Get(id string) *Session {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.sessions[id]
+}
+
+// List returns info about all sessions.
+func (m *Manager) List() []SessionInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]SessionInfo, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		s.mu.Lock()
+		running := s.running
+		s.mu.Unlock()
+		result = append(result, SessionInfo{
+			ID:      s.ID,
+			Name:    s.Name,
+			Model:   s.Model,
+			Running: running,
+		})
+	}
+	return result
+}
+
+// SetModel changes the AI model for a session.
+func (m *Manager) SetModel(id, model string) error {
+	s := m.Get(id)
+	if s == nil {
+		return fmt.Errorf("session not found: %s", id)
+	}
+	cfg := m.aiCfg
+	cfg.Model = model
+	aiClient, err := ai.NewClient(cfg)
+	if err != nil {
+		return fmt.Errorf("create ai client: %w", err)
+	}
+	s.mu.Lock()
+	s.Model = model
+	s.aiClient = aiClient
+	s.aiCfg = cfg
+	s.mu.Unlock()
+	return nil
+}
+
+// Send processes a user message asynchronously.
+func (s *Session) Send(ctx context.Context, text string) {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		s.hub.Broadcast(ServerMsg{
+			Type:      MsgTypeEvent,
+			Kind:      KindError,
+			SessionID: s.ID,
+			Message:   "A run is already in progress. Use /abort first.",
+		})
+		return
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	s.cancelFn = cancel
+	s.running = true
+	s.mu.Unlock()
+
+	// Record user message
+	s.mu.Lock()
+	s.Messages = append(s.Messages, ai.ChatMessage{
+		Role:    ai.RoleUser,
+		Content: text,
+	})
+	s.mu.Unlock()
+
+	// Notify clients
+	s.hub.Broadcast(ServerMsg{
+		Type:      MsgTypeEvent,
+		Kind:      KindMessage,
+		SessionID: s.ID,
+		Role:      "user",
+		Content:   text,
+	})
+
+	go func() {
+		defer func() {
+			s.mu.Lock()
+			s.running = false
+			s.cancelFn = nil
+			s.mu.Unlock()
+			cancel()
+		}()
+
+		s.hub.Broadcast(ServerMsg{
+			Type:      MsgTypeEvent,
+			Kind:      KindRunStart,
+			SessionID: s.ID,
+		})
+
+		s.processRound(runCtx)
+
+		s.hub.Broadcast(ServerMsg{
+			Type:      MsgTypeEvent,
+			Kind:      KindRunEnd,
+			SessionID: s.ID,
+		})
+	}()
+}
+
+// processRound runs one round of the AI conversation loop.
+func (s *Session) processRound(ctx context.Context) {
+	s.mu.Lock()
+	msgs := make([]ai.ChatMessage, len(s.Messages))
+	copy(msgs, s.Messages)
+	aiClient := s.aiClient
+	s.mu.Unlock()
+
+	// Try streaming first
+	if sc, ok := aiClient.(ai.StreamingClient); ok {
+		s.processStream(ctx, sc, msgs)
+		return
+	}
+	// Fallback: non-streaming
+	s.processNonStream(ctx, aiClient, msgs)
+}
+
+// processStream uses the streaming API.
+func (s *Session) processStream(ctx context.Context, sc ai.StreamingClient, msgs []ai.ChatMessage) {
+	stream := sc.CompleteStreamWithTools(ctx, msgs, nil)
+	var buf strings.Builder
+
+	for chunk := range stream {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		if chunk.Error != nil {
+			if ctx.Err() == nil {
+				s.hub.Broadcast(ServerMsg{
+					Type:      MsgTypeEvent,
+					Kind:      KindError,
+					SessionID: s.ID,
+					Message:   chunk.Error.Error(),
+				})
+			}
+			return
+		}
+
+		content := chunk.Content
+		// Skip tool-call marker (tool calling not wired up in TUI yet)
+		if strings.HasPrefix(content, "\n__TOOL_CALLS__:") {
+			continue
+		}
+
+		if content != "" {
+			buf.WriteString(content)
+			s.hub.Broadcast(ServerMsg{
+				Type:      MsgTypeEvent,
+				Kind:      KindToken,
+				SessionID: s.ID,
+				Content:   content,
+			})
+		}
+	}
+
+	finalText := buf.String()
+	if finalText == "" {
+		return
+	}
+
+	s.mu.Lock()
+	s.Messages = append(s.Messages, ai.ChatMessage{
+		Role:    ai.RoleAssistant,
+		Content: finalText,
+	})
+	s.mu.Unlock()
+
+	s.hub.Broadcast(ServerMsg{
+		Type:      MsgTypeEvent,
+		Kind:      KindMessage,
+		SessionID: s.ID,
+		Role:      "assistant",
+		Content:   finalText,
+	})
+}
+
+// processNonStream falls back to non-streaming and simulates token delivery.
+func (s *Session) processNonStream(ctx context.Context, client ai.Client, msgs []ai.ChatMessage) {
+	legacyMsgs := make([]ai.Message, len(msgs))
+	for i, m := range msgs {
+		legacyMsgs[i] = ai.Message{Role: m.Role, Content: m.Content}
+	}
+
+	text, err := client.Complete(ctx, legacyMsgs)
+	if err != nil {
+		if ctx.Err() == nil {
+			s.hub.Broadcast(ServerMsg{
+				Type:      MsgTypeEvent,
+				Kind:      KindError,
+				SessionID: s.ID,
+				Message:   err.Error(),
+			})
+		}
+		return
+	}
+
+	// Simulate streaming at ~80 chars/tick
+	const chunkSize = 8
+	for i := 0; i < len(text); i += chunkSize {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		end := i + chunkSize
+		if end > len(text) {
+			end = len(text)
+		}
+		s.hub.Broadcast(ServerMsg{
+			Type:      MsgTypeEvent,
+			Kind:      KindToken,
+			SessionID: s.ID,
+			Content:   text[i:end],
+		})
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	s.mu.Lock()
+	s.Messages = append(s.Messages, ai.ChatMessage{
+		Role:    ai.RoleAssistant,
+		Content: text,
+	})
+	s.mu.Unlock()
+
+	s.hub.Broadcast(ServerMsg{
+		Type:      MsgTypeEvent,
+		Kind:      KindMessage,
+		SessionID: s.ID,
+		Role:      "assistant",
+		Content:   text,
+	})
+}
+
+// Abort cancels the active run.
+func (s *Session) Abort() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cancelFn != nil {
+		log.Printf("[session] aborting run in %s", s.ID)
+		s.cancelFn()
+	}
+}
+
+// RequestApproval suspends the session run until the user responds.
+func (s *Session) RequestApproval(command string) bool {
+	id := fmt.Sprintf("appr-%d", time.Now().UnixNano())
+	req := &ApprovalRequest{
+		ID:        id,
+		SessionID: s.ID,
+		Command:   command,
+		Response:  make(chan bool, 1),
+	}
+
+	s.approvalsMu.Lock()
+	s.approvals[id] = req
+	s.approvalsMu.Unlock()
+
+	s.hub.Broadcast(ServerMsg{
+		Type:       MsgTypeEvent,
+		Kind:       KindApproval,
+		SessionID:  s.ID,
+		ApprovalID: id,
+		Command:    command,
+	})
+
+	approved := <-req.Response
+	return approved
+}
+
+// Approve responds to an approval request.
+func (s *Session) Approve(approvalID string, approved bool) {
+	s.approvalsMu.Lock()
+	req, ok := s.approvals[approvalID]
+	if ok {
+		delete(s.approvals, approvalID)
+	}
+	s.approvalsMu.Unlock()
+
+	if ok {
+		req.Response <- approved
+	}
+}

--- a/internal/controlserver/types.go
+++ b/internal/controlserver/types.go
@@ -1,0 +1,79 @@
+package controlserver
+
+// Message type constants for server→client messages.
+const (
+	MsgTypeEvent     = "event"
+	MsgTypeSessions  = "sessions"
+	MsgTypeError     = "error"
+	MsgTypeConnected = "connected"
+)
+
+// Event kind constants (embedded in MsgTypeEvent messages).
+const (
+	KindToken     = "token"
+	KindMessage   = "message"
+	KindToolStart = "tool_start"
+	KindToolEnd   = "tool_end"
+	KindRunStart  = "run_start"
+	KindRunEnd    = "run_end"
+	KindError     = "error"
+	KindApproval  = "approval_request"
+	KindQueue     = "queue_update"
+)
+
+// Command type constants for client→server messages.
+const (
+	CmdSend         = "send"
+	CmdAbort        = "abort"
+	CmdApprove      = "approve"
+	CmdSetModel     = "set_model"
+	CmdListSessions = "list_sessions"
+	CmdNewSession   = "new_session"
+	CmdSwitch       = "switch_session"
+)
+
+// ServerMsg is sent from the control server to TUI clients.
+type ServerMsg struct {
+	Type       string        `json:"type"`
+	Kind       string        `json:"kind,omitempty"`
+	SessionID  string        `json:"session_id,omitempty"`
+	Content    string        `json:"content,omitempty"`
+	Role       string        `json:"role,omitempty"`
+	ToolName   string        `json:"tool_name,omitempty"`
+	ToolArgs   string        `json:"tool_args,omitempty"`
+	ToolResult string        `json:"tool_result,omitempty"`
+	ToolError  string        `json:"tool_error,omitempty"`
+	ApprovalID string        `json:"approval_id,omitempty"`
+	Command    string        `json:"command,omitempty"`
+	QueueDepth int           `json:"queue_depth,omitempty"`
+	Sessions   []SessionInfo `json:"sessions,omitempty"`
+	Message    string        `json:"message,omitempty"`
+}
+
+// ClientMsg is sent from TUI clients to the control server.
+type ClientMsg struct {
+	Type       string `json:"type"`
+	SessionID  string `json:"session_id,omitempty"`
+	Text       string `json:"text,omitempty"`
+	Model      string `json:"model,omitempty"`
+	ApprovalID string `json:"approval_id,omitempty"`
+	Approved   bool   `json:"approved"`
+	Name       string `json:"name,omitempty"`
+	Agent      string `json:"agent,omitempty"`
+}
+
+// SessionInfo describes a session for the session list.
+type SessionInfo struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Model   string `json:"model"`
+	Running bool   `json:"running"`
+}
+
+// ApprovalRequest is a pending command approval.
+type ApprovalRequest struct {
+	ID        string
+	SessionID string
+	Command   string
+	Response  chan bool
+}

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+
+	"ok-gobot/internal/controlserver"
+)
+
+// wsConn wraps a raw WebSocket connection.
+type wsConn struct {
+	conn net.Conn
+}
+
+// dialWS establishes a WebSocket connection to the control server.
+func dialWS(addr string) (*wsConn, error) {
+	url := fmt.Sprintf("ws://%s/ws", addr)
+	conn, _, _, err := ws.DefaultDialer.Dial(nil, url)
+	if err != nil {
+		return nil, fmt.Errorf("dial control server %s: %w", url, err)
+	}
+	return &wsConn{conn: conn}, nil
+}
+
+// send serialises and sends a ClientMsg to the server.
+func (c *wsConn) send(msg controlserver.ClientMsg) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	return wsutil.WriteClientText(c.conn, data)
+}
+
+// readMsg reads and deserialises the next ServerMsg.
+func (c *wsConn) readMsg() (controlserver.ServerMsg, error) {
+	data, _, err := wsutil.ReadServerData(c.conn)
+	if err != nil {
+		return controlserver.ServerMsg{}, err
+	}
+	var msg controlserver.ServerMsg
+	if err := json.Unmarshal(data, &msg); err != nil {
+		log.Printf("[tui] bad server message: %v", err)
+		return controlserver.ServerMsg{}, err
+	}
+	return msg, nil
+}
+
+// close closes the WebSocket connection.
+func (c *wsConn) close() {
+	c.conn.Close()
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4,379 +4,843 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"ok-gobot/internal/runtime"
+	"ok-gobot/internal/controlserver"
 )
 
-// SessionStatus describes the current state of a session.
-type SessionStatus string
+// screen tracks which overlay is visible.
+type screen int
 
 const (
-	StatusIdle   SessionStatus = "idle"
-	StatusActive SessionStatus = "active"
-	StatusQueued SessionStatus = "queued"
-	// StatusDone is set on a sub-agent session after its run completes.
-	StatusDone SessionStatus = "done"
+	screenChat     screen = iota
+	screenSessions        // session picker overlay
+	screenModels          // model picker overlay
+	screenApproval        // approval prompt overlay
 )
 
-// HubEventMsg wraps a runtime.RuntimeEvent for delivery to the Bubble Tea model.
-type HubEventMsg runtime.RuntimeEvent
-
-// listenHub returns a tea.Cmd that blocks until the next event arrives on ch,
-// then delivers it as a HubEventMsg. Returns nil when the channel is closed.
-func listenHub(ch <-chan runtime.RuntimeEvent) tea.Cmd {
-	return func() tea.Msg {
-		ev, ok := <-ch
-		if !ok {
-			return nil
-		}
-		return HubEventMsg(ev)
-	}
+// chatEntry is one logical item in the chat log.
+type chatEntry struct {
+	role      string // "user", "assistant", "tool", "error"
+	content   string
+	toolName  string
+	toolArgs  string
+	toolRes   string
+	toolErr   string
+	streaming bool // true while tokens are still arriving
 }
 
-// SessionEntry represents a single session in the session picker.
-type SessionEntry struct {
-	Key        string // canonical session key
-	Label      string // human-readable label
-	Status     SessionStatus
-	IsSubagent bool
-	SpawnedAt  time.Time
+// Model is the root Bubble Tea model.
+type Model struct {
+	// layout
+	width  int
+	height int
+
+	// state
+	screen     screen
+	conn       *wsConn
+	serverAddr string
+
+	// session management
+	sessions      []controlserver.SessionInfo
+	activeSession string
+	running       bool
+
+	// chat log
+	entries   []chatEntry
+	streamBuf strings.Builder // accumulates live tokens
+	streamIdx int             // index in entries of the streaming entry (-1 if none)
+
+	// pending approval
+	approvalID  string
+	approvalCmd string
+	approvalSel int // 0 = yes, 1 = no
+
+	// UI components
+	viewport viewport.Model
+	input    textarea.Model
+
+	// session/model pickers
+	sessionCursor int
+	modelCursor   int
+	modelList     []string
+
+	// misc
+	statusMsg string
+	statusAt  time.Time
+	lastErr   string
+	tick      int
 }
 
-// AppModel is the root Bubble Tea model for the ok-gobot TUI.
-// It combines a session picker list with an optional spawn dialog overlay.
-type AppModel struct {
-	sessions    []SessionEntry
-	selectedIdx int
-	showDialog  bool
-	dialog      SpawnDialog
-	width       int
-	height      int
-	statusMsg   string
-	hubCh       <-chan runtime.RuntimeEvent // nil if no hub connected
+// serverMsgReceived carries a decoded ServerMsg into the Bubble Tea loop.
+type serverMsgReceived struct {
+	msg controlserver.ServerMsg
 }
 
-// NewAppModel creates an AppModel pre-populated with an initial session list.
-func NewAppModel(sessions []SessionEntry) AppModel {
-	if len(sessions) == 0 {
-		sessions = []SessionEntry{
-			{
-				Key:    "agent:default:main",
-				Label:  "main",
-				Status: StatusIdle,
-			},
-		}
-	}
-	return AppModel{sessions: sessions}
+// serverError carries a WebSocket read error.
+type serverError struct{ err error }
+
+// tickMsg drives cursor blinking / status timeout.
+type tickMsg time.Time
+
+// --- Init ---
+
+func (m *Model) Init() tea.Cmd {
+	return tea.Batch(
+		m.listenCmd(),
+		tickEvery(),
+		textarea.Blink,
+	)
 }
 
-// WithHub returns a copy of m subscribed to hub for runtime events.
-// The caller is responsible for calling hub.Unsubscribe with the returned
-// channel when the TUI exits, if cleanup is required.
-func (m AppModel) WithHub(hub *runtime.Hub) AppModel {
-	ch := make(chan runtime.RuntimeEvent, 64)
-	hub.Subscribe(ch)
-	m.hubCh = ch
-	return m
-}
+// --- Update ---
 
-// Init implements tea.Model.
-func (m AppModel) Init() tea.Cmd {
-	if m.hubCh != nil {
-		return listenHub(m.hubCh)
-	}
-	return nil
-}
-
-// Update implements tea.Model.
-func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// When the spawn dialog is open, forward all messages to it.
-	if m.showDialog {
-		return m.updateDialog(msg)
-	}
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.resizeComponents()
+		return m, nil
+
+	case tickMsg:
+		m.tick++
+		cmds = append(cmds, tickEvery())
+		// clear status after 4s
+		if !m.statusAt.IsZero() && time.Since(m.statusAt) > 4*time.Second {
+			m.statusMsg = ""
+		}
+
+	case serverError:
+		m.lastErr = fmt.Sprintf("connection error: %v", msg.err)
+		// try to reconnect after a moment
+		return m, tea.Batch(cmds...)
+
+	case serverMsgReceived:
+		cmds = append(cmds, m.handleServerMsg(msg.msg))
 
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "ctrl+c":
-			return m, tea.Quit
-		case "n":
-			m.dialog = NewSpawnDialog()
-			m.showDialog = true
-			return m, m.dialog.Init()
-		case "j", "down":
-			if m.selectedIdx < len(m.sessions)-1 {
-				m.selectedIdx++
-			}
-		case "k", "up":
-			if m.selectedIdx > 0 {
-				m.selectedIdx--
-			}
-		case "g":
-			m.selectedIdx = 0
-		case "G":
-			m.selectedIdx = len(m.sessions) - 1
-		}
-
-	case HubEventMsg:
-		m = m.applyHubEvent(runtime.RuntimeEvent(msg))
-		if m.hubCh != nil {
-			return m, listenHub(m.hubCh)
-		}
-		return m, nil
+		return m.handleKey(msg, cmds)
 	}
 
-	return m, nil
+	// Forward key events to input when in chat mode
+	if m.screen == screenChat {
+		var inputCmd tea.Cmd
+		m.input, inputCmd = m.input.Update(msg)
+		cmds = append(cmds, inputCmd)
+	}
+
+	// Update viewport
+	var vpCmd tea.Cmd
+	m.viewport, vpCmd = m.viewport.Update(msg)
+	cmds = append(cmds, vpCmd)
+
+	return m, tea.Batch(cmds...)
 }
 
-// applyHubEvent updates session statuses and parent notifications based on a
-// runtime event. It returns the updated model.
-func (m AppModel) applyHubEvent(ev runtime.RuntimeEvent) AppModel {
-	switch ev.Type {
-	case runtime.EventActive:
-		m.sessions = setSessionStatus(m.sessions, ev.SessionKey, StatusActive)
+// handleKey dispatches key presses based on the active screen.
+func (m *Model) handleKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch m.screen {
+	case screenApproval:
+		return m.handleApprovalKey(msg, cmds)
+	case screenSessions:
+		return m.handleSessionKey(msg, cmds)
+	case screenModels:
+		return m.handleModelKey(msg, cmds)
+	default:
+		return m.handleChatKey(msg, cmds)
+	}
+}
 
-	case runtime.EventQueued:
-		m.sessions = setSessionStatus(m.sessions, ev.SessionKey, StatusQueued)
+func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
 
-	case runtime.EventDone, runtime.EventError:
-		m.sessions = setSessionStatus(m.sessions, ev.SessionKey, StatusIdle)
+	case "esc":
+		// do nothing in chat mode, esc closes overlays
+		return m, tea.Batch(cmds...)
 
-	case runtime.EventChildDone:
-		payload, ok := ev.Payload.(runtime.ChildCompletionPayload)
-		if !ok {
+	case "ctrl+s", "enter":
+		if msg.String() == "enter" && !msg.Alt {
+			// Enter without Alt sends message (textarea handles Alt+Enter for newlines)
+			text := strings.TrimSpace(m.input.Value())
+			if text == "" {
+				break
+			}
+			if strings.HasPrefix(text, "/abort") {
+				m.sendCmd(controlserver.ClientMsg{
+					Type:      controlserver.CmdAbort,
+					SessionID: m.activeSession,
+				})
+				m.setStatus("Abort sent")
+			} else if strings.HasPrefix(text, "/new") {
+				parts := strings.Fields(text)
+				name := ""
+				if len(parts) > 1 {
+					name = strings.Join(parts[1:], " ")
+				}
+				m.sendCmd(controlserver.ClientMsg{
+					Type: controlserver.CmdNewSession,
+					Name: name,
+				})
+			} else if strings.HasPrefix(text, "/model") {
+				parts := strings.Fields(text)
+				if len(parts) == 2 {
+					m.sendCmd(controlserver.ClientMsg{
+						Type:      controlserver.CmdSetModel,
+						SessionID: m.activeSession,
+						Model:     parts[1],
+					})
+					m.setStatus("Model override set to " + parts[1])
+				} else {
+					m.screen = screenModels
+					m.modelCursor = 0
+				}
+			} else {
+				m.sendCmd(controlserver.ClientMsg{
+					Type:      controlserver.CmdSend,
+					SessionID: m.activeSession,
+					Text:      text,
+				})
+			}
+			m.input.Reset()
+			return m, tea.Batch(cmds...)
+		}
+
+	case "ctrl+p":
+		// Open session picker
+		m.screen = screenSessions
+		m.sessionCursor = 0
+		return m, tea.Batch(cmds...)
+
+	case "ctrl+m":
+		// Open model picker
+		m.screen = screenModels
+		m.modelCursor = 0
+		return m, tea.Batch(cmds...)
+
+	case "ctrl+a":
+		// Abort shortcut
+		m.sendCmd(controlserver.ClientMsg{
+			Type:      controlserver.CmdAbort,
+			SessionID: m.activeSession,
+		})
+		m.setStatus("Abort sent")
+		return m, tea.Batch(cmds...)
+
+	case "pgup":
+		m.viewport.HalfViewUp()
+	case "pgdown":
+		m.viewport.HalfViewDown()
+	}
+
+	// Forward to textarea
+	var inputCmd tea.Cmd
+	m.input, inputCmd = m.input.Update(msg)
+	cmds = append(cmds, inputCmd)
+	return m, tea.Batch(cmds...)
+}
+
+func (m *Model) handleApprovalKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "left", "h":
+		m.approvalSel = 0
+	case "right", "l":
+		m.approvalSel = 1
+	case "y", "Y":
+		m.approvalSel = 0
+		m.submitApproval()
+	case "n", "N", "esc":
+		m.approvalSel = 1
+		m.submitApproval()
+	case "enter":
+		m.submitApproval()
+	case "ctrl+c":
+		return m, tea.Quit
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m *Model) handleSessionKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+p":
+		m.screen = screenChat
+	case "up", "k":
+		if m.sessionCursor > 0 {
+			m.sessionCursor--
+		}
+	case "down", "j":
+		if m.sessionCursor < len(m.sessions)-1 {
+			m.sessionCursor++
+		}
+	case "enter":
+		if m.sessionCursor < len(m.sessions) {
+			target := m.sessions[m.sessionCursor]
+			m.sendCmd(controlserver.ClientMsg{
+				Type:      controlserver.CmdSwitch,
+				SessionID: target.ID,
+			})
+		}
+		m.screen = screenChat
+	case "n":
+		m.sendCmd(controlserver.ClientMsg{
+			Type: controlserver.CmdNewSession,
+			Name: fmt.Sprintf("Chat %d", len(m.sessions)+1),
+		})
+		m.screen = screenChat
+	case "ctrl+c":
+		return m, tea.Quit
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m *Model) handleModelKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+m":
+		m.screen = screenChat
+	case "up", "k":
+		if m.modelCursor > 0 {
+			m.modelCursor--
+		}
+	case "down", "j":
+		if m.modelCursor < len(m.modelList)-1 {
+			m.modelCursor++
+		}
+	case "enter":
+		if m.modelCursor < len(m.modelList) {
+			model := m.modelList[m.modelCursor]
+			m.sendCmd(controlserver.ClientMsg{
+				Type:      controlserver.CmdSetModel,
+				SessionID: m.activeSession,
+				Model:     model,
+			})
+			m.setStatus("Model set to " + model)
+		}
+		m.screen = screenChat
+	case "ctrl+c":
+		return m, tea.Quit
+	}
+	return m, tea.Batch(cmds...)
+}
+
+// handleServerMsg processes an incoming server event.
+func (m *Model) handleServerMsg(msg controlserver.ServerMsg) tea.Cmd {
+	switch msg.Type {
+	case controlserver.MsgTypeConnected:
+		m.activeSession = msg.SessionID
+		if len(msg.Sessions) > 0 {
+			m.sessions = msg.Sessions
+		}
+
+	case controlserver.MsgTypeSessions:
+		m.sessions = msg.Sessions
+
+	case controlserver.MsgTypeError:
+		m.addEntry(chatEntry{role: "error", content: msg.Message})
+		m.refreshViewport()
+
+	case controlserver.MsgTypeEvent:
+		return m.handleEvent(msg)
+	}
+	return nil
+}
+
+// handleEvent processes an event-type server message.
+func (m *Model) handleEvent(msg controlserver.ServerMsg) tea.Cmd {
+	switch msg.Kind {
+	case controlserver.KindRunStart:
+		m.running = true
+		// start a streaming entry
+		m.streamBuf.Reset()
+		m.streamIdx = len(m.entries)
+		m.entries = append(m.entries, chatEntry{
+			role:      "assistant",
+			streaming: true,
+		})
+		m.refreshViewport()
+
+	case controlserver.KindRunEnd:
+		m.running = false
+		// finalise the streaming entry
+		if m.streamIdx >= 0 && m.streamIdx < len(m.entries) {
+			m.entries[m.streamIdx].streaming = false
+		}
+		m.streamIdx = -1
+		m.refreshViewport()
+
+	case controlserver.KindToken:
+		m.streamBuf.WriteString(msg.Content)
+		if m.streamIdx >= 0 && m.streamIdx < len(m.entries) {
+			m.entries[m.streamIdx].content = m.streamBuf.String()
+		}
+		m.refreshViewport()
+
+	case controlserver.KindMessage:
+		// A completed message - if we have an active streaming entry for this
+		// role, update it; otherwise add a new one.
+		if msg.Role == "assistant" && m.streamIdx >= 0 {
+			// already tracked via token events - just mark done
+			if m.streamIdx < len(m.entries) {
+				m.entries[m.streamIdx].content = msg.Content
+				m.entries[m.streamIdx].streaming = false
+			}
+			m.streamIdx = -1
+		} else if msg.Role == "user" {
+			m.addEntry(chatEntry{role: "user", content: msg.Content})
+		}
+		m.refreshViewport()
+
+	case controlserver.KindToolStart:
+		m.addEntry(chatEntry{
+			role:     "tool",
+			toolName: msg.ToolName,
+			toolArgs: msg.ToolArgs,
+		})
+		m.refreshViewport()
+
+	case controlserver.KindToolEnd:
+		// Find the matching tool entry and add result
+		for i := len(m.entries) - 1; i >= 0; i-- {
+			if m.entries[i].role == "tool" && m.entries[i].toolName == msg.ToolName {
+				m.entries[i].toolRes = msg.ToolResult
+				m.entries[i].toolErr = msg.ToolError
+				break
+			}
+		}
+		m.refreshViewport()
+
+	case controlserver.KindError:
+		m.addEntry(chatEntry{role: "error", content: msg.Message})
+		m.refreshViewport()
+
+	case controlserver.KindApproval:
+		m.approvalID = msg.ApprovalID
+		m.approvalCmd = msg.Command
+		m.approvalSel = 0
+		m.screen = screenApproval
+	}
+	return nil
+}
+
+// --- View ---
+
+func (m *Model) View() string {
+	if m.width == 0 {
+		return "Loading…"
+	}
+
+	header := m.renderHeader()
+	status := m.renderStatus()
+
+	// Reserve lines for header (1), status (1), input border + textarea
+	inputHeight := m.inputAreaHeight()
+	chatHeight := m.height - lipgloss.Height(header) - lipgloss.Height(status) - inputHeight
+
+	if chatHeight < 2 {
+		chatHeight = 2
+	}
+	m.viewport.Height = chatHeight
+
+	chat := m.viewport.View()
+	input := m.renderInput()
+
+	base := lipgloss.JoinVertical(lipgloss.Left,
+		header,
+		chat,
+		input,
+		status,
+	)
+
+	// Overlay screens
+	switch m.screen {
+	case screenApproval:
+		return m.overlayApproval(base)
+	case screenSessions:
+		return m.overlaySessionList(base)
+	case screenModels:
+		return m.overlayModelList(base)
+	}
+
+	return base
+}
+
+// renderHeader renders the top status bar.
+func (m *Model) renderHeader() string {
+	// Model info
+	model := "unknown"
+	for _, s := range m.sessions {
+		if s.ID == m.activeSession {
+			model = s.Model
 			break
 		}
-		// Mark child session as done (it remains browsable in the picker).
-		m.sessions = setSessionStatus(m.sessions, payload.ChildSessionKey, StatusDone)
-		// Insert a completion card after the parent session entry.
-		card := SessionEntry{
-			Key:        "notify:" + ev.SessionKey + ":" + payload.ChildSessionKey,
-			Label:      "✓ Sub-agent completed: " + shortSessionKey(payload.ChildSessionKey),
-			Status:     StatusDone,
-			IsSubagent: false,
-			SpawnedAt:  time.Now(),
-		}
-		m.sessions = insertAfterKey(m.sessions, ev.SessionKey, card)
-		m.statusMsg = fmt.Sprintf("✓ Sub-agent done: %s", shortSessionKey(payload.ChildSessionKey))
+	}
 
-	case runtime.EventChildFailed:
-		payload, ok := ev.Payload.(runtime.ChildCompletionPayload)
-		if !ok {
+	runIndicator := ""
+	if m.running {
+		spinner := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+		runIndicator = " " + spinner[m.tick%len(spinner)]
+	}
+
+	left := headerStyle.Render("🦞 ok-gobot" + runIndicator)
+	mid := headerDimStyle.Render("model: " + model)
+	right := headerDimStyle.Render("Ctrl+P sessions · Ctrl+M model · Ctrl+A abort")
+
+	midWidth := m.width - lipgloss.Width(left) - lipgloss.Width(right)
+	if midWidth < 0 {
+		midWidth = 0
+	}
+	mid = lipgloss.NewStyle().
+		Background(lipgloss.Color("17")).
+		Foreground(lipgloss.Color("240")).
+		Width(midWidth).
+		Render(mid)
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, mid, right)
+}
+
+// renderStatus renders the bottom status bar.
+func (m *Model) renderStatus() string {
+	sessionName := ""
+	for _, s := range m.sessions {
+		if s.ID == m.activeSession {
+			sessionName = s.Name
 			break
 		}
-		m.sessions = setSessionStatus(m.sessions, payload.ChildSessionKey, StatusDone)
-		errStr := "unknown error"
-		if payload.Err != nil {
-			errStr = payload.Err.Error()
-		}
-		card := SessionEntry{
-			Key:        "notify:" + ev.SessionKey + ":" + payload.ChildSessionKey,
-			Label:      "✗ Sub-agent failed: " + shortSessionKey(payload.ChildSessionKey),
-			Status:     StatusDone,
-			IsSubagent: false,
-			SpawnedAt:  time.Now(),
-		}
-		m.sessions = insertAfterKey(m.sessions, ev.SessionKey, card)
-		m.statusMsg = fmt.Sprintf("✗ Sub-agent failed (%s): %s", shortSessionKey(payload.ChildSessionKey), errStr)
 	}
-	return m
+
+	left := statusKeyStyle.Render("session")
+	leftVal := statusValueStyle.Render(" " + sessionName + " ")
+
+	var errPart string
+	if m.lastErr != "" {
+		errPart = inlineErrorStyle.Render(" " + m.lastErr)
+	}
+
+	statusText := m.statusMsg
+	if statusText == "" {
+		statusText = "/abort · /new · /model [name] · enter to send"
+	}
+	hint := statusBarStyle.Width(m.width - lipgloss.Width(left) - lipgloss.Width(leftVal) - lipgloss.Width(errPart)).
+		Render(statusText)
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, leftVal, hint, errPart)
 }
 
-// setSessionStatus returns a copy of entries with the status of the entry
-// matching key updated to status. No-op if the key is not found.
-func setSessionStatus(entries []SessionEntry, key string, status SessionStatus) []SessionEntry {
-	for i, s := range entries {
-		if s.Key == key {
-			entries[i].Status = status
-			return entries
-		}
+// renderInput renders the text input area.
+func (m *Model) renderInput() string {
+	borderStyle := inputBorderStyle
+	if m.screen == screenChat {
+		borderStyle = inputBorderFocusStyle
 	}
-	return entries
+	return borderStyle.Width(m.width - 2).Render(m.input.View())
 }
 
-// insertAfterKey inserts card immediately after the first entry with Key == afterKey.
-// If afterKey is not found, card is appended to the end.
-func insertAfterKey(entries []SessionEntry, afterKey string, card SessionEntry) []SessionEntry {
-	for i, s := range entries {
-		if s.Key == afterKey {
-			result := make([]SessionEntry, 0, len(entries)+1)
-			result = append(result, entries[:i+1]...)
-			result = append(result, card)
-			result = append(result, entries[i+1:]...)
-			return result
-		}
-	}
-	return append(entries, card)
-}
-
-// shortSessionKey returns the last segment of a colon-separated session key,
-// truncated to 30 characters.
-func shortSessionKey(key string) string {
-	parts := strings.Split(key, ":")
-	short := parts[len(parts)-1]
-	if len(short) > 30 {
-		short = short[:27] + "..."
-	}
-	return short
-}
-
-// updateDialog handles messages when the spawn dialog is active.
-func (m AppModel) updateDialog(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg.(type) {
-	case spawnConfirmedMsg:
-		req := msg.(spawnConfirmedMsg).req
-		entry := m.sessionFromRequest(req)
-		m.sessions = append(m.sessions, entry)
-		m.selectedIdx = len(m.sessions) - 1
-		m.showDialog = false
-		m.statusMsg = fmt.Sprintf("Spawned: %s", entry.Label)
-		return m, nil
-
-	case spawnCancelledMsg:
-		m.showDialog = false
-		m.statusMsg = "Spawn cancelled"
-		return m, nil
-	}
-
-	// Forward to dialog.
-	var cmd tea.Cmd
-	m.dialog, cmd = m.dialog.Update(msg)
-	return m, cmd
-}
-
-// sessionFromRequest creates a SessionEntry from a spawn request.
-func (m AppModel) sessionFromRequest(req SubagentSpawnRequest) SessionEntry {
-	slug := fmt.Sprintf("run-%d", time.Now().UnixMilli())
-	label := req.Task
-	if len(label) > 40 {
-		label = label[:37] + "..."
-	}
-	if label == "" {
-		label = slug
-	}
-	return SessionEntry{
-		Key:        fmt.Sprintf("agent:default:subagent:%s", slug),
-		Label:      label,
-		Status:     StatusActive,
-		IsSubagent: true,
-		SpawnedAt:  time.Now(),
-	}
-}
-
-// View implements tea.Model.
-func (m AppModel) View() string {
-	if m.showDialog {
-		return m.dialogOverlay()
-	}
-	return m.sessionListView()
-}
-
-// sessionListView renders the session picker.
-func (m AppModel) sessionListView() string {
+// renderChatLog builds the full chat log string for the viewport.
+func (m *Model) renderChatLog() string {
 	var sb strings.Builder
-
-	headerStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("212")).
-		BorderStyle(lipgloss.NormalBorder()).
-		BorderBottom(true).
-		Width(60).
-		MarginBottom(1)
-
-	sb.WriteString(headerStyle.Render("ok-gobot — Sessions"))
-	sb.WriteString("\n")
-
-	selectedStyle := lipgloss.NewStyle().
-		Background(lipgloss.Color("236")).
-		Foreground(lipgloss.Color("212")).
-		Bold(true).
-		PaddingLeft(1).PaddingRight(1)
-
-	normalStyle := lipgloss.NewStyle().
-		PaddingLeft(1).PaddingRight(1)
-
-	subagentPrefixStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("33"))
-
-	for i, s := range m.sessions {
-		label := s.Label
-		if s.IsSubagent {
-			label = subagentPrefixStyle.Render("↳ ") + label
+	for i, e := range m.entries {
+		if i > 0 {
+			sb.WriteString("\n")
 		}
-
-		statusBadge := statusBadge(s.Status)
-		line := fmt.Sprintf("%-44s %s", label, statusBadge)
-
-		if i == m.selectedIdx {
-			sb.WriteString(selectedStyle.Render(line))
-		} else {
-			sb.WriteString(normalStyle.Render(line))
-		}
-		sb.WriteString("\n")
+		sb.WriteString(m.renderEntry(e))
 	}
-
-	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
-		MarginTop(1)
-
-	sb.WriteString("\n")
-	sb.WriteString(helpStyle.Render("n spawn  j/k navigate  q quit"))
-
-	if m.statusMsg != "" {
-		msgStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("42")).MarginTop(1)
-		sb.WriteString("\n")
-		sb.WriteString(msgStyle.Render(m.statusMsg))
-	}
-
 	return sb.String()
 }
 
-// dialogOverlay renders the spawn dialog centred over the session list.
-func (m AppModel) dialogOverlay() string {
-	dialogContent := m.dialog.View()
+// renderEntry renders one chat entry.
+func (m *Model) renderEntry(e chatEntry) string {
+	switch e.role {
+	case "user":
+		label := userLabelStyle.Render("You")
+		msg := userMsgStyle.Render(wrapText(e.content, m.width-6))
+		return label + "\n" + msg
 
-	boxStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("212")).
-		Padding(1, 2).
-		Width(66)
+	case "assistant":
+		label := botLabelStyle.Render("Bot")
+		text := e.content
+		cursor := ""
+		if e.streaming {
+			cursor = streamingCursorStyle.Render("█")
+		}
+		msg := botMsgStyle.Render(wrapText(text, m.width-6))
+		return label + "\n" + msg + cursor
 
-	box := boxStyle.Render(dialogContent)
+	case "tool":
+		return m.renderToolCard(e)
 
-	if m.width > 0 && m.height > 0 {
-		return lipgloss.Place(m.width, m.height,
-			lipgloss.Center, lipgloss.Center, box)
+	case "error":
+		return inlineErrorStyle.Render("⚠ " + e.content)
 	}
-
-	return box
+	return e.content
 }
 
-// statusBadge returns a coloured status indicator string.
-func statusBadge(s SessionStatus) string {
-	switch s {
-	case StatusActive:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Render("● active")
-	case StatusQueued:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("◌ queued")
-	case StatusDone:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("33")).Render("✓ done")
-	default:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("○ idle")
+// renderToolCard renders a tool invocation card.
+func (m *Model) renderToolCard(e chatEntry) string {
+	var sb strings.Builder
+	sb.WriteString(toolNameStyle.Render("⚙ " + e.toolName))
+	if e.toolArgs != "" {
+		sb.WriteString("\n" + toolArgStyle.Render("  args: "+truncate(e.toolArgs, 120)))
+	}
+	if e.toolRes != "" {
+		sb.WriteString("\n" + toolResultStyle.Render("  → "+truncate(e.toolRes, 200)))
+	}
+	if e.toolErr != "" {
+		sb.WriteString("\n" + toolErrorStyle.Render("  ✗ "+e.toolErr))
+	}
+	inner := sb.String()
+	return toolCardBorderStyle.Width(m.width - 4).Render(inner)
+}
+
+// overlayApproval renders the approval dialog over the base view.
+func (m *Model) overlayApproval(base string) string {
+	yes := approvalYesStyle.Render("  Yes  ")
+	no := approvalNoStyle.Render("  No  ")
+	if m.approvalSel == 1 {
+		yes = approvalNoStyle.Render("  Yes  ")
+		no = approvalYesStyle.Render("  No  ")
+	}
+	buttons := lipgloss.JoinHorizontal(lipgloss.Top, yes, "  ", no)
+
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		approvalTitleStyle.Render("Approval Required"),
+		"",
+		"Command:",
+		approvalCmdStyle.Render("  "+m.approvalCmd+"  "),
+		"",
+		buttons,
+		"",
+		lipgloss.NewStyle().Foreground(colorMuted).Render("← → to select · Enter to confirm · Esc to deny"),
+	)
+
+	box := approvalBoxStyle.Render(content)
+	return placeOverlay(m.width, m.height, base, box)
+}
+
+// overlaySessionList renders the session picker overlay.
+func (m *Model) overlaySessionList(base string) string {
+	var items []string
+	for i, s := range m.sessions {
+		prefix := "  "
+		style := sessionItemStyle
+		if i == m.sessionCursor {
+			prefix = "▶ "
+			style = sessionItemActiveStyle
+		}
+		running := ""
+		if s.Running {
+			running = sessionRunningStyle.Render(" ●")
+		}
+		label := prefix + s.Name + " [" + s.Model + "]" + running
+		if s.ID == m.activeSession {
+			label += " ★"
+		}
+		items = append(items, style.Render(label))
+	}
+	items = append(items, lipgloss.NewStyle().Foreground(colorMuted).Render("  [n] new session"))
+
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		sessionItemActiveStyle.Render("Sessions (Ctrl+P / Esc to close)"),
+		"",
+	)
+	content += strings.Join(items, "\n")
+
+	box := sessionListBorderStyle.Render(content)
+	return placeOverlay(m.width, m.height, base, box)
+}
+
+// overlayModelList renders the model picker overlay.
+func (m *Model) overlayModelList(base string) string {
+	var items []string
+	for i, model := range m.modelList {
+		prefix := "  "
+		style := modelItemStyle
+		if i == m.modelCursor {
+			prefix = "▶ "
+			style = modelItemActiveStyle
+		}
+		items = append(items, style.Render(prefix+model))
+	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		modelItemActiveStyle.Render("Select Model (Ctrl+M / Esc to close)"),
+		"",
+	)
+	content += strings.Join(items, "\n")
+
+	box := modelListBorderStyle.Render(content)
+	return placeOverlay(m.width, m.height, base, box)
+}
+
+// --- Helpers ---
+
+// listenCmd returns a command that reads from the WebSocket and sends messages into Update.
+func (m *Model) listenCmd() tea.Cmd {
+	return func() tea.Msg {
+		msg, err := m.conn.readMsg()
+		if err != nil {
+			return serverError{err: err}
+		}
+		return serverMsgReceived{msg: msg}
 	}
 }
 
-// Run launches the TUI, blocking until the user quits.
-func Run(initial []SessionEntry) error {
-	m := NewAppModel(initial)
-	p := tea.NewProgram(m, tea.WithAltScreen())
-	_, err := p.Run()
-	return err
+// sendCmd sends a ClientMsg over WebSocket (fire and forget).
+func (m *Model) sendCmd(msg controlserver.ClientMsg) {
+	if err := m.conn.send(msg); err != nil {
+		m.lastErr = fmt.Sprintf("send error: %v", err)
+	}
+}
+
+// addEntry appends a chat entry.
+func (m *Model) addEntry(e chatEntry) {
+	m.entries = append(m.entries, e)
+}
+
+// refreshViewport re-renders the chat log into the viewport.
+func (m *Model) refreshViewport() {
+	log := m.renderChatLog()
+	m.viewport.SetContent(log)
+	m.viewport.GotoBottom()
+}
+
+// resizeComponents updates layout-sensitive components after a window resize.
+func (m *Model) resizeComponents() {
+	inputHeight := m.inputAreaHeight()
+	headerH := 1
+	statusH := 1
+	chatH := m.height - headerH - statusH - inputHeight
+	if chatH < 2 {
+		chatH = 2
+	}
+	m.viewport.Width = m.width
+	m.viewport.Height = chatH
+	m.input.SetWidth(m.width - 4) // account for border padding
+	m.refreshViewport()
+}
+
+// inputAreaHeight returns the number of rows the input area occupies.
+func (m *Model) inputAreaHeight() int {
+	// 1 border top + lines + 1 border bottom + padding
+	return m.input.Height() + 2
+}
+
+// setStatus sets a temporary status message.
+func (m *Model) setStatus(s string) {
+	m.statusMsg = s
+	m.statusAt = time.Now()
+}
+
+// submitApproval sends the approval response to the server.
+func (m *Model) submitApproval() {
+	approved := m.approvalSel == 0
+	m.sendCmd(controlserver.ClientMsg{
+		Type:       controlserver.CmdApprove,
+		SessionID:  m.activeSession,
+		ApprovalID: m.approvalID,
+		Approved:   approved,
+	})
+	m.approvalID = ""
+	m.approvalCmd = ""
+	m.screen = screenChat
+}
+
+// tickEvery returns a command that fires after 100ms.
+func tickEvery() tea.Cmd {
+	return tea.Tick(100*time.Millisecond, func(t time.Time) tea.Msg {
+		return tickMsg(t)
+	})
+}
+
+// placeOverlay centres a box string over the base.
+func placeOverlay(totalW, totalH int, base, box string) string {
+	boxW := lipgloss.Width(box)
+	boxH := lipgloss.Height(box)
+
+	x := (totalW - boxW) / 2
+	y := (totalH - boxH) / 2
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+
+	baseLines := strings.Split(base, "\n")
+	boxLines := strings.Split(box, "\n")
+
+	for i, bLine := range boxLines {
+		row := y + i
+		if row >= len(baseLines) {
+			break
+		}
+		baseLine := baseLines[row]
+		baseRunes := []rune(baseLine)
+		// Pad base line if needed
+		for len(baseRunes) < totalW {
+			baseRunes = append(baseRunes, ' ')
+		}
+		// Overwrite the portion with boxLine
+		bRunes := []rune(bLine)
+		for j, r := range bRunes {
+			col := x + j
+			if col < len(baseRunes) {
+				baseRunes[col] = r
+			}
+		}
+		baseLines[row] = string(baseRunes)
+	}
+	return strings.Join(baseLines, "\n")
+}
+
+// wrapText word-wraps text to the given width.
+func wrapText(text string, width int) string {
+	if width <= 0 {
+		return text
+	}
+	var sb strings.Builder
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(hardWrap(line, width))
+	}
+	return sb.String()
+}
+
+// hardWrap wraps a single line at width, inserting newlines.
+func hardWrap(line string, width int) string {
+	if utf8.RuneCountInString(line) <= width {
+		return line
+	}
+	runes := []rune(line)
+	var sb strings.Builder
+	for i := 0; i < len(runes); i += width {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		end := i + width
+		if end > len(runes) {
+			end = len(runes)
+		}
+		sb.WriteString(string(runes[i:end]))
+	}
+	return sb.String()
+}
+
+// truncate shortens a string to at most n runes.
+func truncate(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "…"
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -1,0 +1,162 @@
+package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	// Colors
+	colorPrimary = lipgloss.Color("63")  // purple-ish
+	colorAccent  = lipgloss.Color("86")  // green
+	colorWarning = lipgloss.Color("220") // yellow
+	colorError   = lipgloss.Color("196") // red
+	colorMuted   = lipgloss.Color("240") // dark grey
+	colorUser    = lipgloss.Color("75")  // blue
+	colorBot     = lipgloss.Color("213") // pink/magenta
+	colorTool    = lipgloss.Color("214") // orange
+	colorSubtle  = lipgloss.Color("238") // very dark
+
+	// Status bar at the bottom
+	statusBarStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color("235")).
+			Foreground(lipgloss.Color("250")).
+			Padding(0, 1)
+
+	statusKeyStyle = lipgloss.NewStyle().
+			Background(colorPrimary).
+			Foreground(lipgloss.Color("230")).
+			Padding(0, 1).
+			Bold(true)
+
+	statusValueStyle = lipgloss.NewStyle().
+				Background(lipgloss.Color("236")).
+				Foreground(lipgloss.Color("252")).
+				Padding(0, 1)
+
+	// Header bar
+	headerStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color("17")).
+			Foreground(lipgloss.Color("255")).
+			Padding(0, 1).
+			Bold(true)
+
+	headerDimStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color("17")).
+			Foreground(lipgloss.Color("240")).
+			Padding(0, 1)
+
+	// Chat messages
+	userMsgStyle = lipgloss.NewStyle().
+			Foreground(colorUser).
+			Bold(true)
+
+	botMsgStyle = lipgloss.NewStyle().
+			Foreground(colorBot)
+
+	// Message prefix labels
+	userLabelStyle = lipgloss.NewStyle().
+			Foreground(colorUser).
+			Bold(true)
+
+	botLabelStyle = lipgloss.NewStyle().
+			Foreground(colorBot).
+			Bold(true)
+
+	// Tool event card
+	toolCardBorderStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(colorTool).
+				Padding(0, 1)
+
+	toolNameStyle = lipgloss.NewStyle().
+			Foreground(colorTool).
+			Bold(true)
+
+	toolArgStyle = lipgloss.NewStyle().
+			Foreground(colorMuted)
+
+	toolResultStyle = lipgloss.NewStyle().
+			Foreground(colorAccent)
+
+	toolErrorStyle = lipgloss.NewStyle().
+			Foreground(colorError)
+
+	// Approval dialog
+	approvalBoxStyle = lipgloss.NewStyle().
+				Border(lipgloss.DoubleBorder()).
+				BorderForeground(colorWarning).
+				Padding(1, 2)
+
+	approvalTitleStyle = lipgloss.NewStyle().
+				Foreground(colorWarning).
+				Bold(true)
+
+	approvalCmdStyle = lipgloss.NewStyle().
+				Foreground(colorError).
+				Background(lipgloss.Color("52")).
+				Padding(0, 1)
+
+	approvalYesStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("0")).
+				Background(colorAccent).
+				Padding(0, 2).
+				Bold(true)
+
+	approvalNoStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("0")).
+			Background(colorError).
+			Padding(0, 2).
+			Bold(true)
+
+	// Session list overlay
+	sessionListBorderStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(colorPrimary).
+				Padding(1, 2)
+
+	sessionItemStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("252"))
+
+	sessionItemActiveStyle = lipgloss.NewStyle().
+				Foreground(colorAccent).
+				Bold(true)
+
+	sessionRunningStyle = lipgloss.NewStyle().
+				Foreground(colorWarning)
+
+	// Input area
+	inputBorderStyle = lipgloss.NewStyle().
+				Border(lipgloss.NormalBorder()).
+				BorderForeground(colorPrimary).
+				Padding(0, 1)
+
+	inputBorderFocusStyle = lipgloss.NewStyle().
+				Border(lipgloss.NormalBorder()).
+				BorderForeground(colorAccent).
+				Padding(0, 1)
+
+	// Streaming cursor
+	streamingCursorStyle = lipgloss.NewStyle().
+				Foreground(colorAccent).
+				Bold(true)
+
+	// Error message inline
+	inlineErrorStyle = lipgloss.NewStyle().
+				Foreground(colorError).
+				Italic(true)
+
+	// Model picker
+	modelListBorderStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(colorAccent).
+				Padding(1, 2)
+
+	modelItemStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("252"))
+
+	modelItemActiveStyle = lipgloss.NewStyle().
+				Foreground(colorAccent).
+				Bold(true)
+
+	// Subtle divider
+	_ = lipgloss.NewStyle().
+		Foreground(colorSubtle)
+)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,0 +1,92 @@
+// Package tui provides the terminal UI for ok-gobot built with Bubble Tea.
+// It connects to the local control server over WebSocket and provides
+// a first-class interactive surface alongside Telegram.
+package tui
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"ok-gobot/internal/controlserver"
+)
+
+// defaultModelList is the set of models shown in the model picker.
+var defaultModelList = []string{
+	"moonshotai/kimi-k2.5",
+	"anthropic/claude-opus-4-5-20251101",
+	"anthropic/claude-sonnet-4-5-20250929",
+	"anthropic/claude-haiku-3-5-20241022",
+	"openai/gpt-4o",
+	"openai/gpt-4o-mini",
+	"google/gemini-2.5-pro",
+	"google/gemini-2.5-flash",
+	"deepseek/deepseek-chat-v3-0324",
+}
+
+// Options configures the TUI startup.
+type Options struct {
+	// ServerAddr is the address of the control server (e.g. "127.0.0.1:9099").
+	ServerAddr string
+	// ModelList overrides the built-in model picker list.
+	ModelList []string
+}
+
+// Run starts the Bubble Tea TUI and blocks until the user quits.
+func Run(opts Options) error {
+	conn, err := dialWS(opts.ServerAddr)
+	if err != nil {
+		return fmt.Errorf("connect to control server at %s: %w", opts.ServerAddr, err)
+	}
+
+	modelList := opts.ModelList
+	if len(modelList) == 0 {
+		modelList = defaultModelList
+	}
+
+	m := newModel(conn, opts.ServerAddr, modelList)
+
+	p := tea.NewProgram(m,
+		tea.WithAltScreen(),
+		tea.WithMouseCellMotion(),
+	)
+
+	if _, err := p.Run(); err != nil {
+		return fmt.Errorf("TUI error: %w", err)
+	}
+	return nil
+}
+
+// newModel creates the initial Model.
+func newModel(conn *wsConn, addr string, models []string) *Model {
+	// Textarea for input
+	ta := textarea.New()
+	ta.Placeholder = "Type a message… (Enter to send, Alt+Enter for newline)"
+	ta.Focus()
+	ta.SetHeight(3)
+	ta.SetWidth(80)
+	ta.CharLimit = 4096
+	ta.ShowLineNumbers = false
+
+	// We keep the textarea single-line feel by default; Alt+Enter can add lines
+	ta.KeyMap.InsertNewline.SetKeys("alt+enter")
+
+	// Viewport for chat log
+	vp := viewport.New(80, 20)
+	vp.SetContent("")
+
+	// Seed the listenCmd loop - get the first server msg to discover sessions
+	// We send a list_sessions command right away
+	_ = conn.send(controlserver.ClientMsg{Type: controlserver.CmdListSessions})
+
+	return &Model{
+		conn:       conn,
+		serverAddr: addr,
+		streamIdx:  -1,
+		viewport:   vp,
+		input:      ta,
+		modelList:  models,
+	}
+}


### PR DESCRIPTION
Implements #17

## Changes

### New: `internal/controlserver` package
- **WebSocket hub** — manages connected TUI clients, broadcasts events to all
- **Session manager** — creates and manages AI conversation sessions in-process; each session has its own AI client and conversation history
- **HTTP server** — listens on `127.0.0.1:9099` (configurable), upgrades `/ws` to WebSocket, serves `/health`
- **JSON event protocol** — server→client events (`token`, `message`, `tool_start`, `tool_end`, `run_start`, `run_end`, `approval_request`, `queue_update`) and client→server commands (`send`, `abort`, `approve`, `set_model`, `list_sessions`, `new_session`, `switch_session`)

### New: `internal/tui` package
- **Bubble Tea model** — full Update/View cycle with `viewport` for scrollable chat log and `textarea` for input
- **Lip Gloss styles** — colour-coded: user messages (blue), bot messages (pink), tool cards (orange), approval dialogs (yellow/red)
- **Live token streaming** — characters stream in real time with a blinking `█` cursor during active runs
- **Tool event cards** — inline rounded-border cards showing tool name, args, result/error
- **Session picker overlay** — `Ctrl+P` opens a list of sessions; `Enter` switches, `n` creates a new one
- **Model picker overlay** — `Ctrl+M` opens a model list; `Enter` applies override for the current session
- **Approval prompt dialog** — blocks rendering until user presses `y`/`n` or `Enter`; response sent back over WebSocket
- **Abort** — `Ctrl+A` or `/abort` in chat sends a cancel signal; active run's context is cancelled server-side
- **Run state spinner** — animated `⠋…⠏` indicator in the header while a run is active
- **In-chat commands** — `/abort`, `/new [name]`, `/model <name>`
- **WebSocket client** — connects to the control server with `gobwas/ws` (already in go.mod)

### New: `internal/cli/tui.go`
- `ok-gobot tui` command
- Starts an embedded control server automatically (or `--server` to use an external one)
- `--no-server` flag to skip the embedded server
- `--models` flag to override the model picker list

### New dependency: Bubble Tea ecosystem
- `github.com/charmbracelet/bubbletea`
- `github.com/charmbracelet/lipgloss`
- `github.com/charmbracelet/bubbles` (viewport, textarea)

## Testing

- `go build ./...` — clean build
- `go vet ./...` — no issues
- `go test ./...` — all existing tests pass (pre-existing flaky debounce timing test passes in non-loaded runs)
- `./ok-gobot tui --help` — displays full help with key bindings
- Manual: `./ok-gobot tui` starts the embedded control server and launches the TUI (requires AI API key in config)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a comprehensive TUI (Terminal User Interface) using Bubble Tea, along with a WebSocket-based control server for managing AI conversation sessions. The architecture separates concerns well with dedicated packages for the control server and TUI client.

**Major additions:**
- `internal/controlserver` package provides session management, WebSocket hub, and HTTP server
- `internal/tui` package implements full Bubble Tea UI with streaming, overlays, and keyboard controls
- Clean separation between server-side session logic and client-side rendering

**Key issues identified:**
- Critical: TUI listen loop only processes one WebSocket message then stops (already flagged)
- WebSocket connection not properly closed when TUI exits (already flagged)
- Approval requests block indefinitely without timeout, risking goroutine leaks (already flagged)
- Approval map entries accumulate without cleanup on timeout/disconnect (already flagged)
- Connection error handling incomplete - no reconnection logic (already flagged)
- Minor: Sequential broadcast could block if a client becomes slow

**Strengths:**
- Well-structured code with clear separation of concerns
- Proper mutex usage for concurrent access
- Good use of Bubble Tea patterns for UI state management
- Comprehensive command set and keyboard shortcuts

The implementation is well-architected but has several resource management issues that need resolution before production use.

<h3>Confidence Score: 2/5</h3>

- This PR has critical bugs that prevent core functionality from working correctly
- The TUI will only receive the first WebSocket message due to the listen loop not restarting, making it essentially non-functional for interactive use. Combined with resource leaks (unclosed connections, goroutine leaks from blocking approvals, memory leaks in approval map), this needs fixes before merge
- Pay close attention to `internal/tui/model.go` (listen loop bug) and `internal/controlserver/session.go` (approval timeout and memory leak issues)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/controlserver/hub.go | WebSocket client hub with broadcast capability - simple but broadcasts sequentially |
| internal/controlserver/server.go | HTTP server with WebSocket upgrade and command routing - solid implementation |
| internal/controlserver/session.go | Session manager with AI client integration - has known issues with approval timeout and memory leak |
| internal/tui/model.go | Bubble Tea model implementation - critical bug where WebSocket listen loop only fires once |
| internal/tui/tui.go | TUI entry point - WebSocket connection not closed on exit (known issue) |

</details>



<sub>Last reviewed commit: 7ec9dc8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->