### PR TITLE
Phase C: /abort command for Telegram

### DIFF
--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -1,0 +1,107 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestRuntimeHubIsActiveAndCancel verifies IsActive and Cancel semantics.
+func TestRuntimeHubIsActiveAndCancel(t *testing.T) {
+	hub := NewRuntimeHub()
+	key := NewDMSessionKey(100)
+
+	// Before any run, IsActive must be false.
+	if hub.IsActive(key) {
+		t.Fatal("expected IsActive=false before any submit")
+	}
+
+	// Cancel on an idle session must not panic.
+	hub.Cancel(key)
+
+	// Inject a slot directly to simulate an active run without needing a real agent.
+	ctx, cancel := context.WithCancel(context.Background())
+	hub.mu.Lock()
+	hub.active[key] = &runSlot{cancel: cancel}
+	hub.mu.Unlock()
+
+	if !hub.IsActive(key) {
+		t.Fatal("expected IsActive=true after slot injection")
+	}
+
+	hub.Cancel(key)
+
+	// The context must be cancelled within a short window.
+	select {
+	case <-ctx.Done():
+		// ok
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Cancel did not cancel the slot context within 100ms")
+	}
+
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("expected context.Canceled after Cancel, got %v", ctx.Err())
+	}
+
+	// Simulate the goroutine cleanup removing the slot.
+	hub.mu.Lock()
+	delete(hub.active, key)
+	hub.mu.Unlock()
+
+	if hub.IsActive(key) {
+		t.Fatal("expected IsActive=false after slot removal")
+	}
+}
+
+// TestRuntimeHubCancelIdleIsNoop verifies Cancel on an idle session is a no-op.
+func TestRuntimeHubCancelIdleIsNoop(t *testing.T) {
+	hub := NewRuntimeHub()
+	key := NewGroupSessionKey(999)
+
+	// Must not panic on repeated calls.
+	hub.Cancel(key)
+	hub.Cancel(key)
+
+	if hub.IsActive(key) {
+		t.Fatal("expected IsActive=false for idle session")
+	}
+}
+
+// TestRuntimeHubSessionKeyFormats verifies the canonical session key helpers.
+func TestRuntimeHubSessionKeyFormats(t *testing.T) {
+	dm := NewDMSessionKey(12345)
+	group := NewGroupSessionKey(67890)
+
+	if dm != "dm:12345" {
+		t.Errorf("DM key = %q, want %q", dm, "dm:12345")
+	}
+	if group != "group:67890" {
+		t.Errorf("Group key = %q, want %q", group, "group:67890")
+	}
+}
+
+// TestRuntimeHubCancelErrorIsContextCanceled verifies that when a running slot
+// is cancelled, the context's error is context.Canceled — the same error that
+// would propagate through ProcessRequest and be sent as RunEventError.
+// This is relevant for the /abort command which calls hub.Cancel and expects
+// the bot to detect the error as a cancellation (not a real failure).
+func TestRuntimeHubCancelErrorIsContextCanceled(t *testing.T) {
+	hub := NewRuntimeHub()
+	key := NewDMSessionKey(200)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	hub.mu.Lock()
+	hub.active[key] = &runSlot{cancel: cancel}
+	hub.mu.Unlock()
+
+	hub.Cancel(key)
+
+	<-ctx.Done()
+
+	// errors.Is must match context.Canceled so that the bot's hub_handler
+	// can distinguish a user-initiated abort from a real error.
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Errorf("errors.Is(ctx.Err(), context.Canceled) = false, got %v", ctx.Err())
+	}
+}

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -86,8 +87,8 @@ func (b *Bot) processViaHub(ctx context.Context, c telebot.Context, sessionKey a
 		case agent.RunEventError:
 			stopTyping()
 			ackMsg := b.takeAck(chatID)
-			if ctx.Err() != nil {
-				// Cancelled — silently clear the ⏳ placeholder.
+			if ctx.Err() != nil || errors.Is(ev.Err, context.Canceled) {
+				// Cancelled (by /abort, /stop, or app shutdown) — silently clear the ⏳ placeholder.
 				if ackMsg != nil {
 					b.api.Delete(ackMsg) //nolint:errcheck
 				}


### PR DESCRIPTION
Closes #56

## Summary

- `/abort` command was already registered and had a handler, but when the hub cancelled the active run, `processViaHub` would incorrectly send a spurious `❌ Sorry, I encountered an error...` message to the user because it only checked the app-level `ctx.Err()` (which is never nil during a user-initiated abort)
- Fixed `hub_handler.go` to also check `errors.Is(ev.Err, context.Canceled)`, so that any run cancelled via `/abort` or `/stop` is silently cleaned up rather than surfacing as an error
- Added unit tests for `agent.RuntimeHub`: `IsActive`, `Cancel`, idle no-op, and the `context.Canceled` error contract

## Behaviour

- `/abort` sends `⛔ Aborted` immediately (< 2s) and cancels the active run
- Works in any chat type (DM and group) via `sessionKeyForChat`
- Queue is not broken: `processViaHub` returns cleanly on cancellation, then the deferred `queueManager.EndRun` fires and processes any queued messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed spurious error message when `/abort` or `/stop` commands cancel an active run. Previously, only `ctx.Err()` (app-level context) was checked, causing user-initiated cancellations to incorrectly show as errors. Now also checks `errors.Is(ev.Err, context.Canceled)` to properly detect session-level cancellation.

- Added `errors.Is(ev.Err, context.Canceled)` check in `hub_handler.go` line 90
- Comprehensive unit tests verify `RuntimeHub` cancellation behavior and `context.Canceled` error contract
- Queue processing remains intact: cancelled runs return cleanly and `queueManager.EndRun` processes queued messages

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused bug fix with comprehensive test coverage
- The change is minimal, well-understood, and properly tested. It adds a single condition to distinguish user-initiated cancellation from actual errors, fixing a specific UX issue without affecting other functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/hub_handler.go | Added `errors.Is(ev.Err, context.Canceled)` check to properly distinguish user-initiated cancellation from actual errors |
| internal/agent/runtime_test.go | Added comprehensive unit tests for RuntimeHub: IsActive, Cancel, idle behavior, and context.Canceled error contract |

</details>



<sub>Last reviewed commit: 94ec76c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->