### PR TITLE
Telegram /note command: zero-friction quick capture to daily memory file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ All commands are auto-registered with BotFather for slash autocomplete.
 | `/status` | Rich status: version, model, tokens, context, uptime |
 | `/clear` | Clear conversation history |
 | `/new` | Full session reset (history + model + agent) |
+| `/note <text>` | Quick-capture note to today's memory file |
 | `/stop` | Cancel active AI request |
 | `/memory` | Show today's memory |
 | `/tools` | List available tools |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -219,6 +219,7 @@ Beyond the core commands (`/start`, `/help`, `/status`, `/clear`, `/model`, `/ag
 |---------|-------------|
 | `/whoami` | Show your user ID, username, and chat ID |
 | `/new` | Reset session (clear history + model override + agent) |
+| `/note <text>` | Append a quick note directly to today's memory file |
 | `/stop` | Cancel the currently running AI request |
 | `/commands` | List all registered commands |
 | `/usage` | Set usage footer mode (off/tokens/full) |

--- a/internal/agent/memory.go
+++ b/internal/agent/memory.go
@@ -59,13 +59,26 @@ func (m *Memory) GetNote(date string) (*DailyNote, error) {
 
 // AppendToToday appends content to today's note
 func (m *Memory) AppendToToday(content string) error {
+	timestamp := time.Now().Format("15:04")
+	entry := fmt.Sprintf("\n## %s\n\n%s\n", timestamp, content)
+
+	return m.appendToTodayRaw(entry)
+}
+
+// AppendQuickNoteToToday appends a quick-capture note to today's note.
+// Format: "\n\n## Quick Note (HH:MM)\n<text>"
+func (m *Memory) AppendQuickNoteToToday(content string) error {
+	timestamp := time.Now().Format("15:04")
+	entry := fmt.Sprintf("\n\n## Quick Note (%s)\n%s", timestamp, content)
+
+	return m.appendToTodayRaw(entry)
+}
+
+func (m *Memory) appendToTodayRaw(entry string) error {
 	note, err := m.GetTodayNote()
 	if err != nil {
 		return err
 	}
-
-	timestamp := time.Now().Format("15:04")
-	entry := fmt.Sprintf("\n## %s\n\n%s\n", timestamp, content)
 
 	// Append to file
 	f, err := os.OpenFile(note.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)

--- a/internal/agent/memory_test.go
+++ b/internal/agent/memory_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAppendQuickNoteToToday_CreatesNoteWithExpectedFormat(t *testing.T) {
+	basePath := t.TempDir()
+	m := &Memory{BasePath: basePath}
+
+	const quickNote = "Remember to verify the deployment checklists."
+	if err := m.AppendQuickNoteToToday(quickNote); err != nil {
+		t.Fatalf("AppendQuickNoteToToday failed: %v", err)
+	}
+
+	today := time.Now().Format("2006-01-02")
+	notePath := filepath.Join(basePath, "memory", today+".md")
+
+	data, err := os.ReadFile(notePath)
+	if err != nil {
+		t.Fatalf("failed to read daily note: %v", err)
+	}
+
+	content := string(data)
+	expectedHeader := fmt.Sprintf("# Memory: %s\n\n", today)
+	if !strings.HasPrefix(content, expectedHeader) {
+		t.Fatalf("expected note to start with header %q, got %q", expectedHeader, content)
+	}
+
+	re := regexp.MustCompile(`\n\n## Quick Note \(\d{2}:\d{2}\)\nRemember to verify the deployment checklists\.$`)
+	if !re.MatchString(content) {
+		t.Fatalf("daily note does not contain expected quick note format; content: %q", content)
+	}
+}
+
+func TestAppendQuickNoteToToday_AppendsToExistingNote(t *testing.T) {
+	basePath := t.TempDir()
+	m := &Memory{BasePath: basePath}
+
+	today := time.Now().Format("2006-01-02")
+	memoryDir := filepath.Join(basePath, "memory")
+	if err := os.MkdirAll(memoryDir, 0o755); err != nil {
+		t.Fatalf("failed to create memory dir: %v", err)
+	}
+
+	notePath := filepath.Join(memoryDir, today+".md")
+	existing := fmt.Sprintf("# Memory: %s\n\n## 08:15\nUser: Existing entry\n", today)
+	if err := os.WriteFile(notePath, []byte(existing), 0o644); err != nil {
+		t.Fatalf("failed to seed note: %v", err)
+	}
+
+	if err := m.AppendQuickNoteToToday("Ship /note without an LLM turn."); err != nil {
+		t.Fatalf("AppendQuickNoteToToday failed: %v", err)
+	}
+
+	data, err := os.ReadFile(notePath)
+	if err != nil {
+		t.Fatalf("failed to read updated note: %v", err)
+	}
+
+	content := string(data)
+	if !strings.HasPrefix(content, existing) {
+		t.Fatalf("existing content was not preserved; got: %q", content)
+	}
+	if !strings.Contains(content, "\n\n## Quick Note (") {
+		t.Fatalf("quick note heading not found; got: %q", content)
+	}
+	if !strings.HasSuffix(content, "Ship /note without an LLM turn.") {
+		t.Fatalf("quick note text should be the last line; got: %q", content)
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -153,7 +153,7 @@ func (a *App) Start(ctx context.Context) error {
 	}
 
 	// Initialize memory system
-	a.memory = agent.NewMemory("")
+	a.memory = agent.NewMemory(soulPath)
 
 	// Initialize AI client if configured
 	if a.config.AI.APIKey != "" {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -99,6 +99,11 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 	// Create group manager
 	groupManager := NewGroupManager(store, groupsCfg.DefaultMode, api.Me.Username)
 
+	memoryBasePath := ""
+	if personality != nil {
+		memoryBasePath = personality.BasePath
+	}
+
 	b := &Bot{
 		api:              api,
 		store:            store,
@@ -109,7 +114,7 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		agentRegistry:    agentRegistry,
 		toolRegistry:     toolRegistry,
 		safety:           agent.NewSafety(),
-		memory:           agent.NewMemory(""),
+		memory:           agent.NewMemory(memoryBasePath),
 		authManager:      authManager,
 		groupManager:     groupManager,
 		approvalManager:  NewApprovalManager(api),
@@ -175,6 +180,7 @@ func (b *Bot) registerCommands() {
 		{Text: "status", Description: "Show current status"},
 		{Text: "whoami", Description: "Show your sender info"},
 		{Text: "new", Description: "Start a new session"},
+		{Text: "note", Description: "Quick note to today's memory"},
 		{Text: "clear", Description: "Clear conversation history"},
 		{Text: "stop", Description: "Stop the current run"},
 		{Text: "abort", Description: "Abort the current run"},
@@ -243,6 +249,7 @@ func (b *Bot) Start(ctx context.Context) error {
 /help - Show this help
 /status - Check bot status
 /clear - Clear conversation history
+/note <text> - Quick note to today's memory
 /memory - Show today's memory
 /tools - List available tools
 /model - Manage AI model (list/set/clear)

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -30,6 +30,10 @@ func (b *Bot) registerExtraHandlers() {
 		return b.handleNewCommand(c)
 	}))
 
+	b.api.Handle("/note", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
+		return b.handleNoteCommand(c)
+	}))
+
 	b.api.Handle("/stop", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleStopCommand(c)
 	}))
