### PR TITLE
feat: /task command with --model --thinking flags (#19)

### DIFF
--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -1,0 +1,15 @@
+package agent
+
+// SubagentSpawnRequest defines parameters for spawning a child sub-agent.
+type SubagentSpawnRequest struct {
+	Description string // Task description passed to the sub-agent
+	Model       string // Optional model override (empty = use caller's default)
+	ThinkLevel  string // Optional thinking level: off, low, medium, high
+}
+
+// SubagentResult holds the outcome of a completed sub-agent run.
+type SubagentResult struct {
+	Success bool
+	Summary string
+	Error   error
+}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -140,6 +140,7 @@ func (b *Bot) registerCommands() {
 		{Text: "new", Description: "Start a new session"},
 		{Text: "clear", Description: "Clear conversation history"},
 		{Text: "stop", Description: "Stop the current run"},
+		{Text: "task", Description: "Spawn a sub-agent task [--model ...] [--thinking ...]"},
 		{Text: "memory", Description: "Show today's memory"},
 		{Text: "tools", Description: "List available tools"},
 		{Text: "model", Description: "Show or set AI model"},

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -14,6 +14,10 @@ import (
 
 // registerExtraHandlers registers all additional command handlers
 func (b *Bot) registerExtraHandlers() {
+	b.api.Handle("/task", func(c telebot.Context) error {
+		return b.handleTaskCommand(c)
+	})
+
 	b.api.Handle("/whoami", func(c telebot.Context) error {
 		return b.handleWhoamiCommand(c)
 	})
@@ -105,6 +109,7 @@ func (b *Bot) handleCommandsCommand(c telebot.Context) error {
 		{"new", "Start a new session"},
 		{"clear", "Clear conversation history"},
 		{"stop", "Stop the current run"},
+		{"task", "Spawn a sub-agent task [--model ...] [--thinking ...]"},
 		{"memory", "Show today's memory"},
 		{"tools", "List available tools"},
 		{"model", "Show or set AI model"},

--- a/internal/bot/task_command.go
+++ b/internal/bot/task_command.go
@@ -1,0 +1,159 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/ai"
+)
+
+// parseTaskArgs parses the /task command payload into a SubagentSpawnRequest.
+// Syntax: <description> [--model <model>] [--thinking <level>]
+func parseTaskArgs(payload string) (agent.SubagentSpawnRequest, error) {
+	var req agent.SubagentSpawnRequest
+
+	if strings.TrimSpace(payload) == "" {
+		return req, fmt.Errorf("no task description provided")
+	}
+
+	words := strings.Fields(payload)
+	var descWords []string
+
+	for i := 0; i < len(words); i++ {
+		switch words[i] {
+		case "--model":
+			if i+1 >= len(words) {
+				return req, fmt.Errorf("--model requires a value")
+			}
+			i++
+			req.Model = words[i]
+		case "--thinking":
+			if i+1 >= len(words) {
+				return req, fmt.Errorf("--thinking requires a value")
+			}
+			i++
+			level := words[i]
+			validLevels := map[string]bool{"off": true, "low": true, "medium": true, "high": true}
+			if !validLevels[level] {
+				return req, fmt.Errorf("--thinking must be one of: off, low, medium, high")
+			}
+			req.ThinkLevel = level
+		default:
+			descWords = append(descWords, words[i])
+		}
+	}
+
+	req.Description = strings.Join(descWords, " ")
+	if req.Description == "" {
+		return req, fmt.Errorf("no task description provided")
+	}
+
+	return req, nil
+}
+
+// handleTaskCommand handles the /task command.
+// It spawns a sub-agent as an isolated child session and notifies the parent
+// chat with a summary or failure message when the sub-agent finishes.
+func (b *Bot) handleTaskCommand(c telebot.Context) error {
+	chatID := c.Chat().ID
+	payload := strings.TrimSpace(c.Message().Payload)
+
+	req, err := parseTaskArgs(payload)
+	if err != nil {
+		return c.Send(fmt.Sprintf("❌ Usage: /task <description> [--model <model>] [--thinking off|low|medium|high]\n\nError: %s", err))
+	}
+
+	// Resolve model: use request override, then session override, then default
+	model := req.Model
+	if model == "" {
+		model = b.getEffectiveModel(chatID)
+	}
+	// Resolve alias if set
+	model = b.resolveModelAlias(model)
+
+	// Acknowledge immediately so the user knows the task is queued
+	thinkNote := ""
+	if req.ThinkLevel != "" {
+		thinkNote = fmt.Sprintf(" (thinking: %s)", req.ThinkLevel)
+	}
+	ackMsg := fmt.Sprintf("⚙️ Sub-agent started%s\nModel: `%s`\nTask: %s",
+		thinkNote, model, req.Description)
+	if err := c.Send(ackMsg, &telebot.SendOptions{ParseMode: telebot.ModeMarkdown}); err != nil {
+		log.Printf("[task] failed to send ack: %v", err)
+	}
+
+	// Capture chat reference for the notification goroutine
+	chat := c.Chat()
+
+	go func() {
+		log.Printf("[task] spawning sub-agent for chat=%d model=%s thinking=%s desc=%.80s",
+			chatID, model, req.ThinkLevel, req.Description)
+
+		result := b.runSubagent(req, model)
+
+		var notifText string
+		if result.Success {
+			notifText = fmt.Sprintf("✅ *Task completed*\n\n%s", result.Summary)
+		} else {
+			notifText = fmt.Sprintf("❌ *Task failed*\n\n%s", result.Error.Error())
+		}
+
+		if _, err := b.api.Send(chat, notifText, &telebot.SendOptions{ParseMode: telebot.ModeMarkdown}); err != nil {
+			log.Printf("[task] failed to send completion notification to chat=%d: %v", chatID, err)
+		}
+	}()
+
+	return nil
+}
+
+// runSubagent creates a fresh ToolCallingAgent and processes the task description.
+// It is designed to run in its own goroutine as an isolated child session.
+func (b *Bot) runSubagent(req agent.SubagentSpawnRequest, model string) agent.SubagentResult {
+	// Build an AI client for the requested model
+	var aiClient ai.Client
+	if model != b.aiConfig.Model {
+		cfg := ai.ProviderConfig{
+			Name:    b.aiConfig.Provider,
+			APIKey:  b.aiConfig.APIKey,
+			Model:   model,
+			BaseURL: b.aiConfig.BaseURL,
+		}
+		var err error
+		aiClient, err = ai.NewClient(cfg)
+		if err != nil {
+			log.Printf("[task] failed to create AI client for model %s: %v", model, err)
+			aiClient = b.ai // fall back to default
+		}
+	} else {
+		aiClient = b.ai
+	}
+
+	// Get personality from default agent profile
+	profile := b.getActiveAgentProfile(0) // 0 = no chat, returns default
+	filteredTools := b.getFilteredToolRegistry(profile)
+
+	subAgent := agent.NewToolCallingAgent(aiClient, filteredTools, profile.Personality)
+	subAgent.SetModelAliases(b.aiConfig.ModelAliases)
+	if req.ThinkLevel != "" {
+		subAgent.SetThinkLevel(req.ThinkLevel)
+	}
+
+	// Run the sub-agent with a background context (not tied to the HTTP request)
+	ctx := context.Background()
+	resp, err := subAgent.ProcessRequest(ctx, req.Description, "")
+	if err != nil {
+		return agent.SubagentResult{Success: false, Error: err}
+	}
+
+	summary := resp.Message
+	if strings.TrimSpace(summary) == "" {
+		summary = "Task completed with no output."
+	}
+
+	return agent.SubagentResult{Success: true, Summary: summary}
+}


### PR DESCRIPTION
Implements #19

## Changes

- **`internal/agent/subagent.go`** — new file: defines `SubagentSpawnRequest` (description, model, think-level) and `SubagentResult` (success, summary, error) types used for child session lifecycle
- **`internal/bot/task_command.go`** — new file: `parseTaskArgs` that parses `<description> [--model <model>] [--thinking off|low|medium|high]` flags, `handleTaskCommand` that acknowledges the request immediately and spawns `runSubagent` in a goroutine, `runSubagent` that creates a fresh `ToolCallingAgent` (isolated child session, no parent history) and notifies the parent chat on completion or failure
- **`internal/bot/commands.go`** — register `/task` handler and add it to `/commands` list
- **`internal/bot/bot.go`** — add `/task` to BotFather command registration

## Acceptance Criteria

- [x] `/task` parses description and optional `--model`, `--thinking` flags
- [x] Sub-agent is spawned as a child session via `SubagentSpawnRequest`
- [x] Parent Telegram session receives a completion notification (summary or failure) when the child run finishes

## Testing

- All existing tests pass (`go test ./...`)
- Binary builds successfully (`go build ./cmd/ok-gobot/`)
- Flag parser manually verified: description-only, `--model`, `--thinking`, combined flags, flags before description, error cases (missing value, invalid thinking level, empty description)

### Usage examples
```
/task write a hello world Go program
/task write a hello world Go program --model sonnet
/task write a hello world Go program --thinking high
/task write a hello world Go program --model anthropic/claude-3.5-sonnet --thinking medium
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the `/task` command to spawn isolated sub-agent sessions with configurable model and thinking level flags. The implementation successfully parses command arguments, spawns sub-agents asynchronously, and notifies the parent session upon completion.

**Key changes:**
- Added `SubagentSpawnRequest` and `SubagentResult` types for sub-agent lifecycle management
- Implemented flag parser supporting `--model` and `--thinking` options with proper validation
- Sub-agent runs in separate goroutine with fresh `ToolCallingAgent` instance (no parent history)
- Immediate acknowledgment sent to avoid blocking user interaction

**Issues found:**
- **Critical:** Missing authorization check in `/task` handler allows unauthorized users to spawn sub-agents. Media handlers and admin commands explicitly verify access, but `/task` bypasses this check.
- Sub-agents use `context.Background()` preventing cancellation - no way to stop a running sub-agent task
- Minor Markdown rendering risk if model name contains special characters

<h3>Confidence Score: 2/5</h3>

- Not safe to merge - missing authorization check creates security vulnerability
- The authorization bypass is a critical security issue that allows any Telegram user to spawn potentially expensive sub-agent tasks regardless of bot access controls. The implementation is otherwise sound (good error handling, clean architecture), but this security gap must be addressed before merging.
- `internal/bot/task_command.go` requires authorization check at the start of `handleTaskCommand` function (similar to media handlers pattern)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/agent/subagent.go | Added simple type definitions for sub-agent spawn requests and results |
| internal/bot/task_command.go | Implemented `/task` command with flag parsing and async sub-agent execution, but missing authorization check allows unauthorized users to spawn sub-agents |
| internal/bot/bot.go | Registered `/task` command in BotFather command list |
| internal/bot/commands.go | Registered `/task` handler and added to commands list |

</details>



<sub>Last reviewed commit: cb52648</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->