### PR TITLE
Phase C: Immediate ⏳ placeholder on Telegram inbound

### DIFF
--- a/internal/ai/thinking_test.go
+++ b/internal/ai/thinking_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestThinkingForLevel(t *testing.T) {
 	tests := []struct {
-		level        string
-		wantNil      bool
-		wantType     string
-		wantBudget   int
+		level      string
+		wantNil    bool
+		wantType   string
+		wantBudget int
 	}{
 		{"off", true, "", 0},
 		{"", true, "", 0},

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -382,7 +382,10 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 
 		// Check queue mode — if a run is active this may queue, steer, or interrupt.
 		if b.handleWithQueueMode(ctx, sessionKey, chatID, content) {
-			return nil // Message was queued or steered; no ⏳ needed yet.
+			// Session was busy — send ⏳ queued placeholder immediately so the user
+			// knows their message was received while a run was in progress.
+			b.sendQueuedAck(c.Chat())
+			return nil
 		}
 
 		// Send ⏳ placeholder and typing indicator immediately (within ~0ms of receipt),
@@ -958,6 +961,19 @@ func (b *Bot) takeAck(chatID int64) *telebot.Message {
 // The placeholder message ID is stored in ackManager for subsequent live-edit updates.
 // Only one ack is created per chat — if one already exists the call is a no-op.
 func (b *Bot) sendImmediateAck(chat *telebot.Chat) {
+	b.sendAck(chat, "⏳")
+}
+
+// sendQueuedAck sends a ⏳ queued placeholder immediately when a message arrives
+// while the session is already busy processing another request.
+// Only one ack is created per chat — if one already exists the call is a no-op.
+func (b *Bot) sendQueuedAck(chat *telebot.Chat) {
+	b.sendAck(chat, "⏳ queued — previous run in progress")
+}
+
+// sendAck sends a placeholder message with text and a typing indicator in parallel.
+// Only one ack is created per chat — if one already exists the call is a no-op.
+func (b *Bot) sendAck(chat *telebot.Chat, text string) {
 	chatID := chat.ID
 	if b.ackManager.Exists(chatID) {
 		return
@@ -966,15 +982,15 @@ func (b *Bot) sendImmediateAck(chat *telebot.Chat) {
 	// Typing indicator in parallel — satisfies "sendChatAction immediately" requirement
 	go b.api.Notify(chat, telebot.Typing)
 
-	// Send ⏳ placeholder
-	ackMsg, err := b.api.Send(chat, "⏳")
+	// Send placeholder
+	ackMsg, err := b.api.Send(chat, text)
 	if err != nil {
 		log.Printf("[ack] failed to send placeholder for chat=%d: %v", chatID, err)
 		return
 	}
 
 	b.ackManager.Set(chatID, &AckHandle{Message: ackMsg, ChatID: chatID})
-	log.Printf("[ack] placeholder sent for chat=%d msg_id=%d", chatID, ackMsg.ID)
+	log.Printf("[ack] placeholder sent for chat=%d msg_id=%d text=%q", chatID, ackMsg.ID, text)
 }
 
 // SetupLocalCommandApproval configures the LocalCommand tool with approval function


### PR DESCRIPTION
## Summary

- When a Telegram message arrives while the session is idle, ⏳ is sent immediately (already existed)
- When a Telegram message arrives while the session is **busy**, `⏳ queued — previous run in progress` is now sent immediately before returning
- Both paths share a single `sendAck(chat, text)` helper; typing indicator runs in parallel in both cases
- The queued placeholder is stored in `AckHandleManager` so it can be edited with the final response once the queued run executes

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Build clean (`go build ./...`)
- Manual: send a message while bot is mid-run → should receive `⏳ queued — previous run in progress` within 1 second
- Manual: send a message when bot is idle → should receive `⏳` within 1 second
- Manual: verify works in both DM and group chats

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented immediate user feedback when messages are queued during active bot sessions. When a message arrives while the bot is processing another request, users now receive `⏳ queued — previous run in progress` within ~1 second instead of waiting silently. The implementation cleanly refactors the acknowledgment logic by extracting a common `sendAck` helper used by both idle and busy paths, maintaining thread-safety through the existing mutex-protected `AckHandleManager`. The queued placeholder is correctly reused and edited with the final response when the queued message is eventually processed.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with high confidence
- Clean implementation with proper thread-safety, good code refactoring to reduce duplication, well-tested (all existing tests pass), and addresses the user experience issue effectively. The logic correctly handles edge cases like multiple queued messages.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/bot.go | Added immediate `⏳ queued` acknowledgment when messages arrive during active session, with good refactoring to share ack logic |

</details>



<sub>Last reviewed commit: 6c77076</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->