### PR TITLE
Bootstrap: hot-reload personality files via fsnotify

### DIFF
--- a/internal/agent/personality.go
+++ b/internal/agent/personality.go
@@ -1,13 +1,18 @@
 // Package agent implements the AI agent personality and memory system.
 package agent
 
-import "ok-gobot/internal/bootstrap"
+import (
+	"sync"
+
+	"ok-gobot/internal/bootstrap"
+)
 
 // SkillEntry represents a discovered skill.
 type SkillEntry = bootstrap.SkillEntry
 
 // Personality wraps the canonical bootstrap loader.
 type Personality struct {
+	mu       sync.RWMutex
 	BasePath string
 	Files    map[string]string
 	Skills   []SkillEntry
@@ -23,50 +28,66 @@ func NewPersonality(basePath string) (*Personality, error) {
 
 	return &Personality{
 		BasePath: loader.BasePath,
-		Files:    loader.Files,
-		Skills:   loader.Skills,
+		Files:    cloneFiles(loader.Files),
+		Skills:   cloneSkills(loader.Skills),
 		loader:   loader,
 	}, nil
 }
 
-// Loader exposes the canonical bootstrap loader.
+// Loader exposes the canonical bootstrap loader snapshot.
 func (p *Personality) Loader() *bootstrap.Loader {
 	if p == nil {
 		return nil
 	}
-	if p.loader != nil {
-		return p.loader
-	}
-	return &bootstrap.Loader{
-		BasePath: p.BasePath,
-		Files:    p.Files,
-		Skills:   p.Skills,
-	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.loaderSnapshotLocked()
 }
 
 // GetSystemPrompt builds the complete system prompt from all loaded files.
 func (p *Personality) GetSystemPrompt() string {
-	return p.Loader().SystemPrompt()
+	loader := p.Loader()
+	if loader == nil {
+		return ""
+	}
+	return loader.SystemPrompt()
 }
 
 // GetFileContent returns the raw content of a specific file.
 func (p *Personality) GetFileContent(filename string) (string, bool) {
-	return p.Loader().FileContent(filename)
+	loader := p.Loader()
+	if loader == nil {
+		return "", false
+	}
+	return loader.FileContent(filename)
 }
 
 // HasFile checks if a file was loaded.
 func (p *Personality) HasFile(filename string) bool {
-	return p.Loader().HasFile(filename)
+	loader := p.Loader()
+	if loader == nil {
+		return false
+	}
+	return loader.HasFile(filename)
 }
 
 // GetName extracts the agent name from IDENTITY.md.
 func (p *Personality) GetName() string {
-	return p.Loader().Name()
+	loader := p.Loader()
+	if loader == nil {
+		return "Штрудель"
+	}
+	return loader.Name()
 }
 
 // GetEmoji extracts the emoji from IDENTITY.md.
 func (p *Personality) GetEmoji() string {
-	return p.Loader().Emoji()
+	loader := p.Loader()
+	if loader == nil {
+		return "🕯️"
+	}
+	return loader.Emoji()
 }
 
 // Reload refreshes all files from disk.
@@ -75,38 +96,91 @@ func (p *Personality) Reload() error {
 		return nil
 	}
 
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if p.loader == nil {
 		loader, err := bootstrap.NewLoader(p.BasePath)
 		if err != nil {
 			return err
 		}
 		p.loader = loader
-		p.BasePath = loader.BasePath
-		p.Files = loader.Files
-		p.Skills = loader.Skills
-		return nil
+	} else {
+		if err := p.loader.Reload(); err != nil {
+			return err
+		}
 	}
 
-	if err := p.loader.Reload(); err != nil {
-		return err
-	}
 	p.BasePath = p.loader.BasePath
-	p.Files = p.loader.Files
-	p.Skills = p.loader.Skills
+	p.Files = cloneFiles(p.loader.Files)
+	p.Skills = cloneSkills(p.loader.Skills)
 	return nil
 }
 
 // GetMinimalSystemPrompt returns only IDENTITY + SOUL sections (for sub-agents).
 func (p *Personality) GetMinimalSystemPrompt() string {
-	return p.Loader().MinimalPrompt()
+	loader := p.Loader()
+	if loader == nil {
+		return ""
+	}
+	return loader.MinimalPrompt()
 }
 
 // GetIdentityLine returns a single identity line (for ultra-minimal sub-agents).
 func (p *Personality) GetIdentityLine() string {
-	return p.Loader().IdentityLine()
+	loader := p.Loader()
+	if loader == nil {
+		return "You are Штрудель 🕯️."
+	}
+	return loader.IdentityLine()
 }
 
 // GetSkillsSummary returns a formatted list of available skills.
 func (p *Personality) GetSkillsSummary() string {
-	return p.Loader().SkillsSummary()
+	loader := p.Loader()
+	if loader == nil {
+		return ""
+	}
+	return loader.SkillsSummary()
+}
+
+func (p *Personality) loaderSnapshotLocked() *bootstrap.Loader {
+	if p == nil {
+		return nil
+	}
+
+	basePath := p.BasePath
+	files := cloneFiles(p.Files)
+	skills := cloneSkills(p.Skills)
+	if p.loader != nil {
+		basePath = p.loader.BasePath
+		files = cloneFiles(p.loader.Files)
+		skills = cloneSkills(p.loader.Skills)
+	}
+
+	return &bootstrap.Loader{
+		BasePath: basePath,
+		Files:    files,
+		Skills:   skills,
+	}
+}
+
+func cloneFiles(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return map[string]string{}
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func cloneSkills(src []SkillEntry) []SkillEntry {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]SkillEntry, len(src))
+	copy(dst, src)
+	return dst
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -342,7 +342,7 @@ func (a *App) startBootstrapWatcher(name string, personality *agent.Personality)
 			log.Printf("[bootstrap] failed to reload %s bootstrap from %s: %v", name, personality.BasePath, err)
 			return
 		}
