### PR TITLE
Phase D: TUI with Bubble Tea

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -22,6 +22,7 @@ const (
 	screenSessions        // session picker overlay
 	screenModels          // model picker overlay
 	screenApproval        // approval prompt overlay
+	screenSpawn           // sub-agent spawn dialog
 )
 
 // chatEntry is one logical item in the chat log.
@@ -60,6 +61,13 @@ type Model struct {
 	approvalID  string
 	approvalCmd string
 	approvalSel int // 0 = yes, 1 = no
+
+	// sub-agent spawn dialog
+	spawnDialog      SpawnDialog
+	pendingSpawnTask string // task to send to the next newly created session
+
+	// queue depth indicator
+	queueDepth int
 
 	// UI components
 	viewport viewport.Model
@@ -126,12 +134,33 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case serverMsgReceived:
 		cmds = append(cmds, m.handleServerMsg(msg.msg))
 
+	case spawnConfirmedMsg:
+		m.screen = screenChat
+		name := msg.req.Task
+		if len([]rune(name)) > 30 {
+			name = string([]rune(name)[:30]) + "…"
+		}
+		m.pendingSpawnTask = msg.req.Task
+		m.sendCmd(controlserver.ClientMsg{
+			Type:  controlserver.CmdNewSession,
+			Name:  name,
+			Model: msg.req.Model,
+		})
+		m.setStatus("Spawning sub-agent…")
+
+	case spawnCancelledMsg:
+		m.screen = screenChat
+
 	case tea.KeyMsg:
 		return m.handleKey(msg, cmds)
 	}
 
-	// Forward key events to input when in chat mode
-	if m.screen == screenChat {
+	// Forward events to the active overlay or chat input.
+	if m.screen == screenSpawn {
+		var spawnCmd tea.Cmd
+		m.spawnDialog, spawnCmd = m.spawnDialog.Update(msg)
+		cmds = append(cmds, spawnCmd)
+	} else if m.screen == screenChat {
 		var inputCmd tea.Cmd
 		m.input, inputCmd = m.input.Update(msg)
 		cmds = append(cmds, inputCmd)
@@ -154,6 +183,8 @@ func (m *Model) handleKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 		return m.handleSessionKey(msg, cmds)
 	case screenModels:
 		return m.handleModelKey(msg, cmds)
+	case screenSpawn:
+		return m.handleSpawnKey(msg, cmds)
 	default:
 		return m.handleChatKey(msg, cmds)
 	}
@@ -204,6 +235,9 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 					m.screen = screenModels
 					m.modelCursor = 0
 				}
+			} else if strings.HasPrefix(text, "/spawn") {
+				m.spawnDialog = NewSpawnDialog()
+				m.screen = screenSpawn
 			} else {
 				m.sendCmd(controlserver.ClientMsg{
 					Type:      controlserver.CmdSend,
@@ -234,6 +268,12 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 			SessionID: m.activeSession,
 		})
 		m.setStatus("Abort sent")
+		return m, tea.Batch(cmds...)
+
+	case "ctrl+n":
+		// Open spawn dialog
+		m.spawnDialog = NewSpawnDialog()
+		m.screen = screenSpawn
 		return m, tea.Batch(cmds...)
 
 	case "pgup":
@@ -339,6 +379,17 @@ func (m *Model) handleServerMsg(msg controlserver.ServerMsg) tea.Cmd {
 		if len(msg.Sessions) > 0 {
 			m.sessions = msg.Sessions
 		}
+		// If we have a pending spawn task, send it to the new session.
+		if m.pendingSpawnTask != "" {
+			task := m.pendingSpawnTask
+			m.pendingSpawnTask = ""
+			m.sendCmd(controlserver.ClientMsg{
+				Type:      controlserver.CmdSend,
+				SessionID: m.activeSession,
+				Text:      task,
+			})
+			m.setStatus("Sub-agent task sent")
+		}
 
 	case controlserver.MsgTypeSessions:
 		m.sessions = msg.Sessions
@@ -351,6 +402,15 @@ func (m *Model) handleServerMsg(msg controlserver.ServerMsg) tea.Cmd {
 		return m.handleEvent(msg)
 	}
 	return nil
+}
+
+func (m *Model) handleSpawnKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.spawnDialog, cmd = m.spawnDialog.Update(msg)
+	cmds = append(cmds, cmd)
+
+	// Check for spawn dialog result messages
+	return m, tea.Batch(cmds...)
 }
 
 // handleEvent processes an event-type server message.
