### PR TITLE
P1: Browser snapshot_id+ref resolver (no CSS-by-axref)

### DIFF
--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -536,6 +536,12 @@ func (a *ToolCallingAgent) parseToolCall(response string) *ToolCall {
 	return &toolCall
 }
 
+// JSONExecutor is implemented by tools that accept structured JSON params
+// directly, bypassing positional arg conversion.
+type JSONExecutor interface {
+	ExecuteJSON(ctx context.Context, params map[string]string) (string, error)
+}
+
 // executeToolFromJSON executes a tool with JSON arguments
 func (a *ToolCallingAgent) executeToolFromJSON(ctx context.Context, toolName string, argsJSON string) (string, error) {
 	tool, ok := a.tools.Get(toolName)
@@ -547,6 +553,16 @@ func (a *ToolCallingAgent) executeToolFromJSON(ctx context.Context, toolName str
 	var argsMap map[string]interface{}
 	if err := json.Unmarshal([]byte(argsJSON), &argsMap); err != nil {
 		return "", fmt.Errorf("failed to parse arguments: %w", err)
+	}
+
+	// If the tool supports structured JSON params, use that path directly.
+	// This preserves all named params (e.g. snapshot_id, ref) without loss.
+	if je, ok := tool.(JSONExecutor); ok {
+		strParams := make(map[string]string, len(argsMap))
+		for k, v := range argsMap {
+			strParams[k] = fmt.Sprintf("%v", v)
+		}
+		return je.ExecuteJSON(ctx, strParams)
 	}
 
 	// Convert args map to string slice

--- a/internal/browser/snapshot.go
+++ b/internal/browser/snapshot.go
@@ -1,0 +1,343 @@
+package browser
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chromedp/cdproto/accessibility"
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/dom"
+	"github.com/chromedp/cdproto/input"
+	"github.com/chromedp/chromedp"
+)
+
+const (
+	defaultSnapshotTTL = 30 * time.Second
+	maxSnapshots       = 20
+)
+
+// ElementRef describes an interactive element in a snapshot.
+type ElementRef struct {
+	Ref           string            `json:"ref"`
+	Role          string            `json:"role"`
+	Name          string            `json:"name"`
+	BackendNodeID cdp.BackendNodeID `json:"-"`
+}
+
+// Snapshot holds a page accessibility snapshot with ref mappings.
+type Snapshot struct {
+	ID        string       `json:"snapshot_id"`
+	URL       string       `json:"url"`
+	Title     string       `json:"title"`
+	Elements  []ElementRef `json:"elements"`
+	CreatedAt time.Time    `json:"-"`
+
+	refMap map[string]cdp.BackendNodeID
+}
+
+// SnapshotStore is a TTL-based in-memory cache for page snapshots.
+type SnapshotStore struct {
+	mu        sync.RWMutex
+	snapshots map[string]*Snapshot
+	ttl       time.Duration
+}
+
+// NewSnapshotStore creates a new store with the given TTL.
+func NewSnapshotStore(ttl time.Duration) *SnapshotStore {
+	if ttl <= 0 {
+		ttl = defaultSnapshotTTL
+	}
+	return &SnapshotStore{
+		snapshots: make(map[string]*Snapshot),
+		ttl:       ttl,
+	}
+}
+
+// Put stores a snapshot. If the store exceeds maxSnapshots, the oldest entry is evicted.
+func (s *SnapshotStore) Put(snap *Snapshot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Evict expired entries first.
+	now := time.Now()
+	for id, sn := range s.snapshots {
+		if now.Sub(sn.CreatedAt) > s.ttl {
+			delete(s.snapshots, id)
+		}
+	}
+
+	// If still at capacity, evict oldest.
+	if len(s.snapshots) >= maxSnapshots {
+		var oldestID string
+		var oldestTime time.Time
+		for id, sn := range s.snapshots {
+			if oldestID == "" || sn.CreatedAt.Before(oldestTime) {
+				oldestID = id
+				oldestTime = sn.CreatedAt
+			}
+		}
+		if oldestID != "" {
+			delete(s.snapshots, oldestID)
+		}
+	}
+
+	s.snapshots[snap.ID] = snap
+}
+
+// Get returns a snapshot by ID. Returns nil if not found or expired.
+func (s *SnapshotStore) Get(id string) *Snapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	snap, ok := s.snapshots[id]
+	if !ok {
+		return nil
+	}
+	if time.Since(snap.CreatedAt) > s.ttl {
+		return nil
+	}
+	return snap
+}
+
+// Resolve returns the BackendNodeID for a given snapshot_id + ref.
+func (s *SnapshotStore) Resolve(snapshotID, ref string) (cdp.BackendNodeID, error) {
+	snap := s.Get(snapshotID)
+	if snap == nil {
+		return 0, fmt.Errorf("snapshot %q not found or expired — take a new snapshot first", snapshotID)
+	}
+	nodeID, ok := snap.refMap[ref]
+	if !ok {
+		return 0, fmt.Errorf("ref %q not found in snapshot %q", ref, snapshotID)
+	}
+	return nodeID, nil
+}
+
+// Len returns the number of non-expired snapshots.
+func (s *SnapshotStore) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	count := 0
+	now := time.Now()
+	for _, sn := range s.snapshots {
+		if now.Sub(sn.CreatedAt) <= s.ttl {
+			count++
+		}
+	}
+	return count
+}
+
+// generateID returns a short random hex string.
+func generateID() string {
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// interactiveRoles lists AX roles that are typically actionable.
+var interactiveRoles = map[string]bool{
+	"button":        true,
+	"link":          true,
+	"textbox":       true,
+	"checkbox":      true,
+	"radio":         true,
+	"combobox":      true,
+	"menuitem":      true,
+	"tab":           true,
+	"switch":        true,
+	"searchbox":     true,
+	"spinbutton":    true,
+	"slider":        true,
+	"option":        true,
+	"menuitemradio": true,
+	"treeitem":      true,
+}
+
+// TakeSnapshot captures the accessibility tree of the current page,
+// assigns refs to interactive elements, and stores the snapshot.
+func TakeSnapshot(ctx context.Context, store *SnapshotStore) (*Snapshot, error) {
+	// Get page URL + title.
+	var url, title string
+	if err := chromedp.Run(ctx,
+		chromedp.Location(&url),
+		chromedp.Title(&title),
+	); err != nil {
+		return nil, fmt.Errorf("failed to get page info: %w", err)
+	}
+
+	// Fetch the full accessibility tree.
+	var nodes []*accessibility.Node
+	if err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		var err error
+		nodes, err = accessibility.GetFullAXTree().Do(ctx)
+		return err
+	})); err != nil {
+		return nil, fmt.Errorf("failed to get accessibility tree: %w", err)
+	}
+
+	// Build refs for interactive elements.
+	elements := make([]ElementRef, 0, 64)
+	refMap := make(map[string]cdp.BackendNodeID, 64)
+	counter := 0
+
+	for _, node := range nodes {
+		if node.Ignored {
+			continue
+		}
+		if node.BackendDOMNodeID == 0 {
+			continue
+		}
+
+		role := axValueString(node.Role)
+		if role == "" {
+			continue
+		}
+		name := axValueString(node.Name)
+
+		if !interactiveRoles[role] && name == "" {
+			continue
+		}
+		if !interactiveRoles[role] {
+			continue
+		}
+
+		counter++
+		ref := fmt.Sprintf("e%d", counter)
+		elements = append(elements, ElementRef{
+			Ref:           ref,
+			Role:          role,
+			Name:          name,
+			BackendNodeID: node.BackendDOMNodeID,
+		})
+		refMap[ref] = node.BackendDOMNodeID
+	}
+
+	snap := &Snapshot{
+		ID:        generateID(),
+		URL:       url,
+		Title:     title,
+		Elements:  elements,
+		CreatedAt: time.Now(),
+		refMap:    refMap,
+	}
+	store.Put(snap)
+	return snap, nil
+}
+
+// ClickByRef clicks an element identified by snapshot_id + ref.
+func ClickByRef(ctx context.Context, store *SnapshotStore, snapshotID, ref string) error {
+	backendID, err := store.Resolve(snapshotID, ref)
+	if err != nil {
+		return err
+	}
+	return clickByBackendNodeID(ctx, backendID)
+}
+
+// TypeByRef types text into an element identified by snapshot_id + ref.
+func TypeByRef(ctx context.Context, store *SnapshotStore, snapshotID, ref, text string) error {
+	backendID, err := store.Resolve(snapshotID, ref)
+	if err != nil {
+		return err
+	}
+	return typeByBackendNodeID(ctx, backendID, text)
+}
+
+// FocusByRef focuses an element identified by snapshot_id + ref.
+func FocusByRef(ctx context.Context, store *SnapshotStore, snapshotID, ref string) error {
+	backendID, err := store.Resolve(snapshotID, ref)
+	if err != nil {
+		return err
+	}
+	return focusByBackendNodeID(ctx, backendID)
+}
+
+// clickByBackendNodeID clicks the center of the element.
+func clickByBackendNodeID(ctx context.Context, backendID cdp.BackendNodeID) error {
+	return chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		// Get element position.
+		quads, err := dom.GetContentQuads().WithBackendNodeID(backendID).Do(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get element position: %w", err)
+		}
+		if len(quads) == 0 {
+			return fmt.Errorf("element has no visible quads")
+		}
+
+		// Compute center of first quad (8 floats: 4 x,y pairs).
+		q := quads[0]
+		if len(q) < 8 {
+			return fmt.Errorf("invalid quad data")
+		}
+		x := (q[0] + q[2] + q[4] + q[6]) / 4
+		y := (q[1] + q[3] + q[5] + q[7]) / 4
+
+		// Dispatch mouse press + release.
+		if err := input.DispatchMouseEvent(input.MousePressed, x, y).
+			WithButton(input.Left).WithClickCount(1).Do(ctx); err != nil {
+			return err
+		}
+		return input.DispatchMouseEvent(input.MouseReleased, x, y).
+			WithButton(input.Left).WithClickCount(1).Do(ctx)
+	}))
+}
+
+// focusByBackendNodeID focuses the element.
+func focusByBackendNodeID(ctx context.Context, backendID cdp.BackendNodeID) error {
+	return chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		return dom.Focus().WithBackendNodeID(backendID).Do(ctx)
+	}))
+}
+
+// typeByBackendNodeID focuses the element and dispatches key events.
+func typeByBackendNodeID(ctx context.Context, backendID cdp.BackendNodeID, text string) error {
+	return chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		// Focus first.
+		if err := dom.Focus().WithBackendNodeID(backendID).Do(ctx); err != nil {
+			return fmt.Errorf("failed to focus element: %w", err)
+		}
+
+		// Dispatch key events for each character.
+		for _, ch := range text {
+			s := string(ch)
+			if err := input.DispatchKeyEvent(input.KeyChar).WithText(s).Do(ctx); err != nil {
+				return fmt.Errorf("failed to type character %q: %w", s, err)
+			}
+		}
+		return nil
+	}))
+}
+
+// FormatSnapshot returns a human-readable text representation of a snapshot.
+func FormatSnapshot(snap *Snapshot) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "snapshot_id: %s\n", snap.ID)
+	fmt.Fprintf(&b, "url: %s\n", snap.URL)
+	fmt.Fprintf(&b, "title: %s\n", snap.Title)
+	fmt.Fprintf(&b, "elements: %d\n\n", len(snap.Elements))
+	for _, e := range snap.Elements {
+		if e.Name != "" {
+			fmt.Fprintf(&b, "  [%s] %s %q\n", e.Ref, e.Role, e.Name)
+		} else {
+			fmt.Fprintf(&b, "  [%s] %s\n", e.Ref, e.Role)
+		}
+	}
+	return b.String()
+}
+
+// axValueString extracts the string value from an AX Value.
+func axValueString(v *accessibility.Value) string {
+	if v == nil {
+		return ""
+	}
+	raw := string(v.Value)
+	// Strip surrounding quotes from JSON string values.
+	raw = strings.TrimSpace(raw)
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		raw = raw[1 : len(raw)-1]
+	}
+	return raw
+}

