### PR TITLE
Memory: optional LLM metadata extraction during indexing (people/topics/action_items)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -43,6 +43,8 @@ memory:
   embeddings_base_url: "https://api.openai.com/v1"
   embeddings_api_key: ""  # Can reuse ai.api_key
   embeddings_model: "text-embedding-3-small"
+  metadata_extraction: false
+  metadata_model: "haiku"  # Lightweight model alias/name for metadata extraction
 
 # Multi-Agent Configuration (optional)
 # Configure multiple agents with different personalities, models, and tool restrictions

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -21,6 +21,8 @@ memory:
   embeddings_base_url: "https://api.openai.com/v1"
   embeddings_api_key: ""  # Leave empty to reuse ai.api_key
   embeddings_model: "text-embedding-3-small"
+  metadata_extraction: false
+  metadata_model: "haiku"
 ```
 
 ### Configuration Options
@@ -29,6 +31,8 @@ memory:
 - **embeddings_base_url**: API endpoint for embeddings (OpenAI-compatible)
 - **embeddings_api_key**: API key for embeddings (if empty, reuses `ai.api_key`)
 - **embeddings_model**: Embedding model to use (default: `text-embedding-3-small`)
+- **metadata_extraction**: When `true`, extracts structured metadata (`people/topics/action_items/type`) during indexing
+- **metadata_model**: Lightweight LLM model used for metadata extraction (default: `haiku`)
 
 ### Supported Embedding Providers
 
@@ -57,13 +61,14 @@ memory save Meeting scheduled for Friday at 3pm
 #### Search Memories
 
 ```
-memory search <query> [--limit=<n>]
+memory search <query> [--limit=<n>] [--person=<name>]
 ```
 
 Example:
 ```
 memory search What programming languages does the user prefer? --limit=5
 memory search upcoming meetings
+memory search release decisions --person=Anton
 ```
 
 Returns the most semantically similar memories with similarity scores.
@@ -114,11 +119,12 @@ Deletes the memory with the specified ID.
 ### Database Schema
 
 ```sql
