### PR TITLE
Bootstrap: stop loading MEMORY.md into system prompt

### DIFF
--- a/internal/agent/personality_test.go
+++ b/internal/agent/personality_test.go
@@ -1,0 +1,151 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"ok-gobot/internal/tools"
+)
+
+type staticTool struct {
+	name string
+	desc string
+}
+
+func (t *staticTool) Name() string        { return t.name }
+func (t *staticTool) Description() string { return t.desc }
+func (t *staticTool) Execute(ctx context.Context, args ...string) (string, error) {
+	return "", nil
+}
+
+func writeTestFile(t *testing.T, baseDir, name, content string) {
+	t.Helper()
+	path := filepath.Join(baseDir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create directory for %s: %v", name, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", name, err)
+	}
+}
+
+func TestNewPersonality_DoesNotLoadMemoryMD(t *testing.T) {
+	tmp := t.TempDir()
+	writeTestFile(t, tmp, "MEMORY.md", "private memory that must not be eagerly loaded")
+
+	p, err := NewPersonality(tmp)
+	if err != nil {
+		t.Fatalf("NewPersonality() error = %v", err)
+	}
+
+	if p.HasFile("MEMORY.md") {
+		t.Fatalf("MEMORY.md should not be loaded into personality files")
+	}
+}
+
+func TestGetSystemPrompt_ExcludesMemoryAndUsesBootstrapOrder(t *testing.T) {
+	tmp := t.TempDir()
+
+	writeTestFile(t, tmp, "SOUL.md", "SOUL_SECTION")
+	writeTestFile(t, tmp, "IDENTITY.md", "IDENTITY_SECTION")
+	writeTestFile(t, tmp, "USER.md", "USER_SECTION")
+	writeTestFile(t, tmp, "TOOLS.md", "TOOLS_SECTION")
+	writeTestFile(t, tmp, "AGENTS.md", "AGENTS_SECTION")
+	writeTestFile(t, tmp, "MEMORY.md", "MEMORY_SECRET_SHOULD_NOT_APPEAR")
+
+	today := time.Now().Format("2006-01-02")
+	writeTestFile(t, tmp, filepath.Join("memory", today+".md"), "TODAY_MEMORY_SHOULD_NOT_APPEAR")
+
+	p, err := NewPersonality(tmp)
+	if err != nil {
+		t.Fatalf("NewPersonality() error = %v", err)
+	}
+
+	prompt := p.GetSystemPrompt()
+	if strings.Contains(prompt, "MEMORY_SECRET_SHOULD_NOT_APPEAR") {
+		t.Fatalf("system prompt should not contain MEMORY.md content")
+	}
+	if strings.Contains(prompt, "TODAY_MEMORY_SHOULD_NOT_APPEAR") {
+		t.Fatalf("system prompt should not contain daily memory content")
+	}
+	if strings.Contains(prompt, "## LONG-TERM MEMORY") {
+		t.Fatalf("system prompt should not include LONG-TERM MEMORY section")
+	}
+
+	sections := []string{
+		"## SOUL",
+		"## IDENTITY",
+		"## USER CONTEXT",
+		"## TOOLS REFERENCE",
+		"## AGENT PROTOCOL",
+	}
+
+	lastPos := -1
+	for _, section := range sections {
+		pos := strings.Index(prompt, section)
+		if pos == -1 {
+			t.Fatalf("missing section %q in system prompt", section)
+		}
+		if pos <= lastPos {
+			t.Fatalf("section %q is out of order in system prompt", section)
+		}
+		lastPos = pos
+	}
+}
+
+func TestBuildSystemPrompt_OrdersSkillsAfterAgentsAndMentionsMemoryTools(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(&staticTool{name: "memory", desc: "legacy memory tool"})
+
+	personality := &Personality{
+		Files: map[string]string{
+			"SOUL.md":     "SOUL_SECTION",
+			"IDENTITY.md": "IDENTITY_SECTION",
+			"USER.md":     "USER_SECTION",
+			"TOOLS.md":    "TOOLS_SECTION",
+			"AGENTS.md":   "AGENTS_SECTION",
+		},
+		Skills: []SkillEntry{
+			{
+				Name:        "repo-inspector",
+				Description: "Inspect repository quickly",
+				Path:        "/tmp/skills/repo-inspector/SKILL.md",
+			},
+		},
+	}
+
+	agent := NewToolCallingAgent(nil, registry, personality)
+	prompt := agent.buildSystemPrompt()
+
+	sections := []string{
+		"## SOUL",
+		"## IDENTITY",
+		"## USER CONTEXT",
+		"## TOOLS REFERENCE",
+		"## AGENT PROTOCOL",
+		"## Skills",
+	}
+
+	lastPos := -1
+	for _, section := range sections {
+		pos := strings.Index(prompt, section)
+		if pos == -1 {
+			t.Fatalf("missing section %q in prompt", section)
+		}
+		if pos <= lastPos {
+			t.Fatalf("section %q is out of order in prompt", section)
+		}
+		lastPos = pos
+	}
+
+	if !strings.Contains(prompt, "memory_search") {
+		t.Fatalf("prompt should instruct proactive use of memory_search")
+	}
+	if !strings.Contains(prompt, "memory_get") {
+		t.Fatalf("prompt should instruct proactive use of memory_get")
+	}
+}