--- a/internal/browser/snapshot_test.go
+++ b/internal/browser/snapshot_test.go
@@ -1,0 +1,215 @@
+package browser
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto/cdp"
+)
+
+func TestSnapshotStore_PutAndGet(t *testing.T) {
+	store := NewSnapshotStore(5 * time.Second)
+
+	snap := &Snapshot{
+		ID:        "abc123",
+		URL:       "https://example.com",
+		Title:     "Example",
+		CreatedAt: time.Now(),
+		refMap: map[string]cdp.BackendNodeID{
+			"e1": 100,
+			"e2": 200,
+		},
+		Elements: []ElementRef{
+			{Ref: "e1", Role: "button", Name: "Submit", BackendNodeID: 100},
+			{Ref: "e2", Role: "link", Name: "Home", BackendNodeID: 200},
+		},
+	}
+
+	store.Put(snap)
+
+	got := store.Get("abc123")
+	if got == nil {
+		t.Fatal("expected snapshot, got nil")
+	}
+	if got.URL != "https://example.com" {
+		t.Errorf("URL = %q, want %q", got.URL, "https://example.com")
+	}
+	if len(got.Elements) != 2 {
+		t.Errorf("len(Elements) = %d, want 2", len(got.Elements))
+	}
+}
+
+func TestSnapshotStore_GetMissing(t *testing.T) {
+	store := NewSnapshotStore(5 * time.Second)
+	if got := store.Get("nonexistent"); got != nil {
+		t.Errorf("expected nil for missing snapshot, got %+v", got)
+	}
+}
+
+func TestSnapshotStore_TTLExpiry(t *testing.T) {
+	store := NewSnapshotStore(50 * time.Millisecond)
+
+	snap := &Snapshot{
+		ID:        "exp1",
+		CreatedAt: time.Now(),
+		refMap:    map[string]cdp.BackendNodeID{"e1": 1},
+	}
+	store.Put(snap)
+
+	// Should be available immediately.
+	if store.Get("exp1") == nil {
+		t.Fatal("expected snapshot before TTL expiry")
+	}
+
+	// Wait for expiry.
+	time.Sleep(100 * time.Millisecond)
+
+	if store.Get("exp1") != nil {
+		t.Error("expected nil after TTL expiry")
+	}
+}
+
+func TestSnapshotStore_Resolve(t *testing.T) {
+	store := NewSnapshotStore(5 * time.Second)
+
+	snap := &Snapshot{
+		ID:        "res1",
+		CreatedAt: time.Now(),
+		refMap: map[string]cdp.BackendNodeID{
+			"e1": 42,
+			"e2": 99,
+		},
+	}
+	store.Put(snap)
+
+	// Valid ref.
+	nodeID, err := store.Resolve("res1", "e1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nodeID != 42 {
+		t.Errorf("nodeID = %d, want 42", nodeID)
+	}
+
+	// Invalid ref.
+	_, err = store.Resolve("res1", "e99")
+	if err == nil {
+		t.Error("expected error for invalid ref")
+	}
+
+	// Invalid snapshot.
+	_, err = store.Resolve("nonexistent", "e1")
+	if err == nil {
+		t.Error("expected error for invalid snapshot_id")
+	}
+}
+
+func TestSnapshotStore_ResolveExpired(t *testing.T) {
+	store := NewSnapshotStore(50 * time.Millisecond)
+
+	snap := &Snapshot{
+		ID:        "exp2",
+		CreatedAt: time.Now(),
+		refMap:    map[string]cdp.BackendNodeID{"e1": 1},
+	}
+	store.Put(snap)
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, err := store.Resolve("exp2", "e1")
+	if err == nil {
+		t.Error("expected error for expired snapshot")
+	}
+	if err != nil && !containsSubstring(err.Error(), "expired") && !containsSubstring(err.Error(), "not found") {
+		t.Errorf("error should mention expired/not found, got: %v", err)
+	}
+}
+
+func TestSnapshotStore_EvictsOldest(t *testing.T) {
+	store := NewSnapshotStore(10 * time.Second)
+
+	// Fill beyond capacity.
+	for i := 0; i < maxSnapshots+5; i++ {
+		snap := &Snapshot{
+			ID:        generateID(),
+			CreatedAt: time.Now(),
+			refMap:    map[string]cdp.BackendNodeID{},
+		}
+		store.Put(snap)
+	}
+
+	if store.Len() > maxSnapshots {
+		t.Errorf("store.Len() = %d, want <= %d", store.Len(), maxSnapshots)
+	}
+}
+
+func TestSnapshotStore_Len(t *testing.T) {
+	store := NewSnapshotStore(5 * time.Second)
+
+	if store.Len() != 0 {
+		t.Errorf("empty store Len() = %d, want 0", store.Len())
+	}
+
+	store.Put(&Snapshot{ID: "a", CreatedAt: time.Now(), refMap: map[string]cdp.BackendNodeID{}})
+	store.Put(&Snapshot{ID: "b", CreatedAt: time.Now(), refMap: map[string]cdp.BackendNodeID{}})
+
+	if store.Len() != 2 {
+		t.Errorf("Len() = %d, want 2", store.Len())
+	}
+}
+
+func TestFormatSnapshot(t *testing.T) {
+	snap := &Snapshot{
+		ID:    "fmt1",
+		URL:   "https://example.com",
+		Title: "Test Page",
+		Elements: []ElementRef{
+			{Ref: "e1", Role: "button", Name: "OK"},
+			{Ref: "e2", Role: "link", Name: ""},
+		},
+	}
+
+	out := FormatSnapshot(snap)
+	if !containsSubstring(out, "snapshot_id: fmt1") {
+		t.Errorf("output missing snapshot_id, got:\n%s", out)
+	}
+	if !containsSubstring(out, "[e1] button") {
+		t.Errorf("output missing e1, got:\n%s", out)
+	}
+	if !containsSubstring(out, `"OK"`) {
+		t.Errorf("output missing name, got:\n%s", out)
+	}
+	if !containsSubstring(out, "[e2] link") {
+		t.Errorf("output missing e2, got:\n%s", out)
+	}
+}
+
+func TestGenerateID(t *testing.T) {
+	id1 := generateID()
+	id2 := generateID()
+	if id1 == id2 {
+		t.Error("generateID returned duplicate IDs")
+	}
+	if len(id1) != 8 {
+		t.Errorf("expected 8-char hex ID, got %q (len %d)", id1, len(id1))
+	}
+}
+
+func TestAxValueString(t *testing.T) {
+	if got := axValueString(nil); got != "" {
+		t.Errorf("axValueString(nil) = %q, want empty", got)
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && contains(s, sub))
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tools/browser_tool.go
+++ b/internal/tools/browser_tool.go
@@ -12,6 +12,7 @@ import (
 // BrowserTool provides browser automation capabilities
 type BrowserTool struct {
 	manager   *browser.Manager
+	snapshots *browser.SnapshotStore
 	activeCtx context.Context    // persistent tab context
 	cancelTab context.CancelFunc // cancel for active tab
 }
@@ -19,7 +20,8 @@ type BrowserTool struct {
 // NewBrowserTool creates a new browser tool
 func NewBrowserTool(profilePath string) *BrowserTool {
 	return &BrowserTool{
-		manager: browser.NewManager(profilePath),
+		manager:   browser.NewManager(profilePath),
+		snapshots: browser.NewSnapshotStore(0), // default TTL
 	}
 }
 
@@ -28,13 +30,13 @@ func (b *BrowserTool) Name() string {
 }
 
 func (b *BrowserTool) Description() string {
-	return "Open and control a real Chrome browser on the user's computer. Use 'browser navigate <url>' to open websites, 'browser click <selector>' to click elements, 'browser fill <selector> <value>' to fill forms, 'browser screenshot' to take screenshots, 'browser text <selector>' to extract text. You CAN and SHOULD open websites for the user."
+	return `Control a real Chrome browser. Workflow: call "snapshot" to get a snapshot_id and element refs, then use "click", "fill", or "focus" with snapshot_id+ref to interact. Commands: start, stop, navigate <url>, snapshot, click (ref or selector), fill (ref or selector + value), focus (ref), screenshot, text <selector>, wait <selector>.`
 }
 
 // Execute runs browser commands
 func (b *BrowserTool) Execute(ctx context.Context, args ...string) (string, error) {
 	if len(args) == 0 {
-		return "", fmt.Errorf("usage: browser <start|stop|navigate|click|fill|screenshot|wait|text>")
+		return "", fmt.Errorf("usage: browser <start|stop|navigate|snapshot|click|fill|focus|screenshot|wait|text>")
 	}
 
 	command := args[0]
@@ -49,18 +51,16 @@ func (b *BrowserTool) Execute(ctx context.Context, args ...string) (string, erro
 			return "", fmt.Errorf("URL required")
 		}
 		return b.navigate(args[1])
+	case "snapshot":
+		return b.snapshot()
 	case "click":
-		if len(args) < 2 {
-			return "", fmt.Errorf("selector required")
-		}
-		return b.click(args[1])
+		return b.clickDispatch(args[1:])
 	case "fill":
-		if len(args) < 3 {
-			return "", fmt.Errorf("selector and value required")
-		}
-		return b.fill(args[1], args[2])
+		return b.fillDispatch(args[1:])
+	case "focus":
+		return b.focusDispatch(args[1:])
 	case "screenshot":
-		return b.screenshot()
+		return b.screenshotCmd()
 	case "wait":
 		if len(args) < 2 {
 			return "", fmt.Errorf("selector required")
@@ -71,6 +71,79 @@ func (b *BrowserTool) Execute(ctx context.Context, args ...string) (string, erro
 			return "", fmt.Errorf("selector required")
 		}
 		return b.getText(args[1])
+	default:
+		return "", fmt.Errorf("unknown command: %s", command)
+	}
+}
+
+// ExecuteJSON runs a browser command with structured JSON parameters.
+// This is the preferred entry point from the tool-calling agent.
+func (b *BrowserTool) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
+	command := params["command"]
+	if command == "" {
+		return "", fmt.Errorf("command is required")
+	}
+
+	switch command {
+	case "start":
+		return b.start()
+	case "stop":
+		return b.stop()
+	case "navigate":
+		url := params["url"]
+		if url == "" {
+			return "", fmt.Errorf("url is required for navigate")
+		}
+		return b.navigate(url)
+	case "snapshot":
+		return b.snapshot()
+	case "click":
+		sid := params["snapshot_id"]
+		ref := params["ref"]
+		sel := params["selector"]
+		if sid != "" && ref != "" {
+			return b.clickByRef(sid, ref)
+		}
+		if sel != "" {
+			return b.clickCSS(sel)
+		}
+		return "", fmt.Errorf("click requires snapshot_id+ref or selector")
+	case "fill":
+		val := params["value"]
+		if val == "" {
+			return "", fmt.Errorf("value is required for fill")
+		}
+		sid := params["snapshot_id"]
+		ref := params["ref"]
+		sel := params["selector"]
+		if sid != "" && ref != "" {
+			return b.fillByRef(sid, ref, val)
+		}
+		if sel != "" {
+			return b.fillCSS(sel, val)
+		}
+		return "", fmt.Errorf("fill requires snapshot_id+ref or selector")
+	case "focus":
+		sid := params["snapshot_id"]
+		ref := params["ref"]
+		if sid == "" || ref == "" {
+			return "", fmt.Errorf("focus requires snapshot_id and ref")
+		}
+		return b.focusByRef(sid, ref)
+	case "screenshot":
+		return b.screenshotCmd()
+	case "wait":
+		sel := params["selector"]
+		if sel == "" {
+			return "", fmt.Errorf("selector is required for wait")
+		}
+		return b.wait(sel)
+	case "text":
+		sel := params["selector"]
+		if sel == "" {
+			return "", fmt.Errorf("selector is required for text")
+		}
+		return b.getText(sel)
 	default:
 		return "", fmt.Errorf("unknown command: %s", command)
 	}
@@ -112,7 +185,7 @@ func (b *BrowserTool) start() (string, error) {
 		return "", err
 	}
 
-	return "✅ Chrome started successfully", nil
+	return "Chrome started successfully", nil
 }
 
 func (b *BrowserTool) stop() (string, error) {
@@ -122,7 +195,7 @@ func (b *BrowserTool) stop() (string, error) {
 		b.cancelTab = nil
 	}
 	b.manager.Stop()
-	return "✅ Chrome stopped", nil
+	return "Chrome stopped", nil
 }
 
 // NOTE: No context.WithTimeout — chromedp treats context cancellation as "close tab".
@@ -143,42 +216,124 @@ func (b *BrowserTool) navigate(url string) (string, error) {
 		logger.Debugf("Browser: WaitReady after navigate: %v", err)
 	}
 
-	return fmt.Sprintf("✅ Navigated to %s", url), nil
+	return fmt.Sprintf("Navigated to %s", url), nil
 }
 
-func (b *BrowserTool) click(selector string) (string, error) {
+func (b *BrowserTool) snapshot() (string, error) {
 	ctx, err := b.ensureRunning()
 	if err != nil {
 		return "", err
 	}
 
+	snap, err := browser.TakeSnapshot(ctx, b.snapshots)
+	if err != nil {
+		return "", fmt.Errorf("snapshot failed: %w", err)
+	}
+
+	return browser.FormatSnapshot(snap), nil
+}
+
+// --- click dispatchers ---
+
+func (b *BrowserTool) clickDispatch(args []string) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("click requires a selector or snapshot_id+ref")
+	}
+	// Two-arg form: snapshot_id ref
+	if len(args) >= 2 {
+		return b.clickByRef(args[0], args[1])
+	}
+	// Single arg: CSS selector (legacy)
+	return b.clickCSS(args[0])
+}
+
+func (b *BrowserTool) clickByRef(snapshotID, ref string) (string, error) {
+	ctx, err := b.ensureRunning()
+	if err != nil {
+		return "", err
+	}
+	if err := browser.ClickByRef(ctx, b.snapshots, snapshotID, ref); err != nil {
+		return "", fmt.Errorf("click failed: %w", err)
+	}
+	return fmt.Sprintf("Clicked ref %s (snapshot %s)", ref, snapshotID), nil
+}
+
+func (b *BrowserTool) clickCSS(selector string) (string, error) {
+	ctx, err := b.ensureRunning()
+	if err != nil {
+		return "", err
+	}
 	if err := chromedp.Run(ctx,
 		chromedp.WaitVisible(selector),
 		chromedp.Click(selector),
 	); err != nil {
 		return "", fmt.Errorf("failed to click: %w", err)
 	}
-
-	return fmt.Sprintf("✅ Clicked %s", selector), nil
+	return fmt.Sprintf("Clicked %s", selector), nil
 }
 