@@ -111,6 +115,7 @@ func (b *Bot) handleCommandsCommand(c telebot.Context) error {
 		{"status", "Show current status"},
 		{"whoami", "Show your sender info"},
 		{"new", "Start a new session"},
+		{"note", "Quick-capture note into today's memory"},
 		{"clear", "Clear conversation history"},
 		{"stop", "Stop the current run"},
 		{"abort", "Abort the current run"},
@@ -153,6 +158,21 @@ func (b *Bot) handleNewCommand(c telebot.Context) error {
 	}
 
 	return c.Send("✅ New session started. History and counters cleared.")
+}
+
+// handleNoteCommand appends a quick note directly to today's memory file.
+func (b *Bot) handleNoteCommand(c telebot.Context) error {
+	noteText := strings.TrimSpace(c.Message().Payload)
+	if noteText == "" {
+		return c.Send("❌ Usage: /note <text>")
+	}
+
+	if err := b.memory.AppendQuickNoteToToday(noteText); err != nil {
+		log.Printf("Failed to append quick note: %v", err)
+		return c.Send("❌ Failed to save quick note")
+	}
+
+	return c.Send("📝 Quick note saved.")
 }
 
 // handleStopCommand stops the current AI run via the runtime hub.


### PR DESCRIPTION
Closes #97

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a new `/note` command for zero-friction quick capture to daily memory files, allowing users to append timestamped notes without triggering an LLM interaction.

**Key changes:**
- Added `AppendQuickNoteToToday()` method with format: `## Quick Note (HH:MM)` 
- Refactored common append logic into `appendToTodayRaw()` helper
- Registered `/note` command with proper authorization guards
- Updated memory initialization in both `app.go` and `bot.go` to use personality base paths
- Added comprehensive test coverage for new functionality

The implementation is clean, follows existing code patterns, and includes proper error handling and input validation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- Clean implementation with good test coverage, proper error handling, consistent with existing patterns, and no logical or security issues identified
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/agent/memory.go | Added `AppendQuickNoteToToday()` method and refactored common append logic into `appendToTodayRaw()` - clean implementation with proper formatting |
| internal/agent/memory_test.go | New test file with comprehensive coverage for quick note functionality - tests both new file creation and appending to existing files |
| internal/bot/commands.go | Implemented `/note` command handler with proper input validation and error handling - clean and straightforward |

</details>



<sub>Last reviewed commit: 779484a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->