### PR TITLE
P2: Harden Telegram DM auth + deny audit logging

### DIFF
--- a/internal/bot/auth.go
+++ b/internal/bot/auth.go
@@ -65,6 +65,11 @@ func (am *AuthManager) CheckAccess(userID int64, chatID int64) bool {
 	}
 }
 
+// CheckDirectMessageAccess checks DM access by sender ID only.
+func (am *AuthManager) CheckDirectMessageAccess(userID int64) bool {
+	return am.CheckAccess(userID, userID)
+}
+
 // IsAdmin checks if a user is the admin
 func (am *AuthManager) IsAdmin(userID int64) bool {
 	return am.config.AdminID != 0 && am.config.AdminID == userID

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -228,15 +228,15 @@ func (b *Bot) Start(ctx context.Context) error {
 	})
 
 	// Handle commands
-	b.api.Handle("/start", func(c telebot.Context) error {
+	b.api.Handle("/start", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		greeting := fmt.Sprintf("🦞 Welcome! I'm %s %s\n\n%s",
 			name,
 			emoji,
 			"I'm your personal AI assistant. Just send me a message and I'll help you out.")
 		return c.Send(greeting)
-	})
+	}))
 
-	b.api.Handle("/help", func(c telebot.Context) error {
+	b.api.Handle("/help", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		help := fmt.Sprintf(`🦞 %s Commands:
 
 /start - Start the bot
@@ -251,28 +251,28 @@ func (b *Bot) Start(ctx context.Context) error {
 /pair <code> - Pair with bot using pairing code
 /reload - Reload configuration (admin only)`, name)
 		return c.Send(help)
-	})
+	}))
 
-	b.api.Handle("/status", func(c telebot.Context) error {
+	b.api.Handle("/status", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleStatusCommand(c)
-	})
+	}))
 
-	b.api.Handle("/tools", func(c telebot.Context) error {
+	b.api.Handle("/tools", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		var toolsList []string
 		for _, t := range b.toolRegistry.List() {
 			toolsList = append(toolsList, fmt.Sprintf("• %s: %s", t.Name(), t.Description()))
 		}
 		return c.Send(fmt.Sprintf("🔧 Available Tools:\n\n%s", strings.Join(toolsList, "\n")))
-	})
+	}))
 
-	b.api.Handle("/clear", func(c telebot.Context) error {
+	b.api.Handle("/clear", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		if err := b.store.SaveSession(c.Chat().ID, ""); err != nil {
 			return c.Send("❌ Failed to clear history")
 		}
 		return c.Send("✅ Conversation history cleared")
-	})
+	}))
 
-	b.api.Handle("/memory", func(c telebot.Context) error {
+	b.api.Handle("/memory", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		note, err := b.memory.GetTodayNote()
 		if err != nil {
 			return c.Send("❌ Failed to load memory")
@@ -284,31 +284,31 @@ func (b *Bot) Start(ctx context.Context) error {
 
 		return c.Send(fmt.Sprintf("📓 *Today's Memory*\n\n%s", note.Content),
 			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
-	})
+	}))
 
-	b.api.Handle("/model", func(c telebot.Context) error {
+	b.api.Handle("/model", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleModelCommand(c)
-	})
+	}))
 
-	b.api.Handle("/activate", func(c telebot.Context) error {
+	b.api.Handle("/activate", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleActivateCommand(c)
-	})
+	}))
 
-	b.api.Handle("/standby", func(c telebot.Context) error {
+	b.api.Handle("/standby", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleStandbyCommand(c)
-	})
+	}))
 
-	b.api.Handle("/auth", func(c telebot.Context) error {
+	b.api.Handle("/auth", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleAuthCommand(c)
-	})
+	}))
 
-	b.api.Handle("/pair", func(c telebot.Context) error {
+	b.api.Handle("/pair", b.guardUnauthorizedDM(true, func(c telebot.Context) error {
 		return b.handlePairCommand(c)
-	})
+	}))
 
-	b.api.Handle("/reload", func(c telebot.Context) error {
+	b.api.Handle("/reload", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleReloadCommand(c)
-	})
+	}))
 
 	// Start bot in goroutine
 	go b.api.Start()
@@ -344,9 +344,12 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 	logger.Debugf("Bot: message from user=%d (@%s) chat=%d len=%d", userID, username, chatID, len(content))
 
 	// Check authorization first (skip for /pair command)