-func (b *BrowserTool) fill(selector, value string) (string, error) {
+// --- fill dispatchers ---
+
+func (b *BrowserTool) fillDispatch(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("fill requires (selector value) or (snapshot_id ref value)")
+	}
+	// Three-arg form: snapshot_id ref value
+	if len(args) >= 3 {
+		return b.fillByRef(args[0], args[1], args[2])
+	}
+	// Two-arg form: selector value (legacy)
+	return b.fillCSS(args[0], args[1])
+}
+
+func (b *BrowserTool) fillByRef(snapshotID, ref, value string) (string, error) {
 	ctx, err := b.ensureRunning()
 	if err != nil {
 		return "", err
 	}
+	if err := browser.TypeByRef(ctx, b.snapshots, snapshotID, ref, value); err != nil {
+		return "", fmt.Errorf("fill failed: %w", err)
+	}
+	return fmt.Sprintf("Filled ref %s (snapshot %s)", ref, snapshotID), nil
+}
 
+func (b *BrowserTool) fillCSS(selector, value string) (string, error) {
+	ctx, err := b.ensureRunning()
+	if err != nil {
+		return "", err
+	}
 	if err := chromedp.Run(ctx,
 		chromedp.WaitVisible(selector),
 		chromedp.SendKeys(selector, value),
 	); err != nil {
 		return "", fmt.Errorf("failed to fill: %w", err)
 	}
-
-	return fmt.Sprintf("✅ Filled %s", selector), nil
+	return fmt.Sprintf("Filled %s", selector), nil
 }
 
