### PR TITLE
MCP server: expose memory_search, memory_get, memory_capture for cross-tool access

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ tts:
 memory:
   enabled: false
   embeddings_model: "text-embedding-3-small"
+  mcp:
+    enabled: false
+    host: "127.0.0.1"
+    port: 9233
+    endpoint: "/mcp"
+    allow_writes: false
 
 api:
   enabled: false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -45,6 +45,12 @@ memory:
   embeddings_model: "text-embedding-3-small"
   metadata_extraction: false
   metadata_model: "haiku"  # Lightweight model alias/name for metadata extraction
+  mcp:
+    enabled: false       # Optional MCP server for cross-tool memory access
+    host: "127.0.0.1"    # Local-only by default
+    port: 9233
+    endpoint: "/mcp"
+    allow_writes: false  # Required for memory_capture writes
 
 # Multi-Agent Configuration (optional)
 # Configure multiple agents with different personalities, models, and tool restrictions

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -23,6 +23,12 @@ memory:
   embeddings_model: "text-embedding-3-small"
   metadata_extraction: false
   metadata_model: "haiku"
+  mcp:
+    enabled: false
+    host: "127.0.0.1"
+    port: 9233
+    endpoint: "/mcp"
+    allow_writes: false
 ```
 
 ### Configuration Options
@@ -33,6 +39,9 @@ memory:
 - **embeddings_model**: Embedding model to use (default: `text-embedding-3-small`)
 - **metadata_extraction**: When `true`, extracts structured metadata (`people/topics/action_items/type`) during indexing
 - **metadata_model**: Lightweight LLM model used for metadata extraction (default: `haiku`)
+- **mcp.enabled**: Enable optional MCP server exposing `memory_search`, `memory_get`, `memory_capture`
+- **mcp.host / mcp.port / mcp.endpoint**: MCP bind/interface settings (`127.0.0.1` by default for local-only access)
+- **mcp.allow_writes**: Must be explicitly `true` to allow `memory_capture` writes
 
 ### Supported Embedding Providers
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-shiori/go-readability v0.0.0-20251205110129-5db1dc9836f0
 	github.com/gobwas/ws v1.4.0
+	github.com/mark3labs/mcp-go v0.44.1
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.1
@@ -24,6 +25,8 @@ require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
@@ -40,8 +43,11 @@ require (
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
@@ -56,7 +62,9 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,10 +81,14 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -266,6 +270,8 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
@@ -308,6 +314,9 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
+github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -339,6 +348,10 @@ github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgx
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mark3labs/mcp-go v0.44.1 h1:2PKppYlT9X2fXnE8SNYQLAX4hNjfPB0oNLqQVcN6mE8=
+github.com/mark3labs/mcp-go v0.44.1/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -475,8 +488,12 @@ github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNG
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,6 +17,7 @@ import (
 	"ok-gobot/internal/cron"
 	"ok-gobot/internal/logger"
 	"ok-gobot/internal/memory"
+	"ok-gobot/internal/memorymcp"
 	"ok-gobot/internal/storage"
 )
 
@@ -31,6 +32,7 @@ type App struct {
 	memory        *agent.Memory
 	scheduler     *cron.Scheduler
 	memoryManager *memory.MemoryManager
+	memoryMCP     *memorymcp.Server
 	apiServer     *api.APIServer
 	watcher       *config.ConfigWatcher
 	controlServer *control.Server
@@ -243,6 +245,24 @@ func (a *App) Start(ctx context.Context) error {
 		}
 	}
 
+	// Initialize and start memory MCP server if enabled
+	if a.config.Memory.MCP.Enabled {
+		mcpCfg := memorymcp.Config{
+			Enabled:     a.config.Memory.MCP.Enabled,
+			Host:        a.config.Memory.MCP.Host,
+			Port:        a.config.Memory.MCP.Port,
+			Endpoint:    a.config.Memory.MCP.Endpoint,
+			AllowWrites: a.config.Memory.MCP.AllowWrites,
+		}
+		a.memoryMCP = memorymcp.New(mcpCfg, a.memoryManager, a.memory)
+		go func() {
+			if err := a.memoryMCP.Start(ctx); err != nil {
+				log.Printf("[memory-mcp] server error: %v", err)
+			}
+		}()
+		log.Printf("🧠 Memory MCP server enabled on %s (writes=%v)", a.memoryMCP.URL(), mcpCfg.AllowWrites)
+	}
+
 	// Initialize bot
 	aiCfg := bot.AIConfig{
 		Provider:        a.config.AI.Provider,
@@ -323,6 +343,12 @@ func (a *App) Stop() error {
 		ctx := context.Background()
 		if err := a.apiServer.Stop(ctx); err != nil {
 			log.Printf("Error stopping API server: %v", err)
+		}
+	}
+	if a.memoryMCP != nil {
+		ctx := context.Background()
+		if err := a.memoryMCP.Stop(ctx); err != nil {
+			log.Printf("Error stopping memory MCP server: %v", err)
 		}
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,12 +105,22 @@ type TTSConfig struct {
 
 // MemoryConfig holds semantic memory configuration
 type MemoryConfig struct {
-	Enabled            bool   `mapstructure:"enabled"`             // Enable semantic memory
-	EmbeddingsBaseURL  string `mapstructure:"embeddings_base_url"` // API base URL for embeddings
-	EmbeddingsAPIKey   string `mapstructure:"embeddings_api_key"`  // API key for embeddings (can reuse ai.api_key)
-	EmbeddingsModel    string `mapstructure:"embeddings_model"`    // Embeddings model to use
-	MetadataExtraction bool   `mapstructure:"metadata_extraction"` // Extract structured metadata while indexing memories
-	MetadataModel      string `mapstructure:"metadata_model"`      // LLM model used for metadata extraction
+	Enabled            bool            `mapstructure:"enabled"`             // Enable semantic memory
+	EmbeddingsBaseURL  string          `mapstructure:"embeddings_base_url"` // API base URL for embeddings
+	EmbeddingsAPIKey   string          `mapstructure:"embeddings_api_key"`  // API key for embeddings (can reuse ai.api_key)
+	EmbeddingsModel    string          `mapstructure:"embeddings_model"`    // Embeddings model to use
+	MetadataExtraction bool            `mapstructure:"metadata_extraction"` // Extract structured metadata while indexing memories
+	MetadataModel      string          `mapstructure:"metadata_model"`      // LLM model used for metadata extraction
+	MCP                MemoryMCPConfig `mapstructure:"mcp"`                 // Optional MCP server exposing memory tools
+}
+
+// MemoryMCPConfig holds memory MCP server configuration
+type MemoryMCPConfig struct {
+	Enabled     bool   `mapstructure:"enabled"`      // Enable memory MCP server
+	Host        string `mapstructure:"host"`         // Bind host (default loopback only)
+	Port        int    `mapstructure:"port"`         // MCP server port
+	Endpoint    string `mapstructure:"endpoint"`     // MCP endpoint path
+	AllowWrites bool   `mapstructure:"allow_writes"` // Allow write tools such as memory_capture
 }
 
 // AgentConfig holds configuration for a single agent
@@ -153,6 +163,11 @@ func Load() (*Config, error) {
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
 	v.SetDefault("memory.metadata_extraction", false)
 	v.SetDefault("memory.metadata_model", "haiku")
+	v.SetDefault("memory.mcp.enabled", false)
+	v.SetDefault("memory.mcp.host", "127.0.0.1")
+	v.SetDefault("memory.mcp.port", 9233)
+	v.SetDefault("memory.mcp.endpoint", "/mcp")
+	v.SetDefault("memory.mcp.allow_writes", false)
 	v.SetDefault("control.enabled", true)
 	v.SetDefault("control.port", 8787)
 	v.SetDefault("control.token", "")
@@ -241,6 +256,11 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
 	v.SetDefault("memory.metadata_extraction", false)
 	v.SetDefault("memory.metadata_model", "haiku")
+	v.SetDefault("memory.mcp.enabled", false)
+	v.SetDefault("memory.mcp.host", "127.0.0.1")
+	v.SetDefault("memory.mcp.port", 9233)
+	v.SetDefault("memory.mcp.endpoint", "/mcp")
+	v.SetDefault("memory.mcp.allow_writes", false)
 	v.SetDefault("control.enabled", true)
 	v.SetDefault("control.port", 8787)
 	v.SetDefault("control.token", "")
@@ -353,6 +373,11 @@ func (c *Config) Save() error {
 	v.Set("memory.embeddings_model", c.Memory.EmbeddingsModel)
 	v.Set("memory.metadata_extraction", c.Memory.MetadataExtraction)
 	v.Set("memory.metadata_model", c.Memory.MetadataModel)
+	v.Set("memory.mcp.enabled", c.Memory.MCP.Enabled)
+	v.Set("memory.mcp.host", c.Memory.MCP.Host)
+	v.Set("memory.mcp.port", c.Memory.MCP.Port)
+	v.Set("memory.mcp.endpoint", c.Memory.MCP.Endpoint)
+	v.Set("memory.mcp.allow_writes", c.Memory.MCP.AllowWrites)
 	v.Set("storage_path", c.StoragePath)
 	v.Set("soul_path", c.SoulPath)
 	v.Set("log_level", c.LogLevel)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -82,3 +82,94 @@ memory:
 		t.Errorf("expected memory.metadata_model override, got %q", cfg.Memory.MetadataModel)
 	}
 }
+
+func TestLoadFromDefaultMemoryMCPConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-memory-mcp-default-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+  provider: "openrouter"
+storage_path: "/tmp/test.db"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+
+	if cfg.Memory.MCP.Enabled {
+		t.Fatalf("expected memory.mcp.enabled=false by default")
+	}
+	if cfg.Memory.MCP.Host != "127.0.0.1" {
+		t.Fatalf("expected memory.mcp.host=%q, got %q", "127.0.0.1", cfg.Memory.MCP.Host)
+	}
+	if cfg.Memory.MCP.Port != 9233 {
+		t.Fatalf("expected memory.mcp.port=%d, got %d", 9233, cfg.Memory.MCP.Port)
+	}
+	if cfg.Memory.MCP.Endpoint != "/mcp" {
+		t.Fatalf("expected memory.mcp.endpoint=%q, got %q", "/mcp", cfg.Memory.MCP.Endpoint)
+	}
+	if cfg.Memory.MCP.AllowWrites {
+		t.Fatalf("expected memory.mcp.allow_writes=false by default")
+	}
+}
+
+func TestLoadFromExplicitMemoryMCPConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-memory-mcp-explicit-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+  provider: "openrouter"
+storage_path: "/tmp/test.db"
+memory:
+  mcp:
+    enabled: true
+    host: "0.0.0.0"
+    port: 4001
+    endpoint: "/tooling/mcp"
+    allow_writes: true
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+
+	if !cfg.Memory.MCP.Enabled {
+		t.Fatalf("expected memory.mcp.enabled=true")
+	}
+	if cfg.Memory.MCP.Host != "0.0.0.0" {
+		t.Fatalf("expected memory.mcp.host=%q, got %q", "0.0.0.0", cfg.Memory.MCP.Host)
+	}
+	if cfg.Memory.MCP.Port != 4001 {
+		t.Fatalf("expected memory.mcp.port=%d, got %d", 4001, cfg.Memory.MCP.Port)
+	}
+	if cfg.Memory.MCP.Endpoint != "/tooling/mcp" {
+		t.Fatalf("expected memory.mcp.endpoint=%q, got %q", "/tooling/mcp", cfg.Memory.MCP.Endpoint)
+	}
+	if !cfg.Memory.MCP.AllowWrites {
+		t.Fatalf("expected memory.mcp.allow_writes=true")
+	}
+}

--- a/internal/memorymcp/server.go
+++ b/internal/memorymcp/server.go
@@ -1,0 +1,455 @@
+package memorymcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/memory"
+)
+
+var markdownHeaderRegexp = regexp.MustCompile(`^(#{1,6})\s+(.+?)\s*$`)
+
+// Config configures the optional memory MCP server.
+type Config struct {
+	Enabled     bool
+	Host        string
+	Port        int
+	Endpoint    string
+	AllowWrites bool
+}
+
+// DefaultConfig returns safe defaults:
+// disabled, loopback bind, and writes denied.
+func DefaultConfig() Config {
+	return Config{
+		Enabled:     false,
+		Host:        "127.0.0.1",
+		Port:        9233,
+		Endpoint:    "/mcp",
+		AllowWrites: false,
+	}
+}
+
+// Server exposes memory operations over MCP.
+type Server struct {
+	cfg           Config
+	memoryManager *memory.MemoryManager
+	dailyMemory   *agent.Memory
+	mcpServer     *mcpserver.MCPServer
+	httpServer    *mcpserver.StreamableHTTPServer
+}
+
+// New creates a memory MCP server instance.
+func New(cfg Config, manager *memory.MemoryManager, dailyMemory *agent.Memory) *Server {
+	defaults := DefaultConfig()
+	if strings.TrimSpace(cfg.Host) == "" {
+		cfg.Host = defaults.Host
+	}
+	if cfg.Port <= 0 {
+		cfg.Port = defaults.Port
+	}
+	if strings.TrimSpace(cfg.Endpoint) == "" {
+		cfg.Endpoint = defaults.Endpoint
+	}
+	if !strings.HasPrefix(cfg.Endpoint, "/") {
+		cfg.Endpoint = "/" + cfg.Endpoint
+	}
+
+	s := &Server{
+		cfg:           cfg,
+		memoryManager: manager,
+		dailyMemory:   dailyMemory,
+	}
+
+	mcpSrv := mcpserver.NewMCPServer(
+		"ok-gobot-memory",
+		"1.0.0",
+		mcpserver.WithToolCapabilities(true),
+	)
+
+	mcpSrv.AddTool(mcp.NewTool(
+		"memory_search",
+		mcp.WithDescription("Semantic memory search over indexed memory."),
+		mcp.WithString("query", mcp.Description("Search query"), mcp.Required()),
+		mcp.WithNumber("topK", mcp.Description("Maximum number of results to return"), mcp.DefaultNumber(5)),
+	), s.handleMemorySearch)
+
+	mcpSrv.AddTool(mcp.NewTool(
+		"memory_get",
+		mcp.WithDescription("Read a memory markdown file, optionally by header path."),
+		mcp.WithString("file", mcp.Description("Memory file path, for example MEMORY.md or memory/2026-03-04.md"), mcp.Required()),
+		mcp.WithString("header_path", mcp.Description("Optional markdown header path, for example Projects > OK Gobot")),
+	), s.handleMemoryGet)
+
+	mcpSrv.AddTool(mcp.NewTool(
+		"memory_capture",
+		mcp.WithDescription("Capture memory content into daily or explicit memory file."),
+		mcp.WithString("content", mcp.Description("Content to capture"), mcp.Required()),
+		mcp.WithString("file", mcp.Description("Optional target file path. Defaults to today's memory note.")),
+	), s.handleMemoryCapture)
+
+	s.mcpServer = mcpSrv
+	s.httpServer = mcpserver.NewStreamableHTTPServer(mcpSrv, mcpserver.WithEndpointPath(cfg.Endpoint))
+
+	return s
+}
+
+// Addr returns the server listen address.
+func (s *Server) Addr() string {
+	return net.JoinHostPort(s.cfg.Host, strconv.Itoa(s.cfg.Port))
+}
+
+// URL returns the full MCP endpoint URL.
+func (s *Server) URL() string {
+	return fmt.Sprintf("http://%s%s", s.Addr(), s.cfg.Endpoint)
+}
+
+// Start runs the MCP HTTP server and blocks until stopped.
+func (s *Server) Start(ctx context.Context) error {
+	if s.httpServer == nil {
+		return fmt.Errorf("memory mcp server is not initialized")
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = s.httpServer.Shutdown(context.Background())
+	}()
+
+	if err := s.httpServer.Start(s.Addr()); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("memory mcp start failed: %w", err)
+	}
+	return nil
+}
+
+// Stop gracefully shuts down the MCP server.
+func (s *Server) Stop(ctx context.Context) error {
+	if s.httpServer == nil {
+		return nil
+	}
+	return s.httpServer.Shutdown(ctx)
+}
+
+func (s *Server) handleMemorySearch(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	query := strings.TrimSpace(request.GetString("query", ""))
+	if query == "" {
+		return mcp.NewToolResultError("memory_search requires a non-empty query"), nil
+	}
+
+	topK := request.GetInt("topK", 5)
+	if topK <= 0 {
+		topK = 5
+	}
+
+	if s.memoryManager == nil {
+		return mcp.NewToolResultError("memory_search backend is not configured (enable memory.enabled)"), nil
+	}
+
+	results, err := s.memoryManager.Recall(ctx, query, topK)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("memory_search failed: %v", err)), nil
+	}
+
+	type searchResult struct {
+		ID         int64   `json:"id"`
+		Content    string  `json:"content"`
+		Category   string  `json:"category"`
+		Similarity float32 `json:"similarity"`
+		CreatedAt  string  `json:"created_at"`
+	}
+
+	out := make([]searchResult, 0, len(results))
+	for _, r := range results {
+		out = append(out, searchResult{
+			ID:         r.ID,
+			Content:    r.Content,
+			Category:   r.Category,
+			Similarity: r.Similarity,
+			CreatedAt:  r.CreatedAt.Format(time.RFC3339),
+		})
+	}
+
+	payload := map[string]interface{}{
+		"query":   query,
+		"topK":    topK,
+		"results": out,
+	}
+
+	resp, err := mcp.NewToolResultJSON(payload)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("memory_search response encoding failed: %v", err)), nil
+	}
+	return resp, nil
+}
+
+func (s *Server) handleMemoryGet(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	file := strings.TrimSpace(request.GetString("file", ""))
+	if file == "" {
+		return mcp.NewToolResultError("memory_get requires file"), nil
+	}
+
+	headerPath := strings.TrimSpace(request.GetString("header_path", ""))
+	content, resolvedPath, err := s.readMemoryFile(file, headerPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("memory_get failed: %v", err)), nil
+	}
+
+	payload := map[string]interface{}{
+		"file":          file,
+		"resolved_file": resolvedPath,
+		"header_path":   headerPath,
+		"content":       content,
+	}
+
+	resp, err := mcp.NewToolResultJSON(payload)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("memory_get response encoding failed: %v", err)), nil
+	}
+	return resp, nil
+}
+
+func (s *Server) handleMemoryCapture(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if !s.cfg.AllowWrites {
+		return mcp.NewToolResultError("memory_capture is disabled; set memory.mcp.allow_writes=true to enable writes"), nil
+	}
+
+	content := strings.TrimSpace(request.GetString("content", ""))
+	if content == "" {
+		return mcp.NewToolResultError("memory_capture requires non-empty content"), nil
+	}
+
+	file := strings.TrimSpace(request.GetString("file", ""))
+	resolvedPath, err := s.captureMemory(content, file)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("memory_capture failed: %v", err)), nil
+	}
+
+	payload := map[string]interface{}{
+		"status": "captured",
+		"file":   resolvedPath,
+	}
+
+	resp, err := mcp.NewToolResultJSON(payload)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("memory_capture response encoding failed: %v", err)), nil
+	}
+	return resp, nil
+}
+
+func (s *Server) readMemoryFile(file, headerPath string) (string, string, error) {
+	resolvedPath, err := resolveWithinBase(s.basePath(), file)
+	if err != nil {
+		return "", "", err
+	}
+
+	contentBytes, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		return "", "", err
+	}
+	content := string(contentBytes)
+	if headerPath == "" {
+		return content, resolvedPath, nil
+	}
+
+	section, err := extractMarkdownSectionByHeaderPath(content, headerPath)
+	if err != nil {
+		return "", "", err
+	}
+	return section, resolvedPath, nil
+}
+
+func (s *Server) captureMemory(content, file string) (string, error) {
+	if strings.TrimSpace(file) == "" {
+		if s.dailyMemory != nil {
+			if err := s.dailyMemory.AppendToToday(content); err != nil {
+				return "", err
+			}
+			note, err := s.dailyMemory.GetTodayNote()
+			if err != nil {
+				return "", err
+			}
+			return note.Path, nil
+		}
+		today := time.Now().Format("2006-01-02")
+		file = filepath.ToSlash(filepath.Join("memory", today+".md"))
+	}
+
+	resolvedPath, err := resolveWithinBase(s.basePath(), file)
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(resolvedPath), 0o755); err != nil {
+		return "", err
+	}
+
+	prefix := content
+	if !strings.HasSuffix(prefix, "\n") {
+		prefix += "\n"
+	}
+
+	if existing, err := os.ReadFile(resolvedPath); err == nil && len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		prefix = "\n" + prefix
+	}
+
+	f, err := os.OpenFile(resolvedPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(prefix); err != nil {
+		return "", err
+	}
+	return resolvedPath, nil
+}
+
+func (s *Server) basePath() string {
+	if s.dailyMemory != nil && strings.TrimSpace(s.dailyMemory.BasePath) != "" {
+		return s.dailyMemory.BasePath
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "."
+	}
+	return filepath.Join(homeDir, "ok-gobot-soul")
+}
+
+func resolveWithinBase(basePath, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+
+	cleanBase := filepath.Clean(basePath)
+	var fullPath string
+	if filepath.IsAbs(path) {
+		fullPath = filepath.Clean(path)
+	} else {
+		fullPath = filepath.Join(cleanBase, filepath.Clean(path))
+	}
+
+	basePrefix := cleanBase + string(os.PathSeparator)
+	if fullPath != cleanBase && !strings.HasPrefix(fullPath, basePrefix) {
+		return "", fmt.Errorf("path %q escapes memory base path %q", path, cleanBase)
+	}
+	return fullPath, nil
+}
+
+func extractMarkdownSectionByHeaderPath(markdown, headerPath string) (string, error) {
+	target := normalizeHeaderPath(parseHeaderPath(headerPath))
+	if len(target) == 0 {
+		return strings.TrimSpace(markdown), nil
+	}
+
+	lines := strings.Split(markdown, "\n")
+	headerStack := make([]string, 0, 6)
+
+	sectionStart := -1
+	sectionEnd := len(lines)
+	targetLevel := 0
+
+	for idx, line := range lines {
+		matches := markdownHeaderRegexp.FindStringSubmatch(line)
+		if len(matches) != 3 {
+			continue
+		}
+
+		level := len(matches[1])
+		title := normalizeHeaderToken(cleanMarkdownHeaderTitle(matches[2]))
+
+		if level-1 < len(headerStack) {
+			headerStack = headerStack[:level-1]
+		}
+		headerStack = append(headerStack, title)
+
+		if sectionStart >= 0 && level <= targetLevel {
+			sectionEnd = idx
+			break
+		}
+
+		if headersMatch(headerStack, target) {
+			sectionStart = idx
+			targetLevel = level
+		}
+	}
+
+	if sectionStart < 0 {
+		return "", fmt.Errorf("header path %q not found", headerPath)
+	}
+
+	section := strings.TrimSpace(strings.Join(lines[sectionStart:sectionEnd], "\n"))
+	if section == "" {
+		return "", fmt.Errorf("header path %q resolved to an empty section", headerPath)
+	}
+
+	return section, nil
+}
+
+func parseHeaderPath(path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+
+	parts := strings.Split(path, ">")
+	if len(parts) == 1 {
+		parts = strings.Split(path, "/")
+	}
+
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func normalizeHeaderPath(parts []string) []string {
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = normalizeHeaderToken(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func headersMatch(current, target []string) bool {
+	if len(current) < len(target) {
+		return false
+	}
+	start := len(current) - len(target)
+	for i := range target {
+		if current[start+i] != target[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func cleanMarkdownHeaderTitle(title string) string {
+	title = strings.TrimSpace(title)
+	title = strings.TrimRight(title, "#")
+	return strings.TrimSpace(title)
+}
+
+func normalizeHeaderToken(s string) string {
+	fields := strings.Fields(strings.ToLower(strings.TrimSpace(s)))
+	return strings.Join(fields, " ")
+}

--- a/internal/memorymcp/server_test.go
+++ b/internal/memorymcp/server_test.go
@@ -1,0 +1,157 @@
+package memorymcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"ok-gobot/internal/agent"
+)
+
+func TestMCPServerRegistersExpectedToolsAndSupportsMemoryGet(t *testing.T) {
+	tmpDir := t.TempDir()
+	memoryFile := filepath.Join(tmpDir, "MEMORY.md")
+	markdown := strings.Join([]string{
+		"# Memory",
+		"",
+		"## Projects",
+		"Shared notes",
+		"",
+		"### Alpha",
+		"Important detail",
+		"",
+		"## Personal",
+		"Other section",
+	}, "\n")
+	if err := os.WriteFile(memoryFile, []byte(markdown), 0o644); err != nil {
+		t.Fatalf("failed to write MEMORY.md: %v", err)
+	}
+
+	srv := New(Config{AllowWrites: false}, nil, agent.NewMemory(tmpDir))
+	c := newInProcessClient(t, srv)
+
+	toolsResult, err := c.ListTools(context.Background(), mcp.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+
+	found := map[string]bool{}
+	for _, tool := range toolsResult.Tools {
+		found[tool.Name] = true
+	}
+
+	for _, name := range []string{"memory_search", "memory_get", "memory_capture"} {
+		if !found[name] {
+			t.Fatalf("expected tool %q to be registered", name)
+		}
+	}
+
+	call := mcp.CallToolRequest{}
+	call.Params.Name = "memory_get"
+	call.Params.Arguments = map[string]any{
+		"file":        "MEMORY.md",
+		"header_path": "Projects > Alpha",
+	}
+
+	result, err := c.CallTool(context.Background(), call)
+	if err != nil {
+		t.Fatalf("memory_get call failed: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("memory_get returned error result: %s", mcp.GetTextFromContent(result.Content[0]))
+	}
+
+	structured, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("expected structured content map, got %T", result.StructuredContent)
+	}
+	content, _ := structured["content"].(string)
+	if !strings.Contains(content, "### Alpha") {
+		t.Fatalf("expected section heading in memory_get output, got: %s", content)
+	}
+	if strings.Contains(content, "## Personal") {
+		t.Fatalf("expected section-scoped content from memory_get")
+	}
+}
+
+func TestMemoryCaptureRequiresWriteFlag(t *testing.T) {
+	srv := New(Config{AllowWrites: false}, nil, agent.NewMemory(t.TempDir()))
+	c := newInProcessClient(t, srv)
+
+	call := mcp.CallToolRequest{}
+	call.Params.Name = "memory_capture"
+	call.Params.Arguments = map[string]any{"content": "remember this"}
+
+	result, err := c.CallTool(context.Background(), call)
+	if err != nil {
+		t.Fatalf("memory_capture call failed: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected memory_capture to be blocked when writes are disabled")
+	}
+}
+
+func TestMemoryCaptureWritesToTodayNoteWhenEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	daily := agent.NewMemory(tmpDir)
+	srv := New(Config{AllowWrites: true}, nil, daily)
+	c := newInProcessClient(t, srv)
+
+	call := mcp.CallToolRequest{}
+	call.Params.Name = "memory_capture"
+	call.Params.Arguments = map[string]any{"content": "capture line"}
+
+	result, err := c.CallTool(context.Background(), call)
+	if err != nil {
+		t.Fatalf("memory_capture call failed: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected successful memory_capture, got error: %s", mcp.GetTextFromContent(result.Content[0]))
+	}
+
+	note, err := daily.GetTodayNote()
+	if err != nil {
+		t.Fatalf("failed to load today note: %v", err)
+	}
+
+	content, err := os.ReadFile(note.Path)
+	if err != nil {
+		t.Fatalf("failed to read note file: %v", err)
+	}
+	if !strings.Contains(string(content), "capture line") {
+		t.Fatalf("expected captured text in note file, got:\n%s", string(content))
+	}
+}
+
+func newInProcessClient(t *testing.T, srv *Server) *client.Client {
+	t.Helper()
+
+	c, err := client.NewInProcessClient(srv.mcpServer)
+	if err != nil {
+		t.Fatalf("failed to create in-process client: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("failed to start in-process client: %v", err)
+	}
+
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "memorymcp-test-client", Version: "1.0.0"}
+	initReq.Params.Capabilities = mcp.ClientCapabilities{}
+	if _, err := c.Initialize(ctx, initReq); err != nil {
+		t.Fatalf("failed to initialize in-process client: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = c.Close()
+	})
+
+	return c
+}


### PR DESCRIPTION
Closes #96

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements an optional MCP (Model Context Protocol) server that exposes memory operations for cross-tool access, addressing issue #96.

**Key Changes:**
- Added new MCP server implementation in `internal/memorymcp/` exposing three tools: `memory_search` (semantic search), `memory_get` (read markdown files with optional header path filtering), and `memory_capture` (write to memory files)
- Integrated MCP server into app lifecycle with conditional startup when `memory.mcp.enabled=true`
- Added comprehensive configuration support with secure defaults: disabled by default, loopback-only binding (`127.0.0.1`), and write operations disabled unless explicitly enabled
- Implemented security controls including path traversal prevention via `resolveWithinBase()` and write permission enforcement
- Added full test coverage for server functionality and configuration loading
- Updated documentation across README, config.example.yaml, and docs/MEMORY.md

**Security Posture:**
The implementation follows security best practices with defense-in-depth:
- Local-only binding by default prevents external access
- Path validation prevents directory traversal attacks
- Write operations require explicit opt-in via `allow_writes=true`
- All configuration options are well-documented with security implications explained

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-architected with proper security controls, comprehensive test coverage, and clear documentation. All security-sensitive defaults (disabled, loopback-only, no writes) are appropriate. The code follows existing patterns in the codebase and includes both unit tests and integration tests.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/memorymcp/server.go | New MCP server implementation exposing memory_search, memory_get, and memory_capture tools with proper security controls (path traversal prevention, write flag enforcement, local-only default binding) |
| internal/memorymcp/server_test.go | Comprehensive test coverage for MCP server: tool registration, memory_get with header path extraction, write flag enforcement, and memory capture functionality |
| internal/app/app.go | Integrated MCP server lifecycle management: conditional initialization when memory.mcp.enabled=true, graceful startup in goroutine, and proper cleanup in Stop() |
| internal/config/config.go | Added MemoryMCPConfig struct and configuration defaults (disabled, loopback-only, writes disabled) for secure-by-default MCP server setup |
| internal/config/config_test.go | Test coverage for MCP config loading with both default values and explicit overrides, ensuring correct configuration parsing |

</details>



<sub>Last reviewed commit: f6b8e82</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->