@@ -421,6 +481,9 @@ func (m *Model) handleEvent(msg controlserver.ServerMsg) tea.Cmd {
 		m.addEntry(chatEntry{role: "error", content: msg.Message})
 		m.refreshViewport()
 
+	case controlserver.KindQueue:
+		m.queueDepth = msg.QueueDepth
+
 	case controlserver.KindApproval:
 		m.approvalID = msg.ApprovalID
 		m.approvalCmd = msg.Command
@@ -467,6 +530,8 @@ func (m *Model) View() string {
 		return m.overlaySessionList(base)
 	case screenModels:
 		return m.overlayModelList(base)
+	case screenSpawn:
+		return m.overlaySpawnDialog(base)
 	}
 
 	return base
@@ -489,9 +554,14 @@ func (m *Model) renderHeader() string {
 		runIndicator = " " + spinner[m.tick%len(spinner)]
 	}
 
-	left := headerStyle.Render("🦞 ok-gobot" + runIndicator)
+	queueStr := ""
+	if m.queueDepth > 0 {
+		queueStr = fmt.Sprintf(" [Q:%d]", m.queueDepth)
+	}
+
+	left := headerStyle.Render("🦞 ok-gobot" + runIndicator + queueStr)
 	mid := headerDimStyle.Render("model: " + model)
-	right := headerDimStyle.Render("Ctrl+P sessions · Ctrl+M model · Ctrl+A abort")
+	right := headerDimStyle.Render("Ctrl+P sessions · Ctrl+M model · Ctrl+N spawn · Ctrl+A abort")
 
 	midWidth := m.width - lipgloss.Width(left) - lipgloss.Width(right)
 	if midWidth < 0 {
@@ -526,7 +596,7 @@ func (m *Model) renderStatus() string {
 
 	statusText := m.statusMsg
 	if statusText == "" {
-		statusText = "/abort · /new · /model [name] · enter to send"
+		statusText = "/abort · /new · /model [name] · /spawn · enter to send"
 	}
 	hint := statusBarStyle.Width(m.width - lipgloss.Width(left) - lipgloss.Width(leftVal) - lipgloss.Width(errPart)).
 		Render(statusText)
@@ -676,6 +746,13 @@ func (m *Model) overlayModelList(base string) string {
 	content += strings.Join(items, "\n")
 
 	box := modelListBorderStyle.Render(content)
+	return placeOverlay(m.width, m.height, base, box)
+}
+
+// overlaySpawnDialog renders the sub-agent spawn dialog over the base view.
+func (m *Model) overlaySpawnDialog(base string) string {
+	inner := m.spawnDialog.View()
+	box := spawnDialogBorderStyle.Render(inner)
 	return placeOverlay(m.width, m.height, base, box)
 }
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -156,6 +156,12 @@ var (
 				Foreground(colorAccent).
 				Bold(true)
 
+	// Sub-agent spawn dialog
+	spawnDialogBorderStyle = lipgloss.NewStyle().
+				Border(lipgloss.DoubleBorder()).
+				BorderForeground(lipgloss.Color("212")).
+				Padding(1, 2)
+
 	// Subtle divider
 	_ = lipgloss.NewStyle().
 		Foreground(colorSubtle)


### PR DESCRIPTION
## Summary

- Implements interactive Bubble Tea TUI (`ok-gobot tui`) connecting to the control server over WebSocket
- Live chat log with token streaming and spinner indicator
- Tool event cards displayed inline in the chat log
- Session picker overlay (Ctrl+P) and model picker overlay (Ctrl+M)
- `/abort` command and Ctrl+A shortcut to cancel active AI runs
- Sub-agent spawn dialog (Ctrl+N or `/spawn`) — creates a new session and sends the task automatically
- Approval prompt dialog with keyboard navigation (y/n, ← →, Enter)
- Queue depth indicator `[Q:N]` in the header bar

## What was already implemented

The branch already contained the TUI skeleton (`internal/tui/`), the CLI `tui` command, WebSocket client, styles, and the `SpawnDialog` form. This PR wires them together:

- `screenSpawn` added to the screen enum
- `SpawnDialog` integrated into the main `Model` (open via `/spawn` or Ctrl+N)
- Two-step spawn flow: create session → auto-send task when new session is confirmed
- `KindQueue` events handled → queue depth displayed in header
- Status bar and header hints updated to mention spawn and abort shortcuts

## Test plan

- [ ] `ok-gobot tui` starts and connects to embedded control server
- [ ] Type a message and verify streaming response appears
- [ ] Ctrl+P opens session picker; Enter switches session
- [ ] Ctrl+M opens model picker; Enter changes model
- [ ] Ctrl+A sends abort; `/abort` command also works
- [ ] Ctrl+N opens spawn dialog; fill fields → Enter to confirm → new session created and task sent
- [ ] Approval dialog appears when backend requests approval; y/n responds correctly
- [ ] Queue depth `[Q:N]` shows in header when queueDepth > 0

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Completes Phase D TUI implementation by wiring the SpawnDialog into the Bubble Tea event loop. Adds keyboard shortcuts (`Ctrl+N`, `/spawn`), integrates the two-step spawn flow (create session → auto-send task), displays queue depth in the header, and adds the spawn dialog overlay rendering. The implementation follows existing patterns for overlays and keyboard handling.

- Added `screenSpawn` to screen enum and integrated spawn dialog into main model
- Implemented pending spawn task flow: dialog confirmation creates session, then sends task on `MsgTypeConnected`
- Added queue depth indicator `[Q:N]` displayed in header when `queueDepth > 0`
- Updated keyboard shortcuts and status bar hints to include spawn commands
- Added spawn dialog overlay rendering consistent with other dialog styles

**Minor issue**: Race condition exists where `pendingSpawnTask` could be sent to wrong session if user creates multiple sessions quickly (e.g., spawns then immediately uses `/new`). The first `MsgTypeConnected` that arrives will receive the task, which may not be the spawn session.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with awareness of edge case race condition
- Implementation is solid and follows existing patterns. The race condition with `pendingSpawnTask` is unlikely in practice since it requires very specific timing, but worth fixing to prevent spawn tasks from being sent to wrong sessions.
- internal/tui/model.go - review the `pendingSpawnTask` logic at line 382

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tui/model.go | Integrates spawn dialog with keyboard shortcuts, WebSocket flow, and queue depth display. Contains a potential race condition with pendingSpawnTask if multiple sessions are created concurrently. |
| internal/tui/styles.go | Adds spawn dialog border style consistent with existing dialog styles. |

</details>



<sub>Last reviewed commit: 5a1767a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->