+	if !strings.HasPrefix(content, "/pair") && b.denyUnauthorizedDirectMessage(msg) {
+		return c.Send(unauthorizedDMMessage)
+	}
 	if !strings.HasPrefix(content, "/pair") && !b.authManager.CheckAccess(userID, chatID) {
 		logger.Debugf("Bot: auth denied for user=%d chat=%d", userID, chatID)
-		return c.Send("🔒 Not authorized. Please contact the bot administrator.")
+		return c.Send(unauthorizedDMMessage)
 	}
 
 	// Check for stop phrase first — cancel any active run before confirming.
@@ -439,7 +442,6 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 	// No AI configured — echo the message.
 	return c.Send(fmt.Sprintf("You said: %s", content))
 }
-
 
 // handleStreamingRequest processes message with streaming response
 func (b *Bot) handleStreamingRequest(ctx context.Context, c telebot.Context, content, session string) error {

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -14,61 +14,61 @@ import (
 
 // registerExtraHandlers registers all additional command handlers
 func (b *Bot) registerExtraHandlers() {
-	b.api.Handle("/abort", func(c telebot.Context) error {
+	b.api.Handle("/abort", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleAbortCommand(c)
-	})
+	}))
 
-	b.api.Handle("/whoami", func(c telebot.Context) error {
+	b.api.Handle("/whoami", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleWhoamiCommand(c)
-	})
+	}))
 
-	b.api.Handle("/commands", func(c telebot.Context) error {
+	b.api.Handle("/commands", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleCommandsCommand(c)
-	})
+	}))
 
-	b.api.Handle("/new", func(c telebot.Context) error {
+	b.api.Handle("/new", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleNewCommand(c)
-	})
+	}))
 
-	b.api.Handle("/stop", func(c telebot.Context) error {
+	b.api.Handle("/stop", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleStopCommand(c)
-	})
+	}))
 
-	b.api.Handle("/usage", func(c telebot.Context) error {
+	b.api.Handle("/usage", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleUsageCommand(c)
-	})
+	}))
 
-	b.api.Handle("/context", func(c telebot.Context) error {
+	b.api.Handle("/context", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleContextCommand(c)
-	})
+	}))
 
-	b.api.Handle("/compact", func(c telebot.Context) error {
+	b.api.Handle("/compact", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleCompactCommand(c)
-	})
+	}))
 
-	b.api.Handle("/think", func(c telebot.Context) error {
+	b.api.Handle("/think", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleThinkCommand(c)
-	})
+	}))
 
-	b.api.Handle("/verbose", func(c telebot.Context) error {
+	b.api.Handle("/verbose", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleVerboseCommand(c)
-	})
+	}))
 
-	b.api.Handle("/queue", func(c telebot.Context) error {
+	b.api.Handle("/queue", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleQueueCommand(c)
-	})
+	}))
 
-	b.api.Handle("/tts", func(c telebot.Context) error {
+	b.api.Handle("/tts", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleTTSCommand(c)
-	})
+	}))
 
-	b.api.Handle("/restart", func(c telebot.Context) error {
+	b.api.Handle("/restart", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleRestartCommand(c)
-	})
+	}))
 
-	b.api.Handle("/task", func(c telebot.Context) error {
+	b.api.Handle("/task", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleTaskCommand(c)
-	})
+	}))
 }
 
 // handleWhoamiCommand shows sender info

--- a/internal/bot/config_reload.go
+++ b/internal/bot/config_reload.go
@@ -20,9 +20,9 @@ func (b *Bot) SetConfigWatcher(watcher ConfigWatcher) {
 
 // RegisterReloadCommand registers the /reload command handler
 func (b *Bot) RegisterReloadCommand() {
-	b.api.Handle("/reload", func(c telebot.Context) error {
+	b.api.Handle("/reload", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleReloadCommand(c)
-	})
+	}))
 }
 
 // handleReloadCommand handles the /reload command (admin only)

