### PR TITLE
Create v2 SQLite tables + migration from legacy chat_id sessions

### DIFF
--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -144,6 +144,50 @@ func (s *Store) migrate() error {
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_subagent_runs_parent ON subagent_runs(parent_session_key);`,
 		`CREATE INDEX IF NOT EXISTS idx_subagent_runs_status ON subagent_runs(status);`,
+		// ── v2 session tables ────────────────────────────────────────────────
+		// sessions_v2: canonical session keyed by session_key string instead of chat_id integer.
+		`CREATE TABLE IF NOT EXISTS sessions_v2 (
+			session_key          TEXT PRIMARY KEY,
+			agent_id             TEXT NOT NULL DEFAULT '',
+			parent_session_key   TEXT DEFAULT '',
+			model_override       TEXT DEFAULT '',
+			think_level          TEXT DEFAULT '',
+			active_agent         TEXT DEFAULT 'default',
+			usage_mode           TEXT DEFAULT 'off',
+			verbose              INTEGER DEFAULT 0,
+			queue_mode           TEXT DEFAULT 'collect',
+			queue_debounce_ms    INTEGER DEFAULT 1500,
+			message_count        INTEGER DEFAULT 0,
+			input_tokens         INTEGER DEFAULT 0,
+			output_tokens        INTEGER DEFAULT 0,
+			total_tokens         INTEGER DEFAULT 0,
+			context_tokens       INTEGER DEFAULT 0,
+			compaction_count     INTEGER DEFAULT 0,
+			last_summary         TEXT DEFAULT '',
+			promoted_from_chat_id INTEGER DEFAULT 0,
+			created_at           DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at           DATETIME DEFAULT CURRENT_TIMESTAMP
+		);`,
+		// session_messages_v2: full transcript history, keyed by session_key.
+		`CREATE TABLE IF NOT EXISTS session_messages_v2 (
+			id          INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_key TEXT NOT NULL,
+			role        TEXT NOT NULL,
+			content     TEXT NOT NULL,
+			run_id      TEXT DEFAULT '',
+			created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+		);`,
+		`CREATE INDEX IF NOT EXISTS idx_session_messages_v2_key ON session_messages_v2(session_key);`,
+		// session_routes: maps canonical session_key → delivery channel details.
+		`CREATE TABLE IF NOT EXISTS session_routes (
+			session_key TEXT PRIMARY KEY,
+			channel     TEXT NOT NULL DEFAULT 'telegram',
+			chat_id     INTEGER DEFAULT 0,
+			thread_id   INTEGER DEFAULT 0,
+			user_id     INTEGER DEFAULT 0,
+			username    TEXT DEFAULT '',
+			updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+		);`,
 	}
 
 	for _, migration := range migrations {
@@ -657,6 +701,317 @@ func (s *Store) SetActiveAgent(chatID int64, agentName string) error {
 	// Update existing session
 	_, err = s.db.Exec("UPDATE sessions SET active_agent = ? WHERE chat_id = ?", agentName, chatID)
 	return err
+}
+
+// ─── v2 session helpers ──────────────────────────────────────────────────────
+
+// SessionV2 holds the data stored in sessions_v2.
+type SessionV2 struct {
+	SessionKey         string
+	AgentID            string
+	ParentSessionKey   string
+	ModelOverride      string
+	ThinkLevel         string
+	ActiveAgent        string
+	UsageMode          string
+	Verbose            bool
+	QueueMode          string
+	QueueDebounceMs    int
+	MessageCount       int
+	InputTokens        int
+	OutputTokens       int
+	TotalTokens        int
+	ContextTokens      int
+	CompactionCount    int
+	LastSummary        string
+	PromotedFromChatID int64
+	CreatedAt          string
+	UpdatedAt          string
+}
+
+// GetSessionV2 retrieves the v2 session for the given session key.
+// Returns nil (no error) when the session does not yet exist.
+func (s *Store) GetSessionV2(sessionKey string) (*SessionV2, error) {
+	var sess SessionV2
+	var verbose int
+	var lastSummary sql.NullString
+	err := s.db.QueryRow(`
+		SELECT session_key, agent_id, parent_session_key, model_override, think_level,
+		       active_agent, usage_mode, verbose, queue_mode, queue_debounce_ms,
+		       message_count, input_tokens, output_tokens, total_tokens, context_tokens,
+		       compaction_count, last_summary, promoted_from_chat_id, created_at, updated_at
+		FROM sessions_v2 WHERE session_key = ?
+	`, sessionKey).Scan(
+		&sess.SessionKey, &sess.AgentID, &sess.ParentSessionKey, &sess.ModelOverride, &sess.ThinkLevel,
+		&sess.ActiveAgent, &sess.UsageMode, &verbose, &sess.QueueMode, &sess.QueueDebounceMs,
+		&sess.MessageCount, &sess.InputTokens, &sess.OutputTokens, &sess.TotalTokens, &sess.ContextTokens,
+		&sess.CompactionCount, &lastSummary, &sess.PromotedFromChatID, &sess.CreatedAt, &sess.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	sess.Verbose = verbose != 0
+	if lastSummary.Valid {
+		sess.LastSummary = lastSummary.String
+	}
+	return &sess, nil
+}
+
+// UpsertSessionV2 creates or updates a v2 session record.
+func (s *Store) UpsertSessionV2(sess *SessionV2) error {
+	verbose := 0
+	if sess.Verbose {
+		verbose = 1
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO sessions_v2
+			(session_key, agent_id, parent_session_key, model_override, think_level,
+			 active_agent, usage_mode, verbose, queue_mode, queue_debounce_ms,
+			 message_count, input_tokens, output_tokens, total_tokens, context_tokens,
+			 compaction_count, last_summary, promoted_from_chat_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(session_key) DO UPDATE SET
+			agent_id             = excluded.agent_id,
+			parent_session_key   = excluded.parent_session_key,
+			model_override       = excluded.model_override,
+			think_level          = excluded.think_level,
+			active_agent         = excluded.active_agent,
+			usage_mode           = excluded.usage_mode,
+			verbose              = excluded.verbose,
+			queue_mode           = excluded.queue_mode,
+			queue_debounce_ms    = excluded.queue_debounce_ms,
+			message_count        = excluded.message_count,
+			input_tokens         = excluded.input_tokens,
+			output_tokens        = excluded.output_tokens,
+			total_tokens         = excluded.total_tokens,
+			context_tokens       = excluded.context_tokens,
+			compaction_count     = excluded.compaction_count,
+			last_summary         = excluded.last_summary,
+			promoted_from_chat_id = excluded.promoted_from_chat_id,
+			updated_at           = CURRENT_TIMESTAMP
+	`,
+		sess.SessionKey, sess.AgentID, sess.ParentSessionKey, sess.ModelOverride, sess.ThinkLevel,
+		sess.ActiveAgent, sess.UsageMode, verbose, sess.QueueMode, sess.QueueDebounceMs,
+		sess.MessageCount, sess.InputTokens, sess.OutputTokens, sess.TotalTokens, sess.ContextTokens,
+		sess.CompactionCount, sess.LastSummary, sess.PromotedFromChatID,
+	)
+	return err
+}
+
+// SessionMessageV2 holds one row from session_messages_v2.
+type SessionMessageV2 struct {
+	ID         int64
+	SessionKey string
+	Role       string
+	Content    string
+	RunID      string
+	CreatedAt  string
+}
+
+// SaveSessionMessageV2 appends a message to the v2 transcript for sessionKey.
+func (s *Store) SaveSessionMessageV2(sessionKey, role, content, runID string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO session_messages_v2 (session_key, role, content, run_id)
+		VALUES (?, ?, ?, ?)
+	`, sessionKey, role, content, runID)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`
+		UPDATE sessions_v2 SET message_count = message_count + 1, updated_at = CURRENT_TIMESTAMP
+		WHERE session_key = ?
+	`, sessionKey)
+	return err
+}
+
+// GetSessionMessagesV2 retrieves up to limit messages for sessionKey in
+// chronological order (oldest first).
+func (s *Store) GetSessionMessagesV2(sessionKey string, limit int) ([]SessionMessageV2, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.Query(`
+		SELECT id, session_key, role, content, run_id, created_at
+		FROM session_messages_v2
+		WHERE session_key = ?
+		ORDER BY created_at ASC, id ASC
+		LIMIT ?
+	`, sessionKey, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var msgs []SessionMessageV2
+	for rows.Next() {
+		var m SessionMessageV2
+		if err := rows.Scan(&m.ID, &m.SessionKey, &m.Role, &m.Content, &m.RunID, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs, rows.Err()
+}
+
+// SessionRoute holds one row from session_routes.
+type SessionRoute struct {
+	SessionKey string
+	Channel    string
+	ChatID     int64
+	ThreadID   int
+	UserID     int64
+	Username   string
+	UpdatedAt  string
+}
+
+// UpsertSessionRoute creates or updates the delivery route for sessionKey.
+func (s *Store) UpsertSessionRoute(route SessionRoute) error {
+	_, err := s.db.Exec(`
+		INSERT INTO session_routes (session_key, channel, chat_id, thread_id, user_id, username)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(session_key) DO UPDATE SET
+			channel   = excluded.channel,
+			chat_id   = excluded.chat_id,
+			thread_id = excluded.thread_id,
+			user_id   = excluded.user_id,
+			username  = excluded.username,
+			updated_at = CURRENT_TIMESTAMP
+	`, route.SessionKey, route.Channel, route.ChatID, route.ThreadID, route.UserID, route.Username)
+	return err
+}
+
+// GetSessionRoute retrieves the delivery route for sessionKey.
+// Returns nil (no error) when not found.
+func (s *Store) GetSessionRoute(sessionKey string) (*SessionRoute, error) {
+	var r SessionRoute
+	err := s.db.QueryRow(`
+		SELECT session_key, channel, chat_id, thread_id, user_id, username, updated_at
+		FROM session_routes WHERE session_key = ?
+	`, sessionKey).Scan(&r.SessionKey, &r.Channel, &r.ChatID, &r.ThreadID, &r.UserID, &r.Username, &r.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// PromoteLegacySession ensures a v2 session exists for sessionKey.
+//
+// If a v2 row already exists the call is a no-op (idempotent). Otherwise:
+//   - A new sessions_v2 row is created using metadata copied from the legacy
+//     sessions row that corresponds to chatID (if one exists).
+//   - All legacy session_messages for chatID are copied (not deleted) into
+//     session_messages_v2.
+//   - A session_routes row is created/updated for the channel + chatID.
+//
+// Callers should invoke this on the first inbound message for a session_key
+// that was previously known only by its raw chat_id.
+func (s *Store) PromoteLegacySession(sessionKey, agentID, channel string, chatID int64) error {
+	// Fast-path: v2 session already exists.
+	existing, err := s.GetSessionV2(sessionKey)
+	if err != nil {
+		return fmt.Errorf("promote: check existing: %w", err)
+	}
+	if existing != nil {
+		return nil
+	}
+
+	// Try to read legacy metadata for this chatID.
+	sess := &SessionV2{
+		SessionKey:         sessionKey,
+		AgentID:            agentID,
+		ActiveAgent:        "default",
+		QueueMode:          "collect",
+		QueueDebounceMs:    1500,
+		PromotedFromChatID: 0,
+	}
+
+	var (
+		verbose     int
+		lastSummary sql.NullString
+	)
+	legacyErr := s.db.QueryRow(`
+		SELECT model_override, think_level, active_agent, usage_mode, verbose,
+		       queue_mode, queue_debounce_ms, message_count,
+		       input_tokens, output_tokens, total_tokens, context_tokens,
+		       compaction_count, last_summary
+		FROM sessions WHERE chat_id = ?
+	`, chatID).Scan(
+		&sess.ModelOverride, &sess.ThinkLevel, &sess.ActiveAgent, &sess.UsageMode, &verbose,
+		&sess.QueueMode, &sess.QueueDebounceMs, &sess.MessageCount,
+		&sess.InputTokens, &sess.OutputTokens, &sess.TotalTokens, &sess.ContextTokens,
+		&sess.CompactionCount, &lastSummary,
+	)
+	if legacyErr != nil && legacyErr != sql.ErrNoRows {
+		return fmt.Errorf("promote: read legacy session: %w", legacyErr)
+	}
+	if legacyErr == nil {
+		sess.PromotedFromChatID = chatID
+		sess.Verbose = verbose != 0
+		if lastSummary.Valid {
+			sess.LastSummary = lastSummary.String
+		}
+	}
+
+	// Insert the v2 session row.
+	if err := s.UpsertSessionV2(sess); err != nil {
+		return fmt.Errorf("promote: upsert sessions_v2: %w", err)
+	}
+
+	// Copy legacy messages (if any) into session_messages_v2.
+	// We collect all rows first, then insert, to avoid holding an open cursor
+	// while performing write operations on the same SQLite connection.
+	if sess.PromotedFromChatID != 0 {
+		type legacyMsg struct{ role, content, createdAt string }
+		var legacyMsgs []legacyMsg
+
+		rows, err := s.db.Query(`
+			SELECT sm.role, sm.content, sm.created_at
+			FROM session_messages sm
+			WHERE sm.chat_id = ?
+			ORDER BY sm.created_at ASC, sm.id ASC
+		`, chatID)
+		if err != nil {
+			return fmt.Errorf("promote: query legacy messages: %w", err)
+		}
+		for rows.Next() {
+			var m legacyMsg
+			if err := rows.Scan(&m.role, &m.content, &m.createdAt); err != nil {
+				rows.Close()
+				return fmt.Errorf("promote: scan legacy message: %w", err)
+			}
+			legacyMsgs = append(legacyMsgs, m)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("promote: iterate legacy messages: %w", err)
+		}
+
+		for _, m := range legacyMsgs {
+			if _, err := s.db.Exec(`
+				INSERT INTO session_messages_v2 (session_key, role, content, created_at)
+				VALUES (?, ?, ?, ?)
+			`, sessionKey, m.role, m.content, m.createdAt); err != nil {
+				return fmt.Errorf("promote: insert session_messages_v2: %w", err)
+			}
+		}
+	}
+
+	// Record the delivery route.
+	if err := s.UpsertSessionRoute(SessionRoute{
+		SessionKey: sessionKey,
+		Channel:    channel,
+		ChatID:     chatID,
+	}); err != nil {
+		return fmt.Errorf("promote: upsert session_routes: %w", err)
+	}
+
+	return nil
 }
 
 // SubagentRun holds a persisted record of a sub-agent run.

--- a/internal/storage/sqlite_v2_test.go
+++ b/internal/storage/sqlite_v2_test.go
@@ -1,0 +1,297 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// newTestStore creates a temporary SQLite store for testing.
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+// TestV2TablesCreated verifies that the v2 tables are created by the migration.
+func TestV2TablesCreated(t *testing.T) {
+	s := newTestStore(t)
+
+	tables := []string{"sessions_v2", "session_messages_v2", "session_routes"}
+	for _, tbl := range tables {
+		var name string
+		err := s.db.QueryRow(
+			"SELECT name FROM sqlite_master WHERE type='table' AND name=?", tbl,
+		).Scan(&name)
+		if err != nil {
+			t.Errorf("table %q not found: %v", tbl, err)
+		}
+	}
+}
+
+// TestUpsertAndGetSessionV2 verifies basic insert/read of sessions_v2.
+func TestUpsertAndGetSessionV2(t *testing.T) {
+	s := newTestStore(t)
+
+	sess := &SessionV2{
+		SessionKey:      "agent:bot:telegram:group:-100",
+		AgentID:         "bot",
+		ModelOverride:   "claude-3-5-sonnet",
+		ThinkLevel:      "low",
+		ActiveAgent:     "default",
+		UsageMode:       "on",
+		Verbose:         true,
+		QueueMode:       "collect",
+		QueueDebounceMs: 2000,
+	}
+	if err := s.UpsertSessionV2(sess); err != nil {
+		t.Fatalf("UpsertSessionV2: %v", err)
+	}
+
+	got, err := s.GetSessionV2(sess.SessionKey)
+	if err != nil {
+		t.Fatalf("GetSessionV2: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected session, got nil")
+	}
+	if got.SessionKey != sess.SessionKey {
+		t.Errorf("SessionKey = %q, want %q", got.SessionKey, sess.SessionKey)
+	}
+	if got.ModelOverride != sess.ModelOverride {
+		t.Errorf("ModelOverride = %q, want %q", got.ModelOverride, sess.ModelOverride)
+	}
+	if !got.Verbose {
+		t.Error("Verbose should be true")
+	}
+	if got.QueueDebounceMs != 2000 {
+		t.Errorf("QueueDebounceMs = %d, want 2000", got.QueueDebounceMs)
+	}
+}
+
+// TestGetSessionV2NotFound verifies that missing keys return nil without error.
+func TestGetSessionV2NotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	got, err := s.GetSessionV2("nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+// TestSaveAndGetSessionMessagesV2 verifies message storage and retrieval.
+func TestSaveAndGetSessionMessagesV2(t *testing.T) {
+	s := newTestStore(t)
+	key := "agent:bot:main"
+
+	// Seed a v2 session so message_count updates work.
+	if err := s.UpsertSessionV2(&SessionV2{SessionKey: key, AgentID: "bot"}); err != nil {
+		t.Fatalf("UpsertSessionV2: %v", err)
+	}
+
+	msgs := []struct{ role, content, runID string }{
+		{"user", "hello", ""},
+		{"assistant", "hi there", "run-1"},
+		{"user", "bye", ""},
+	}
+	for _, m := range msgs {
+		if err := s.SaveSessionMessageV2(key, m.role, m.content, m.runID); err != nil {
+			t.Fatalf("SaveSessionMessageV2: %v", err)
+		}
+	}
+
+	got, err := s.GetSessionMessagesV2(key, 10)
+	if err != nil {
+		t.Fatalf("GetSessionMessagesV2: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(got))
+	}
+	if got[0].Role != "user" || got[0].Content != "hello" {
+		t.Errorf("unexpected first message: %+v", got[0])
+	}
+	if got[1].RunID != "run-1" {
+		t.Errorf("expected run_id 'run-1', got %q", got[1].RunID)
+	}
+
+	// Verify message_count was incremented.
+	sess, err := s.GetSessionV2(key)
+	if err != nil {
+		t.Fatalf("GetSessionV2: %v", err)
+	}
+	if sess.MessageCount != 3 {
+		t.Errorf("MessageCount = %d, want 3", sess.MessageCount)
+	}
+}
+
+// TestUpsertAndGetSessionRoute verifies session_routes CRUD.
+func TestUpsertAndGetSessionRoute(t *testing.T) {
+	s := newTestStore(t)
+
+	route := SessionRoute{
+		SessionKey: "agent:bot:telegram:group:-100",
+		Channel:    "telegram",
+		ChatID:     -100,
+		ThreadID:   5,
+		UserID:     42,
+		Username:   "alice",
+	}
+	if err := s.UpsertSessionRoute(route); err != nil {
+		t.Fatalf("UpsertSessionRoute: %v", err)
+	}
+
+	got, err := s.GetSessionRoute(route.SessionKey)
+	if err != nil {
+		t.Fatalf("GetSessionRoute: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected route, got nil")
+	}
+	if got.ChatID != -100 {
+		t.Errorf("ChatID = %d, want -100", got.ChatID)
+	}
+	if got.Username != "alice" {
+		t.Errorf("Username = %q, want alice", got.Username)
+	}
+}
+
+// TestGetSessionRouteNotFound verifies missing keys return nil without error.
+func TestGetSessionRouteNotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	got, err := s.GetSessionRoute("nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+// TestPromoteLegacySession_NoLegacy verifies that promotion creates a bare v2
+// session even when there is no legacy data for chatID.
+func TestPromoteLegacySession_NoLegacy(t *testing.T) {
+	s := newTestStore(t)
+
+	key := "agent:bot:telegram:group:-200"
+	if err := s.PromoteLegacySession(key, "bot", "telegram", -200); err != nil {
+		t.Fatalf("PromoteLegacySession: %v", err)
+	}
+
+	sess, err := s.GetSessionV2(key)
+	if err != nil {
+		t.Fatalf("GetSessionV2: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected v2 session after promotion")
+	}
+	if sess.PromotedFromChatID != 0 {
+		t.Errorf("PromotedFromChatID = %d, want 0 (no legacy)", sess.PromotedFromChatID)
+	}
+
+	route, err := s.GetSessionRoute(key)
+	if err != nil {
+		t.Fatalf("GetSessionRoute: %v", err)
+	}
+	if route == nil || route.ChatID != -200 {
+		t.Errorf("unexpected route: %+v", route)
+	}
+}
+
+// TestPromoteLegacySession_WithLegacy verifies that promotion copies metadata
+// and messages from the legacy tables, leaving the originals intact.
+func TestPromoteLegacySession_WithLegacy(t *testing.T) {
+	s := newTestStore(t)
+
+	chatID := int64(-300)
+
+	// Populate legacy session.
+	if err := s.SaveSession(chatID, ""); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+	if err := s.SetModelOverride(chatID, "gpt-4o"); err != nil {
+		t.Fatalf("SetModelOverride: %v", err)
+	}
+
+	// Populate legacy messages.
+	for _, pair := range [][2]string{
+		{"user", "legacy message 1"},
+		{"assistant", "legacy reply 1"},
+	} {
+		if err := s.SaveSessionMessage(chatID, pair[0], pair[1]); err != nil {
+			t.Fatalf("SaveSessionMessage: %v", err)
+		}
+	}
+
+	key := "agent:bot:telegram:group:-300"
+	if err := s.PromoteLegacySession(key, "bot", "telegram", chatID); err != nil {
+		t.Fatalf("PromoteLegacySession: %v", err)
+	}
+
+	// Check v2 session has legacy metadata.
+	sess, err := s.GetSessionV2(key)
+	if err != nil {
+		t.Fatalf("GetSessionV2: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("expected v2 session")
+	}
+	if sess.ModelOverride != "gpt-4o" {
+		t.Errorf("ModelOverride = %q, want gpt-4o", sess.ModelOverride)
+	}
+	if sess.PromotedFromChatID != chatID {
+		t.Errorf("PromotedFromChatID = %d, want %d", sess.PromotedFromChatID, chatID)
+	}
+
+	// Check v2 messages were copied.
+	msgs, err := s.GetSessionMessagesV2(key, 10)
+	if err != nil {
+		t.Fatalf("GetSessionMessagesV2: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 v2 messages, got %d", len(msgs))
+	}
+	if msgs[0].Content != "legacy message 1" {
+		t.Errorf("unexpected first message: %q", msgs[0].Content)
+	}
+
+	// Legacy tables must be untouched.
+	legacy, err := s.GetSessionMessages(chatID, 10)
+	if err != nil {
+		t.Fatalf("GetSessionMessages (legacy): %v", err)
+	}
+	if len(legacy) != 2 {
+		t.Fatalf("legacy messages should still be 2, got %d", len(legacy))
+	}
+}
+
+// TestPromoteLegacySession_Idempotent verifies that a second call is a no-op.
+func TestPromoteLegacySession_Idempotent(t *testing.T) {
+	s := newTestStore(t)
+
+	key := "agent:bot:telegram:group:-400"
+	chatID := int64(-400)
+
+	for i := 0; i < 3; i++ {
+		if err := s.PromoteLegacySession(key, "bot", "telegram", chatID); err != nil {
+			t.Fatalf("call %d: PromoteLegacySession: %v", i, err)
+		}
+	}
+
+	// Should only have one sessions_v2 row.
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM sessions_v2 WHERE session_key = ?", key).Scan(&count); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 sessions_v2 row, got %d", count)
+	}
+}
+


### PR DESCRIPTION
## Summary

- Adds three new v2 tables (`sessions_v2`, `session_messages_v2`, `session_routes`) via the existing migrations slice so they are created on startup without touching the legacy `sessions` / `session_messages` tables
- Adds `PromoteLegacySession(sessionKey, agentID, channel, chatID)` which lazily promotes a `chat_id`-keyed legacy session to a canonical v2 session key on first use: metadata is copied from `sessions` and transcript history is copied from `session_messages` into `session_messages_v2`, leaving all legacy data intact (no data loss)
- Adds full CRUD helpers for all three v2 tables: `UpsertSessionV2`, `GetSessionV2`, `SaveSessionMessageV2`, `GetSessionMessagesV2`, `UpsertSessionRoute`, `GetSessionRoute`

## Test plan

- [x] `TestV2TablesCreated` — verifies all three tables exist after migration
- [x] `TestUpsertAndGetSessionV2` — round-trip read/write of `sessions_v2`
- [x] `TestGetSessionV2NotFound` — missing key returns nil, no error
- [x] `TestSaveAndGetSessionMessagesV2` — message storage + `message_count` increment
- [x] `TestUpsertAndGetSessionRoute` — delivery route CRUD
- [x] `TestGetSessionRouteNotFound` — missing key returns nil
- [x] `TestPromoteLegacySession_NoLegacy` — creates bare v2 session when no legacy data exists
- [x] `TestPromoteLegacySession_WithLegacy` — copies metadata and messages from legacy tables, leaves originals intact
- [x] `TestPromoteLegacySession_Idempotent` — second+ call is a no-op (one row in `sessions_v2`)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces v2 session tables with a clean migration path from the legacy `chat_id`-based system to canonical session keys. The implementation includes three new tables (`sessions_v2`, `session_messages_v2`, `session_routes`) and comprehensive CRUD operations.

**Key changes:**
- New v2 table schemas created via migration slice, preserving legacy tables
- `PromoteLegacySession` performs lazy one-time migration copying metadata and messages
- Full CRUD helpers for all three tables with proper NULL handling and error wrapping
- Comprehensive test coverage (9 tests) validating tables, operations, and migration scenarios

**Issue found:**
- `PromoteLegacySession` lacks transaction safety — if message copying fails after session creation, subsequent calls will skip the failed operation, causing permanent message loss from the legacy system

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the transaction safety issue in `PromoteLegacySession`
- Score reflects solid implementation with comprehensive tests, but the transaction safety issue in the migration path could cause message loss under failure conditions. The rest of the code is well-structured with proper error handling, NULL safety, and idempotency.
- `internal/storage/sqlite.go` (lines 961-1012) needs transaction wrapping in `PromoteLegacySession`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/storage/sqlite.go | Adds v2 session tables with migration schemas and CRUD helpers; needs transaction safety in PromoteLegacySession |
| internal/storage/sqlite_v2_test.go | Comprehensive tests cover table creation, CRUD operations, and migration scenarios including idempotency |

</details>



<sub>Last reviewed commit: 171f520</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->