### PR TITLE
Set runtime.mode=hub as default

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -79,6 +79,10 @@ agents: []
 #   /agent list - List all available agents
 #   /agent <name> - Switch to specified agent
 
+# Runtime configuration
+runtime:
+  mode: "hub"  # hub (default) or legacy — selects execution path; legacy will be removed in a future release
+
 # Storage and logging
 storage_path: "~/.ok-gobot/ok-gobot.db"
 soul_path: "~/ok-gobot-soul"  # Default personality directory (deprecated, use agents)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,14 @@ type ControlConfig struct {
 	AllowLoopbackWithoutToken bool   `mapstructure:"allow_loopback_without_token"`
 }
 
+// RuntimeConfig holds runtime execution configuration.
+type RuntimeConfig struct {
+	// Mode selects the execution path: "hub" (default) or "legacy".
+	// "hub" routes all requests through the RuntimeHub for per-session concurrency.
+	// "legacy" is kept temporarily for rollback; it will be removed in a future release.
+	Mode string `mapstructure:"mode"`
+}
+
 // Config holds all application configuration
 type Config struct {
 	ConfigPath   string            `mapstructure:"-"`
@@ -39,6 +47,7 @@ type Config struct {
 	Auth         AuthConfig        `mapstructure:"auth"`
 	API          APIConfig         `mapstructure:"api"`
 	Control      ControlConfig     `mapstructure:"control"`
+	Runtime      RuntimeConfig     `mapstructure:"runtime"`
 	Groups       GroupsConfig      `mapstructure:"groups"`
 	TTS          TTSConfig         `mapstructure:"tts"`
 	Memory       MemoryConfig      `mapstructure:"memory"`
@@ -142,6 +151,7 @@ func Load() (*Config, error) {
 	v.SetDefault("control.port", 9222)
 	v.SetDefault("control.token", "")
 	v.SetDefault("control.allow_loopback_without_token", true)
+	v.SetDefault("runtime.mode", "hub")
 
 	// Environment variable prefix
 	v.SetEnvPrefix("OKGOBOT")
@@ -227,6 +237,7 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("control.port", 9222)
 	v.SetDefault("control.token", "")
 	v.SetDefault("control.allow_loopback_without_token", true)
+	v.SetDefault("runtime.mode", "hub")
 
 	// Environment variable prefix
 	v.SetEnvPrefix("OKGOBOT")
@@ -287,6 +298,12 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid auth.mode: %s (must be 'open', 'allowlist', or 'pairing')", c.Auth.Mode)
 	}
 
+	// Validate runtime mode
+	validRuntimeModes := map[string]bool{"hub": true, "legacy": true}
+	if c.Runtime.Mode != "" && !validRuntimeModes[c.Runtime.Mode] {
+		return fmt.Errorf("invalid runtime.mode: %s (must be 'hub' or 'legacy')", c.Runtime.Mode)
+	}
+
 	// Check storage path is set
 	if c.StoragePath == "" {
 		return fmt.Errorf("storage_path is required")
@@ -329,6 +346,7 @@ func (c *Config) Save() error {
 	v.Set("storage_path", c.StoragePath)
 	v.Set("soul_path", c.SoulPath)
 	v.Set("log_level", c.LogLevel)
+	v.Set("runtime.mode", c.Runtime.Mode)
 
 	return v.WriteConfig()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadFromDefaultRuntimeMode(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+  provider: "openrouter"
+storage_path: "/tmp/test.db"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+
+	if cfg.Runtime.Mode != "hub" {
+		t.Errorf("expected runtime.mode=%q, got %q", "hub", cfg.Runtime.Mode)
+	}
+}
+
+func TestLoadFromExplicitRuntimeMode(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-explicit-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+  provider: "openrouter"
+storage_path: "/tmp/test.db"
+runtime:
+  mode: "legacy"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+
+	if cfg.Runtime.Mode != "legacy" {
+		t.Errorf("expected runtime.mode=%q, got %q", "legacy", cfg.Runtime.Mode)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `RuntimeConfig` struct with a `Mode` field to `internal/config`
- Wire `Runtime RuntimeConfig` into the top-level `Config` struct
- Set `runtime.mode` default to `"hub"` in both `Load()` and `LoadFrom()`
- Document `runtime.mode` in `config.example.yaml`
- Add unit tests verifying the default value and explicit override

Existing deployments that omit `runtime.mode` will automatically use the hub runtime after upgrade. The `"legacy"` value remains accepted for rollback and will be removed in a future cleanup release.

Closes #22

## Test plan

- [x] `TestLoadFromDefaultRuntimeMode` — verifies `runtime.mode` defaults to `"hub"` when omitted from config
- [x] `TestLoadFromExplicitRuntimeMode` — verifies an explicit `runtime.mode: legacy` is honoured
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds infrastructure for `runtime.mode` configuration, defaulting to `"hub"` to route requests through RuntimeHub for per-session concurrency. The implementation is clean and well-tested:

- Added `RuntimeConfig` struct with clear documentation
- Set defaults in both `Load()` and `LoadFrom()`  
- Added validation and persistence via `Save()`
- Documented in `config.example.yaml` with deprecation notice for legacy mode
- Tests verify both default and explicit override behavior

The change is backward-compatible - existing configs without `runtime.mode` will automatically use the hub runtime.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with only a minor style inconsistency in validation logic
- The implementation is solid with proper defaults, validation, tests, and documentation. The only issue is a minor validation inconsistency that allows empty string values, which doesn't match the pattern used for similar config fields. This won't cause runtime issues since defaults are properly set, but improving consistency would be beneficial.
- No files require special attention - the validation inconsistency in `internal/config/config.go` is minor and optional to fix

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| config.example.yaml | Added clear documentation for `runtime.mode` config option with default value and deprecation notice |
| internal/config/config.go | Added `RuntimeConfig` struct, wired into `Config`, set defaults, and added validation - validation has minor inconsistency allowing empty string |
| internal/config/config_test.go | Added comprehensive tests for default and explicit `runtime.mode` values |

</details>



<sub>Last reviewed commit: 2d7d492</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->