### PR TITLE
feat: wire cron/message/semantic memory tools through real runtime deps (#5)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -184,11 +184,15 @@ func (a *App) Start(ctx context.Context) error {
 		log.Println("📅 Cron scheduler started")
 	}
 
-	// Initialize semantic memory when enabled
+	// Initialize semantic memory manager if enabled
 	if a.config.Memory.Enabled {
+		apiKey := a.config.Memory.EmbeddingsAPIKey
+		if apiKey == "" {
+			apiKey = a.config.AI.APIKey
+		}
 		embClient := memory.NewEmbeddingClient(
 			a.config.Memory.EmbeddingsBaseURL,
-			a.config.Memory.EmbeddingsAPIKey,
+			apiKey,
 			a.config.Memory.EmbeddingsModel,
 		)
 		memStore, err := memory.NewMemoryStore(a.store.DB())

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -20,7 +20,6 @@ func sessionKeyForChat(chat *telebot.Chat) agent.SessionKey {
 	return agent.NewGroupSessionKey(chat.ID)
 }
 
-
 // processViaHub routes a user request through the RuntimeHub instead of calling
 // the agent directly. Telegram becomes a pure transport adapter: it submits the
 // request and then renders the resulting RunEvent.


### PR DESCRIPTION
Implements #5

## Changes

- **`storage.Store.DB()`** — expose underlying `*sql.DB` so the memory package can initialize `MemoryStore` against the same database file without opening a second connection.

- **`bot.New()` signature** — accepts two new parameters: `scheduler tools.CronScheduler` and `memoryManager *memory.MemoryManager`. These are passed in by `app.Start()` which already owns both instances.

- **`Bot.SendToChat()`** — new method that satisfies the `tools.MessageSender` interface. The message tool is registered *after* the Bot struct is created (self-reference), so it receives the live bot instance rather than nil.

- **Cron tool** — registered with the live `*cron.Scheduler` instance (chatID=0 for the shared registry; per-chat cron tools are created by the agent handler for the agent-registry path).

- **Memory tool** — registered with a real `*memory.MemoryManager` backed by the app's SQLite database and the configured embeddings API.

- **`app.Start()`** — initializes `*memory.MemoryManager` when `memory.enabled=true`. Falls back to `ai.api_key` when `memory.embeddings_api_key` is not set, so users don't need to duplicate their API key in config.

## Testing

- `go build ./...` — clean build
- `go vet ./...` — no issues
- `go test ./...` — all tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a user-friendly fallback mechanism for the embeddings API key configuration. When `memory.embeddings_api_key` is not set, the system now falls back to using `ai.api_key`, eliminating the need for users to duplicate their API key in the config file. This behavior is already documented in the `MemoryConfig` struct comment.

- Simplified configuration by reusing `ai.api_key` when `embeddings_api_key` is empty
- Removed unnecessary whitespace in `hub_handler.go`

The changes are minimal, safe, and align with the documented configuration behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal (9 lines modified across 2 files), implement documented behavior, and improve user experience by providing a sensible default. No logical errors, security issues, or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/app/app.go | Added API key fallback logic for embeddings (uses `ai.api_key` when `embeddings_api_key` is not set) |
| internal/bot/hub_handler.go | Removed extra blank line (formatting cleanup) |

</details>



<sub>Last reviewed commit: a143ff2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->