### PR TITLE
feat: tool event status lines in Telegram placeholder (#14)

### DIFF
--- a/internal/bot/tool_status_test.go
+++ b/internal/bot/tool_status_test.go
@@ -1,8 +1,12 @@
 package bot
 
 import (
+	"errors"
 	"strings"
 	"testing"
+	"time"
+
+	"ok-gobot/internal/agent"
 )
 
 func TestToolStatusTracker_Empty(t *testing.T) {
@@ -86,4 +90,80 @@ func TestToolStatusTracker_MultipleConcurrent(t *testing.T) {
 	if !strings.Contains(out, "⚙️ parse…") {
 		t.Errorf("expected parse still in-progress, got %q", out)
 	}
+}
+
+func TestToolStatusTracker_OnFinished_NoMatchingEntry(t *testing.T) {
+	// OnFinished with no prior OnStarted should be a no-op (not panic).
+	var tr ToolStatusTracker
+	tr.OnFinished("ghost", false)
+	if tr.HasAny() {
+		t.Error("expected tracker to be empty after OnFinished with no prior OnStarted")
+	}
+}
+
+func TestToolStatusTracker_SameName_MarksLastPending(t *testing.T) {
+	// When the same tool is called twice, OnFinished should mark the last pending entry.
+	var tr ToolStatusTracker
+	tr.OnStarted("search")
+	tr.OnFinished("search", false) // first call done
+	tr.OnStarted("search")         // second call started
+	out := tr.Format()
+	// Should show one done and one in-progress.
+	if !strings.Contains(out, "✅ search") {
+		t.Errorf("expected first search to be marked done, got %q", out)
+	}
+	if !strings.Contains(out, "⚙️ search…") {
+		t.Errorf("expected second search to be in-progress, got %q", out)
+	}
+}
+
+// TestPlaceholderEditor_OnToolEvent_delegatesToTracker verifies that
+// OnToolEvent correctly delegates to the embedded ToolStatusTracker.
+// We use a nil bot/msg to avoid any real Telegram calls.
+func TestPlaceholderEditor_OnToolEvent_delegatesToTracker(t *testing.T) {
+	// Build an editor with nil bot/msg and zero rate-limit so the goroutine exits fast.
+	editor := &PlaceholderEditor{minInterval: 0}
+
+	if editor.HasAny() {
+		t.Fatal("expected HasAny=false before any events")
+	}
+
+	// Simulate tool started.
+	editor.OnToolEvent(agent.ToolEvent{Type: agent.ToolEventStarted, ToolName: "search"})
+
+	if !editor.HasAny() {
+		t.Fatal("expected HasAny=true after ToolEventStarted")
+	}
+	if !strings.Contains(editor.tracker.Format(), "⚙️ search…") {
+		t.Errorf("expected in-progress line, got %q", editor.tracker.Format())
+	}
+
+	// Simulate tool finished successfully.
+	editor.OnToolEvent(agent.ToolEvent{Type: agent.ToolEventFinished, ToolName: "search"})
+
+	if !strings.Contains(editor.tracker.Format(), "✅ search") {
+		t.Errorf("expected success line, got %q", editor.tracker.Format())
+	}
+
+	// Let the goroutine(s) spawned by schedule() drain.
+	time.Sleep(10 * time.Millisecond)
+}
+
+// TestPlaceholderEditor_OnToolEvent_errorDelegation verifies that a failed
+// tool event propagates the error flag through to the tracker.
+func TestPlaceholderEditor_OnToolEvent_errorDelegation(t *testing.T) {
+	editor := &PlaceholderEditor{minInterval: 0}
+
+	editor.OnToolEvent(agent.ToolEvent{Type: agent.ToolEventStarted, ToolName: "patch"})
+	editor.OnToolEvent(agent.ToolEvent{
+		Type:     agent.ToolEventFinished,
+		ToolName: "patch",
+		Err:      errors.New("write failed"),
+	})
+
+	if !strings.Contains(editor.tracker.Format(), "❌ patch") {
+		t.Errorf("expected error line, got %q", editor.tracker.Format())
+	}
+
+	time.Sleep(10 * time.Millisecond)
 }


### PR DESCRIPTION
Implements #14

## Changes

The core implementation for this feature was already present in `refactor/runtime-hub`:
- `ToolEvent`/`ToolEventStarted`/`ToolEventFinished` in `internal/agent/tool_agent.go` with `SetToolEventCallback`
- `ToolStatusTracker` + `PlaceholderEditor` in `internal/bot/tool_status.go`
- Live status update wiring in `internal/bot/hub_handler.go` via `processViaHub`

This PR adds comprehensive tests that verify the `PlaceholderEditor` correctly delegates tool lifecycle events to the `ToolStatusTracker`, including edge cases not covered by the existing tests:

- **`TestToolStatusTracker_OnFinished_NoMatchingEntry`**: `OnFinished` is a no-op when no matching started entry exists (prevents panic)
- **`TestToolStatusTracker_SameName_MarksLastPending`**: when the same tool is called twice, `OnFinished` marks the last pending entry (not the already-completed one)
- **`TestPlaceholderEditor_OnToolEvent_delegatesToTracker`**: `OnToolEvent` correctly dispatches `started`/`finished` events to the embedded tracker and the `HasAny()` delegation works
- **`TestPlaceholderEditor_OnToolEvent_errorDelegation`**: error flag in `ToolEventFinished` propagates through to the tracker so the ❌ line renders correctly

## Acceptance Criteria Verification

- ✅ `tool.started` event appends a `⚙️ <tool_name>…` status line — implemented in `ToolStatusTracker.OnStarted`, displayed via `PlaceholderEditor.schedule()`
- ✅ `tool.finished` updates the line to ✅ or ❌ — implemented in `ToolStatusTracker.OnFinished`
- ✅ Only the last N (5) tool status lines are shown — enforced in `ToolStatusTracker.Format()` with `maxToolStatusLines`

## Testing

```
go test ./internal/bot/ -run TestToolStatus -v
go test ./internal/bot/ -run TestPlaceholderEditor -v
go test ./...
```

All tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds four well-structured test cases that verify edge case handling in the tool status tracking system. The tests cover: OnFinished being a no-op when no matching entry exists, correct handling of duplicate tool names, PlaceholderEditor delegation to ToolStatusTracker, and error flag propagation from ToolEvent to tracker status lines.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Test-only PR that adds coverage for existing implementation. No production code changes, tests follow Go conventions, edge cases are properly handled, and test logic correctly matches the implementation behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/tool_status_test.go | Adds comprehensive test coverage for ToolStatusTracker edge cases and PlaceholderEditor delegation |

</details>



<sub>Last reviewed commit: 48d90f9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->