### PR TITLE
Browser: accessibility tree snapshot + in-process ref resolver

### DIFF
--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -499,7 +499,7 @@ func (a *ToolCallingAgent) executeToolFromJSON(ctx context.Context, toolName str
 		// Structured tool with "command" field (e.g. browser, file)
 		args = []string{cmd}
 		// Append known positional params in order
-		for _, key := range []string{"url", "path", "selector", "value", "query", "content", "expression", "task"} {
+		for _, key := range []string{"url", "path", "snapshot_id", "ref", "selector", "value", "query", "content", "expression", "task"} {
 			if v, ok := argsMap[key]; ok {
 				if rendered := stringifyToolArg(v); rendered != "" {
 					args = append(args, rendered)

--- a/internal/agent/tool_agent_test.go
+++ b/internal/agent/tool_agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"ok-gobot/internal/ai"
@@ -158,6 +159,46 @@ func TestToolCallingAgent_BrowserNavigate(t *testing.T) {
 
 	t.Logf("Browser args: %v", browserTool.allArgs)
 	t.Logf("Response: %s", resp.Message)
+}
+
+func TestToolCallingAgent_BrowserClickBySnapshotRef(t *testing.T) {
+	browserTool := &mockTool{
+		name: "browser",
+		desc: "Browser automation",
+		schema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"command":     map[string]interface{}{"type": "string"},
+				"snapshot_id": map[string]interface{}{"type": "string"},
+				"ref":         map[string]interface{}{"type": "string"},
+			},
+			"required": []string{"command", "snapshot_id", "ref"},
+		},
+	}
+
+	registry := tools.NewRegistry()
+	registry.Register(browserTool)
+
+	mockAI := &mockAIClient{
+		toolCallName: "browser",
+		toolCallArgs: `{"command":"click","snapshot_id":"snap-123","ref":"r7"}`,
+		finalText:    "Clicked",
+	}
+
+	personality := &Personality{
+		Files: map[string]string{"IDENTITY.md": "Test Bot"},
+	}
+
+	agent := NewToolCallingAgent(mockAI, registry, personality)
+	_, err := agent.ProcessRequest(context.Background(), "click the continue button", "")
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+
+	want := []string{"click", "snap-123", "r7"}
+	if !reflect.DeepEqual(browserTool.allArgs, want) {
+		t.Fatalf("browser args = %v, want %v", browserTool.allArgs, want)
+	}
 }
 
 func TestToolCallingAgent_FileRead(t *testing.T) {

--- a/internal/browser/manager.go
+++ b/internal/browser/manager.go
@@ -58,6 +58,15 @@ type Manager struct {
 	mu        sync.Mutex
 	instances map[string]*profileInstance
 
+	snapshotMu    sync.RWMutex
+	snapshotCache map[string]snapshotCacheEntry
+
+	resolveTabID   tabIDResolver
+	getFullAXTree  fullAXTreeGetter
+	resolveNodeIDs nodeIDsResolver
+	clickByNodeID  clickByNodeIDFunc
+	typeByNodeID   typeByNodeIDFunc
+
 	launchFn func(cfg profileConfig, userDataDir string, debugPort int) (*profileInstance, error)
 	healthFn func(port int) error
 
@@ -79,10 +88,11 @@ func newManager(profilePath string, enableSignals bool) *Manager {
 	}
 
 	m := &Manager{
-		ProfilePath: profilePath,
-		UserDataDir: profilePath,
-		Headless:    false, // Default to visible for user interaction
-		instances:   make(map[string]*profileInstance),
+		ProfilePath:   profilePath,
+		UserDataDir:   profilePath,
+		Headless:      false, // Default to visible for user interaction
+		instances:     make(map[string]*profileInstance),
+		snapshotCache: make(map[string]snapshotCacheEntry),
 		httpClient: &http.Client{
 			Timeout: healthProbeTimeout,
 		},
@@ -91,6 +101,11 @@ func newManager(profilePath string, enableSignals bool) *Manager {
 
 	m.launchFn = m.launchProfile
 	m.healthFn = m.healthCheckCDP
+	m.resolveTabID = m.defaultTabIDForContext
+	m.getFullAXTree = getFullAXTree
+	m.resolveNodeIDs = pushNodesByBackendIDs
+	m.clickByNodeID = m.defaultClickByNodeID
+	m.typeByNodeID = m.defaultTypeByNodeID
 
 	return m
 }
@@ -122,6 +137,7 @@ func (m *Manager) Stop() {
 	for _, name := range profiles {
 		m.stopProfileLocked(name)
 	}
+	m.clearSnapshotCache()
 }
 
 // StopProfile closes a single named profile if running.
@@ -169,6 +185,7 @@ func (m *Manager) NewTabForProfile(profile string) (context.Context, context.Can
 	}
 
 	ctx, cancel := chromedp.NewContext(browserCtx)
+	m.attachNavigationInvalidation(ctx)
 	return ctx, cancel, nil
 }
 

--- a/internal/browser/snapshot.go
+++ b/internal/browser/snapshot.go
@@ -3,341 +3,339 @@ package browser
 import (
 	"context"
 	"crypto/rand"
-	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/chromedp/cdproto/accessibility"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
-	"github.com/chromedp/cdproto/input"
+	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
 )
 
-const (
-	defaultSnapshotTTL = 30 * time.Second
-	maxSnapshots       = 20
-)
-
-// ElementRef describes an interactive element in a snapshot.
-type ElementRef struct {
-	Ref           string            `json:"ref"`
-	Role          string            `json:"role"`
-	Name          string            `json:"name"`
-	BackendNodeID cdp.BackendNodeID `json:"-"`
+// AXNode is a simplified accessibility node used in browser snapshots.
+type AXNode struct {
+	Ref      string   `json:"ref"`
+	Role     string   `json:"role,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	Children []AXNode `json:"children,omitempty"`
 }
 
-// Snapshot holds a page accessibility snapshot with ref mappings.
-type Snapshot struct {
-	ID        string       `json:"snapshot_id"`
-	URL       string       `json:"url"`
-	Title     string       `json:"title"`
-	Elements  []ElementRef `json:"elements"`
-	CreatedAt time.Time    `json:"-"`
-
-	refMap map[string]cdp.BackendNodeID
+type snapshotCacheEntry struct {
+	snapshotID  string
+	refToNodeID map[string]cdp.NodeID
 }
 
-// SnapshotStore is a TTL-based in-memory cache for page snapshots.
-type SnapshotStore struct {
-	mu        sync.RWMutex
-	snapshots map[string]*Snapshot
-	ttl       time.Duration
-}
+type tabIDResolver func(ctx context.Context) string
+type fullAXTreeGetter func(ctx context.Context) ([]*accessibility.Node, error)
+type nodeIDsResolver func(ctx context.Context, backendIDs []cdp.BackendNodeID) ([]cdp.NodeID, error)
+type clickByNodeIDFunc func(ctx context.Context, nodeID cdp.NodeID) error
+type typeByNodeIDFunc func(ctx context.Context, nodeID cdp.NodeID, value string) error
 
-// NewSnapshotStore creates a new store with the given TTL.
-func NewSnapshotStore(ttl time.Duration) *SnapshotStore {
-	if ttl <= 0 {
-		ttl = defaultSnapshotTTL
+// Snapshot captures the current accessibility tree and returns a ref-addressable
+// snapshot, while caching ref -> nodeId mappings in-process.
+func (m *Manager) Snapshot(ctx context.Context) (string, []AXNode, error) {
+	if ctx == nil {
+		return "", nil, fmt.Errorf("context is required")
 	}
-	return &SnapshotStore{
-		snapshots: make(map[string]*Snapshot),
-		ttl:       ttl,
+
+	axTree, err := m.getFullAXTree(ctx)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get accessibility tree: %w", err)
 	}
-}
 
-// Put stores a snapshot. If the store exceeds maxSnapshots, the oldest entry is evicted.
-func (s *SnapshotStore) Put(snap *Snapshot) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// Evict expired entries first.
-	now := time.Now()
-	for id, sn := range s.snapshots {
-		if now.Sub(sn.CreatedAt) > s.ttl {
-			delete(s.snapshots, id)
+	backendIDs := collectBackendNodeIDs(axTree)
+	backendToNodeID := make(map[cdp.BackendNodeID]cdp.NodeID, len(backendIDs))
+	if len(backendIDs) > 0 {
+		nodeIDs, err := m.resolveNodeIDs(ctx, backendIDs)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to resolve backend DOM node IDs: %w", err)
 		}
-	}
-
-	// If still at capacity, evict oldest.
-	if len(s.snapshots) >= maxSnapshots {
-		var oldestID string
-		var oldestTime time.Time
-		for id, sn := range s.snapshots {
-			if oldestID == "" || sn.CreatedAt.Before(oldestTime) {
-				oldestID = id
-				oldestTime = sn.CreatedAt
+		if len(nodeIDs) != len(backendIDs) {
+			return "", nil, fmt.Errorf("mismatched node ID mapping count: got %d, want %d", len(nodeIDs), len(backendIDs))
+		}
+		for i, backendID := range backendIDs {
+			if nodeIDs[i] == 0 {
+				continue
 			}
-		}
-		if oldestID != "" {
-			delete(s.snapshots, oldestID)
+			backendToNodeID[backendID] = nodeIDs[i]
 		}
 	}
 
-	s.snapshots[snap.ID] = snap
+	nodes, refMap := buildAXSnapshot(axTree, backendToNodeID)
+	snapshotID, err := newSnapshotID()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to generate snapshot ID: %w", err)
+	}
+
+	tabID := m.resolveTabID(ctx)
+	if tabID == "" {
+		return "", nil, fmt.Errorf("failed to resolve tab ID for snapshot")
+	}
+	m.storeSnapshotForTab(tabID, snapshotID, refMap)
+
+	return snapshotID, nodes, nil
 }
 
-// Get returns a snapshot by ID. Returns nil if not found or expired.
-func (s *SnapshotStore) Get(id string) *Snapshot {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+// ClickByRef clicks on a node previously returned by Snapshot.
+func (m *Manager) ClickByRef(ctx context.Context, snapshotID, ref string) error {
+	nodeID, err := m.resolveNodeID(ctx, snapshotID, ref)
+	if err != nil {
+		return err
+	}
+	if err := m.clickByNodeID(ctx, nodeID); err != nil {
+		return fmt.Errorf("failed to click ref %q: %w", ref, err)
+	}
+	return nil
+}
 
-	snap, ok := s.snapshots[id]
+// TypeByRef types text into a node previously returned by Snapshot.
+func (m *Manager) TypeByRef(ctx context.Context, snapshotID, ref, value string) error {
+	nodeID, err := m.resolveNodeID(ctx, snapshotID, ref)
+	if err != nil {
+		return err
+	}
+	if err := m.typeByNodeID(ctx, nodeID, value); err != nil {
+		return fmt.Errorf("failed to type into ref %q: %w", ref, err)
+	}
+	return nil
+}
+
+func (m *Manager) resolveNodeID(ctx context.Context, snapshotID, ref string) (cdp.NodeID, error) {
+	if snapshotID == "" {
+		return 0, fmt.Errorf("snapshot_id is required")
+	}
+	if ref == "" {
+		return 0, fmt.Errorf("ref is required")
+	}
+
+	tabID := m.resolveTabID(ctx)
+	if tabID == "" {
+		return 0, fmt.Errorf("failed to resolve tab ID")
+	}
+
+	m.snapshotMu.RLock()
+	entry, ok := m.snapshotCache[tabID]
+	m.snapshotMu.RUnlock()
 	if !ok {
-		return nil
+		return 0, fmt.Errorf("no snapshot cache for current tab")
 	}
-	if time.Since(snap.CreatedAt) > s.ttl {
-		return nil
+	if entry.snapshotID != snapshotID {
+		return 0, fmt.Errorf("snapshot_id %q is stale for current tab", snapshotID)
 	}
-	return snap
-}
 
-// Resolve returns the BackendNodeID for a given snapshot_id + ref.
-func (s *SnapshotStore) Resolve(snapshotID, ref string) (cdp.BackendNodeID, error) {
-	snap := s.Get(snapshotID)
-	if snap == nil {
-		return 0, fmt.Errorf("snapshot %q not found or expired — take a new snapshot first", snapshotID)
-	}
-	nodeID, ok := snap.refMap[ref]
+	nodeID, ok := entry.refToNodeID[ref]
 	if !ok {
 		return 0, fmt.Errorf("ref %q not found in snapshot %q", ref, snapshotID)
 	}
+
 	return nodeID, nil
 }
 
-// Len returns the number of non-expired snapshots.
-func (s *SnapshotStore) Len() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	count := 0
-	now := time.Now()
-	for _, sn := range s.snapshots {
-		if now.Sub(sn.CreatedAt) <= s.ttl {
-			count++
-		}
-	}
-	return count
-}
-
-// generateID returns a short random hex string.
-func generateID() string {
-	b := make([]byte, 4)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)
-}
-
-// interactiveRoles lists AX roles that are typically actionable.
-var interactiveRoles = map[string]bool{
-	"button":        true,
-	"link":          true,
-	"textbox":       true,
-	"checkbox":      true,
-	"radio":         true,
-	"combobox":      true,
-	"menuitem":      true,
-	"tab":           true,
-	"switch":        true,
-	"searchbox":     true,
-	"spinbutton":    true,
-	"slider":        true,
-	"option":        true,
-	"menuitemradio": true,
-	"treeitem":      true,
-}
-
-// TakeSnapshot captures the accessibility tree of the current page,
-// assigns refs to interactive elements, and stores the snapshot.
-func TakeSnapshot(ctx context.Context, store *SnapshotStore) (*Snapshot, error) {
-	// Get page URL + title.
-	var url, title string
-	if err := chromedp.Run(ctx,
-		chromedp.Location(&url),
-		chromedp.Title(&title),
-	); err != nil {
-		return nil, fmt.Errorf("failed to get page info: %w", err)
+func (m *Manager) attachNavigationInvalidation(ctx context.Context) {
+	if ctx == nil {
+		return
 	}
 
-	// Fetch the full accessibility tree.
-	var nodes []*accessibility.Node
-	if err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
-		var err error
-		nodes, err = accessibility.GetFullAXTree().Do(ctx)
-		return err
-	})); err != nil {
-		return nil, fmt.Errorf("failed to get accessibility tree: %w", err)
+	chromedp.ListenTarget(ctx, func(event interface{}) {
+		switch event.(type) {
+		case *page.EventFrameNavigated, *page.EventNavigatedWithinDocument, *dom.EventDocumentUpdated:
+			m.invalidateSnapshotForContext(ctx)
+		}
+	})
+}
+
+func (m *Manager) invalidateSnapshotForContext(ctx context.Context) {
+	tabID := m.resolveTabID(ctx)
+	if tabID == "" {
+		return
+	}
+	m.invalidateSnapshotForTab(tabID)
+}
+
+func (m *Manager) invalidateSnapshotForTab(tabID string) {
+	if tabID == "" {
+		return
+	}
+	m.snapshotMu.Lock()
+	delete(m.snapshotCache, tabID)
+	m.snapshotMu.Unlock()
+}
+
+func (m *Manager) storeSnapshotForTab(tabID, snapshotID string, refToNodeID map[string]cdp.NodeID) {
+	copyMap := make(map[string]cdp.NodeID, len(refToNodeID))
+	for ref, nodeID := range refToNodeID {
+		copyMap[ref] = nodeID
 	}
 
-	// Build refs for interactive elements.
-	elements := make([]ElementRef, 0, 64)
-	refMap := make(map[string]cdp.BackendNodeID, 64)
-	counter := 0
-
-	for _, node := range nodes {
-		if node.Ignored {
-			continue
-		}
-		if node.BackendDOMNodeID == 0 {
-			continue
-		}
-
-		role := axValueString(node.Role)
-		if role == "" {
-			continue
-		}
-		name := axValueString(node.Name)
-
-		if !interactiveRoles[role] && name == "" {
-			continue
-		}
-		if !interactiveRoles[role] {
-			continue
-		}
-
-		counter++
-		ref := fmt.Sprintf("e%d", counter)
-		elements = append(elements, ElementRef{
-			Ref:           ref,
-			Role:          role,
-			Name:          name,
-			BackendNodeID: node.BackendDOMNodeID,
-		})
-		refMap[ref] = node.BackendDOMNodeID
+	m.snapshotMu.Lock()
+	m.snapshotCache[tabID] = snapshotCacheEntry{
+		snapshotID:  snapshotID,
+		refToNodeID: copyMap,
 	}
-
-	snap := &Snapshot{
-		ID:        generateID(),
-		URL:       url,
-		Title:     title,
-		Elements:  elements,
-		CreatedAt: time.Now(),
-		refMap:    refMap,
-	}
-	store.Put(snap)
-	return snap, nil
+	m.snapshotMu.Unlock()
 }
 
-// ClickByRef clicks an element identified by snapshot_id + ref.
-func ClickByRef(ctx context.Context, store *SnapshotStore, snapshotID, ref string) error {
-	backendID, err := store.Resolve(snapshotID, ref)
-	if err != nil {
-		return err
-	}
-	return clickByBackendNodeID(ctx, backendID)
+func (m *Manager) clearSnapshotCache() {
+	m.snapshotMu.Lock()
+	m.snapshotCache = make(map[string]snapshotCacheEntry)
+	m.snapshotMu.Unlock()
 }
 
-// TypeByRef types text into an element identified by snapshot_id + ref.
-func TypeByRef(ctx context.Context, store *SnapshotStore, snapshotID, ref, text string) error {
-	backendID, err := store.Resolve(snapshotID, ref)
-	if err != nil {
-		return err
-	}
-	return typeByBackendNodeID(ctx, backendID, text)
-}
-
-// FocusByRef focuses an element identified by snapshot_id + ref.
-func FocusByRef(ctx context.Context, store *SnapshotStore, snapshotID, ref string) error {
-	backendID, err := store.Resolve(snapshotID, ref)
-	if err != nil {
-		return err
-	}
-	return focusByBackendNodeID(ctx, backendID)
-}
-
-// clickByBackendNodeID clicks the center of the element.
-func clickByBackendNodeID(ctx context.Context, backendID cdp.BackendNodeID) error {
-	return chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
-		// Get element position.
-		quads, err := dom.GetContentQuads().WithBackendNodeID(backendID).Do(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get element position: %w", err)
-		}
-		if len(quads) == 0 {
-			return fmt.Errorf("element has no visible quads")
-		}
-
-		// Compute center of first quad (8 floats: 4 x,y pairs).
-		q := quads[0]
-		if len(q) < 8 {
-			return fmt.Errorf("invalid quad data")
-		}
-		x := (q[0] + q[2] + q[4] + q[6]) / 4
-		y := (q[1] + q[3] + q[5] + q[7]) / 4
-
-		// Dispatch mouse press + release.
-		if err := input.DispatchMouseEvent(input.MousePressed, x, y).
-			WithButton(input.Left).WithClickCount(1).Do(ctx); err != nil {
-			return err
-		}
-		return input.DispatchMouseEvent(input.MouseReleased, x, y).
-			WithButton(input.Left).WithClickCount(1).Do(ctx)
-	}))
-}
-
-// focusByBackendNodeID focuses the element.
-func focusByBackendNodeID(ctx context.Context, backendID cdp.BackendNodeID) error {
-	return chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
-		return dom.Focus().WithBackendNodeID(backendID).Do(ctx)
-	}))
-}
-
-// typeByBackendNodeID focuses the element and dispatches key events.
-func typeByBackendNodeID(ctx context.Context, backendID cdp.BackendNodeID, text string) error {
-	return chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
-		// Focus first.
-		if err := dom.Focus().WithBackendNodeID(backendID).Do(ctx); err != nil {
-			return fmt.Errorf("failed to focus element: %w", err)
-		}
-
-		// Dispatch key events for each character.
-		for _, ch := range text {
-			s := string(ch)
-			if err := input.DispatchKeyEvent(input.KeyChar).WithText(s).Do(ctx); err != nil {
-				return fmt.Errorf("failed to type character %q: %w", s, err)
-			}
-		}
-		return nil
-	}))
-}
-
-// FormatSnapshot returns a human-readable text representation of a snapshot.
-func FormatSnapshot(snap *Snapshot) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "snapshot_id: %s\n", snap.ID)
-	fmt.Fprintf(&b, "url: %s\n", snap.URL)
-	fmt.Fprintf(&b, "title: %s\n", snap.Title)
-	fmt.Fprintf(&b, "elements: %d\n\n", len(snap.Elements))
-	for _, e := range snap.Elements {
-		if e.Name != "" {
-			fmt.Fprintf(&b, "  [%s] %s %q\n", e.Ref, e.Role, e.Name)
-		} else {
-			fmt.Fprintf(&b, "  [%s] %s\n", e.Ref, e.Role)
-		}
-	}
-	return b.String()
-}
-
-// axValueString extracts the string value from an AX Value.
-func axValueString(v *accessibility.Value) string {
-	if v == nil {
+func (m *Manager) defaultTabIDForContext(ctx context.Context) string {
+	c := chromedp.FromContext(ctx)
+	if c == nil || c.Target == nil || c.Target.TargetID == "" {
 		return ""
 	}
-	raw := string(v.Value)
-	// Strip surrounding quotes from JSON string values.
-	raw = strings.TrimSpace(raw)
-	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
-		raw = raw[1 : len(raw)-1]
+	return string(c.Target.TargetID)
+}
+
+func getFullAXTree(ctx context.Context) ([]*accessibility.Node, error) {
+	return accessibility.GetFullAXTree().Do(ctx)
+}
+
+func pushNodesByBackendIDs(ctx context.Context, backendIDs []cdp.BackendNodeID) ([]cdp.NodeID, error) {
+	return dom.PushNodesByBackendIDsToFrontend(backendIDs).Do(ctx)
+}
+
+func (m *Manager) defaultClickByNodeID(ctx context.Context, nodeID cdp.NodeID) error {
+	return chromedp.Run(ctx,
+		chromedp.WaitVisible([]cdp.NodeID{nodeID}, chromedp.ByNodeID),
+		chromedp.Click([]cdp.NodeID{nodeID}, chromedp.ByNodeID),
+	)
+}
+
+func (m *Manager) defaultTypeByNodeID(ctx context.Context, nodeID cdp.NodeID, value string) error {
+	return chromedp.Run(ctx,
+		chromedp.WaitVisible([]cdp.NodeID{nodeID}, chromedp.ByNodeID),
+		chromedp.Focus([]cdp.NodeID{nodeID}, chromedp.ByNodeID),
+		chromedp.SendKeys([]cdp.NodeID{nodeID}, value, chromedp.ByNodeID),
+	)
+}
+
+func collectBackendNodeIDs(axTree []*accessibility.Node) []cdp.BackendNodeID {
+	seen := make(map[cdp.BackendNodeID]struct{})
+	backendIDs := make([]cdp.BackendNodeID, 0)
+
+	for _, node := range axTree {
+		if node == nil || node.BackendDOMNodeID == 0 {
+			continue
+		}
+		if _, ok := seen[node.BackendDOMNodeID]; ok {
+			continue
+		}
+		seen[node.BackendDOMNodeID] = struct{}{}
+		backendIDs = append(backendIDs, node.BackendDOMNodeID)
 	}
-	return raw
+
+	return backendIDs
+}
+
+func buildAXSnapshot(
+	axTree []*accessibility.Node,
+	backendToNodeID map[cdp.BackendNodeID]cdp.NodeID,
+) ([]AXNode, map[string]cdp.NodeID) {
+	nodesByID := make(map[accessibility.NodeID]*accessibility.Node, len(axTree))
+	for _, node := range axTree {
+		if node == nil {
+			continue
+		}
+		nodesByID[node.NodeID] = node
+	}
+
+	roots := make([]accessibility.NodeID, 0)
+	for _, node := range axTree {
+		if node == nil {
+			continue
+		}
+		if node.ParentID == "" {
+			roots = append(roots, node.NodeID)
+			continue
+		}
+		if _, ok := nodesByID[node.ParentID]; !ok {
+			roots = append(roots, node.NodeID)
+		}
+	}
+
+	visited := make(map[accessibility.NodeID]bool, len(nodesByID))
+	refToNodeID := make(map[string]cdp.NodeID)
+	refCounter := 0
+
+	var visit func(accessibility.NodeID) AXNode
+	visit = func(id accessibility.NodeID) AXNode {
+		node := nodesByID[id]
+		refCounter++
+		ref := fmt.Sprintf("r%d", refCounter)
+
+		result := AXNode{
+			Ref:  ref,
+			Role: normalizeAXValue(node.Role),
+			Name: normalizeAXValue(node.Name),
+		}
+
+		if nodeID, ok := backendToNodeID[node.BackendDOMNodeID]; ok && nodeID != 0 {
+			refToNodeID[ref] = nodeID
+		}
+
+		visited[id] = true
+
+		for _, childID := range node.ChildIDs {
+			if _, ok := nodesByID[childID]; !ok || visited[childID] {
+				continue
+			}
+			result.Children = append(result.Children, visit(childID))
+		}
+
+		return result
+	}
+
+	out := make([]AXNode, 0, len(roots))
+	for _, rootID := range roots {
+		if visited[rootID] {
+			continue
+		}
+		out = append(out, visit(rootID))
+	}
+
+	for _, node := range axTree {
+		if node == nil || visited[node.NodeID] {
+			continue
+		}
+		out = append(out, visit(node.NodeID))
+	}
+
+	return out, refToNodeID
+}
+
+func normalizeAXValue(v *accessibility.Value) string {
+	if v == nil || len(v.Value) == 0 {
+		return ""
+	}
+
+	raw := []byte(v.Value)
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return asString
+	}
+
+	var generic interface{}
+	if err := json.Unmarshal(raw, &generic); err == nil {
+		return fmt.Sprintf("%v", generic)
+	}
+
+	return strings.TrimSpace(v.Value.String())
+}
+
+func newSnapshotID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+
+	// Set UUID v4 variant bits.
+	raw[6] = (raw[6] & 0x0f) | 0x40
+	raw[8] = (raw[8] & 0x3f) | 0x80
+
+	return fmt.Sprintf("%x-%x-%x-%x-%x", raw[0:4], raw[4:6], raw[6:8], raw[8:10], raw[10:16]), nil
 }

--- a/internal/browser/snapshot_test.go
+++ b/internal/browser/snapshot_test.go
@@ -1,215 +1,168 @@
 package browser
 
 import (
+	"context"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
 	"testing"
-	"time"
 
+	"github.com/chromedp/cdproto/accessibility"
 	"github.com/chromedp/cdproto/cdp"
+	"github.com/go-json-experiment/json/jsontext"
 )
 
-func TestSnapshotStore_PutAndGet(t *testing.T) {
-	store := NewSnapshotStore(5 * time.Second)
-
-	snap := &Snapshot{
-		ID:        "abc123",
-		URL:       "https://example.com",
-		Title:     "Example",
-		CreatedAt: time.Now(),
-		refMap: map[string]cdp.BackendNodeID{
-			"e1": 100,
-			"e2": 200,
-		},
-		Elements: []ElementRef{
-			{Ref: "e1", Role: "button", Name: "Submit", BackendNodeID: 100},
-			{Ref: "e2", Role: "link", Name: "Home", BackendNodeID: 200},
-		},
+func TestSnapshotBuildsRefMapAndCachesByTab(t *testing.T) {
+	manager := NewManager("")
+	manager.resolveTabID = func(context.Context) string { return "tab-1" }
+	manager.getFullAXTree = func(context.Context) ([]*accessibility.Node, error) {
+		return []*accessibility.Node{
+			{
+				NodeID:           accessibility.NodeID("root"),
+				Role:             stringAXValue("RootWebArea"),
+				Name:             stringAXValue("Example"),
+				ChildIDs:         []accessibility.NodeID{accessibility.NodeID("button")},
+				BackendDOMNodeID: cdp.BackendNodeID(1),
+			},
+			{
+				NodeID:           accessibility.NodeID("button"),
+				ParentID:         accessibility.NodeID("root"),
+				Role:             stringAXValue("button"),
+				Name:             stringAXValue("Continue"),
+				BackendDOMNodeID: cdp.BackendNodeID(2),
+			},
+		}, nil
+	}
+	manager.resolveNodeIDs = func(_ context.Context, backendIDs []cdp.BackendNodeID) ([]cdp.NodeID, error) {
+		want := []cdp.BackendNodeID{cdp.BackendNodeID(1), cdp.BackendNodeID(2)}
+		if !reflect.DeepEqual(backendIDs, want) {
+			t.Fatalf("resolveNodeIDs backendIDs = %v, want %v", backendIDs, want)
+		}
+		return []cdp.NodeID{cdp.NodeID(1001), cdp.NodeID(2002)}, nil
 	}
 
-	store.Put(snap)
-
-	got := store.Get("abc123")
-	if got == nil {
-		t.Fatal("expected snapshot, got nil")
-	}
-	if got.URL != "https://example.com" {
-		t.Errorf("URL = %q, want %q", got.URL, "https://example.com")
-	}
-	if len(got.Elements) != 2 {
-		t.Errorf("len(Elements) = %d, want 2", len(got.Elements))
-	}
-}
-
-func TestSnapshotStore_GetMissing(t *testing.T) {
-	store := NewSnapshotStore(5 * time.Second)
-	if got := store.Get("nonexistent"); got != nil {
-		t.Errorf("expected nil for missing snapshot, got %+v", got)
-	}
-}
-
-func TestSnapshotStore_TTLExpiry(t *testing.T) {
-	store := NewSnapshotStore(50 * time.Millisecond)
-
-	snap := &Snapshot{
-		ID:        "exp1",
-		CreatedAt: time.Now(),
-		refMap:    map[string]cdp.BackendNodeID{"e1": 1},
-	}
-	store.Put(snap)
-
-	// Should be available immediately.
-	if store.Get("exp1") == nil {
-		t.Fatal("expected snapshot before TTL expiry")
-	}
-
-	// Wait for expiry.
-	time.Sleep(100 * time.Millisecond)
-
-	if store.Get("exp1") != nil {
-		t.Error("expected nil after TTL expiry")
-	}
-}
-
-func TestSnapshotStore_Resolve(t *testing.T) {
-	store := NewSnapshotStore(5 * time.Second)
-
-	snap := &Snapshot{
-		ID:        "res1",
-		CreatedAt: time.Now(),
-		refMap: map[string]cdp.BackendNodeID{
-			"e1": 42,
-			"e2": 99,
-		},
-	}
-	store.Put(snap)
-
-	// Valid ref.
-	nodeID, err := store.Resolve("res1", "e1")
+	snapshotID, nodes, err := manager.Snapshot(context.Background())
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if nodeID != 42 {
-		t.Errorf("nodeID = %d, want 42", nodeID)
+		t.Fatalf("Snapshot failed: %v", err)
 	}
 
-	// Invalid ref.
-	_, err = store.Resolve("res1", "e99")
-	if err == nil {
-		t.Error("expected error for invalid ref")
+	uuidPattern := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	if !uuidPattern.MatchString(snapshotID) {
+		t.Fatalf("snapshotID %q is not a valid UUID v4", snapshotID)
 	}
 
-	// Invalid snapshot.
-	_, err = store.Resolve("nonexistent", "e1")
-	if err == nil {
-		t.Error("expected error for invalid snapshot_id")
+	if len(nodes) != 1 {
+		t.Fatalf("Snapshot nodes length = %d, want 1", len(nodes))
 	}
-}
-
-func TestSnapshotStore_ResolveExpired(t *testing.T) {
-	store := NewSnapshotStore(50 * time.Millisecond)
-
-	snap := &Snapshot{
-		ID:        "exp2",
-		CreatedAt: time.Now(),
-		refMap:    map[string]cdp.BackendNodeID{"e1": 1},
+	if len(nodes[0].Children) != 1 {
+		t.Fatalf("Snapshot root children = %d, want 1", len(nodes[0].Children))
 	}
-	store.Put(snap)
 
-	time.Sleep(100 * time.Millisecond)
-
-	_, err := store.Resolve("exp2", "e1")
-	if err == nil {
-		t.Error("expected error for expired snapshot")
+	buttonRef := nodes[0].Children[0].Ref
+	if buttonRef == "" {
+		t.Fatal("button ref is empty")
 	}
-	if err != nil && !containsSubstring(err.Error(), "expired") && !containsSubstring(err.Error(), "not found") {
-		t.Errorf("error should mention expired/not found, got: %v", err)
+
+	nodeID, err := manager.resolveNodeID(context.Background(), snapshotID, buttonRef)
+	if err != nil {
+		t.Fatalf("resolveNodeID failed: %v", err)
+	}
+	if nodeID != cdp.NodeID(2002) {
+		t.Fatalf("resolved nodeID = %d, want %d", nodeID, cdp.NodeID(2002))
 	}
 }
 
-func TestSnapshotStore_EvictsOldest(t *testing.T) {
-	store := NewSnapshotStore(10 * time.Second)
+func TestClickByRefUsesResolvedNodeID(t *testing.T) {
+	manager := NewManager("")
+	manager.resolveTabID = func(context.Context) string { return "tab-1" }
+	manager.storeSnapshotForTab("tab-1", "snap-1", map[string]cdp.NodeID{
+		"r7": cdp.NodeID(77),
+	})
 
-	// Fill beyond capacity.
-	for i := 0; i < maxSnapshots+5; i++ {
-		snap := &Snapshot{
-			ID:        generateID(),
-			CreatedAt: time.Now(),
-			refMap:    map[string]cdp.BackendNodeID{},
+	var clicked cdp.NodeID
+	manager.clickByNodeID = func(_ context.Context, nodeID cdp.NodeID) error {
+		clicked = nodeID
+		return nil
+	}
+
+	if err := manager.ClickByRef(context.Background(), "snap-1", "r7"); err != nil {
+		t.Fatalf("ClickByRef failed: %v", err)
+	}
+	if clicked != cdp.NodeID(77) {
+		t.Fatalf("clicked nodeID = %d, want %d", clicked, cdp.NodeID(77))
+	}
+}
+
+func TestSnapshotReplacesCacheForSameTab(t *testing.T) {
+	manager := NewManager("")
+	manager.resolveTabID = func(context.Context) string { return "tab-1" }
+
+	calls := 0
+	manager.getFullAXTree = func(context.Context) ([]*accessibility.Node, error) {
+		calls++
+		nodeID := accessibility.NodeID(fmt.Sprintf("node-%d", calls))
+		backendID := cdp.BackendNodeID(calls)
+		return []*accessibility.Node{
+			{
+				NodeID:           nodeID,
+				Role:             stringAXValue("button"),
+				Name:             stringAXValue("Next"),
+				BackendDOMNodeID: backendID,
+			},
+		}, nil
+	}
+	manager.resolveNodeIDs = func(_ context.Context, backendIDs []cdp.BackendNodeID) ([]cdp.NodeID, error) {
+		if len(backendIDs) != 1 {
+			t.Fatalf("backendIDs length = %d, want 1", len(backendIDs))
 		}
-		store.Put(snap)
+		return []cdp.NodeID{cdp.NodeID(9000 + int64(backendIDs[0]))}, nil
 	}
 
-	if store.Len() > maxSnapshots {
-		t.Errorf("store.Len() = %d, want <= %d", store.Len(), maxSnapshots)
+	snapshotID1, nodes1, err := manager.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("first Snapshot failed: %v", err)
+	}
+	if len(nodes1) != 1 {
+		t.Fatalf("first snapshot nodes length = %d, want 1", len(nodes1))
+	}
+
+	snapshotID2, nodes2, err := manager.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("second Snapshot failed: %v", err)
+	}
+	if snapshotID1 == snapshotID2 {
+		t.Fatal("snapshot IDs should differ across snapshots")
+	}
+	if len(nodes2) != 1 {
+		t.Fatalf("second snapshot nodes length = %d, want 1", len(nodes2))
+	}
+
+	if _, err := manager.resolveNodeID(context.Background(), snapshotID1, nodes1[0].Ref); err == nil {
+		t.Fatal("expected first snapshot_id to be stale after second snapshot")
+	}
+
+	nodeID, err := manager.resolveNodeID(context.Background(), snapshotID2, nodes2[0].Ref)
+	if err != nil {
+		t.Fatalf("resolveNodeID for second snapshot failed: %v", err)
+	}
+	if nodeID != cdp.NodeID(9002) {
+		t.Fatalf("resolved nodeID = %d, want %d", nodeID, cdp.NodeID(9002))
 	}
 }
 
-func TestSnapshotStore_Len(t *testing.T) {
-	store := NewSnapshotStore(5 * time.Second)
+func TestInvalidateSnapshotForTab(t *testing.T) {
+	manager := NewManager("")
+	manager.resolveTabID = func(context.Context) string { return "tab-1" }
+	manager.storeSnapshotForTab("tab-1", "snap-1", map[string]cdp.NodeID{"r1": cdp.NodeID(1)})
 
-	if store.Len() != 0 {
-		t.Errorf("empty store Len() = %d, want 0", store.Len())
-	}
+	manager.invalidateSnapshotForTab("tab-1")
 
-	store.Put(&Snapshot{ID: "a", CreatedAt: time.Now(), refMap: map[string]cdp.BackendNodeID{}})
-	store.Put(&Snapshot{ID: "b", CreatedAt: time.Now(), refMap: map[string]cdp.BackendNodeID{}})
-
-	if store.Len() != 2 {
-		t.Errorf("Len() = %d, want 2", store.Len())
+	if _, err := manager.resolveNodeID(context.Background(), "snap-1", "r1"); err == nil {
+		t.Fatal("expected cache miss after invalidation")
 	}
 }
 
-func TestFormatSnapshot(t *testing.T) {
-	snap := &Snapshot{
-		ID:    "fmt1",
-		URL:   "https://example.com",
-		Title: "Test Page",
-		Elements: []ElementRef{
-			{Ref: "e1", Role: "button", Name: "OK"},
-			{Ref: "e2", Role: "link", Name: ""},
-		},
-	}
-
-	out := FormatSnapshot(snap)
-	if !containsSubstring(out, "snapshot_id: fmt1") {
-		t.Errorf("output missing snapshot_id, got:\n%s", out)
-	}
-	if !containsSubstring(out, "[e1] button") {
-		t.Errorf("output missing e1, got:\n%s", out)
-	}
-	if !containsSubstring(out, `"OK"`) {
-		t.Errorf("output missing name, got:\n%s", out)
-	}
-	if !containsSubstring(out, "[e2] link") {
-		t.Errorf("output missing e2, got:\n%s", out)
-	}
-}
-
-func TestGenerateID(t *testing.T) {
-	id1 := generateID()
-	id2 := generateID()
-	if id1 == id2 {
-		t.Error("generateID returned duplicate IDs")
-	}
-	if len(id1) != 8 {
-		t.Errorf("expected 8-char hex ID, got %q (len %d)", id1, len(id1))
-	}
-}
-
-func TestAxValueString(t *testing.T) {
-	if got := axValueString(nil); got != "" {
-		t.Errorf("axValueString(nil) = %q, want empty", got)
-	}
-}
-
-func containsSubstring(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && contains(s, sub))
-}
-
-func contains(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
+func stringAXValue(v string) *accessibility.Value {
+	return &accessibility.Value{Value: jsontext.Value(strconv.Quote(v))}
 }

--- a/internal/tools/browser_tool.go
+++ b/internal/tools/browser_tool.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/chromedp/chromedp"
@@ -12,7 +13,6 @@ import (
 // BrowserTool provides browser automation capabilities
 type BrowserTool struct {
 	manager   *browser.Manager
-	snapshots *browser.SnapshotStore
 	activeCtx context.Context    // persistent tab context
 	cancelTab context.CancelFunc // cancel for active tab
 }
@@ -20,8 +20,7 @@ type BrowserTool struct {
 // NewBrowserTool creates a new browser tool
 func NewBrowserTool(profilePath string) *BrowserTool {
 	return &BrowserTool{
-		manager:   browser.NewManager(profilePath),
-		snapshots: browser.NewSnapshotStore(0), // default TTL
+		manager: browser.NewManager(profilePath),
 	}
 }
 
@@ -30,13 +29,13 @@ func (b *BrowserTool) Name() string {
 }
 
 func (b *BrowserTool) Description() string {
-	return `Control a real Chrome browser. Workflow: call "snapshot" to get a snapshot_id and element refs, then use "click", "fill", or "focus" with snapshot_id+ref to interact. Commands: start, stop, navigate <url>, snapshot, click (ref or selector), fill (ref or selector + value), focus (ref), screenshot, text <selector>, wait <selector>.`
+	return "Control a real Chrome browser. Use snapshot to get accessibility refs, then click/type with snapshot_id+ref. Commands: start, stop, navigate, snapshot, click, type, fill, screenshot, text, wait."
 }
 
 // Execute runs browser commands
 func (b *BrowserTool) Execute(ctx context.Context, args ...string) (string, error) {
 	if len(args) == 0 {
-		return "", fmt.Errorf("usage: browser <start|stop|navigate|snapshot|click|fill|focus|screenshot|wait|text>")
+		return "", fmt.Errorf("usage: browser <start|stop|navigate|snapshot|click|type|fill|screenshot|wait|text>")
 	}
 
 	command := args[0]
@@ -55,10 +54,8 @@ func (b *BrowserTool) Execute(ctx context.Context, args ...string) (string, erro
 		return b.snapshot()
 	case "click":
 		return b.clickDispatch(args[1:])
-	case "fill":
-		return b.fillDispatch(args[1:])
-	case "focus":
-		return b.focusDispatch(args[1:])
+	case "type", "fill":
+		return b.typeDispatch(args[1:])
 	case "screenshot":
 		return b.screenshotCmd()
 	case "wait":
@@ -77,7 +74,6 @@ func (b *BrowserTool) Execute(ctx context.Context, args ...string) (string, erro
 }
 
 // ExecuteJSON runs a browser command with structured JSON parameters.
-// This is the preferred entry point from the tool-calling agent.
 func (b *BrowserTool) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
 	command := params["command"]
 	if command == "" {
@@ -98,54 +94,69 @@ func (b *BrowserTool) ExecuteJSON(ctx context.Context, params map[string]string)
 	case "snapshot":
 		return b.snapshot()
 	case "click":
-		sid := params["snapshot_id"]
+		snapshotID := params["snapshot_id"]
 		ref := params["ref"]
-		sel := params["selector"]
-		if sid != "" && ref != "" {
-			return b.clickByRef(sid, ref)
+		selector := params["selector"]
+		if snapshotID != "" && ref != "" {
+			return b.clickByRef(snapshotID, ref)
 		}
-		if sel != "" {
-			return b.clickCSS(sel)
+		if selector != "" {
+			return b.clickCSS(selector)
 		}
 		return "", fmt.Errorf("click requires snapshot_id+ref or selector")
-	case "fill":
-		val := params["value"]
-		if val == "" {
-			return "", fmt.Errorf("value is required for fill")
+	case "type", "fill":
+		value := params["value"]
+		if value == "" {
+			return "", fmt.Errorf("value is required for %s", command)
 		}
-		sid := params["snapshot_id"]
+		snapshotID := params["snapshot_id"]
 		ref := params["ref"]
-		sel := params["selector"]
-		if sid != "" && ref != "" {
-			return b.fillByRef(sid, ref, val)
+		selector := params["selector"]
+		if snapshotID != "" && ref != "" {
+			return b.typeByRef(snapshotID, ref, value)
 		}
-		if sel != "" {
-			return b.fillCSS(sel, val)
+		if selector != "" {
+			return b.fillCSS(selector, value)
 		}
-		return "", fmt.Errorf("fill requires snapshot_id+ref or selector")
-	case "focus":
-		sid := params["snapshot_id"]
-		ref := params["ref"]
-		if sid == "" || ref == "" {
-			return "", fmt.Errorf("focus requires snapshot_id and ref")
-		}
-		return b.focusByRef(sid, ref)
+		return "", fmt.Errorf("%s requires snapshot_id+ref or selector", command)
 	case "screenshot":
 		return b.screenshotCmd()
 	case "wait":
-		sel := params["selector"]
-		if sel == "" {
+		selector := params["selector"]
+		if selector == "" {
 			return "", fmt.Errorf("selector is required for wait")
 		}
-		return b.wait(sel)
+		return b.wait(selector)
 	case "text":
-		sel := params["selector"]
-		if sel == "" {
+		selector := params["selector"]
+		if selector == "" {
 			return "", fmt.Errorf("selector is required for text")
 		}
-		return b.getText(sel)
+		return b.getText(selector)
 	default:
 		return "", fmt.Errorf("unknown command: %s", command)
+	}
+}
+
+func (b *BrowserTool) clickDispatch(args []string) (string, error) {
+	switch len(args) {
+	case 1:
+		return b.clickCSS(args[0])
+	case 2:
+		return b.clickByRef(args[0], args[1])
+	default:
+		return "", fmt.Errorf("usage: browser click <selector> OR browser click <snapshot_id> <ref>")
+	}
+}
+
+func (b *BrowserTool) typeDispatch(args []string) (string, error) {
+	switch len(args) {
+	case 2:
+		return b.fillCSS(args[0], args[1])
+	case 3:
+		return b.typeByRef(args[0], args[1], args[2])
+	default:
+		return "", fmt.Errorf("usage: browser type <selector> <value> OR browser type <snapshot_id> <ref> <value>")
 	}
 }
 
@@ -232,26 +243,20 @@ func (b *BrowserTool) snapshot() (string, error) {
 		return "", err
 	}
 
-	snap, err := browser.TakeSnapshot(ctx, b.snapshots)
+	snapshotID, nodes, err := b.manager.Snapshot(ctx)
 	if err != nil {
-		return "", fmt.Errorf("snapshot failed: %w", err)
+		return "", fmt.Errorf("failed to create accessibility snapshot: %w", err)
 	}
 
-	return browser.FormatSnapshot(snap), nil
-}
-
-// --- click dispatchers ---
-
-func (b *BrowserTool) clickDispatch(args []string) (string, error) {
-	if len(args) == 0 {
-		return "", fmt.Errorf("click requires a selector or snapshot_id+ref")
+	payload, err := json.Marshal(map[string]interface{}{
+		"snapshot_id": snapshotID,
+		"nodes":       nodes,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to encode snapshot response: %w", err)
 	}
-	// Two-arg form: snapshot_id ref
-	if len(args) >= 2 {
-		return b.clickByRef(args[0], args[1])
-	}
-	// Single arg: CSS selector (legacy)
-	return b.clickCSS(args[0])
+
+	return string(payload), nil
 }
 
 func (b *BrowserTool) clickByRef(snapshotID, ref string) (string, error) {
@@ -259,7 +264,7 @@ func (b *BrowserTool) clickByRef(snapshotID, ref string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := browser.ClickByRef(ctx, b.snapshots, snapshotID, ref); err != nil {
+	if err := b.manager.ClickByRef(ctx, snapshotID, ref); err != nil {
 		return "", fmt.Errorf("click failed: %w", err)
 	}
 	return fmt.Sprintf("Clicked ref %s (snapshot %s)", ref, snapshotID), nil
@@ -279,29 +284,15 @@ func (b *BrowserTool) clickCSS(selector string) (string, error) {
 	return fmt.Sprintf("Clicked %s", selector), nil
 }
 
-// --- fill dispatchers ---
-
-func (b *BrowserTool) fillDispatch(args []string) (string, error) {
-	if len(args) < 2 {
-		return "", fmt.Errorf("fill requires (selector value) or (snapshot_id ref value)")
-	}
-	// Three-arg form: snapshot_id ref value
-	if len(args) >= 3 {
-		return b.fillByRef(args[0], args[1], args[2])
-	}
-	// Two-arg form: selector value (legacy)
-	return b.fillCSS(args[0], args[1])
-}
-
-func (b *BrowserTool) fillByRef(snapshotID, ref, value string) (string, error) {
+func (b *BrowserTool) typeByRef(snapshotID, ref, value string) (string, error) {
 	ctx, err := b.ensureRunning()
 	if err != nil {
 		return "", err
 	}
-	if err := browser.TypeByRef(ctx, b.snapshots, snapshotID, ref, value); err != nil {
-		return "", fmt.Errorf("fill failed: %w", err)
+	if err := b.manager.TypeByRef(ctx, snapshotID, ref, value); err != nil {
+		return "", fmt.Errorf("type failed: %w", err)
 	}
-	return fmt.Sprintf("Filled ref %s (snapshot %s)", ref, snapshotID), nil
+	return fmt.Sprintf("Typed into ref %s (snapshot %s)", ref, snapshotID), nil
 }
 
 func (b *BrowserTool) fillCSS(selector, value string) (string, error) {
@@ -317,28 +308,6 @@ func (b *BrowserTool) fillCSS(selector, value string) (string, error) {
 	}
 	return fmt.Sprintf("Filled %s", selector), nil
 }
-
-// --- focus dispatcher ---
-
-func (b *BrowserTool) focusDispatch(args []string) (string, error) {
-	if len(args) < 2 {
-		return "", fmt.Errorf("focus requires snapshot_id and ref")
-	}
-	return b.focusByRef(args[0], args[1])
-}
-
-func (b *BrowserTool) focusByRef(snapshotID, ref string) (string, error) {
-	ctx, err := b.ensureRunning()
-	if err != nil {
-		return "", err
-	}
-	if err := browser.FocusByRef(ctx, b.snapshots, snapshotID, ref); err != nil {
-		return "", fmt.Errorf("focus failed: %w", err)
-	}
-	return fmt.Sprintf("Focused ref %s (snapshot %s)", ref, snapshotID), nil
-}
-
-// --- other commands ---
 
 func (b *BrowserTool) screenshotCmd() (string, error) {
 	ctx, err := b.ensureRunning()
@@ -390,7 +359,7 @@ func (b *BrowserTool) GetSchema() map[string]interface{} {
 			"command": map[string]interface{}{
 				"type":        "string",
 				"description": "Browser command to execute",
-				"enum":        []string{"navigate", "snapshot", "click", "fill", "focus", "screenshot", "text", "wait", "start", "stop"},
+				"enum":        []string{"navigate", "snapshot", "click", "type", "fill", "screenshot", "text", "wait", "start", "stop"},
 			},
 			"url": map[string]interface{}{
 				"type":        "string",
@@ -398,19 +367,19 @@ func (b *BrowserTool) GetSchema() map[string]interface{} {
 			},
 			"snapshot_id": map[string]interface{}{
 				"type":        "string",
-				"description": "Snapshot ID returned by 'snapshot' command (for click, fill, focus by ref)",
+				"description": "Snapshot ID returned by browser snapshot (for ref-based actions)",
 			},
 			"ref": map[string]interface{}{
 				"type":        "string",
-				"description": "Element ref from snapshot (e.g. 'e1', 'e2') — used with snapshot_id for click, fill, focus",
+				"description": "Node ref from snapshot tree",
 			},
 			"selector": map[string]interface{}{
 				"type":        "string",
-				"description": "CSS selector (fallback for click, fill, text, wait when not using snapshot refs)",
+				"description": "CSS selector (for click/type/text/wait)",
 			},
 			"value": map[string]interface{}{
 				"type":        "string",
-				"description": "Value to type (for 'fill' command)",
+				"description": "Value to type (for type/fill)",
 			},
 		},
 		"required": []string{"command"},


### PR DESCRIPTION
Closes #92

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the browser snapshot system from a TTL-based standalone store to an in-process tab-scoped cache with automatic navigation invalidation. The snapshot now returns the full accessibility tree structure as JSON instead of a filtered list of interactive elements. Key changes include moving snapshot management into the Manager, adding dependency injection for testability, switching to UUID v4 snapshot IDs, and consolidating the type/fill commands while removing the focus command.

**Major architectural changes:**
- Snapshots are now cached per-tab with automatic invalidation on navigation events
- Each tab maintains only one snapshot at a time (taking a new snapshot invalidates the previous one)
- All AX tree nodes receive refs (not just interactive elements), which increases snapshot size but provides more flexibility
- Snapshot output changed from human-readable text to structured JSON with nested tree representation

**Testing:**
- Comprehensive test coverage with dependency injection for all CDP interactions
- Tests verify cache invalidation, tab isolation, and ref resolution

The implementation is clean and well-tested. The main tradeoff is snapshot size - complex pages will generate larger payloads with thousands of refs compared to the previous filtered approach.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it's a well-tested refactor with proper concurrency control
- Score reflects solid implementation with comprehensive tests and proper locking, but slightly reduced due to significant architectural changes that could impact performance on complex pages (full AX tree vs filtered elements). The single-snapshot-per-tab limitation is also a notable behavioral change from the previous TTL-based multi-snapshot approach.
- `internal/browser/snapshot.go` - monitor performance impact of full AX tree snapshots on complex pages

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/browser/manager.go | Added snapshot cache with per-tab storage and dependency injection for testability |
| internal/browser/snapshot.go | Major refactor: moved from TTL-based store to in-process tab cache, returns full AX tree instead of filtered interactive elements, switched to UUID v4 snapshot IDs |
| internal/tools/browser_tool.go | Updated to use Manager-based snapshot API, removed SnapshotStore, merged type/fill commands, removed focus command, changed snapshot output to JSON |

</details>



<sub>Last reviewed commit: 4cfaa12</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->