-		log.Printf("[bootstrap] reloaded %s bootstrap from %s", name, personality.BasePath)
+		log.Printf("system prompt reloaded (%s from %s)", name, personality.BasePath)
 	})
 	if err != nil {
 		log.Printf("[bootstrap] failed to start watcher for %s bootstrap at %s: %v", name, personality.BasePath, err)

--- a/internal/bootstrap/watcher.go
+++ b/internal/bootstrap/watcher.go
@@ -22,6 +22,8 @@ type Watcher struct {
 	debounce *time.Timer
 }
 
+const bootstrapDebounceDelay = 1 * time.Second
+
 // NewWatcher creates a bootstrap watcher rooted at basePath.
 func NewWatcher(basePath string, onChange func()) (*Watcher, error) {
 	if basePath == "" {
@@ -121,7 +123,7 @@ func (bw *Watcher) debounceReload() {
 		bw.debounce.Stop()
 	}
 
-	bw.debounce = time.AfterFunc(300*time.Millisecond, func() {
+	bw.debounce = time.AfterFunc(bootstrapDebounceDelay, func() {
 		if bw.onChange != nil {
 			bw.onChange()
 		}

--- a/internal/bootstrap/watcher_test.go
+++ b/internal/bootstrap/watcher_test.go
@@ -1,0 +1,104 @@
+package bootstrap
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func writeWatcherFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write file %s: %v", path, err)
+	}
+}
+
+func TestWatcherReloadsOnPromptFileChange(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bootstrap-watcher-*")
+	if err != nil {
+		t.Fatalf("mktemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	soulPath := filepath.Join(tmpDir, "SOUL.md")
+	writeWatcherFile(t, soulPath, "v1")
+
+	reloaded := make(chan struct{}, 1)
+	watcher, err := NewWatcher(tmpDir, func() {
+		reloaded <- struct{}{}
+	})
+	if err != nil {
+		t.Fatalf("new watcher: %v", err)
+	}
+	defer watcher.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+	writeWatcherFile(t, soulPath, "v2")
+
+	select {
+	case <-reloaded:
+	case <-time.After(4 * time.Second):
+		t.Fatal("timed out waiting for reload event")
+	}
+}
+
+func TestWatcherDebouncesPromptFileChanges(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bootstrap-watcher-debounce-*")
+	if err != nil {
+		t.Fatalf("mktemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	soulPath := filepath.Join(tmpDir, "SOUL.md")
+	writeWatcherFile(t, soulPath, "v1")
+
+	var reloadCount atomic.Int32
+	watcher, err := NewWatcher(tmpDir, func() {
+		reloadCount.Add(1)
+	})
+	if err != nil {
+		t.Fatalf("new watcher: %v", err)
+	}
+	defer watcher.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+	writeWatcherFile(t, soulPath, "v2")
+	time.Sleep(150 * time.Millisecond)
+	writeWatcherFile(t, soulPath, "v3")
+	time.Sleep(150 * time.Millisecond)
+	writeWatcherFile(t, soulPath, "v4")
+
+	time.Sleep(2500 * time.Millisecond)
+	if got := reloadCount.Load(); got != 1 {
+		t.Fatalf("expected one debounced reload, got %d", got)
+	}
+}
+
+func TestWatcherIgnoresUntrackedFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bootstrap-watcher-ignore-*")
+	if err != nil {
+		t.Fatalf("mktemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	writeWatcherFile(t, filepath.Join(tmpDir, "SOUL.md"), "stable")
+
+	var reloadCount atomic.Int32
+	watcher, err := NewWatcher(tmpDir, func() {
+		reloadCount.Add(1)
+	})
+	if err != nil {
+		t.Fatalf("new watcher: %v", err)
+	}
+	defer watcher.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+	writeWatcherFile(t, filepath.Join(tmpDir, "notes.md"), "not tracked")
+
+	time.Sleep(1500 * time.Millisecond)
+	if got := reloadCount.Load(); got != 0 {
+		t.Fatalf("expected no reload for untracked file, got %d", got)
+	}
+}


### PR DESCRIPTION
Closes #95

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully implements hot-reload functionality for personality files using fsnotify. The changes add proper thread-safety with `sync.RWMutex` to the Personality struct and implement data cloning to prevent race conditions when files are reloaded while in use.

**Key changes:**
- Added `sync.RWMutex` to `Personality` struct for safe concurrent access during reloads
- Implemented `cloneFiles()` and `cloneSkills()` helpers to create independent snapshots
- Modified `Loader()` to return cloned snapshots instead of direct references
- Added comprehensive nil checks throughout all Personality methods
- Increased debounce delay from 300ms to 1 second to reduce reload frequency
- Added test coverage for watcher reload, debounce, and file filtering behavior

The implementation correctly uses read/write locks to protect the personality state during reloads. Existing requests continue using their snapshot of the personality data while new requests pick up the updated configuration.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk - solid implementation of hot-reload with proper thread-safety
- Well-designed implementation with proper concurrency controls using RWMutex, comprehensive test coverage for the watcher functionality, and safe snapshot-based approach. Only minor performance optimization opportunity identified. The changes are additive and don't break existing functionality.
- No files require special attention - all changes follow good practices

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/agent/personality.go | Added thread-safety with RWMutex, implemented data cloning for safe concurrent access, and added comprehensive nil checks |
| internal/bootstrap/watcher.go | Changed debounce delay from 300ms to 1 second constant for clearer configuration |
| internal/bootstrap/watcher_test.go | Added comprehensive tests for reload, debounce, and file filtering behavior |
| internal/app/app.go | Improved log message formatting for bootstrap reloads |

</details>



<sub>Last reviewed commit: 86c8190</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->