-func (b *BrowserTool) screenshot() (string, error) {
+// --- focus dispatcher ---
+
+func (b *BrowserTool) focusDispatch(args []string) (string, error) {
+	if len(args) < 2 {
+		return "", fmt.Errorf("focus requires snapshot_id and ref")
+	}
+	return b.focusByRef(args[0], args[1])
+}
+
+func (b *BrowserTool) focusByRef(snapshotID, ref string) (string, error) {
+	ctx, err := b.ensureRunning()
+	if err != nil {
+		return "", err
+	}
+	if err := browser.FocusByRef(ctx, b.snapshots, snapshotID, ref); err != nil {
+		return "", fmt.Errorf("focus failed: %w", err)
+	}
+	return fmt.Sprintf("Focused ref %s (snapshot %s)", ref, snapshotID), nil
+}
+
+// --- other commands ---
+
+func (b *BrowserTool) screenshotCmd() (string, error) {
 	ctx, err := b.ensureRunning()
 	if err != nil {
 		return "", err
@@ -190,7 +345,7 @@ func (b *BrowserTool) screenshot() (string, error) {
 	}
 
 	// TODO: Save screenshot to file and return path
-	return fmt.Sprintf("📸 Screenshot taken (%d bytes)", len(buf)), nil
+	return fmt.Sprintf("Screenshot taken (%d bytes)", len(buf)), nil
 }
 
 func (b *BrowserTool) wait(selector string) (string, error) {
@@ -203,7 +358,7 @@ func (b *BrowserTool) wait(selector string) (string, error) {
 		return "", fmt.Errorf("timeout waiting for element: %w", err)
 	}
 
-	return fmt.Sprintf("✅ Element %s is visible", selector), nil
+	return fmt.Sprintf("Element %s is visible", selector), nil
 }
 
 func (b *BrowserTool) getText(selector string) (string, error) {
@@ -227,20 +382,28 @@ func (b *BrowserTool) GetSchema() map[string]interface{} {
 		"properties": map[string]interface{}{
 			"command": map[string]interface{}{
 				"type":        "string",
-				"description": "Browser command: navigate, click, fill, screenshot, text, wait, start, stop",
-				"enum":        []string{"navigate", "click", "fill", "screenshot", "text", "wait", "start", "stop"},
+				"description": "Browser command to execute",
+				"enum":        []string{"navigate", "snapshot", "click", "fill", "focus", "screenshot", "text", "wait", "start", "stop"},
 			},
 			"url": map[string]interface{}{
 				"type":        "string",
 				"description": "URL to navigate to (for 'navigate' command)",
 			},
+			"snapshot_id": map[string]interface{}{
+				"type":        "string",
+				"description": "Snapshot ID returned by 'snapshot' command (for click, fill, focus by ref)",
+			},
+			"ref": map[string]interface{}{
+				"type":        "string",
+				"description": "Element ref from snapshot (e.g. 'e1', 'e2') — used with snapshot_id for click, fill, focus",
+			},
 			"selector": map[string]interface{}{
 				"type":        "string",
-				"description": "CSS selector (for click, fill, text, wait commands)",
+				"description": "CSS selector (fallback for click, fill, text, wait when not using snapshot refs)",
 			},
 			"value": map[string]interface{}{
 				"type":        "string",
-				"description": "Value to fill (for 'fill' command)",
+				"description": "Value to type (for 'fill' command)",
 			},
 		},
 		"required": []string{"command"},


### PR DESCRIPTION
## Summary
- Add `SnapshotStore` with TTL (30s) and LRU eviction for caching page accessibility snapshots
- `TakeSnapshot` captures the Chrome AX tree via CDP, assigns element refs (`e1`, `e2`...) to interactive elements, and maps them to `BackendNodeID`
- `ClickByRef`/`TypeByRef`/`FocusByRef` resolve `snapshot_id + ref` to CDP backend node IDs for precise element interaction
- Browser tool gains `snapshot` and `focus` commands; `click`/`fill` accept both `snapshot_id+ref` and legacy CSS selectors
- `ExecuteJSON` interface allows tools with structured params (snapshot_id, ref) to bypass positional arg conversion
- Updated JSON schema exposes `snapshot_id` and `ref` parameters to AI models

Closes #73

## Test plan
- [x] Unit tests for SnapshotStore (TTL, eviction, resolve, format)
- [ ] Manual: `snapshot → click(ref)` end-to-end with live browser
- [ ] Manual: verify expired snapshot returns clear error message
- [ ] Manual: verify invalid ref returns clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements snapshot-based browser element interaction using Chrome accessibility tree, enabling precise element targeting via refs instead of fragile CSS selectors. The PR adds a TTL-based `SnapshotStore`, element ref mapping (`e1`, `e2`, etc.), and a `JSONExecutor` interface to preserve structured params during tool execution.

**Key Changes:**
- `SnapshotStore` with 30s TTL and LRU eviction (max 20 snapshots)
- `TakeSnapshot()` captures AX tree and assigns refs to interactive elements
- `ClickByRef`/`TypeByRef`/`FocusByRef` resolve `snapshot_id + ref` to CDP backend node IDs
- `ExecuteJSON` interface bypasses positional arg conversion for tools with structured params
- Browser tool gains `snapshot` and `focus` commands; `click`/`fill` support both refs and legacy CSS selectors
- Comprehensive unit tests for snapshot store operations

**Minor Issues:**
- Redundant conditional at `snapshot.go:201-206` (no functional impact)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk - well-tested core functionality with backwards compatibility
- Clean architecture with comprehensive unit tests. The snapshot storage, TTL handling, and LRU eviction logic are well-implemented. Minor style issue (redundant condition) has no functional impact. Strong backwards compatibility via dual execution paths.
- No files require special attention - all changes are well-structured and tested

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/agent/tool_agent.go | Added `JSONExecutor` interface for tools that accept structured JSON params, with clean fallback to positional args for legacy tools |
| internal/browser/snapshot.go | Core snapshot capture and element interaction logic; contains redundant conditional at lines 201-206 that has no functional impact |
| internal/browser/snapshot_test.go | Comprehensive unit tests covering TTL, LRU eviction, resolution, and formatting with good edge case coverage |
| internal/tools/browser_tool.go | Implements both legacy positional args and new JSON-based execution paths with proper snapshot integration and clear error messages |

</details>



<sub>Last reviewed commit: 040a7c4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->