--- a/internal/bot/dm_auth.go
+++ b/internal/bot/dm_auth.go
@@ -1,0 +1,46 @@
+package bot
+
+import (
+	"time"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/logger"
+)
+
+const unauthorizedDMMessage = "🔒 Not authorized. Please contact the bot administrator."
+
+func (b *Bot) denyUnauthorizedDirectMessage(msg *telebot.Message) bool {
+	if msg == nil || msg.Chat == nil || msg.Sender == nil {
+		return false
+	}
+	if msg.Chat.Type != telebot.ChatPrivate {
+		return false
+	}
+	if b.authManager.CheckDirectMessageAccess(msg.Sender.ID) {
+		return false
+	}
+
+	b.auditUnauthorizedDirectMessage(msg)
+	return true
+}
+
+func (b *Bot) auditUnauthorizedDirectMessage(msg *telebot.Message) {
+	logger.Warnf(
+		"audit=telegram_dm_auth_deny timestamp=%s sender_id=%d chat_id=%d channel=telegram_dm chat_type=%s username=%q reason=unauthorized_dm_sender",
+		time.Now().UTC().Format(time.RFC3339),
+		msg.Sender.ID,
+		msg.Chat.ID,
+		msg.Chat.Type,
+		msg.Sender.Username,
+	)
+}
+
+func (b *Bot) guardUnauthorizedDM(allowUnauthorizedDM bool, handler telebot.HandlerFunc) telebot.HandlerFunc {
+	return func(c telebot.Context) error {
+		if !allowUnauthorizedDM && b.denyUnauthorizedDirectMessage(c.Message()) {
+			return c.Send(unauthorizedDMMessage)
+		}
+		return handler(c)
+	}
+}

--- a/internal/bot/dm_auth_test.go
+++ b/internal/bot/dm_auth_test.go
@@ -1,0 +1,233 @@
+package bot
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/storage"
+)
+
+type fakeContext struct {
+	telebot.Context
+	msg  *telebot.Message
+	sent []string
+}
+
+func (c *fakeContext) Message() *telebot.Message {
+	return c.msg
+}
+
+func (c *fakeContext) Chat() *telebot.Chat {
+	return c.msg.Chat
+}
+
+func (c *fakeContext) Sender() *telebot.User {
+	return c.msg.Sender
+}
+
+func (c *fakeContext) Send(what interface{}, _ ...interface{}) error {
+	c.sent = append(c.sent, fmt.Sprint(what))
+	return nil
+}
+
+func TestHandleMessage_DeniesUnauthorizedDirectMessageWithoutSideEffects(t *testing.T) {
+	bot, store, memoryRoot := newUnauthorizedDMTestBot(t)
+
+	ctx := &fakeContext{
+		msg: &telebot.Message{
+			ID:   101,
+			Text: "hello from an intruder",
+			Chat: &telebot.Chat{ID: 7001, Type: telebot.ChatPrivate},
+			Sender: &telebot.User{
+				ID:       9001,
+				Username: "intruder",
+			},
+		},
+	}
+
+	logs := captureLogs(t, func() {
+		if err := bot.handleMessage(context.Background(), ctx); err != nil {
+			t.Fatalf("handleMessage() error = %v", err)
+		}
+	})
+
+	if len(ctx.sent) != 1 || ctx.sent[0] != unauthorizedDMMessage {
+		t.Fatalf("unexpected responses: %#v", ctx.sent)
+	}
+
+	assertTableCount(t, store, "messages", 0)
+	assertTableCount(t, store, "sessions", 0)
+	assertTableCount(t, store, "session_messages", 0)
+
+	if _, err := os.Stat(filepath.Join(memoryRoot, "memory")); !os.IsNotExist(err) {
+		t.Fatalf("expected no memory writes, stat err = %v", err)
+	}
+
+	if !strings.Contains(logs, "audit=telegram_dm_auth_deny") {
+		t.Fatalf("expected audit log, got %q", logs)
+	}
+	for _, want := range []string{
+		"sender_id=9001",
+		"chat_id=7001",
+		"channel=telegram_dm",
+		`username="intruder"`,
+		"reason=unauthorized_dm_sender",
+	} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("expected %q in logs: %q", want, logs)
+		}
+	}
+	if !regexp.MustCompile(`timestamp=\d{4}-\d{2}-\d{2}T`).MatchString(logs) {
+		t.Fatalf("expected RFC3339 timestamp in logs: %q", logs)
+	}
+}
+
+func TestGuardUnauthorizedDM_BlocksWrappedHandlerBeforeStateMutation(t *testing.T) {
+	bot, store, _ := newUnauthorizedDMTestBot(t)
+	const chatID = 7002
+
+	if err := store.SaveSession(chatID, "existing shared session"); err != nil {
+		t.Fatalf("SaveSession() error = %v", err)
+	}
+
+	called := false
+	handler := bot.guardUnauthorizedDM(false, func(c telebot.Context) error {
+		called = true
+		return store.SaveSession(c.Chat().ID, "")
+	})
+
+	ctx := &fakeContext{
+		msg: &telebot.Message{
+			ID:   102,
+			Text: "/clear",
+			Chat: &telebot.Chat{ID: chatID, Type: telebot.ChatPrivate},
+			Sender: &telebot.User{
+				ID:       9002,
+				Username: "blocked_user",
+			},
+		},
+	}
+
+	if err := handler(ctx); err != nil {
+		t.Fatalf("guarded handler error = %v", err)
+	}
+
+	if called {
+		t.Fatal("expected wrapped handler not to be called")
+	}
+	if len(ctx.sent) != 1 || ctx.sent[0] != unauthorizedDMMessage {
+		t.Fatalf("unexpected responses: %#v", ctx.sent)
+	}
+
+	session, err := store.GetSession(chatID)
+	if err != nil {
+		t.Fatalf("GetSession() error = %v", err)
+	}
+	if session != "existing shared session" {
+		t.Fatalf("session mutated on deny: %q", session)
+	}
+}
+
+func TestGuardUnauthorizedDM_AllowsExplicitlyUnauthenticatedPairingCommand(t *testing.T) {
+	bot, _, _ := newUnauthorizedDMTestBot(t)
+
+	called := false
+	handler := bot.guardUnauthorizedDM(true, func(c telebot.Context) error {
+		called = true
+		return c.Send("paired")
+	})
+
+	ctx := &fakeContext{
+		msg: &telebot.Message{
+			ID:   103,
+			Text: "/pair 123456",
+			Chat: &telebot.Chat{ID: 7003, Type: telebot.ChatPrivate},
+			Sender: &telebot.User{
+				ID:       9003,
+				Username: "new_user",
+			},
+		},
+	}
+
+	if err := handler(ctx); err != nil {
+		t.Fatalf("guarded handler error = %v", err)
+	}
+
+	if !called {
+		t.Fatal("expected wrapped pairing handler to be called")
+	}
+	if len(ctx.sent) != 1 || ctx.sent[0] != "paired" {
+		t.Fatalf("unexpected responses: %#v", ctx.sent)
+	}
+}
+
+func newUnauthorizedDMTestBot(t *testing.T) (*Bot, *storage.Store, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	store, err := storage.New(filepath.Join(root, "bot.db"))
+	if err != nil {
+		t.Fatalf("storage.New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("store.Close() error = %v", err)
+		}
+	})
+
+	bot := &Bot{
+		store:  store,
+		memory: agent.NewMemory(root),
+		authManager: &AuthManager{
+			store:        store,
+			config:       config.AuthConfig{Mode: "allowlist"},
+			pairingCodes: make(map[string]*PairingCode),
+		},
+		groupManager: NewGroupManager(store, "active", "okgobot"),
+		safety:       agent.NewSafety(),
+		rateLimiter:  NewRateLimiter(10, time.Minute),
+	}
+
+	return bot, store, root
+}
+
+func assertTableCount(t *testing.T, store *storage.Store, table string, want int) {
+	t.Helper()
+
+	var got int
+	if err := store.DB().QueryRow("SELECT COUNT(*) FROM " + table).Scan(&got); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	if got != want {
+		t.Fatalf("table %s count = %d, want %d", table, got, want)
+	}
+}
+
+func captureLogs(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	origWriter := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origWriter)
+		log.SetFlags(origFlags)
+	})
+
+	fn()
+	return buf.String()
+}