--- a/internal/bootstrap/loader.go
+++ b/internal/bootstrap/loader.go
@@ -26,6 +26,15 @@ var managedFiles = []string{
 	"HEARTBEAT.md",
 }
 
+var filesToLoad = []string{
+	"SOUL.md",
+	"IDENTITY.md",
+	"USER.md",
+	"AGENTS.md",
+	"TOOLS.md",
+	"HEARTBEAT.md",
+}
+
 // SkillEntry represents a discovered skill.
 type SkillEntry struct {
 	Name        string
@@ -97,7 +106,7 @@ func (l *Loader) Reload() error {
 }
 
 func (l *Loader) loadFiles() error {
-	for _, filename := range managedFiles {
+	for _, filename := range filesToLoad {
 		path := filepath.Join(l.BasePath, filename)
 		content, err := os.ReadFile(path)
 		if err != nil {
@@ -135,15 +144,16 @@ func (l *Loader) SystemPrompt() string {
 
 	var prompt strings.Builder
 
-	if identity, ok := l.Files["IDENTITY.md"]; ok {
-		prompt.WriteString("## IDENTITY\n\n")
-		prompt.WriteString(identity)
-		prompt.WriteString("\n\n")
-	}
-
+	// Bootstrap order: SOUL -> IDENTITY -> USER -> TOOLS -> AGENTS.
 	if soul, ok := l.Files["SOUL.md"]; ok {
 		prompt.WriteString("## SOUL\n\n")
 		prompt.WriteString(soul)
+		prompt.WriteString("\n\n")
+	}
+
+	if identity, ok := l.Files["IDENTITY.md"]; ok {
+		prompt.WriteString("## IDENTITY\n\n")
+		prompt.WriteString(identity)
 		prompt.WriteString("\n\n")
 	}
 
@@ -153,28 +163,15 @@ func (l *Loader) SystemPrompt() string {
 		prompt.WriteString("\n\n")
 	}
 
-	if agents, ok := l.Files["AGENTS.md"]; ok {
-		prompt.WriteString("## AGENT PROTOCOL\n\n")
-		prompt.WriteString(agents)
-		prompt.WriteString("\n\n")
-	}
-
 	if toolsRef, ok := l.Files["TOOLS.md"]; ok {
 		prompt.WriteString("## TOOLS REFERENCE\n\n")
 		prompt.WriteString(toolsRef)
 		prompt.WriteString("\n\n")
 	}
 
-	if memory, ok := l.Files["MEMORY.md"]; ok {
-		prompt.WriteString("## LONG-TERM MEMORY\n\n")
-		prompt.WriteString(memory)
-		prompt.WriteString("\n\n")
-	}
-
-	today := l.currentTime().Format("2006-01-02")
-	if daily, ok := l.Files["memory/"+today+".md"]; ok {
-		prompt.WriteString("## TODAY'S ACTIVITY\n\n")
-		prompt.WriteString(daily)
+	if agents, ok := l.Files["AGENTS.md"]; ok {
+		prompt.WriteString("## AGENT PROTOCOL\n\n")
+		prompt.WriteString(agents)
 		prompt.WriteString("\n\n")
 	}
 

--- a/internal/bootstrap/loader_test.go
+++ b/internal/bootstrap/loader_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,16 +31,23 @@ func TestLoaderBuildsSystemPromptFromFiles(t *testing.T) {
 	}
 
 	expected := "" +
-		"## IDENTITY\n\n# Identity\nName: TestBot\nEmoji: 🤖\n\n" +
 		"## SOUL\n\nSoul line\n\n" +
+		"## IDENTITY\n\n# Identity\nName: TestBot\nEmoji: 🤖\n\n" +
 		"## USER CONTEXT\n\nUser line\n\n" +
-		"## AGENT PROTOCOL\n\nAgents line\n\n" +
 		"## TOOLS REFERENCE\n\nTools line\n\n" +
-		"## LONG-TERM MEMORY\n\nMemory line\n\n" +
-		"## TODAY'S ACTIVITY\n\nToday line\n\n"
+		"## AGENT PROTOCOL\n\nAgents line\n\n"
 
 	if got := loader.SystemPrompt(); got != expected {
 		t.Fatalf("SystemPrompt() mismatch\nwant:\n%s\ngot:\n%s", expected, got)
+	}
+	if loader.HasFile("MEMORY.md") {
+		t.Fatalf("MEMORY.md should not be loaded into bootstrap files")
+	}
+	if got := loader.SystemPrompt(); strings.Contains(got, "Memory line") {
+		t.Fatalf("SystemPrompt() should not contain MEMORY.md content")
+	}
+	if got := loader.SystemPrompt(); strings.Contains(got, "Today line") {
+		t.Fatalf("SystemPrompt() should not contain daily memory content")
 	}
 
 	if got := loader.MinimalPrompt(); got != "## IDENTITY\n\n# Identity\nName: TestBot\nEmoji: 🤖\n\n## SOUL\n\nSoul line\n\n" {
@@ -78,8 +86,8 @@ func TestBuildPromptPreservesFullPromptSections(t *testing.T) {
 	})
 
 	expected := "" +
-		"## IDENTITY\n\n- **Name:** TestBot\n- **Emoji:** 🤖\n\n" +
 		"## SOUL\n\nSoul line\n\n" +
+		"## IDENTITY\n\n- **Name:** TestBot\n- **Emoji:** 🤖\n\n" +
 		"\nYou have access to the following tools:\n\n" +
 		"Tool: memory\nDescription: Memory tool\n\n" +
 		"\n## Tool Usage Guidelines\n\n" +
@@ -95,7 +103,8 @@ func TestBuildPromptPreservesFullPromptSections(t *testing.T) {
 		"The system will suppress this and send nothing to the user.\n\n" +
 		"## Memory\n\n" +
 		"Before answering anything about prior work, decisions, dates, people, preferences, or todos:\n" +
-		"search memory first using the memory tool, then use the results to inform your answer.\n\n" +
+		"proactively call memory_search first, then call memory_get for surrounding context when needed.\n" +
+		"If memory_search/memory_get are unavailable, use the legacy memory tool search command as fallback.\n\n" +
 		"## Reply Tags\n\n" +
 		"To reply to the user's message natively (as a Telegram reply): include [[reply_to_current]] anywhere in your response.\n" +
 		"To reply to a specific message: include [[reply_to:<message_id>]]. Tags are stripped from the final message.\n\n" +

--- a/internal/bootstrap/prompt.go
+++ b/internal/bootstrap/prompt.go
@@ -71,10 +71,17 @@ func BuildPrompt(loader *Loader, registry *tools.Registry, opts PromptOptions) s
 		prompt.WriteString("The system will suppress this and send nothing to the user.\n\n")
 
 		if registry != nil {
-			if _, hasMemory := registry.Get("memory"); hasMemory {
+			_, hasMemorySearch := registry.Get("memory_search")
+			_, hasMemoryGet := registry.Get("memory_get")
+			_, hasLegacyMemory := registry.Get("memory")
+			if hasMemorySearch || hasMemoryGet || hasLegacyMemory {
 				prompt.WriteString("## Memory\n\n")
 				prompt.WriteString("Before answering anything about prior work, decisions, dates, people, preferences, or todos:\n")
-				prompt.WriteString("search memory first using the memory tool, then use the results to inform your answer.\n\n")
+				prompt.WriteString("proactively call memory_search first, then call memory_get for surrounding context when needed.\n")
+				if hasLegacyMemory && (!hasMemorySearch || !hasMemoryGet) {
+					prompt.WriteString("If memory_search/memory_get are unavailable, use the legacy memory tool search command as fallback.\n")
+				}
+				prompt.WriteString("\n")
 			}
 		}
 


### PR DESCRIPTION
Closes #90

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully removes `MEMORY.md` and daily memory content from the system prompt while updating the bootstrap section ordering to `SOUL` → `IDENTITY` → `USER` → `TOOLS` → `AGENTS`. The changes include comprehensive test coverage and updated memory tool instructions.

- Excluded `MEMORY.md` from `filesToLoad` array to prevent loading into bootstrap files
- Removed `LONG-TERM MEMORY` and `TODAY'S ACTIVITY` sections from `SystemPrompt()`
- Reordered system prompt sections for better logical flow
- Updated memory tool instructions to reference `memory_search` and `memory_get` tools with legacy fallback
- Added comprehensive test coverage in `personality_test.go`

Minor cleanup opportunity: daily memory files (today/yesterday) are still loaded into `l.Files` at lines 121-130 but never used, which could be removed for consistency.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - the changes are well-tested and backward compatible
- Score reflects solid implementation with comprehensive tests, but notes minor dead code (daily memory file loading) that could be cleaned up for consistency
- internal/bootstrap/loader.go lines 121-130 contain unused code that loads daily memory files

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bootstrap/loader.go | Excluded MEMORY.md from loading, reordered system prompt sections, but daily memory files (lines 121-130) are still loaded without being used |
| internal/bootstrap/loader_test.go | Updated tests to verify MEMORY.md and daily memory exclusion from system prompt, updated expected section ordering |
| internal/bootstrap/prompt.go | Updated memory tool instructions to reference memory_search and memory_get tools with legacy fallback |
| internal/agent/personality_test.go | New comprehensive test coverage for MEMORY.md exclusion, section ordering, and memory tool instructions |

</details>



<sub>Last reviewed commit: 50d905c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->