### PR TITLE
feat: sub-agent spawn API in runtime (#18)

### DIFF
--- a/internal/runtime/subagent.go
+++ b/internal/runtime/subagent.go
@@ -1,0 +1,108 @@
+package runtime
+
+import (
+	"crypto/rand"
+	"fmt"
+	"strings"
+	"time"
+
+	"ok-gobot/internal/session"
+)
+
+// SubagentSpawnRequest carries all parameters needed to spawn a sub-agent run.
+type SubagentSpawnRequest struct {
+	// ParentSessionKey is the canonical session key of the calling session.
+	// Must follow the format: agent:<agentId>:<rest>
+	ParentSessionKey string
+
+	// Task is the task description sent to the sub-agent.
+	Task string
+
+	// Model is the model identifier to use for the sub-agent run.
+	// Empty string means the sub-agent inherits the default model.
+	Model string
+
+	// Thinking controls the reasoning level: "off", "low", "medium", "high".
+	Thinking string
+
+	// ToolAllowlist is the set of tool names the sub-agent is permitted to call.
+	// An empty slice means no restriction (all tools allowed).
+	ToolAllowlist []string
+
+	// WorkspaceRoot is the absolute path scoped to the sub-agent's workspace.
+	WorkspaceRoot string
+
+	// DeliverBack, when true, routes the sub-agent result back to the parent session.
+	DeliverBack bool
+}
+
+// SubagentHandle holds the resolved identifiers for a successfully spawned sub-agent.
+type SubagentHandle struct {
+	// SessionKey is the canonical key assigned to the child session.
+	// Format: agent:<agentId>:subagent:<runSlug>
+	SessionKey string
+
+	// RunSlug is the unique slug component used to construct SessionKey.
+	RunSlug string
+
+	// AgentID is the agent identifier extracted from the parent session key.
+	AgentID string
+
+	// Ack is the AckHandle returned by Hub.Submit for the child run.
+	Ack AckHandle
+}
+
+// SpawnSubagent creates an isolated child session worker for req.
+//
+// It extracts the agentID from req.ParentSessionKey, generates a unique
+// runSlug, constructs the canonical child session key
+// (agent:<agentId>:subagent:<runSlug>), and submits run to the Hub.
+//
+// The caller is responsible for any persistence of the subagent run record;
+// SpawnSubagent only manages the runtime lifecycle.
+func (h *Hub) SpawnSubagent(req SubagentSpawnRequest, run RunFunc) (*SubagentHandle, error) {
+	agentID, err := extractAgentID(req.ParentSessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("runtime: SpawnSubagent: %w", err)
+	}
+
+	runSlug := newRunSlug()
+	childKey := session.Subagent(agentID, runSlug)
+
+	ack := h.Submit(childKey, runSlug, run)
+
+	return &SubagentHandle{
+		SessionKey: childKey,
+		RunSlug:    runSlug,
+		AgentID:    agentID,
+		Ack:        ack,
+	}, nil
+}
+
+// extractAgentID parses the agent ID from a canonical session key.
+// Expected format: agent:<agentId>:<rest> or agent:<agentId>
+func extractAgentID(sessionKey string) (string, error) {
+	const prefix = "agent:"
+	if !strings.HasPrefix(sessionKey, prefix) {
+		return "", fmt.Errorf("session key must begin with %q, got %q", prefix, sessionKey)
+	}
+	rest := sessionKey[len(prefix):]
+	if rest == "" {
+		return "", fmt.Errorf("empty agent ID in session key %q", sessionKey)
+	}
+	idx := strings.Index(rest, ":")
+	if idx == 0 {
+		return "", fmt.Errorf("empty agent ID in session key %q", sessionKey)
+	}
+	if idx == -1 {
+		return rest, nil
+	}
+	return rest[:idx], nil
+}
+
+// newRunSlug returns a unique slug using a nanosecond timestamp and 4 random bytes.
+func newRunSlug() string {
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%d-%x", time.Now().UnixNano(), b)
+}

--- a/internal/runtime/subagent_test.go
+++ b/internal/runtime/subagent_test.go
@@ -1,0 +1,171 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestExtractAgentID verifies that agent IDs are correctly parsed from session keys.
+func TestExtractAgentID(t *testing.T) {
+	cases := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{input: "agent:myAgent:main", want: "myAgent"},
+		{input: "agent:bot1:telegram:dm:12345", want: "bot1"},
+		{input: "agent:bot2:telegram:group:99", want: "bot2"},
+		{input: "agent:molt:subagent:abc-123", want: "molt"},
+		{input: "agent:solo", want: "solo"},
+		{input: "telegram:foo", wantErr: true},
+		{input: "agent:", wantErr: true},
+		{input: "agent::rest", wantErr: true},
+		{input: "", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		got, err := extractAgentID(tc.input)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("extractAgentID(%q): expected error, got %q", tc.input, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("extractAgentID(%q): unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("extractAgentID(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestNewRunSlugUnique verifies that successive slugs are unique.
+func TestNewRunSlugUnique(t *testing.T) {
+	seen := make(map[string]bool, 100)
+	for i := 0; i < 100; i++ {
+		s := newRunSlug()
+		if seen[s] {
+			t.Fatalf("newRunSlug returned duplicate slug %q", s)
+		}
+		seen[s] = true
+	}
+}
+
+// TestSpawnSubagentSessionKeyFormat verifies that SpawnSubagent produces a child
+// session key in the expected "agent:<agentId>:subagent:<runSlug>" format.
+func TestSpawnSubagentSessionKeyFormat(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	hub := NewHub(ctx, 10)
+
+	var executed bool
+	req := SubagentSpawnRequest{
+		ParentSessionKey: "agent:testAgent:telegram:dm:42",
+		Task:             "do something",
+		Model:            "claude-3-haiku",
+		Thinking:         "low",
+		ToolAllowlist:    []string{"search", "file"},
+		WorkspaceRoot:    "/tmp/workspace",
+		DeliverBack:      true,
+	}
+
+	done := make(chan struct{})
+	handle, err := hub.SpawnSubagent(req, func(ctx context.Context, ack AckHandle) {
+		defer close(done)
+		executed = true
+		ack.Close(nil)
+	})
+
+	if err != nil {
+		t.Fatalf("SpawnSubagent returned unexpected error: %v", err)
+	}
+
+	// Verify handle fields.
+	if handle.AgentID != "testAgent" {
+		t.Errorf("AgentID = %q, want %q", handle.AgentID, "testAgent")
+	}
+	if handle.RunSlug == "" {
+		t.Error("RunSlug is empty")
+	}
+	wantPrefix := "agent:testAgent:subagent:"
+	if !strings.HasPrefix(handle.SessionKey, wantPrefix) {
+		t.Errorf("SessionKey = %q, want prefix %q", handle.SessionKey, wantPrefix)
+	}
+	if !strings.HasSuffix(handle.SessionKey, handle.RunSlug) {
+		t.Errorf("SessionKey = %q does not end with RunSlug %q", handle.SessionKey, handle.RunSlug)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Error("sub-agent run did not complete in time")
+	}
+
+	if !executed {
+		t.Error("RunFunc was never executed")
+	}
+}
+
+// TestSpawnSubagentInvalidParent verifies that SpawnSubagent returns an error
+// for invalid parent session keys.
+func TestSpawnSubagentInvalidParent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	hub := NewHub(ctx, 10)
+
+	_, err := hub.SpawnSubagent(SubagentSpawnRequest{
+		ParentSessionKey: "not-a-valid-key",
+		Task:             "irrelevant",
+	}, func(ctx context.Context, ack AckHandle) { ack.Close(nil) })
+
+	if err == nil {
+		t.Error("expected error for invalid parent session key, got nil")
+	}
+}
+
+// TestSpawnSubagentIsolated verifies that child sessions run independently of
+// each other and of the parent session.
+func TestSpawnSubagentIsolated(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	hub := NewHub(ctx, 10)
+
+	const numSubagents = 3
+	done := make(chan string, numSubagents)
+
+	for i := 0; i < numSubagents; i++ {
+		req := SubagentSpawnRequest{
+			ParentSessionKey: "agent:parent:main",
+			Task:             "task",
+		}
+		handle, err := hub.SpawnSubagent(req, func(ctx context.Context, ack AckHandle) {
+			time.Sleep(20 * time.Millisecond)
+			ack.Close(nil)
+		})
+		if err != nil {
+			t.Fatalf("SpawnSubagent[%d] error: %v", i, err)
+		}
+		key := handle.SessionKey
+		go func() { done <- key }()
+	}
+
+	keys := make(map[string]bool)
+	for i := 0; i < numSubagents; i++ {
+		select {
+		case k := <-done:
+			if keys[k] {
+				t.Errorf("duplicate session key: %q", k)
+			}
+			keys[k] = true
+		case <-time.After(4 * time.Second):
+			t.Fatal("timed out waiting for sub-agent completion")
+		}
+	}
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -118,6 +118,27 @@ func (s *Store) migrate() error {
 			paired_by TEXT
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_authorized_users_user_id ON authorized_users(user_id);`,
+		// Sub-agent runs table
+		`CREATE TABLE IF NOT EXISTS subagent_runs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			run_slug TEXT UNIQUE NOT NULL,
+			session_key TEXT NOT NULL,
+			parent_session_key TEXT NOT NULL,
+			agent_id TEXT NOT NULL,
+			task TEXT NOT NULL,
+			model TEXT DEFAULT '',
+			thinking TEXT DEFAULT '',
+			tool_allowlist TEXT DEFAULT '',
+			workspace_root TEXT DEFAULT '',
+			deliver_back INTEGER DEFAULT 0,
+			status TEXT NOT NULL DEFAULT 'pending',
+			result TEXT DEFAULT '',
+			error TEXT DEFAULT '',
+			spawned_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			completed_at DATETIME
+		);`,
+		`CREATE INDEX IF NOT EXISTS idx_subagent_runs_parent ON subagent_runs(parent_session_key);`,
+		`CREATE INDEX IF NOT EXISTS idx_subagent_runs_status ON subagent_runs(status);`,
 	}
 
 	for _, migration := range migrations {
@@ -631,4 +652,96 @@ func (s *Store) SetActiveAgent(chatID int64, agentName string) error {
 	// Update existing session
 	_, err = s.db.Exec("UPDATE sessions SET active_agent = ? WHERE chat_id = ?", agentName, chatID)
 	return err
+}
+
+// SubagentRun holds a persisted record of a sub-agent run.
+type SubagentRun struct {
+	ID               int64
+	RunSlug          string
+	SessionKey       string
+	ParentSessionKey string
+	AgentID          string
+	Task             string
+	Model            string
+	Thinking         string
+	ToolAllowlist    string // comma-separated
+	WorkspaceRoot    string
+	DeliverBack      bool
+	Status           string // "pending", "running", "done", "error"
+	Result           string
+	Error            string
+	SpawnedAt        string
+	CompletedAt      string
+}
+
+// RecordSubagentSpawn inserts a new subagent_runs row with status "pending".
+// toolAllowlist should be a comma-separated string of allowed tool names.
+func (s *Store) RecordSubagentSpawn(runSlug, sessionKey, parentSessionKey, agentID, task, model, thinking, toolAllowlist, workspaceRoot string, deliverBack bool) error {
+	deliverBackInt := 0
+	if deliverBack {
+		deliverBackInt = 1
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO subagent_runs
+			(run_slug, session_key, parent_session_key, agent_id, task, model, thinking, tool_allowlist, workspace_root, deliver_back, status)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')
+	`, runSlug, sessionKey, parentSessionKey, agentID, task, model, thinking, toolAllowlist, workspaceRoot, deliverBackInt)
+	return err
+}
+
+// UpdateSubagentStatus updates the status, result, and error of a subagent run.
+// Pass status="running" when the run starts; "done" or "error" on completion.
+// completedAt is ignored for non-terminal statuses.
+func (s *Store) UpdateSubagentStatus(runSlug, status, result, errMsg string) error {
+	switch status {
+	case "done", "error":
+		_, err := s.db.Exec(`
+			UPDATE subagent_runs
+			SET status = ?, result = ?, error = ?, completed_at = CURRENT_TIMESTAMP
+			WHERE run_slug = ?
+		`, status, result, errMsg, runSlug)
+		return err
+	default:
+		_, err := s.db.Exec(`
+			UPDATE subagent_runs SET status = ? WHERE run_slug = ?
+		`, status, runSlug)
+		return err
+	}
+}
+
+// GetSubagentRuns returns subagent runs for a given parent session key, newest first.
+func (s *Store) GetSubagentRuns(parentSessionKey string, limit int) ([]SubagentRun, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.Query(`
+		SELECT id, run_slug, session_key, parent_session_key, agent_id,
+		       task, model, thinking, tool_allowlist, workspace_root,
+		       deliver_back, status, result, error, spawned_at,
+		       COALESCE(completed_at, '') AS completed_at
+		FROM subagent_runs
+		WHERE parent_session_key = ?
+		ORDER BY spawned_at DESC
+		LIMIT ?
+	`, parentSessionKey, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var runs []SubagentRun
+	for rows.Next() {
+		var r SubagentRun
+		var deliverBackInt int
+		if err := rows.Scan(
+			&r.ID, &r.RunSlug, &r.SessionKey, &r.ParentSessionKey, &r.AgentID,
+			&r.Task, &r.Model, &r.Thinking, &r.ToolAllowlist, &r.WorkspaceRoot,
+			&deliverBackInt, &r.Status, &r.Result, &r.Error, &r.SpawnedAt, &r.CompletedAt,
+		); err != nil {
+			return nil, err
+		}
+		r.DeliverBack = deliverBackInt != 0
+		runs = append(runs, r)
+	}
+	return runs, rows.Err()
 }


### PR DESCRIPTION
Implements #18

## Changes

- **`internal/runtime/subagent.go`** — New file defining `SubagentSpawnRequest` and `SubagentHandle` types, plus `Hub.SpawnSubagent` method. Extracts `agentID` from the parent session key and constructs the child key in the canonical `agent:<agentId>:subagent:<runSlug>` format using `session.Subagent`. Generates a time+random slug for uniqueness. Callers receive a `SubagentHandle` with the child session key, run slug, agent ID, and `AckHandle` for progress/lifecycle events.

- **`internal/runtime/subagent_test.go`** — Tests covering: `extractAgentID` parsing correctness, `newRunSlug` uniqueness, session key format validation after spawn, error return on invalid parent key, and concurrent isolation of multiple child sessions.

- **`internal/storage/sqlite.go`** — Adds `subagent_runs` table via migration (idempotent) with columns for spawn metadata, status (`pending`/`running`/`done`/`error`), result, error text, and timestamps. Adds `RecordSubagentSpawn`, `UpdateSubagentStatus`, and `GetSubagentRuns` methods on `Store`.

## Testing

All existing and new tests pass:

```
go test ./...   # all packages pass
go build ./cmd/ok-gobot/
./ok-gobot version  # ok-gobot v0.1.0 (go)
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a clean sub-agent spawning API that integrates well with the existing runtime hub architecture. The implementation extracts agent IDs from parent session keys and constructs canonical child session keys following the established pattern `agent:<agentId>:subagent:<runSlug>`. The storage layer properly tracks sub-agent lifecycle with status transitions and timestamps.

**Key Changes:**
- Added `SubagentSpawnRequest` and `SubagentHandle` types for structured sub-agent creation
- Implemented `Hub.SpawnSubagent` method that generates unique run slugs and submits to the runtime hub
- Added comprehensive tests covering parsing, uniqueness, and concurrent isolation
- Created `subagent_runs` database table with proper indexing for parent session lookup and status filtering
- Storage methods support the full lifecycle: spawn recording, status updates, and run queries

**Minor Issue:**
- One style improvement for error handling in random number generation

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor style improvement recommended
- The implementation is well-designed with proper separation of concerns between runtime and storage layers. Comprehensive test coverage validates key functionality including edge cases and concurrent execution. The only issue found is a minor style improvement for error handling that doesn't affect correctness in practice.
- No files require special attention beyond the noted style improvement in `internal/runtime/subagent.go`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/runtime/subagent.go | Implements sub-agent spawn API with session key management and unique slug generation. Minor issue: error from `crypto/rand.Read` is ignored. |
| internal/runtime/subagent_test.go | Comprehensive test coverage for sub-agent spawning, including edge cases and concurrent isolation tests. |
| internal/storage/sqlite.go | Adds `subagent_runs` table and methods for persisting sub-agent spawn metadata and status updates. |

</details>



<sub>Last reviewed commit: e26a7f5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->