--- a/internal/bot/media_handler.go
+++ b/internal/bot/media_handler.go
@@ -117,24 +117,24 @@ func (mgb *MediaGroupBuffer) Stop() {
 // registerMediaHandlers sets up handlers for photos, voice, stickers, documents
 func (b *Bot) registerMediaHandlers(ctx context.Context) {
 	// Handle photos
-	b.api.Handle(telebot.OnPhoto, func(c telebot.Context) error {
+	b.api.Handle(telebot.OnPhoto, b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handlePhotoMessage(ctx, c)
-	})
+	}))
 
 	// Handle voice messages
-	b.api.Handle(telebot.OnVoice, func(c telebot.Context) error {
+	b.api.Handle(telebot.OnVoice, b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleVoiceMessage(ctx, c)
-	})
+	}))
 
 	// Handle stickers (static only)
-	b.api.Handle(telebot.OnSticker, func(c telebot.Context) error {
+	b.api.Handle(telebot.OnSticker, b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleStickerMessage(ctx, c)
-	})
+	}))
 
 	// Handle documents
-	b.api.Handle(telebot.OnDocument, func(c telebot.Context) error {
+	b.api.Handle(telebot.OnDocument, b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleDocumentMessage(ctx, c)
-	})
+	}))
 }
 
 // handlePhotoMessage processes incoming photos