-CREATE TABLE memories (
+CREATE TABLE memory_chunks (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     content TEXT NOT NULL,
     embedding BLOB NOT NULL,
     category TEXT,
+    metadata TEXT NOT NULL DEFAULT '{}',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 ```

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -125,7 +125,7 @@ Semantic memory with vector embeddings. Stores memories in SQLite, searches with
 
 ```
 memory save <text> [--category=<cat>]
-memory search <query> [--limit=<n>]
+memory search <query> [--limit=<n>] [--person=<name>]
 memory list
 memory forget <id>
 ```

--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"ok-gobot/internal/ai"
@@ -498,9 +499,34 @@ func (a *ToolCallingAgent) executeToolFromJSON(ctx context.Context, toolName str
 		// Structured tool with "command" field (e.g. browser, file)
 		args = []string{cmd}
 		// Append known positional params in order
-		for _, key := range []string{"url", "path", "selector", "value", "content", "expression", "task"} {
-			if v, ok := argsMap[key].(string); ok {
-				args = append(args, v)
+		for _, key := range []string{"url", "path", "selector", "value", "query", "content", "expression", "task"} {
+			if v, ok := argsMap[key]; ok {
+				if rendered := stringifyToolArg(v); rendered != "" {
+					args = append(args, rendered)
+				}
+			}
+		}
+
+		// Append common optional flags used by structured tools.
+		for _, key := range []string{"category", "limit", "person"} {
+			if v, ok := argsMap[key]; ok {
+				if rendered := stringifyToolArg(v); rendered != "" {
+					args = append(args, fmt.Sprintf("--%s=%s", key, rendered))
+				}
+			}
+		}
+
+		// Preserve nested filter objects as JSON for tools that support it.
+		if filter, ok := argsMap["filter"]; ok {
+			if raw, err := json.Marshal(filter); err == nil && string(raw) != "null" {
+				args = append(args, "--filter="+string(raw))
+			}
+		}
+
+		// `forget`-style commands expect ID as positional argument.
+		if id, ok := argsMap["id"]; ok {
+			if rendered := stringifyToolArg(id); rendered != "" {
+				args = append(args, rendered)
 			}
 		}
 	} else if op, ok := argsMap["operation"].(string); ok {
@@ -519,6 +545,28 @@ func (a *ToolCallingAgent) executeToolFromJSON(ctx context.Context, toolName str
 	}
 
 	return tool.Execute(ctx, args...)
+}
+
+func stringifyToolArg(value interface{}) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(v)
+	case float64:
+		if v == float64(int64(v)) {
+			return strconv.FormatInt(int64(v), 10)
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case bool:
+		return strconv.FormatBool(v)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }
 
 // executeTool runs the specified tool (legacy format)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 
 	"ok-gobot/internal/agent"
@@ -210,7 +211,34 @@ func (a *App) Start(ctx context.Context) error {
 		if err != nil {
 			log.Printf("⚠️ Failed to initialize memory store: %v", err)
 		} else {
-			a.memoryManager = memory.NewMemoryManager(embClient, memStore)
+			var options []memory.MemoryManagerOption
+
+			if a.config.Memory.MetadataExtraction {
+				metadataModel := strings.TrimSpace(a.config.Memory.MetadataModel)
+				if metadataModel == "" {
+					metadataModel = "haiku"
+				}
+				if fullModel, ok := a.config.ModelAliases[metadataModel]; ok {
+					metadataModel = fullModel
+				} else if fullModel, ok := config.DefaultModelAliases[metadataModel]; ok {
+					metadataModel = fullModel
+				}
+
+				metadataClient, err := ai.NewClient(ai.ProviderConfig{
+					Name:    a.config.AI.Provider,
+					APIKey:  a.config.AI.APIKey,
+					BaseURL: a.config.AI.BaseURL,
+					Model:   metadataModel,
+				})
+				if err != nil {
+					log.Printf("⚠️ Failed to initialize memory metadata extractor: %v", err)
+				} else {
+					options = append(options, memory.WithMetadataExtractor(memory.NewLLMMetadataExtractor(metadataClient)))
+					log.Printf("🧠 Memory metadata extraction enabled (model: %s)", metadataModel)
+				}
+			}
+
+			a.memoryManager = memory.NewMemoryManager(embClient, memStore, options...)
 			log.Println("🧠 Semantic memory initialized")
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,10 +105,12 @@ type TTSConfig struct {
 
 // MemoryConfig holds semantic memory configuration
 type MemoryConfig struct {
-	Enabled           bool   `mapstructure:"enabled"`             // Enable semantic memory
-	EmbeddingsBaseURL string `mapstructure:"embeddings_base_url"` // API base URL for embeddings
-	EmbeddingsAPIKey  string `mapstructure:"embeddings_api_key"`  // API key for embeddings (can reuse ai.api_key)
-	EmbeddingsModel   string `mapstructure:"embeddings_model"`    // Embeddings model to use
+	Enabled            bool   `mapstructure:"enabled"`             // Enable semantic memory
+	EmbeddingsBaseURL  string `mapstructure:"embeddings_base_url"` // API base URL for embeddings
+	EmbeddingsAPIKey   string `mapstructure:"embeddings_api_key"`  // API key for embeddings (can reuse ai.api_key)
+	EmbeddingsModel    string `mapstructure:"embeddings_model"`    // Embeddings model to use
+	MetadataExtraction bool   `mapstructure:"metadata_extraction"` // Extract structured metadata while indexing memories
+	MetadataModel      string `mapstructure:"metadata_model"`      // LLM model used for metadata extraction
 }
 
 // AgentConfig holds configuration for a single agent
@@ -149,6 +151,8 @@ func Load() (*Config, error) {
 	v.SetDefault("memory.embeddings_base_url", "https://api.openai.com/v1")
 	v.SetDefault("memory.embeddings_api_key", "")
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
+	v.SetDefault("memory.metadata_extraction", false)
+	v.SetDefault("memory.metadata_model", "haiku")
 	v.SetDefault("control.enabled", true)
 	v.SetDefault("control.port", 8787)
 	v.SetDefault("control.token", "")
@@ -235,6 +239,8 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("memory.embeddings_base_url", "https://api.openai.com/v1")
 	v.SetDefault("memory.embeddings_api_key", "")
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
+	v.SetDefault("memory.metadata_extraction", false)
+	v.SetDefault("memory.metadata_model", "haiku")
 	v.SetDefault("control.enabled", true)
 	v.SetDefault("control.port", 8787)
 	v.SetDefault("control.token", "")
@@ -345,6 +351,8 @@ func (c *Config) Save() error {
 	v.Set("memory.embeddings_base_url", c.Memory.EmbeddingsBaseURL)
 	v.Set("memory.embeddings_api_key", c.Memory.EmbeddingsAPIKey)
 	v.Set("memory.embeddings_model", c.Memory.EmbeddingsModel)
+	v.Set("memory.metadata_extraction", c.Memory.MetadataExtraction)
+	v.Set("memory.metadata_model", c.Memory.MetadataModel)
 	v.Set("storage_path", c.StoragePath)
 	v.Set("soul_path", c.SoulPath)
 	v.Set("log_level", c.LogLevel)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,6 +34,12 @@ storage_path: "/tmp/test.db"
 	if cfg.Runtime.Mode != "hub" {
 		t.Errorf("expected runtime.mode=%q, got %q", "hub", cfg.Runtime.Mode)
 	}
+	if cfg.Memory.MetadataExtraction {
+		t.Errorf("expected memory.metadata_extraction=false by default")
+	}
+	if cfg.Memory.MetadataModel != "haiku" {
+		t.Errorf("expected memory.metadata_model=%q, got %q", "haiku", cfg.Memory.MetadataModel)
+	}
 }
 
 func TestLoadFromExplicitRuntimeMode(t *testing.T) {
@@ -53,6 +59,9 @@ ai:
 storage_path: "/tmp/test.db"
 runtime:
   mode: "legacy"
+memory:
+  metadata_extraction: true
+  metadata_model: "claude-haiku-3.5"
 `
 	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
 		t.Fatalf("Failed to write config file: %v", err)
@@ -65,5 +74,11 @@ runtime:
 
 	if cfg.Runtime.Mode != "legacy" {
 		t.Errorf("expected runtime.mode=%q, got %q", "legacy", cfg.Runtime.Mode)
+	}
+	if !cfg.Memory.MetadataExtraction {
+		t.Errorf("expected memory.metadata_extraction=true")
+	}
+	if cfg.Memory.MetadataModel != "claude-haiku-3.5" {
+		t.Errorf("expected memory.metadata_model override, got %q", cfg.Memory.MetadataModel)
 	}
 }

--- a/internal/memory/manager.go
+++ b/internal/memory/manager.go
@@ -5,18 +5,40 @@ import (
 	"fmt"
 )
 
+// MetadataExtractor extracts structured metadata from raw memory content.
+type MetadataExtractor interface {
+	Extract(ctx context.Context, content string) (ChunkMetadata, error)
+}
+
 // MemoryManager coordinates embeddings and storage
 type MemoryManager struct {
-	client *EmbeddingClient
-	store  *MemoryStore
+	client    *EmbeddingClient
+	store     *MemoryStore
+	extractor MetadataExtractor
+}
+
+// MemoryManagerOption customizes manager initialization.
+type MemoryManagerOption func(*MemoryManager)
+
+// WithMetadataExtractor enables metadata extraction during Remember().
+func WithMetadataExtractor(extractor MetadataExtractor) MemoryManagerOption {
+	return func(m *MemoryManager) {
+		m.extractor = extractor
+	}
 }
 
 // NewMemoryManager creates a new memory manager
-func NewMemoryManager(client *EmbeddingClient, store *MemoryStore) *MemoryManager {
-	return &MemoryManager{
+func NewMemoryManager(client *EmbeddingClient, store *MemoryStore, opts ...MemoryManagerOption) *MemoryManager {
+	manager := &MemoryManager{
 		client: client,
 		store:  store,
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(manager)
+		}
+	}
+	return manager
 }
 
 // Remember stores a new memory with its embedding
@@ -27,8 +49,15 @@ func (m *MemoryManager) Remember(ctx context.Context, content, category string) 
 		return fmt.Errorf("failed to generate embedding: %w", err)
 	}
 
+	metadata := ChunkMetadata{}
+	if m.extractor != nil {
+		if extracted, err := m.extractor.Extract(ctx, content); err == nil {
+			metadata = extracted
+		}
+	}
+
 	// Store memory
-	if err := m.store.Save(ctx, content, category, embedding); err != nil {
+	if err := m.store.SaveWithMetadata(ctx, content, category, embedding, metadata); err != nil {
 		return fmt.Errorf("failed to store memory: %w", err)
 	}
 
@@ -37,6 +66,11 @@ func (m *MemoryManager) Remember(ctx context.Context, content, category string) 
 
 // Recall searches for relevant memories based on a query
 func (m *MemoryManager) Recall(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
+	return m.RecallWithFilter(ctx, query, topK, MemorySearchFilter{})
+}
+
+// RecallWithFilter searches for relevant memories with optional metadata filters.
+func (m *MemoryManager) RecallWithFilter(ctx context.Context, query string, topK int, filter MemorySearchFilter) ([]MemoryResult, error) {
 	// Generate query embedding
 	queryEmbedding, err := m.client.GetEmbedding(ctx, query)
 	if err != nil {
@@ -44,7 +78,7 @@ func (m *MemoryManager) Recall(ctx context.Context, query string, topK int) ([]M
 	}
 
 	// Search for similar memories
-	results, err := m.store.Search(ctx, queryEmbedding, topK)
+	results, err := m.store.SearchWithFilter(ctx, queryEmbedding, topK, filter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search memories: %w", err)
 	}

--- a/internal/memory/metadata.go
+++ b/internal/memory/metadata.go
@@ -1,0 +1,78 @@
+package memory
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ChunkMetadata stores structured memory attributes extracted from text.
+type ChunkMetadata struct {
+	People      []string `json:"people"`
+	Topics      []string `json:"topics"`
+	ActionItems []string `json:"action_items"`
+	Type        string   `json:"type"`
+}
+
+// MemorySearchFilter narrows memory recalls to specific metadata values.
+type MemorySearchFilter struct {
+	Person string
+}
+
+func (m ChunkMetadata) normalize() ChunkMetadata {
+	m.People = dedupeAndTrim(m.People)
+	m.Topics = dedupeAndTrim(m.Topics)
+	m.ActionItems = dedupeAndTrim(m.ActionItems)
+	m.Type = strings.TrimSpace(strings.ToLower(m.Type))
+	return m
+}
+
+func (m ChunkMetadata) toJSON() string {
+	normalized := m.normalize()
+	raw, err := json.Marshal(normalized)
+	if err != nil {
+		return "{}"
+	}
+	return string(raw)
+}
+
+func parseChunkMetadata(raw string) ChunkMetadata {
+	if strings.TrimSpace(raw) == "" {
+		return ChunkMetadata{}
+	}
+	var metadata ChunkMetadata
+	if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
+		return ChunkMetadata{}
+	}
+	return metadata.normalize()
+}
+
+func dedupeAndTrim(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func containsFold(values []string, want string) bool {
+	needle := strings.TrimSpace(want)
+	if needle == "" {
+		return true
+	}
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/memory/metadata_extractor.go
+++ b/internal/memory/metadata_extractor.go
@@ -1,0 +1,65 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"ok-gobot/internal/ai"
+)
+
+// LLMMetadataExtractor uses a lightweight chat model to extract structured metadata.
+type LLMMetadataExtractor struct {
+	client ai.Client
+}
+
+// NewLLMMetadataExtractor creates a metadata extractor backed by an AI client.
+func NewLLMMetadataExtractor(client ai.Client) *LLMMetadataExtractor {
+	return &LLMMetadataExtractor{client: client}
+}
+
+// Extract returns normalized metadata for a memory chunk.
+func (e *LLMMetadataExtractor) Extract(ctx context.Context, content string) (ChunkMetadata, error) {
+	text := strings.TrimSpace(content)
+	if text == "" {
+		return ChunkMetadata{}, nil
+	}
+
+	resp, err := e.client.Complete(ctx, []ai.Message{
+		{
+			Role: "system",
+			Content: "Extract structured metadata from the user text. " +
+				"Return only valid JSON with this exact shape: " +
+				`{"people":[],"topics":[],"action_items":[],"type":"decision|note|todo|question|update|other"}. ` +
+				"Use short phrases. If unknown, use empty arrays and type=note. Do not include markdown.",
+		},
+		{
+			Role:    "user",
+			Content: text,
+		},
+	})
+	if err != nil {
+		return ChunkMetadata{}, err
+	}
+
+	jsonPayload := extractJSONObject(resp)
+	if jsonPayload == "" {
+		return ChunkMetadata{}, fmt.Errorf("metadata extractor returned no JSON object")
+	}
+
+	var metadata ChunkMetadata
+	if err := json.Unmarshal([]byte(jsonPayload), &metadata); err != nil {
+		return ChunkMetadata{}, fmt.Errorf("failed to parse metadata JSON: %w", err)
+	}
+	return metadata.normalize(), nil
+}
+
+func extractJSONObject(input string) string {
+	start := strings.Index(input, "{")
+	end := strings.LastIndex(input, "}")
+	if start == -1 || end == -1 || end < start {
+		return ""
+	}
+	return strings.TrimSpace(input[start : end+1])
+}

--- a/internal/memory/metadata_extractor_test.go
+++ b/internal/memory/metadata_extractor_test.go
@@ -1,0 +1,47 @@
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"ok-gobot/internal/ai"
+)
+
+func TestLLMMetadataExtractorExtract(t *testing.T) {
+	extractor := NewLLMMetadataExtractor(&stubAIClient{
+		response: `{"people":["Anton"," anton "],"topics":["Release"],"action_items":["Send notes"],"type":"Decision"}`,
+	})
+
+	metadata, err := extractor.Extract(context.Background(), "Anton decided we should send notes")
+	if err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+	if len(metadata.People) != 1 || metadata.People[0] != "Anton" {
+		t.Fatalf("unexpected people metadata: %+v", metadata.People)
+	}
+	if metadata.Type != "decision" {
+		t.Fatalf("expected normalized type=decision, got %q", metadata.Type)
+	}
+}
+
+func TestLLMMetadataExtractorExtractRejectsInvalidJSON(t *testing.T) {
+	extractor := NewLLMMetadataExtractor(&stubAIClient{response: "not-json"})
+
+	_, err := extractor.Extract(context.Background(), "text")
+	if err == nil {
+		t.Fatal("expected extract to fail for invalid JSON response")
+	}
+}
+
+type stubAIClient struct {
+	response string
+	err      error
+}
+
+func (s *stubAIClient) Complete(ctx context.Context, messages []ai.Message) (string, error) {
+	return s.response, s.err
+}
+
+func (s *stubAIClient) CompleteWithTools(ctx context.Context, messages []ai.ChatMessage, tools []ai.ToolDefinition) (*ai.ChatCompletionResponse, error) {
+	return nil, nil
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -8,16 +8,20 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"time"
 )
 
+const memoryChunksTable = "memory_chunks"
+
 // MemoryResult represents a memory search result
 type MemoryResult struct {
-	ID         int64     `json:"id"`
-	Content    string    `json:"content"`
-	Category   string    `json:"category"`
-	Similarity float32   `json:"similarity"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID         int64         `json:"id"`
+	Content    string        `json:"content"`
+	Category   string        `json:"category"`
+	Similarity float32       `json:"similarity"`
+	Metadata   ChunkMetadata `json:"metadata"`
+	CreatedAt  time.Time     `json:"created_at"`
 }
 
 // MemoryStore handles storage and retrieval of memories with embeddings
@@ -34,18 +38,35 @@ func NewMemoryStore(db *sql.DB) (*MemoryStore, error) {
 	return store, nil
 }
 
-// migrate creates the memories table
+// migrate ensures the memory_chunks table exists with metadata support.
 func (s *MemoryStore) migrate() error {
+	hasChunksTable, err := s.tableExists(memoryChunksTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect %s table: %w", memoryChunksTable, err)
+	}
+	if !hasChunksTable {
+		hasLegacyTable, err := s.tableExists("memories")
+		if err != nil {
+			return fmt.Errorf("failed to inspect legacy memories table: %w", err)
+		}
+		if hasLegacyTable {
+			if _, err := s.db.Exec(`ALTER TABLE memories RENAME TO memory_chunks`); err != nil {
+				return fmt.Errorf("failed to rename legacy memories table: %w", err)
+			}
+		}
+	}
+
 	migrations := []string{
-		`CREATE TABLE IF NOT EXISTS memories (
+		`CREATE TABLE IF NOT EXISTS memory_chunks (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			content TEXT NOT NULL,
 			embedding BLOB NOT NULL,
 			category TEXT,
+			metadata TEXT NOT NULL DEFAULT '{}',
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		);`,
-		`CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);`,
-		`CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at);`,
+		`CREATE INDEX IF NOT EXISTS idx_memory_chunks_category ON memory_chunks(category);`,
+		`CREATE INDEX IF NOT EXISTS idx_memory_chunks_created_at ON memory_chunks(created_at);`,
 	}
 
 	for _, migration := range migrations {
@@ -54,11 +75,26 @@ func (s *MemoryStore) migrate() error {
 		}
 	}
 
+	hasMetadataColumn, err := s.columnExists(memoryChunksTable, "metadata")
+	if err != nil {
+		return fmt.Errorf("failed to inspect metadata column: %w", err)
+	}
+	if !hasMetadataColumn {
+		if _, err := s.db.Exec(`ALTER TABLE memory_chunks ADD COLUMN metadata TEXT NOT NULL DEFAULT '{}'`); err != nil {
+			return fmt.Errorf("failed to add metadata column: %w", err)
+		}
+	}
+
 	return nil
 }
 
 // Save stores a memory with its embedding
 func (s *MemoryStore) Save(ctx context.Context, content, category string, embedding []float32) error {
+	return s.SaveWithMetadata(ctx, content, category, embedding, ChunkMetadata{})
+}
+
+// SaveWithMetadata stores a memory with embedding and structured metadata.
+func (s *MemoryStore) SaveWithMetadata(ctx context.Context, content, category string, embedding []float32, metadata ChunkMetadata) error {
 	// Encode embedding to binary
 	embeddingBytes, err := encodeEmbedding(embedding)
 	if err != nil {
@@ -67,21 +103,26 @@ func (s *MemoryStore) Save(ctx context.Context, content, category string, embedd
 
 	_, err = s.db.ExecContext(
 		ctx,
-		"INSERT INTO memories (content, embedding, category) VALUES (?, ?, ?)",
-		content, embeddingBytes, category,
+		"INSERT INTO memory_chunks (content, embedding, category, metadata) VALUES (?, ?, ?, ?)",
+		content, embeddingBytes, category, metadata.toJSON(),
 	)
 	return err
 }
 
 // Search finds the most similar memories using cosine similarity
 func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+	return s.SearchWithFilter(ctx, queryEmbedding, topK, MemorySearchFilter{})
+}
+
+// SearchWithFilter finds the most similar memories and applies metadata filters.
+func (s *MemoryStore) SearchWithFilter(ctx context.Context, queryEmbedding []float32, topK int, filter MemorySearchFilter) ([]MemoryResult, error) {
 	if topK <= 0 {
 		topK = 5
 	}
 
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, content, embedding, category, created_at
-		FROM memories
+		SELECT id, content, embedding, category, metadata, created_at
+		FROM memory_chunks
 		ORDER BY created_at DESC
 	`)
 	if err != nil {
@@ -94,9 +135,15 @@ func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK
 		var id int64
 		var content, category string
 		var embeddingBytes []byte
+		var metadataRaw string
 		var createdAt time.Time
 
-		if err := rows.Scan(&id, &content, &embeddingBytes, &category, &createdAt); err != nil {
+		if err := rows.Scan(&id, &content, &embeddingBytes, &category, &metadataRaw, &createdAt); err != nil {
+			continue
+		}
+
+		metadata := parseChunkMetadata(metadataRaw)
+		if !matchesSearchFilter(metadata, filter) {
 			continue
 		}
 
@@ -114,6 +161,7 @@ func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK
 			Content:    content,
 			Category:   category,
 			Similarity: similarity,
+			Metadata:   metadata,
 			CreatedAt:  createdAt,
 		})
 	}
@@ -133,7 +181,7 @@ func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK
 
 // Delete removes a memory by ID
 func (s *MemoryStore) Delete(id int64) error {
-	result, err := s.db.Exec("DELETE FROM memories WHERE id = ?", id)
+	result, err := s.db.Exec("DELETE FROM memory_chunks WHERE id = ?", id)
 	if err != nil {
 		return err
 	}
@@ -157,8 +205,8 @@ func (s *MemoryStore) List(limit int) ([]MemoryResult, error) {
 	}
 
 	rows, err := s.db.Query(`
-		SELECT id, content, category, created_at
-		FROM memories
+		SELECT id, content, category, metadata, created_at
+		FROM memory_chunks
 		ORDER BY created_at DESC
 		LIMIT ?
 	`, limit)
@@ -171,9 +219,10 @@ func (s *MemoryStore) List(limit int) ([]MemoryResult, error) {
 	for rows.Next() {
 		var id int64
 		var content, category string
+		var metadataRaw string
 		var createdAt time.Time
 
-		if err := rows.Scan(&id, &content, &category, &createdAt); err != nil {
+		if err := rows.Scan(&id, &content, &category, &metadataRaw, &createdAt); err != nil {
 			continue
 		}
 
@@ -181,11 +230,54 @@ func (s *MemoryStore) List(limit int) ([]MemoryResult, error) {
 			ID:        id,
 			Content:   content,
 			Category:  category,
+			Metadata:  parseChunkMetadata(metadataRaw),
 			CreatedAt: createdAt,
 		})
 	}
 
 	return results, nil
+}
+
+func matchesSearchFilter(metadata ChunkMetadata, filter MemorySearchFilter) bool {
+	if strings.TrimSpace(filter.Person) != "" && !containsFold(metadata.People, filter.Person) {
+		return false
+	}
+	return true
+}
+
+func (s *MemoryStore) tableExists(name string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(
+		`SELECT COUNT(1) FROM sqlite_master WHERE type = 'table' AND name = ?`,
+		name,
+	).Scan(&count)
+	return count > 0, err
+}
+
+func (s *MemoryStore) columnExists(tableName, columnName string) (bool, error) {
+	rows, err := s.db.Query(fmt.Sprintf("PRAGMA table_info(%s)", tableName))
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			colType    string
+			notNull    int
+			defaultV   sql.NullString
+			primaryKey int
+		)
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &defaultV, &primaryKey); err != nil {
+			return false, err
+		}
+		if name == columnName {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 // cosineSimilarity calculates the cosine similarity between two vectors

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1,7 +1,11 @@
 package memory
 
 import (
+	"context"
+	"database/sql"
 	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestCosineSimilarity(t *testing.T) {
@@ -129,4 +133,109 @@ func TestEncodeDecodeEmbedding(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMemoryStoreMigratesLegacyTableAndAddsMetadata(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	_, err := db.Exec(`
+		CREATE TABLE memories (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			content TEXT NOT NULL,
+			embedding BLOB NOT NULL,
+			category TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		t.Fatalf("failed to create legacy table: %v", err)
+	}
+
+	embeddingBytes, err := encodeEmbedding([]float32{0.2, 0.8})
+	if err != nil {
+		t.Fatalf("failed to encode test embedding: %v", err)
+	}
+
+	_, err = db.Exec("INSERT INTO memories (content, embedding, category) VALUES (?, ?, ?)", "legacy entry", embeddingBytes, "facts")
+	if err != nil {
+		t.Fatalf("failed to insert legacy row: %v", err)
+	}
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	var metadata string
+	err = db.QueryRow("SELECT metadata FROM memory_chunks WHERE content = ?", "legacy entry").Scan(&metadata)
+	if err != nil {
+		t.Fatalf("failed to read migrated row: %v", err)
+	}
+	if metadata != "{}" {
+		t.Fatalf("expected metadata default '{}', got %q", metadata)
+	}
+
+	results, err := store.List(5)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Metadata.People) != 0 || results[0].Metadata.Type != "" {
+		t.Fatalf("expected empty metadata after migration, got %+v", results[0].Metadata)
+	}
+}
+
+func TestMemoryStoreSearchWithPersonFilter(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+	err = store.SaveWithMetadata(ctx, "Discussed release blockers with Anton", "meetings", []float32{1, 0}, ChunkMetadata{
+		People: []string{"Anton"},
+		Topics: []string{"release"},
+		Type:   "decision",
+	})
+	if err != nil {
+		t.Fatalf("SaveWithMetadata failed (Anton): %v", err)
+	}
+
+	err = store.SaveWithMetadata(ctx, "Planning session with Maria", "meetings", []float32{1, 0}, ChunkMetadata{
+		People: []string{"Maria"},
+		Topics: []string{"planning"},
+		Type:   "note",
+	})
+	if err != nil {
+		t.Fatalf("SaveWithMetadata failed (Maria): %v", err)
+	}
+
+	results, err := store.SearchWithFilter(ctx, []float32{1, 0}, 10, MemorySearchFilter{Person: "anton"})
+	if err != nil {
+		t.Fatalf("SearchWithFilter failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for person filter, got %d", len(results))
+	}
+	if results[0].Content != "Discussed release blockers with Anton" {
+		t.Fatalf("unexpected filtered result: %q", results[0].Content)
+	}
+	if len(results[0].Metadata.People) != 1 || results[0].Metadata.People[0] != "Anton" {
+		t.Fatalf("expected metadata people to be preserved, got %+v", results[0].Metadata)
+	}
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+	return db
 }

--- a/internal/tools/memory_tool.go
+++ b/internal/tools/memory_tool.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -83,18 +84,31 @@ func (m *MemoryTool) executeSave(ctx context.Context, args []string) (string, er
 
 func (m *MemoryTool) executeSearch(ctx context.Context, args []string) (string, error) {
 	if len(args) == 0 {
-		return "", fmt.Errorf("usage: memory search <query> [--limit=<n>]")
+		return "", fmt.Errorf("usage: memory search <query> [--limit=<n>] [--person=<name>]")
 	}
 
-	// Parse query and limit
+	// Parse query, limit, and metadata filter
 	var query string
 	limit := 5
+	filter := memory.MemorySearchFilter{}
 
 	for _, arg := range args {
 		if strings.HasPrefix(arg, "--limit=") {
 			limitStr := strings.TrimPrefix(arg, "--limit=")
 			if n, err := strconv.Atoi(limitStr); err == nil && n > 0 {
 				limit = n
+			}
+		} else if strings.HasPrefix(arg, "--person=") {
+			filter.Person = strings.TrimSpace(strings.TrimPrefix(arg, "--person="))
+		} else if strings.HasPrefix(arg, "--filter=") {
+			filterJSON := strings.TrimPrefix(arg, "--filter=")
+			var rawFilter struct {
+				Person string `json:"person"`
+			}
+			if err := json.Unmarshal([]byte(filterJSON), &rawFilter); err == nil {
+				if rawFilter.Person != "" {
+					filter.Person = rawFilter.Person
+				}
 			}
 		} else {
 			if query != "" {
@@ -108,7 +122,7 @@ func (m *MemoryTool) executeSearch(ctx context.Context, args []string) (string, 
 		return "", fmt.Errorf("no query provided")
 	}
 
-	results, err := m.manager.Recall(ctx, query, limit)
+	results, err := m.manager.RecallWithFilter(ctx, query, limit, filter)
 	if err != nil {
 		return "", fmt.Errorf("failed to search memories: %w", err)
 	}
@@ -123,6 +137,18 @@ func (m *MemoryTool) executeSearch(ctx context.Context, args []string) (string, 
 		output.WriteString(fmt.Sprintf("%d. [ID: %d] (similarity: %.2f) [%s]\n",
 			i+1, result.ID, result.Similarity, result.Category))
 		output.WriteString(fmt.Sprintf("   %s\n", result.Content))
+		if len(result.Metadata.People) > 0 {
+			output.WriteString(fmt.Sprintf("   People: %s\n", strings.Join(result.Metadata.People, ", ")))
+		}
+		if len(result.Metadata.Topics) > 0 {
+			output.WriteString(fmt.Sprintf("   Topics: %s\n", strings.Join(result.Metadata.Topics, ", ")))
+		}
+		if len(result.Metadata.ActionItems) > 0 {
+			output.WriteString(fmt.Sprintf("   Action items: %s\n", strings.Join(result.Metadata.ActionItems, " | ")))
+		}
+		if result.Metadata.Type != "" {
+			output.WriteString(fmt.Sprintf("   Type: %s\n", result.Metadata.Type))
+		}
 		output.WriteString(fmt.Sprintf("   Created: %s\n\n", result.CreatedAt.Format("2006-01-02 15:04")))
 	}
 
@@ -179,7 +205,11 @@ func (m *MemoryTool) GetSchema() map[string]interface{} {
 			},
 			"content": map[string]interface{}{
 				"type":        "string",
-				"description": "Content to save (for save command) or query to search (for search command)",
+				"description": "Content to save (for save command)",
+			},
+			"query": map[string]interface{}{
+				"type":        "string",
+				"description": "Search query (for search command)",
 			},
 			"category": map[string]interface{}{
 				"type":        "string",
@@ -192,6 +222,20 @@ func (m *MemoryTool) GetSchema() map[string]interface{} {
 			"id": map[string]interface{}{
 				"type":        "integer",
 				"description": "Memory ID to forget (for forget command)",
+			},
+			"filter": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"person": map[string]interface{}{
+						"type":        "string",
+						"description": "Filter search results by person name from extracted metadata",
+					},
+				},
+				"additionalProperties": false,
+			},
+			"person": map[string]interface{}{
+				"type":        "string",
+				"description": "Shortcut for filter.person when searching",
 			},
 		},
 		"required": []string{"command"},


### PR DESCRIPTION
Closes #98

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional LLM-based metadata extraction during memory indexing, extracting structured metadata (people, topics, action_items, type) from memory content using a lightweight model (default: haiku). Includes person-based filtering for memory search via `--person` flag.

**Key changes:**
- New `ChunkMetadata` structure stores extracted metadata in the database as JSON
- Database migration handles legacy `memories` table rename to `memory_chunks` and adds `metadata` column
- Metadata extraction is optional (disabled by default) and fails gracefully - memories are saved even if extraction errors
- Extended tool argument parsing to support `query`, `person`, `limit`, and nested `filter` parameters
- Comprehensive test coverage for migration, filtering, and metadata extraction
- Documentation updated with configuration examples and usage patterns

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no breaking changes or critical issues
- The implementation is well-structured with proper error handling, backward compatibility via database migrations, comprehensive test coverage, and clear documentation. The feature is optional and fails gracefully, ensuring existing functionality remains unaffected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/memory/metadata_extractor.go | New LLM-based metadata extractor that parses structured metadata from memory content - clean implementation with proper JSON handling |
| internal/memory/metadata.go | Defines metadata structures and filtering logic with proper normalization and deduplication |
| internal/memory/store.go | Enhanced with metadata column, handles legacy table migration cleanly, implements person-based filtering |
| internal/memory/manager.go | Added optional metadata extraction during Remember() with graceful error handling, added RecallWithFilter method |
| internal/app/app.go | Properly initializes metadata extractor when enabled, with model alias resolution and appropriate logging |
| internal/agent/tool_agent.go | Extended to handle `query`, `person`, and `filter` parameters with proper type conversion via new stringifyToolArg helper |
| internal/tools/memory_tool.go | Added `--person` filter support and metadata display in search results, updated schema with query/filter parameters |

</details>



<sub>Last reviewed commit: c0e3162</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->