### PR TITLE
Config: unified reference aligned with ARCHITECTURE-v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GO=go
 # Build flags
 LDFLAGS=-ldflags "-s -w"
 
-.PHONY: all build build-small clean test deps run install
+.PHONY: all build build-small clean test deps run install config-schema
 
 all: build
 
@@ -40,6 +40,9 @@ dev:
 
 config-init:
 	$(GO) run ./cmd/ok-gobot config init
+
+config-schema:
+	$(GO) run ./cmd/gen-config-schema
 
 start:
 	$(GO) run ./cmd/ok-gobot start

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ All commands are auto-registered with BotFather for slash autocomplete.
 ## Configuration
 
 Config file: `~/.ok-gobot/config.yaml` (see [config.example.yaml](config.example.yaml))
+Canonical key reference: [docs/ARCHITECTURE-v2.md §8](docs/ARCHITECTURE-v2.md#8-configuration-reference-canonical)
 
 ```yaml
 telegram:
@@ -225,6 +226,7 @@ ok-gobot/
 - [API Reference](API.md) — HTTP API endpoints
 - [Features](docs/FEATURES.md) — Detailed feature descriptions
 - [Architecture](docs/ARCHITECTURE.md) — System design and data flow
+- [Architecture v2](docs/ARCHITECTURE-v2.md) — Runtime-hub architecture and canonical config reference
 - [Tools Reference](docs/TOOLS.md) — All tools with usage examples
 - [Changelog](docs/CHANGELOG.md)
 - [Daemon](docs/DAEMON.md) — Service management

--- a/cmd/gen-config-schema/main.go
+++ b/cmd/gen-config-schema/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"ok-gobot/internal/configschema"
+)
+
+func main() {
+	in := flag.String("in", "docs/ARCHITECTURE-v2.md", "path to architecture-v2 markdown")
+	out := flag.String("out", "config.schema.json", "path to generated json schema")
+	flag.Parse()
+
+	schema, err := configschema.GenerateSchemaFromFile(*in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "generate schema: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(*out, schema, 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "write schema: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,6 +12,7 @@ ai:
   model: "moonshotai/kimi-k2.5"
   base_url: ""  # For custom providers
   fallback_models: []
+  default_thinking: ""  # Optional: off, low, medium, high, adaptive (provider/model dependent)
 
 # Authentication configuration
 auth:
@@ -25,6 +26,13 @@ api:
   port: 8080      # API server port
   api_key: ""     # Required if enabled - set a secure API key
   webhook_chat: 0 # Default chat ID for webhook messages (optional)
+
+# Loopback control server configuration
+control:
+  enabled: false
+  port: 9222
+  token: ""
+  allow_loopback_without_token: true
 
 # Group chat configuration
 groups:
@@ -101,6 +109,14 @@ control:
 # Runtime configuration
 runtime:
   mode: "hub"  # hub (default) or legacy — selects execution path; legacy will be removed in a future release
+  session_queue_limit: 100  # Per-session queue capacity
+
+# Session key routing configuration
+session:
+  dm_scope: "main"  # main or per_user
+
+# Optional model alias overrides (empty = built-in defaults)
+model_aliases: {}
 
 # Storage and logging
 storage_path: "~/.ok-gobot/ok-gobot.db"

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,340 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "default": {},
+  "description": "Root ok-gobot configuration.",
+  "properties": {
+    "agents": {
+      "default": [],
+      "description": "Optional multi-agent profile definitions.",
+      "items": {
+        "additionalProperties": false,
+        "default": {},
+        "description": "Single agent profile.",
+        "properties": {
+          "allowed_tools": {
+            "default": [],
+            "description": "Tool allowlist for this agent. Empty means all tools.",
+            "items": {
+              "default": "",
+              "description": "Tool name.",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "model": {
+            "default": "",
+            "description": "Optional model override for this agent.",
+            "type": "string"
+          },
+          "name": {
+            "default": "",
+            "description": "Agent profile name used by /agent.",
+            "type": "string"
+          },
+          "soul_path": {
+            "default": "",
+            "description": "Directory containing this agent's personality files.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "ai": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Primary model provider configuration.",
+      "properties": {
+        "api_key": {
+          "default": "",
+          "description": "API key for the selected provider.",
+          "type": "string"
+        },
+        "base_url": {
+          "default": "",
+          "description": "Base URL for custom OpenAI-compatible providers.",
+          "type": "string"
+        },
+        "default_thinking": {
+          "default": "",
+          "description": "Default thinking level for providers/models that support it.",
+          "type": "string"
+        },
+        "fallback_models": {
+          "default": [],
+          "description": "Ordered model fallbacks for automatic failover.",
+          "items": {
+            "default": "",
+            "description": "Fallback model identifier.",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "model": {
+          "default": "moonshotai/kimi-k2.5",
+          "description": "Default model identifier.",
+          "type": "string"
+        },
+        "provider": {
+          "default": "openrouter",
+          "description": "AI provider backend.",
+          "enum": [
+            "openrouter",
+            "openai",
+            "custom"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "api": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "HTTP API server settings.",
+      "properties": {
+        "api_key": {
+          "default": "",
+          "description": "Bearer API key for HTTP endpoints.",
+          "type": "string"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Enable HTTP API server.",
+          "type": "boolean"
+        },
+        "port": {
+          "default": 8080,
+          "description": "HTTP API listen port.",
+          "type": "integer"
+        },
+        "webhook_chat": {
+          "default": 0,
+          "description": "Default chat ID for API webhook forwarding.",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "auth": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Authorization and operator controls.",
+      "properties": {
+        "admin_id": {
+          "default": 0,
+          "description": "Telegram user ID allowed to manage auth.",
+          "type": "integer"
+        },
+        "allowed_users": {
+          "default": [],
+          "description": "Telegram user IDs allowed in allowlist mode.",
+          "items": {
+            "default": 0,
+            "description": "Telegram user ID.",
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "default": "open",
+          "description": "Access mode for incoming users.",
+          "enum": [
+            "open",
+            "allowlist",
+            "pairing"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "control": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Loopback control server settings.",
+      "properties": {
+        "allow_loopback_without_token": {
+          "default": true,
+          "description": "Allow unauthenticated loopback access when token is empty.",
+          "type": "boolean"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Enable control server.",
+          "type": "boolean"
+        },
+        "port": {
+          "default": 9222,
+          "description": "Control server listen port.",
+          "type": "integer"
+        },
+        "token": {
+          "default": "",
+          "description": "Bearer token for control endpoints.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "groups": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Group-chat behavior settings.",
+      "properties": {
+        "default_mode": {
+          "default": "standby",
+          "description": "Default group mode for new groups.",
+          "enum": [
+            "active",
+            "standby"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "log_level": {
+      "default": "info",
+      "description": "Minimum log severity to emit.",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "type": "string"
+    },
+    "memory": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Semantic memory and embeddings settings.",
+      "properties": {
+        "embeddings_api_key": {
+          "default": "",
+          "description": "Embeddings API key. Empty reuses ai.api_key.",
+          "type": "string"
+        },
+        "embeddings_base_url": {
+          "default": "https://api.openai.com/v1",
+          "description": "Base URL for embeddings API.",
+          "type": "string"
+        },
+        "embeddings_model": {
+          "default": "text-embedding-3-small",
+          "description": "Embeddings model identifier.",
+          "type": "string"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Enable semantic memory index and tools.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "model_aliases": {
+      "additionalProperties": {
+        "default": "",
+        "description": "Model identifier for the alias key.",
+        "type": "string"
+      },
+      "default": {},
+      "description": "Optional model alias overrides. Empty uses built-in aliases.",
+      "type": "object"
+    },
+    "runtime": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Runtime behavior and rollout flags.",
+      "properties": {
+        "mode": {
+          "default": "hub",
+          "description": "Execution path: hub runtime (default) or legacy path.",
+          "enum": [
+            "hub",
+            "legacy"
+          ],
+          "type": "string"
+        },
+        "session_queue_limit": {
+          "default": 100,
+          "description": "Per-session queue capacity for runtime mailbox execution.",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "session": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Session-key resolution settings.",
+      "properties": {
+        "dm_scope": {
+          "default": "main",
+          "description": "DM session scope: shared main session or per-user session keys.",
+          "enum": [
+            "main",
+            "per_user"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "soul_path": {
+      "default": "~/ok-gobot-soul",
+      "description": "Default personality directory (deprecated; prefer agents[*].soul_path).",
+      "type": "string"
+    },
+    "storage_path": {
+      "default": "~/.ok-gobot/ok-gobot.db",
+      "description": "SQLite database file path.",
+      "type": "string"
+    },
+    "telegram": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Telegram transport settings.",
+      "properties": {
+        "token": {
+          "default": "",
+          "description": "Bot token from @BotFather. Required to run Telegram transport.",
+          "type": "string"
+        },
+        "webhook": {
+          "default": "",
+          "description": "Optional webhook URL. Empty means polling mode.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tts": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Text-to-speech provider settings.",
+      "properties": {
+        "default_voice": {
+          "default": "",
+          "description": "Provider-specific default TTS voice.",
+          "type": "string"
+        },
+        "provider": {
+          "default": "openai",
+          "description": "Default TTS provider.",
+          "enum": [
+            "openai",
+            "edge"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "ok-gobot configuration",
+  "type": "object"
+}

--- a/docs/ARCHITECTURE-v2.md
+++ b/docs/ARCHITECTURE-v2.md
@@ -1,0 +1,393 @@
+# ok-gobot Architecture v2
+
+## 1. Scope
+
+This document defines the runtime architecture for the hub-based execution model.
+For configuration, this document is the source of truth.
+
+## 2. Runtime Hub
+
+- One runtime hub owns execution scheduling.
+- Different session keys execute in parallel.
+- Each session key executes one run at a time.
+- Transport layers submit requests; they do not execute model logic directly.
+
+## 3. Session Model
+
+Canonical session keys:
+
+- `agent:<agentId>:main`
+- `agent:<agentId>:telegram:dm:<userId>` when DM scope is per-user
+- `agent:<agentId>:telegram:group:<chatId>`
+- `agent:<agentId>:telegram:group:<chatId>:thread:<topicId>`
+- `agent:<agentId>:subagent:<runSlug>`
+
+## 4. Transport Adapters
+
+- Telegram and TUI are adapters over runtime events.
+- Adapters handle input/output rendering and acknowledgments.
+- Execution, queueing, and cancellation stay in runtime.
+
+## 5. Control Plane
+
+The control server provides loopback API/WS access for status, session operations,
+abort, model/agent switching, and sub-agent actions.
+
+## 6. Persistence
+
+SQLite remains the persistence layer for sessions, messages, routes, and runtime metadata.
+
+## 7. Memory
+
+Memory remains markdown-first (`MEMORY.md` + `memory/*.md`) with semantic indexing for retrieval.
+
+## 8. Configuration Reference (Canonical)
+
+`config.schema.json` is generated from the canonical JSON block below. This section is the
+single source of truth for configuration keys, types, defaults, and descriptions.
+
+<!-- CONFIG_CANONICAL:START -->
+```json
+{
+  "type": "object",
+  "default": {},
+  "description": "Root ok-gobot configuration.",
+  "properties": {
+    "telegram": {
+      "type": "object",
+      "default": {},
+      "description": "Telegram transport settings.",
+      "properties": {
+        "token": {
+          "type": "string",
+          "default": "",
+          "description": "Bot token from @BotFather. Required to run Telegram transport."
+        },
+        "webhook": {
+          "type": "string",
+          "default": "",
+          "description": "Optional webhook URL. Empty means polling mode."
+        }
+      }
+    },
+    "ai": {
+      "type": "object",
+      "default": {},
+      "description": "Primary model provider configuration.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "default": "openrouter",
+          "enum": [
+            "openrouter",
+            "openai",
+            "custom"
+          ],
+          "description": "AI provider backend."
+        },
+        "api_key": {
+          "type": "string",
+          "default": "",
+          "description": "API key for the selected provider."
+        },
+        "model": {
+          "type": "string",
+          "default": "moonshotai/kimi-k2.5",
+          "description": "Default model identifier."
+        },
+        "base_url": {
+          "type": "string",
+          "default": "",
+          "description": "Base URL for custom OpenAI-compatible providers."
+        },
+        "fallback_models": {
+          "type": "array",
+          "default": [],
+          "description": "Ordered model fallbacks for automatic failover.",
+          "items": {
+            "type": "string",
+            "default": "",
+            "description": "Fallback model identifier."
+          }
+        },
+        "default_thinking": {
+          "type": "string",
+          "default": "",
+          "description": "Default thinking level for providers/models that support it."
+        }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "default": {},
+      "description": "Authorization and operator controls.",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "default": "open",
+          "enum": [
+            "open",
+            "allowlist",
+            "pairing"
+          ],
+          "description": "Access mode for incoming users."
+        },
+        "allowed_users": {
+          "type": "array",
+          "default": [],
+          "description": "Telegram user IDs allowed in allowlist mode.",
+          "items": {
+            "type": "integer",
+            "default": 0,
+            "description": "Telegram user ID."
+          }
+        },
+        "admin_id": {
+          "type": "integer",
+          "default": 0,
+          "description": "Telegram user ID allowed to manage auth."
+        }
+      }
+    },
+    "api": {
+      "type": "object",
+      "default": {},
+      "description": "HTTP API server settings.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable HTTP API server."
+        },
+        "port": {
+          "type": "integer",
+          "default": 8080,
+          "description": "HTTP API listen port."
+        },
+        "api_key": {
+          "type": "string",
+          "default": "",
+          "description": "Bearer API key for HTTP endpoints."
+        },
+        "webhook_chat": {
+          "type": "integer",
+          "default": 0,
+          "description": "Default chat ID for API webhook forwarding."
+        }
+      }
+    },
+    "control": {
+      "type": "object",
+      "default": {},
+      "description": "Loopback control server settings.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable control server."
+        },
+        "port": {
+          "type": "integer",
+          "default": 9222,
+          "description": "Control server listen port."
+        },
+        "token": {
+          "type": "string",
+          "default": "",
+          "description": "Bearer token for control endpoints."
+        },
+        "allow_loopback_without_token": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow unauthenticated loopback access when token is empty."
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "default": {},
+      "description": "Runtime behavior and rollout flags.",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "default": "hub",
+          "enum": [
+            "hub",
+            "legacy"
+          ],
+          "description": "Execution path: hub runtime (default) or legacy path."
+        },
+        "session_queue_limit": {
+          "type": "integer",
+          "default": 100,
+          "description": "Per-session queue capacity for runtime mailbox execution."
+        }
+      }
+    },
+    "session": {
+      "type": "object",
+      "default": {},
+      "description": "Session-key resolution settings.",
+      "properties": {
+        "dm_scope": {
+          "type": "string",
+          "default": "main",
+          "enum": [
+            "main",
+            "per_user"
+          ],
+          "description": "DM session scope: shared main session or per-user session keys."
+        }
+      }
+    },
+    "groups": {
+      "type": "object",
+      "default": {},
+      "description": "Group-chat behavior settings.",
+      "properties": {
+        "default_mode": {
+          "type": "string",
+          "default": "standby",
+          "enum": [
+            "active",
+            "standby"
+          ],
+          "description": "Default group mode for new groups."
+        }
+      }
+    },
+    "tts": {
+      "type": "object",
+      "default": {},
+      "description": "Text-to-speech provider settings.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "default": "openai",
+          "enum": [
+            "openai",
+            "edge"
+          ],
+          "description": "Default TTS provider."
+        },
+        "default_voice": {
+          "type": "string",
+          "default": "",
+          "description": "Provider-specific default TTS voice."
+        }
+      }
+    },
+    "memory": {
+      "type": "object",
+      "default": {},
+      "description": "Semantic memory and embeddings settings.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable semantic memory index and tools."
+        },
+        "embeddings_base_url": {
+          "type": "string",
+          "default": "https://api.openai.com/v1",
+          "description": "Base URL for embeddings API."
+        },
+        "embeddings_api_key": {
+          "type": "string",
+          "default": "",
+          "description": "Embeddings API key. Empty reuses ai.api_key."
+        },
+        "embeddings_model": {
+          "type": "string",
+          "default": "text-embedding-3-small",
+          "description": "Embeddings model identifier."
+        }
+      }
+    },
+    "agents": {
+      "type": "array",
+      "default": [],
+      "description": "Optional multi-agent profile definitions.",
+      "items": {
+        "type": "object",
+        "default": {},
+        "description": "Single agent profile.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "default": "",
+            "description": "Agent profile name used by /agent."
+          },
+          "soul_path": {
+            "type": "string",
+            "default": "",
+            "description": "Directory containing this agent's personality files."
+          },
+          "model": {
+            "type": "string",
+            "default": "",
+            "description": "Optional model override for this agent."
+          },
+          "allowed_tools": {
+            "type": "array",
+            "default": [],
+            "description": "Tool allowlist for this agent. Empty means all tools.",
+            "items": {
+              "type": "string",
+              "default": "",
+              "description": "Tool name."
+            }
+          }
+        }
+      }
+    },
+    "model_aliases": {
+      "type": "object",
+      "default": {},
+      "description": "Optional model alias overrides. Empty uses built-in aliases.",
+      "additionalProperties": {
+        "type": "string",
+        "default": "",
+        "description": "Model identifier for the alias key."
+      }
+    },
+    "storage_path": {
+      "type": "string",
+      "default": "~/.ok-gobot/ok-gobot.db",
+      "description": "SQLite database file path."
+    },
+    "log_level": {
+      "type": "string",
+      "default": "info",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ],
+      "description": "Minimum log severity to emit."
+    },
+    "soul_path": {
+      "type": "string",
+      "default": "~/ok-gobot-soul",
+      "description": "Default personality directory (deprecated; prefer agents[*].soul_path)."
+    }
+  }
+}
+```
+<!-- CONFIG_CANONICAL:END -->
+
+### 8.1 PRD Extensions
+
+PRD adds rollout-specific configuration extensions to the canonical reference:
+
+- `runtime.mode`
+- `session.dm_scope`
+- `runtime.session_queue_limit`
+
+These keys remain part of the canonical schema above and must stay synchronized with PRD language.
+
+### 8.2 Compatibility Notes
+
+Legacy `openai.api_key` and `openai.model` are still accepted as migration aliases,
+but they are not canonical keys and are intentionally excluded from the schema.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -27,32 +27,15 @@
 ## Important Public Changes
 
 ### Config
-Add:
-```yaml
-control:
-  enabled: true
-  bind: "127.0.0.1"
-  port: 8787
-  token: ""
+Canonical full reference lives in `docs/ARCHITECTURE-v2.md` §8.
 
-runtime:
-  mode: "hub"              # hub | legacy (temporary rollout flag)
-  ack_timeout_ms: 1000
-  telegram_edit_interval_ms: 1500
-  telegram_edit_token_batch: 20
-  max_active_sessions: 0   # 0 = unlimited
-  session_queue_limit: 100
+PRD-specific extensions (relative to existing behavior):
 
-session:
-  main_key: "main"
-  dm_scope: "main"         # main | per_user
-  history_limit: 200
+- `runtime.mode` (`hub` | `legacy`, default: `hub`)
+- `session.dm_scope` (`main` | `per_user`, default: `main`)
+- `runtime.session_queue_limit` (integer, default: `100`)
 
-subagents:
-  enabled: true
-  default_model: ""
-  default_thinking: "low"
-```
+Other config-like values mentioned in this PRD are rollout notes, not canonical keys.
 
 ### CLI
 Add:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,17 @@ type RuntimeConfig struct {
 	// "hub" routes all requests through the RuntimeHub for per-session concurrency.
 	// "legacy" is kept temporarily for rollback; it will be removed in a future release.
 	Mode string `mapstructure:"mode"`
+	// SessionQueueLimit is the per-session queue capacity for runtime mailbox execution.
+	// 0 falls back to runtime defaults where applicable.
+	SessionQueueLimit int `mapstructure:"session_queue_limit"`
+}
+
+// SessionConfig holds session-key derivation behavior.
+type SessionConfig struct {
+	// DMScope controls how DM session keys are created:
+	// "main" (default): shared main session
+	// "per_user": one session per Telegram user
+	DMScope string `mapstructure:"dm_scope"`
 }
 
 // Config holds all application configuration
@@ -50,6 +61,7 @@ type Config struct {
 	API          APIConfig         `mapstructure:"api"`
 	Control      ControlConfig     `mapstructure:"control"`
 	Runtime      RuntimeConfig     `mapstructure:"runtime"`
+	Session      SessionConfig     `mapstructure:"session"`
 	Groups       GroupsConfig      `mapstructure:"groups"`
 	TTS          TTSConfig         `mapstructure:"tts"`
 	Memory       MemoryConfig      `mapstructure:"memory"`
@@ -173,6 +185,8 @@ func Load() (*Config, error) {
 	v.SetDefault("control.token", "")
 	v.SetDefault("control.allow_loopback_without_token", true)
 	v.SetDefault("runtime.mode", "hub")
+	v.SetDefault("runtime.session_queue_limit", 100)
+	v.SetDefault("session.dm_scope", "main")
 
 	// Environment variable prefix
 	v.SetEnvPrefix("OKGOBOT")
@@ -266,6 +280,8 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("control.token", "")
 	v.SetDefault("control.allow_loopback_without_token", true)
 	v.SetDefault("runtime.mode", "hub")
+	v.SetDefault("runtime.session_queue_limit", 100)
+	v.SetDefault("session.dm_scope", "main")
 
 	// Environment variable prefix
 	v.SetEnvPrefix("OKGOBOT")
@@ -331,6 +347,15 @@ func (c *Config) Validate() error {
 	if c.Runtime.Mode != "" && !validRuntimeModes[c.Runtime.Mode] {
 		return fmt.Errorf("invalid runtime.mode: %s (must be 'hub' or 'legacy')", c.Runtime.Mode)
 	}
+	if c.Runtime.SessionQueueLimit < 0 {
+		return fmt.Errorf("invalid runtime.session_queue_limit: %d (must be >= 0)", c.Runtime.SessionQueueLimit)
+	}
+
+	// Validate session DM scope
+	validDMScope := map[string]bool{"main": true, "per_user": true}
+	if c.Session.DMScope != "" && !validDMScope[c.Session.DMScope] {
+		return fmt.Errorf("invalid session.dm_scope: %s (must be 'main' or 'per_user')", c.Session.DMScope)
+	}
 
 	// Check storage path is set
 	if c.StoragePath == "" {
@@ -382,6 +407,8 @@ func (c *Config) Save() error {
 	v.Set("soul_path", c.SoulPath)
 	v.Set("log_level", c.LogLevel)
 	v.Set("runtime.mode", c.Runtime.Mode)
+	v.Set("runtime.session_queue_limit", c.Runtime.SessionQueueLimit)
+	v.Set("session.dm_scope", c.Session.DMScope)
 
 	return v.WriteConfig()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,6 +34,12 @@ storage_path: "/tmp/test.db"
 	if cfg.Runtime.Mode != "hub" {
 		t.Errorf("expected runtime.mode=%q, got %q", "hub", cfg.Runtime.Mode)
 	}
+	if cfg.Runtime.SessionQueueLimit != 100 {
+		t.Errorf("expected runtime.session_queue_limit=%d, got %d", 100, cfg.Runtime.SessionQueueLimit)
+	}
+	if cfg.Session.DMScope != "main" {
+		t.Errorf("expected session.dm_scope=%q, got %q", "main", cfg.Session.DMScope)
+	}
 	if cfg.Memory.MetadataExtraction {
 		t.Errorf("expected memory.metadata_extraction=false by default")
 	}
@@ -59,6 +65,9 @@ ai:
 storage_path: "/tmp/test.db"
 runtime:
   mode: "legacy"
+  session_queue_limit: 42
+session:
+  dm_scope: "per_user"
 memory:
   metadata_extraction: true
   metadata_model: "claude-haiku-3.5"
@@ -74,6 +83,12 @@ memory:
 
 	if cfg.Runtime.Mode != "legacy" {
 		t.Errorf("expected runtime.mode=%q, got %q", "legacy", cfg.Runtime.Mode)
+	}
+	if cfg.Runtime.SessionQueueLimit != 42 {
+		t.Errorf("expected runtime.session_queue_limit=%d, got %d", 42, cfg.Runtime.SessionQueueLimit)
+	}
+	if cfg.Session.DMScope != "per_user" {
+		t.Errorf("expected session.dm_scope=%q, got %q", "per_user", cfg.Session.DMScope)
 	}
 	if !cfg.Memory.MetadataExtraction {
 		t.Errorf("expected memory.metadata_extraction=true")
@@ -171,5 +186,65 @@ memory:
 	}
 	if !cfg.Memory.MCP.AllowWrites {
 		t.Fatalf("expected memory.mcp.allow_writes=true")
+	}
+}
+
+func TestValidateRejectsInvalidRuntimeSessionQueueLimit(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-invalid-queue-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+runtime:
+  session_queue_limit: -1
+storage_path: "/tmp/test.db"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for negative runtime.session_queue_limit")
+	}
+}
+
+func TestValidateRejectsInvalidSessionDMScope(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-invalid-dm-scope-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+session:
+  dm_scope: "invalid"
+storage_path: "/tmp/test.db"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for invalid session.dm_scope")
 	}
 }

--- a/internal/configschema/schema.go
+++ b/internal/configschema/schema.go
@@ -1,0 +1,212 @@
+package configschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+const (
+	canonicalStartMarker = "<!-- CONFIG_CANONICAL:START -->"
+	canonicalEndMarker   = "<!-- CONFIG_CANONICAL:END -->"
+)
+
+// Node defines one canonical config key in ARCHITECTURE-v2 section 8.
+// It intentionally mirrors JSON Schema fields used by this project.
+type Node struct {
+	Type                 string           `json:"type"`
+	Default              any              `json:"default"`
+	Description          string           `json:"description"`
+	Enum                 []string         `json:"enum,omitempty"`
+	Properties           map[string]*Node `json:"properties,omitempty"`
+	Items                *Node            `json:"items,omitempty"`
+	AdditionalProperties *Node            `json:"additionalProperties,omitempty"`
+}
+
+// LoadCanonicalNodeFromFile extracts and parses the canonical config block.
+func LoadCanonicalNodeFromFile(path string) (*Node, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read canonical source: %w", err)
+	}
+	return LoadCanonicalNode(content)
+}
+
+// LoadCanonicalNode extracts and parses the canonical config block.
+func LoadCanonicalNode(markdown []byte) (*Node, error) {
+	raw, err := extractCanonicalJSON(markdown)
+	if err != nil {
+		return nil, err
+	}
+
+	var root Node
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, fmt.Errorf("parse canonical json: %w", err)
+	}
+
+	if err := root.Validate("root"); err != nil {
+		return nil, err
+	}
+	return &root, nil
+}
+
+// GenerateSchemaFromFile loads the canonical source markdown and returns
+// a stable, indented JSON Schema payload.
+func GenerateSchemaFromFile(path string) ([]byte, error) {
+	root, err := LoadCanonicalNodeFromFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return root.MarshalSchema()
+}
+
+// MarshalSchema renders a JSON Schema document for this canonical node.
+func (n *Node) MarshalSchema() ([]byte, error) {
+	doc := n.toSchema()
+	doc["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+	doc["title"] = "ok-gobot configuration"
+
+	encoded, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal schema: %w", err)
+	}
+	return append(encoded, '\n'), nil
+}
+
+// Validate enforces canonical block invariants.
+func (n *Node) Validate(path string) error {
+	if n.Type == "" {
+		return fmt.Errorf("%s.type is required", path)
+	}
+	if n.Default == nil {
+		return fmt.Errorf("%s.default is required", path)
+	}
+	if strings.TrimSpace(n.Description) == "" {
+		return fmt.Errorf("%s.description is required", path)
+	}
+
+	switch n.Type {
+	case "object":
+		if len(n.Properties) == 0 && n.AdditionalProperties == nil {
+			return fmt.Errorf("%s: object must define properties or additionalProperties", path)
+		}
+		for key, child := range n.Properties {
+			if strings.TrimSpace(key) == "" {
+				return fmt.Errorf("%s.properties contains an empty key", path)
+			}
+			if child == nil {
+				return fmt.Errorf("%s.properties.%s is nil", path, key)
+			}
+			if err := child.Validate(path + "." + key); err != nil {
+				return err
+			}
+		}
+		if n.Items != nil {
+			return fmt.Errorf("%s: object must not define items", path)
+		}
+		if n.AdditionalProperties != nil {
+			if err := n.AdditionalProperties.Validate(path + ".*"); err != nil {
+				return err
+			}
+		}
+	case "array":
+		if n.Items == nil {
+			return fmt.Errorf("%s.items is required for array", path)
+		}
+		if err := n.Items.Validate(path + "[]"); err != nil {
+			return err
+		}
+		if len(n.Properties) > 0 {
+			return fmt.Errorf("%s: array must not define properties", path)
+		}
+		if n.AdditionalProperties != nil {
+			return fmt.Errorf("%s: array must not define additionalProperties", path)
+		}
+	case "string", "integer", "number", "boolean":
+		if n.Items != nil {
+			return fmt.Errorf("%s: scalar must not define items", path)
+		}
+		if len(n.Properties) > 0 {
+			return fmt.Errorf("%s: scalar must not define properties", path)
+		}
+		if n.AdditionalProperties != nil {
+			return fmt.Errorf("%s: scalar must not define additionalProperties", path)
+		}
+	default:
+		return fmt.Errorf("%s.type=%q is not supported", path, n.Type)
+	}
+
+	return nil
+}
+
+func (n *Node) toSchema() map[string]any {
+	out := map[string]any{
+		"type":        n.Type,
+		"default":     n.Default,
+		"description": n.Description,
+	}
+
+	if len(n.Enum) > 0 {
+		out["enum"] = n.Enum
+	}
+
+	switch n.Type {
+	case "object":
+		if len(n.Properties) > 0 {
+			properties := make(map[string]any, len(n.Properties))
+			keys := make([]string, 0, len(n.Properties))
+			for key := range n.Properties {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				properties[key] = n.Properties[key].toSchema()
+			}
+			out["properties"] = properties
+		}
+
+		if n.AdditionalProperties != nil {
+			out["additionalProperties"] = n.AdditionalProperties.toSchema()
+		} else {
+			out["additionalProperties"] = false
+		}
+	case "array":
+		out["items"] = n.Items.toSchema()
+	}
+
+	return out
+}
+
+func extractCanonicalJSON(markdown []byte) ([]byte, error) {
+	src := string(markdown)
+	start := strings.Index(src, canonicalStartMarker)
+	if start == -1 {
+		return nil, fmt.Errorf("canonical start marker %q not found", canonicalStartMarker)
+	}
+	end := strings.Index(src, canonicalEndMarker)
+	if end == -1 {
+		return nil, fmt.Errorf("canonical end marker %q not found", canonicalEndMarker)
+	}
+	if end <= start {
+		return nil, fmt.Errorf("canonical markers are malformed")
+	}
+
+	section := src[start+len(canonicalStartMarker) : end]
+	fenceStart := strings.Index(section, "```json")
+	if fenceStart == -1 {
+		return nil, fmt.Errorf("canonical JSON fence not found")
+	}
+	body := section[fenceStart+len("```json"):]
+	fenceEnd := strings.Index(body, "```")
+	if fenceEnd == -1 {
+		return nil, fmt.Errorf("canonical JSON fence is not closed")
+	}
+
+	payload := strings.TrimSpace(body[:fenceEnd])
+	if payload == "" {
+		return nil, fmt.Errorf("canonical JSON payload is empty")
+	}
+	return []byte(payload), nil
+}

--- a/internal/configschema/schema_test.go
+++ b/internal/configschema/schema_test.go
@@ -1,0 +1,89 @@
+package configschema
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestGenerateMatchesCheckedInSchema(t *testing.T) {
+	root := repoRoot(t)
+	architecturePath := filepath.Join(root, "docs", "ARCHITECTURE-v2.md")
+	schemaPath := filepath.Join(root, "config.schema.json")
+
+	got, err := GenerateSchemaFromFile(architecturePath)
+	if err != nil {
+		t.Fatalf("GenerateSchemaFromFile failed: %v", err)
+	}
+
+	want, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read checked-in schema: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("config.schema.json is stale; run `go run ./cmd/gen-config-schema`")
+	}
+}
+
+func TestCanonicalIncludesPRDExtensions(t *testing.T) {
+	root := repoRoot(t)
+	architecturePath := filepath.Join(root, "docs", "ARCHITECTURE-v2.md")
+
+	node, err := LoadCanonicalNodeFromFile(architecturePath)
+	if err != nil {
+		t.Fatalf("LoadCanonicalNodeFromFile failed: %v", err)
+	}
+
+	required := []string{
+		"runtime.mode",
+		"runtime.session_queue_limit",
+		"session.dm_scope",
+	}
+	for _, key := range required {
+		if _, ok := lookup(node, key); !ok {
+			t.Fatalf("canonical key missing: %s", key)
+		}
+	}
+}
+
+func TestCanonicalEveryKeyHasTypeDefaultDescription(t *testing.T) {
+	root := repoRoot(t)
+	architecturePath := filepath.Join(root, "docs", "ARCHITECTURE-v2.md")
+
+	node, err := LoadCanonicalNodeFromFile(architecturePath)
+	if err != nil {
+		t.Fatalf("LoadCanonicalNodeFromFile failed: %v", err)
+	}
+
+	if err := node.Validate("root"); err != nil {
+		t.Fatalf("canonical validation failed: %v", err)
+	}
+}
+
+func lookup(root *Node, path string) (*Node, bool) {
+	cur := root
+	for _, segment := range strings.Split(path, ".") {
+		if cur == nil || cur.Type != "object" {
+			return nil, false
+		}
+		next, ok := cur.Properties[segment]
+		if !ok {
+			return nil, false
+		}
+		cur = next
+	}
+	return cur, true
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -1379,48 +1379,23 @@ func (s *Store) GetSessionMessagesV2(sessionKey string, limit int) ([]SessionMes
 	return msgs, rows.Err()
 }
 
-// SessionRoute holds one row from session_routes.
-type SessionRoute struct {
-	SessionKey string
-	Channel    string
-	ChatID     int64
-	ThreadID   int
-	UserID     int64
-	Username   string
-	UpdatedAt  string
-}
-
 // UpsertSessionRoute creates or updates the delivery route for sessionKey.
+// Unlike SaveSessionRoute it performs no input validation and is suitable
+// for internal callers that build the route inline.
 func (s *Store) UpsertSessionRoute(route SessionRoute) error {
 	_, err := s.db.Exec(`
-		INSERT INTO session_routes (session_key, channel, chat_id, thread_id, user_id, username)
-		VALUES (?, ?, ?, ?, ?, ?)
+		INSERT INTO session_routes (session_key, channel, chat_id, thread_id, reply_to_message_id, user_id, username)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(session_key) DO UPDATE SET
-			channel   = excluded.channel,
-			chat_id   = excluded.chat_id,
-			thread_id = excluded.thread_id,
-			user_id   = excluded.user_id,
-			username  = excluded.username,
-			updated_at = CURRENT_TIMESTAMP
-	`, route.SessionKey, route.Channel, route.ChatID, route.ThreadID, route.UserID, route.Username)
+			channel              = excluded.channel,
+			chat_id              = excluded.chat_id,
+			thread_id            = excluded.thread_id,
+			reply_to_message_id  = excluded.reply_to_message_id,
+			user_id              = excluded.user_id,
+			username             = excluded.username,
+			updated_at           = CURRENT_TIMESTAMP
+	`, route.SessionKey, route.Channel, route.ChatID, route.ThreadID, route.ReplyToMessageID, route.UserID, route.Username)
 	return err
-}
-
-// GetSessionRoute retrieves the delivery route for sessionKey.
-// Returns nil (no error) when not found.
-func (s *Store) GetSessionRoute(sessionKey string) (*SessionRoute, error) {
-	var r SessionRoute
-	err := s.db.QueryRow(`
-		SELECT session_key, channel, chat_id, thread_id, user_id, username, updated_at
-		FROM session_routes WHERE session_key = ?
-	`, sessionKey).Scan(&r.SessionKey, &r.Channel, &r.ChatID, &r.ThreadID, &r.UserID, &r.Username, &r.UpdatedAt)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &r, nil
 }
 
 // PromoteLegacySession ensures a v2 session exists for sessionKey.


### PR DESCRIPTION
Closes #94

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes a canonical configuration reference in `docs/ARCHITECTURE-v2.md` §8 and introduces tooling to generate `config.schema.json` from this single source of truth. The implementation successfully adds new config keys for runtime hub execution (`runtime.session_queue_limit`, `session.dm_scope`) with proper validation and test coverage.

**Key changes:**
- Created canonical config schema in ARCHITECTURE-v2.md with extraction/generation tooling
- Added `internal/configschema` package to parse and validate canonical schema
- Added `cmd/gen-config-schema` CLI tool and `make config-schema` target
- Extended config with `SessionConfig` struct and validation for new hub-mode settings
- Updated PRD to defer to ARCHITECTURE-v2.md as config source of truth
- Refactored `SessionRoute` in storage layer to add `ReplyToMessageID` field

**Issues found:**
- Duplicate `control:` key in `config.example.yaml` (lines 31 and 101) creates YAML parsing conflict
- Canonical schema missing `memory.metadata_extraction`, `memory.metadata_model`, and entire `memory.mcp` object that exist in code implementation (flagged in previous thread)

<h3>Confidence Score: 2/5</h3>

- This PR has one critical YAML syntax bug and schema completeness issues that need resolution before merge
- Score reflects duplicate YAML key causing parsing errors and missing canonical schema properties. While architecture and tests are well-designed, the config.example.yaml duplicate key will cause runtime issues when parsed
- Pay close attention to `config.example.yaml` (duplicate key) and `docs/ARCHITECTURE-v2.md` (incomplete schema)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| config.example.yaml | Added duplicate `control:` key (lines 31 and 101), causing YAML parsing conflict |
| docs/ARCHITECTURE-v2.md | Missing `memory.metadata_extraction`, `memory.metadata_model`, and `memory.mcp.*` properties that exist in code implementation (already flagged in previous thread) |
| config.schema.json | Generated schema file correctly reflects canonical source but inherits missing memory properties |

</details>



<sub>Last reviewed commit: 687f054</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->