### PR TITLE
test(bot): add Peek non-consuming test for AckHandleManager (#11)

### DIFF
--- a/internal/bot/ack_handle_test.go
+++ b/internal/bot/ack_handle_test.go
@@ -60,6 +60,33 @@ func TestAckHandleManager_SetOverwrites(t *testing.T) {
 	}
 }
 
+func TestAckHandleManager_PeekDoesNotConsume(t *testing.T) {
+	m := NewAckHandleManager()
+	m.Set(7, &AckHandle{ChatID: 7, Message: &telebot.Message{ID: 77}})
+
+	first := m.Peek(7)
+	if first == nil || first.Message.ID != 77 {
+		t.Fatalf("expected peek to return handle with msg_id=77, got %+v", first)
+	}
+
+	// Peek must not consume — handle should still be there.
+	second := m.Peek(7)
+	if second == nil || second.Message.ID != 77 {
+		t.Fatalf("expected second peek to still return handle, got %+v", second)
+	}
+
+	// Take must still succeed after peeking.
+	taken := m.Take(7)
+	if taken == nil || taken.Message.ID != 77 {
+		t.Fatalf("expected Take to return handle after Peek, got %+v", taken)
+	}
+
+	// After Take, Peek must return nil.
+	if m.Peek(7) != nil {
+		t.Fatal("expected Peek to return nil after Take")
+	}
+}
+
 func TestAckHandleManager_ConcurrentAccess(t *testing.T) {
 	m := NewAckHandleManager()
 

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -20,7 +20,6 @@ func sessionKeyForChat(chat *telebot.Chat) agent.SessionKey {
 	return agent.NewGroupSessionKey(chat.ID)
 }
 
-
 // processViaHub routes a user request through the RuntimeHub instead of calling
 // the agent directly. Telegram becomes a pure transport adapter: it submits the
 // request and then renders the resulting RunEvent.


### PR DESCRIPTION
Implements #11

## Changes

The ⏳ placeholder-on-inbound-message feature (issue #11) was already
fully implemented in the `refactor/runtime-hub` base branch by commit
`914f7fa`:

- `AckHandle` struct in `internal/bot/ack_handle.go` stores the
  placeholder `*telebot.Message` and `ChatID`
- `AckHandleManager` provides thread-safe `Set` / `Exists` / `Take` /
  `Peek` operations
- `sendImmediateAck` in `bot.go` sends `⏳` + typing indicator in
  parallel on every qualifying inbound message (before debounce or AI
  processing)
- `processViaHub` in `hub_handler.go` calls `takeAck` to edit the
  placeholder in-place with the final AI response (or deletes it on
  cancellation/silent-reply)

This PR adds the one test that was missing from `ack_handle_test.go`:
**`TestAckHandleManager_PeekDoesNotConsume`** — verifying that `Peek`
reads the handle without consuming it, and that `Take` still succeeds
afterwards.  It also applies `go fmt` (removes a stray blank line in
`hub_handler.go`).

## Testing

```
go fmt ./...
go vet ./...
go test ./...
go build ./cmd/ok-gobot/
```

All pass. The new test exercises the `Peek` → `Peek` → `Take` → `Peek`
sequence and asserts correct consume-once semantics.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds test coverage for `AckHandleManager.Peek` method to verify non-consuming read behavior, plus minor formatting cleanup.

**Key Changes:**
- New test `TestAckHandleManager_PeekDoesNotConsume` validates that `Peek` can be called multiple times without consuming the handle, and that `Take` still succeeds afterward
- The test correctly exercises the Peek → Peek → Take → Peek sequence with proper assertions
- Formatting fix removes extraneous blank line in `hub_handler.go` (standard go fmt)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it adds test coverage and applies standard formatting
- The changes are isolated to test code and formatting. The new test correctly validates the non-consuming behavior of Peek, which is already used in production code (`hub_handler.go:39`). No logic changes, no new dependencies, no security concerns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/ack_handle_test.go | Adds `TestAckHandleManager_PeekDoesNotConsume` to verify Peek non-consuming behavior - test is well-structured and comprehensive |
| internal/bot/hub_handler.go | Removes extra blank line between functions (go fmt cleanup) |

</details>



<sub>Last reviewed commit: a5b8c40</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->