@@ -144,8 +144,11 @@ func (b *Bot) handlePhotoMessage(ctx context.Context, c telebot.Context) error {
 	userID := msg.Sender.ID
 
 	// Auth check
+	if b.denyUnauthorizedDirectMessage(msg) {
+		return c.Send(unauthorizedDMMessage)
+	}
 	if !b.authManager.CheckAccess(userID, chatID) {
-		return c.Send("🔒 Not authorized.")
+		return c.Send(unauthorizedDMMessage)
 	}
 
 	// Group check
@@ -216,8 +219,11 @@ func (b *Bot) handleVoiceMessage(ctx context.Context, c telebot.Context) error {
 	chatID := msg.Chat.ID
 	userID := msg.Sender.ID
 
+	if b.denyUnauthorizedDirectMessage(msg) {
+		return c.Send(unauthorizedDMMessage)
+	}
 	if !b.authManager.CheckAccess(userID, chatID) {
-		return c.Send("🔒 Not authorized.")
+		return c.Send(unauthorizedDMMessage)
 	}
 
 	if !b.groupManager.ShouldRespond(chatID, msg, b.api.Me.Username) {
@@ -247,8 +253,11 @@ func (b *Bot) handleStickerMessage(ctx context.Context, c telebot.Context) error
 	chatID := msg.Chat.ID
 	userID := msg.Sender.ID
 
+	if b.denyUnauthorizedDirectMessage(msg) {
+		return c.Send(unauthorizedDMMessage)
+	}
 	if !b.authManager.CheckAccess(userID, chatID) {
-		return c.Send("🔒 Not authorized.")
+		return c.Send(unauthorizedDMMessage)
 	}
 
 	if !b.groupManager.ShouldRespond(chatID, msg, b.api.Me.Username) {
@@ -289,8 +298,11 @@ func (b *Bot) handleDocumentMessage(ctx context.Context, c telebot.Context) erro
 	chatID := msg.Chat.ID
 	userID := msg.Sender.ID
 
+	if b.denyUnauthorizedDirectMessage(msg) {
+		return c.Send(unauthorizedDMMessage)
+	}
 	if !b.authManager.CheckAccess(userID, chatID) {
-		return c.Send("🔒 Not authorized.")
+		return c.Send(unauthorizedDMMessage)
 	}
 
 	if !b.groupManager.ShouldRespond(chatID, msg, b.api.Me.Username) {


### PR DESCRIPTION
Closes #75

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully hardens Telegram direct message authorization and adds comprehensive audit logging for unauthorized access attempts. All command and media handlers are now protected with `guardUnauthorizedDM` middleware that checks authorization before processing requests.

**Key changes:**
- Introduced `CheckDirectMessageAccess` method for DM-specific auth validation
- Created `guardUnauthorizedDM` middleware wrapper that blocks unauthorized DMs before handler execution
- Added structured audit logging with RFC3339 timestamps, user metadata, and denial reasons
- All handlers now consistently return the same unauthorized message via `unauthorizedDMMessage` constant
- `/pair` command explicitly allows unauthorized access to support the pairing flow
- Media handlers (photo, voice, sticker, document) maintain internal auth checks for defense-in-depth
- Comprehensive test coverage validates denial behavior, state protection, and pairing allowance

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- Clean implementation with comprehensive test coverage, proper error handling, and good security practices including defense-in-depth auth checks and structured audit logging
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/dm_auth.go | New file implementing DM auth guard middleware with structured audit logging - clean implementation |
| internal/bot/dm_auth_test.go | Comprehensive test coverage for DM auth with 3 test cases covering denial, guard blocking, and pairing allowance |
| internal/bot/auth.go | Adds CheckDirectMessageAccess helper method - simple wrapper around CheckAccess for DMs |
| internal/bot/bot.go | Wraps all command handlers with guardUnauthorizedDM and adds early DM auth check in handleMessage - consistent protection |
| internal/bot/commands.go | Wraps all extra command handlers with guardUnauthorizedDM - consistent with main bot handlers |
| internal/bot/config_reload.go | Wraps reload command handler with guardUnauthorizedDM - maintains consistency |
| internal/bot/media_handler.go | Wraps media handlers and maintains internal auth checks - provides defense-in-depth security |

</details>



<sub>Last reviewed commit: 21a2be8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->