### PR TITLE
Memory v2: in-RAM cosine search (no SQLite vector extension)

### DIFF
--- a/internal/memory/search.go
+++ b/internal/memory/search.go
@@ -1,0 +1,364 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+)
+
+const (
+	// DefaultSearchThreshold is the default minimum cosine score for memory search.
+	DefaultSearchThreshold float32 = 0.75
+	// DefaultSearchTopK is the default number of snippets returned by memory search.
+	DefaultSearchTopK = 5
+)
+
+// MemorySnippet is a ranked memory match returned from semantic search.
+type MemorySnippet struct {
+	File       string  `json:"file"`
+	HeaderPath string  `json:"header_path"`
+	Text       string  `json:"text"`
+	Score      float32 `json:"score"`
+}
+
+// SearchOptions configures per-query filtering and result count.
+type SearchOptions struct {
+	Threshold float32
+	TopK      int
+}
+
+// Searcher keeps memory chunk embeddings in RAM and performs cosine search in Go.
+type Searcher struct {
+	mu sync.RWMutex
+
+	chunks    []indexedChunk
+	dimension int
+}
+
+type indexedChunk struct {
+	File       string
+	HeaderPath string
+	Text       string
+	Embedding  []float32 // Pre-normalized for fast cosine dot products.
+}
+
+type memoryChunkColumns struct {
+	File      string
+	Header    string
+	Text      string
+	Embedding string
+}
+
+// NewSearcher loads all memory_chunks embeddings into RAM on startup.
+func NewSearcher(ctx context.Context, db *sql.DB) (*Searcher, error) {
+	if db == nil {
+		return nil, fmt.Errorf("memory search db is nil")
+	}
+
+	s := &Searcher{}
+	if err := s.Reload(ctx, db); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// Reload rebuilds the in-memory search index from the memory_chunks table.
+func (s *Searcher) Reload(ctx context.Context, db *sql.DB) error {
+	if db == nil {
+		return fmt.Errorf("memory search db is nil")
+	}
+
+	chunks, dimension, err := loadChunksIntoRAM(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.chunks = chunks
+	s.dimension = dimension
+	s.mu.Unlock()
+
+	return nil
+}
+
+// ChunkCount returns the number of chunks currently loaded in RAM.
+func (s *Searcher) ChunkCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.chunks)
+}
+
+// Search performs a linear cosine search over in-memory chunk vectors.
+func (s *Searcher) Search(queryEmbedding []float32, opts SearchOptions) []MemorySnippet {
+	threshold := opts.Threshold
+	if threshold == 0 {
+		threshold = DefaultSearchThreshold
+	}
+	if threshold < -1 {
+		threshold = -1
+	}
+	if threshold > 1 {
+		threshold = 1
+	}
+
+	topK := opts.TopK
+	if topK <= 0 {
+		topK = DefaultSearchTopK
+	}
+
+	query, ok := normalizeEmbedding(queryEmbedding)
+	if !ok {
+		return nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if len(query) != s.dimension || s.dimension == 0 || topK == 0 {
+		return nil
+	}
+
+	best := make([]MemorySnippet, 0, topK)
+	for _, chunk := range s.chunks {
+		score := dotProduct(query, chunk.Embedding)
+		if score < threshold {
+			continue
+		}
+
+		snippet := MemorySnippet{
+			File:       chunk.File,
+			HeaderPath: chunk.HeaderPath,
+			Text:       chunk.Text,
+			Score:      score,
+		}
+
+		if len(best) < topK {
+			best = append(best, snippet)
+			bubbleUpByScore(best, len(best)-1)
+			continue
+		}
+
+		if score <= best[len(best)-1].Score {
+			continue
+		}
+
+		best[len(best)-1] = snippet
+		bubbleUpByScore(best, len(best)-1)
+	}
+
+	return best
+}
+
+func bubbleUpByScore(snippets []MemorySnippet, idx int) {
+	for idx > 0 && snippets[idx].Score > snippets[idx-1].Score {
+		snippets[idx], snippets[idx-1] = snippets[idx-1], snippets[idx]
+		idx--
+	}
+}
+
+func loadChunksIntoRAM(ctx context.Context, db *sql.DB) ([]indexedChunk, int, error) {
+	columns, err := resolveMemoryChunkColumns(ctx, db)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	headerExpr := "''"
+	if columns.Header != "" {
+		headerExpr = quoteIdentifier(columns.Header)
+	}
+
+	query := fmt.Sprintf(
+		"SELECT %s, %s, %s, %s FROM memory_chunks",
+		quoteIdentifier(columns.File),
+		headerExpr,
+		quoteIdentifier(columns.Text),
+		quoteIdentifier(columns.Embedding),
+	)
+
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed loading memory chunks: %w", err)
+	}
+	defer rows.Close()
+
+	var (
+		chunks    []indexedChunk
+		dimension int
+	)
+
+	for rows.Next() {
+		var (
+			file       sql.NullString
+			headerPath sql.NullString
+			text       sql.NullString
+			rawVector  []byte
+		)
+
+		if err := rows.Scan(&file, &headerPath, &text, &rawVector); err != nil {
+			return nil, 0, fmt.Errorf("failed scanning memory chunk: %w", err)
+		}
+
+		embedding, err := decodeChunkEmbedding(rawVector)
+		if err != nil {
+			continue
+		}
+
+		normalized, ok := normalizeEmbedding(embedding)
+		if !ok {
+			continue
+		}
+
+		if dimension == 0 {
+			dimension = len(normalized)
+		}
+		if len(normalized) != dimension {
+			continue
+		}
+
+		chunks = append(chunks, indexedChunk{
+			File:       file.String,
+			HeaderPath: headerPath.String,
+			Text:       text.String,
+			Embedding:  normalized,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("failed reading memory chunks: %w", err)
+	}
+
+	return chunks, dimension, nil
+}
+
+func resolveMemoryChunkColumns(ctx context.Context, db *sql.DB) (memoryChunkColumns, error) {
+	rows, err := db.QueryContext(ctx, "PRAGMA table_info(memory_chunks)")
+	if err != nil {
+		return memoryChunkColumns{}, fmt.Errorf("failed inspecting memory_chunks schema: %w", err)
+	}
+	defer rows.Close()
+
+	available := make(map[string]string)
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			colType    string
+			notNull    int
+			defaultVal interface{}
+			primaryKey int
+		)
+
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &defaultVal, &primaryKey); err != nil {
+			return memoryChunkColumns{}, fmt.Errorf("failed inspecting memory_chunks schema: %w", err)
+		}
+		available[strings.ToLower(name)] = name
+	}
+	if err := rows.Err(); err != nil {
+		return memoryChunkColumns{}, fmt.Errorf("failed inspecting memory_chunks schema: %w", err)
+	}
+	if len(available) == 0 {
+		return memoryChunkColumns{}, fmt.Errorf("memory_chunks table not found")
+	}
+
+	columns := memoryChunkColumns{
+		File:      pickColumn(available, "file", "file_path", "filepath", "path"),
+		Header:    pickColumn(available, "header_path", "heading_path", "section_path", "header"),
+		Text:      pickColumn(available, "text", "chunk_text", "content"),
+		Embedding: pickColumn(available, "embedding", "vector", "embedding_blob"),
+	}
+
+	if columns.File == "" || columns.Text == "" || columns.Embedding == "" {
+		return memoryChunkColumns{}, fmt.Errorf(
+			"memory_chunks schema missing required columns (need file, text, embedding)",
+		)
+	}
+
+	return columns, nil
+}
+
+func pickColumn(available map[string]string, candidates ...string) string {
+	for _, candidate := range candidates {
+		if name, ok := available[strings.ToLower(candidate)]; ok {
+			return name
+		}
+	}
+	return ""
+}
+
+func quoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+func decodeChunkEmbedding(raw []byte) ([]float32, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty embedding")
+	}
+
+	// Accept JSON-encoded embeddings for compatibility with older importers.
+	if raw[0] == '[' {
+		var values []float32
+		if err := json.Unmarshal(raw, &values); err == nil {
+			return values, nil
+		}
+
+		var values64 []float64
+		if err := json.Unmarshal(raw, &values64); err != nil {
+			return nil, fmt.Errorf("invalid json embedding: %w", err)
+		}
+
+		values = make([]float32, len(values64))
+		for i := range values64 {
+			values[i] = float32(values64[i])
+		}
+		return values, nil
+	}
+
+	if len(raw)%4 != 0 {
+		return nil, fmt.Errorf("invalid embedding size %d (must be multiple of 4)", len(raw))
+	}
+
+	embedding := make([]float32, len(raw)/4)
+	if err := binary.Read(bytes.NewReader(raw), binary.LittleEndian, &embedding); err != nil {
+		return nil, fmt.Errorf("invalid binary embedding: %w", err)
+	}
+
+	return embedding, nil
+}
+
+func normalizeEmbedding(embedding []float32) ([]float32, bool) {
+	if len(embedding) == 0 {
+		return nil, false
+	}
+
+	var normSquared float64
+	for _, value := range embedding {
+		normSquared += float64(value * value)
+	}
+	if normSquared == 0 {
+		return nil, false
+	}
+
+	invNorm := float32(1 / math.Sqrt(normSquared))
+	normalized := make([]float32, len(embedding))
+	for i, value := range embedding {
+		normalized[i] = value * invNorm
+	}
+
+	return normalized, true
+}
+
+func dotProduct(a, b []float32) float32 {
+	var dot float32
+	for i := range a {
+		dot += a[i] * b[i]
+	}
+	return dot
+}

--- a/internal/memory/search_test.go
+++ b/internal/memory/search_test.go
@@ -1,0 +1,245 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestNewSearcherLoadsChunksIntoRAMAtStartup(t *testing.T) {
+	db := newMemoryChunksTestDB(t)
+
+	insertChunk(t, db, "MEMORY.md", "People/Alice", "Alice likes espresso", []float32{1, 0, 0})
+	insertChunk(t, db, "memory/2026-03-04.md", "Decisions/CLI", "Use pure-Go cosine search", []float32{0.95, 0.1, 0})
+	insertChunk(t, db, "memory/2026-03-03.md", "Tasks/Done", "Old unrelated note", []float32{-1, 0, 0})
+
+	searcher, err := NewSearcher(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSearcher() error = %v", err)
+	}
+
+	if got := searcher.ChunkCount(); got != 3 {
+		t.Fatalf("ChunkCount() = %d, want 3", got)
+	}
+
+	// Delete rows to prove search uses in-memory data loaded at startup.
+	if _, err := db.Exec(`DELETE FROM memory_chunks`); err != nil {
+		t.Fatalf("failed deleting chunks from db: %v", err)
+	}
+
+	results := searcher.Search([]float32{1, 0, 0}, SearchOptions{})
+	if len(results) == 0 {
+		t.Fatalf("expected in-memory matches after DB delete, got none")
+	}
+}
+
+func TestSearcherDefaultsThresholdAndTopK(t *testing.T) {
+	db := newMemoryChunksTestDB(t)
+
+	insertChunk(t, db, "memory/1.md", "A", "1", []float32{1.0, 0.0})
+	insertChunk(t, db, "memory/2.md", "A", "2", []float32{0.95, 0.05})
+	insertChunk(t, db, "memory/3.md", "A", "3", []float32{0.9, 0.1})
+	insertChunk(t, db, "memory/4.md", "A", "4", []float32{0.8, 0.2})
+	insertChunk(t, db, "memory/5.md", "A", "5", []float32{0.7, 0.3})
+	insertChunk(t, db, "memory/6.md", "A", "6", []float32{0.6, 0.4})
+	insertChunk(t, db, "memory/7.md", "A", "7", []float32{0.5, 0.5}) // below 0.75 threshold
+
+	searcher, err := NewSearcher(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSearcher() error = %v", err)
+	}
+
+	results := searcher.Search([]float32{1, 0}, SearchOptions{})
+	if len(results) != DefaultSearchTopK {
+		t.Fatalf("len(results) = %d, want %d", len(results), DefaultSearchTopK)
+	}
+
+	for i := 1; i < len(results); i++ {
+		if results[i].Score > results[i-1].Score {
+			t.Fatalf("results are not sorted by descending score")
+		}
+	}
+
+	for _, result := range results {
+		if result.Score < DefaultSearchThreshold {
+			t.Fatalf("got score %.4f below default threshold %.2f", result.Score, DefaultSearchThreshold)
+		}
+	}
+}
+
+func TestSearcherSupportsCustomThresholdAndTopK(t *testing.T) {
+	db := newMemoryChunksTestDB(t)
+
+	insertChunk(t, db, "memory/1.md", "A", "1", []float32{1.0, 0.0})
+	insertChunk(t, db, "memory/2.md", "A", "2", []float32{0.95, 0.05})
+	insertChunk(t, db, "memory/3.md", "A", "3", []float32{0.9, 0.1})
+	insertChunk(t, db, "memory/4.md", "A", "4", []float32{0.8, 0.2})
+	insertChunk(t, db, "memory/5.md", "A", "5", []float32{0.1, 0.9})
+
+	searcher, err := NewSearcher(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSearcher() error = %v", err)
+	}
+
+	results := searcher.Search([]float32{1, 0}, SearchOptions{
+		Threshold: 0.95,
+		TopK:      3,
+	})
+
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+	for _, result := range results {
+		if result.Score < 0.95 {
+			t.Fatalf("got score %.4f below custom threshold", result.Score)
+		}
+	}
+}
+
+func TestSearcherReturnsEmptyOnDimensionMismatch(t *testing.T) {
+	db := newMemoryChunksTestDB(t)
+	insertChunk(t, db, "memory/1.md", "A", "1", []float32{1.0, 0.0})
+
+	searcher, err := NewSearcher(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSearcher() error = %v", err)
+	}
+
+	results := searcher.Search([]float32{1.0, 0.0, 0.0}, SearchOptions{})
+	if len(results) != 0 {
+		t.Fatalf("expected no results for dimension mismatch, got %d", len(results))
+	}
+}
+
+func TestNewSearcherSkipsMalformedEmbeddings(t *testing.T) {
+	db := newMemoryChunksTestDB(t)
+
+	insertChunk(t, db, "memory/good.md", "A", "good", []float32{1.0, 0.0})
+	if _, err := db.Exec(
+		`INSERT INTO memory_chunks (file, header_path, text, embedding) VALUES (?, ?, ?, ?)`,
+		"memory/bad.md",
+		"A",
+		"bad",
+		[]byte{1, 2, 3}, // invalid binary embedding
+	); err != nil {
+		t.Fatalf("failed inserting malformed row: %v", err)
+	}
+
+	searcher, err := NewSearcher(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSearcher() error = %v", err)
+	}
+
+	if got := searcher.ChunkCount(); got != 1 {
+		t.Fatalf("ChunkCount() = %d, want 1", got)
+	}
+}
+
+func TestNewSearcherReturnsSchemaErrorWhenTableMissing(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = NewSearcher(context.Background(), db)
+	if err == nil {
+		t.Fatalf("expected error when memory_chunks table is missing")
+	}
+	if !strings.Contains(err.Error(), "memory_chunks") {
+		t.Fatalf("expected memory_chunks error, got %v", err)
+	}
+}
+
+func BenchmarkSearcher_Search10K(b *testing.B) {
+	const (
+		chunkCount = 10000
+		dimension  = 1536
+	)
+
+	rng := rand.New(rand.NewSource(42))
+	chunks := make([]indexedChunk, chunkCount)
+	for i := 0; i < chunkCount; i++ {
+		chunks[i] = indexedChunk{
+			File:       fmt.Sprintf("memory/%05d.md", i),
+			HeaderPath: fmt.Sprintf("H%d", i%32),
+			Text:       "synthetic chunk",
+			Embedding:  randomNormalizedVector(rng, dimension),
+		}
+	}
+
+	searcher := &Searcher{
+		chunks:    chunks,
+		dimension: dimension,
+	}
+	query := randomNormalizedVector(rng, dimension)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = searcher.Search(query, SearchOptions{})
+	}
+}
+
+func newMemoryChunksTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE memory_chunks (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			file TEXT NOT NULL,
+			header_path TEXT DEFAULT '',
+			text TEXT NOT NULL,
+			embedding BLOB NOT NULL
+		);
+	`)
+	if err != nil {
+		t.Fatalf("failed creating memory_chunks table: %v", err)
+	}
+
+	return db
+}
+
+func insertChunk(t *testing.T, db *sql.DB, file, headerPath, text string, embedding []float32) {
+	t.Helper()
+
+	encoded, err := encodeEmbedding(embedding)
+	if err != nil {
+		t.Fatalf("failed encoding embedding: %v", err)
+	}
+
+	_, err = db.Exec(
+		`INSERT INTO memory_chunks (file, header_path, text, embedding) VALUES (?, ?, ?, ?)`,
+		file,
+		headerPath,
+		text,
+		encoded,
+	)
+	if err != nil {
+		t.Fatalf("failed inserting chunk: %v", err)
+	}
+}
+
+func randomNormalizedVector(rng *rand.Rand, dimensions int) []float32 {
+	vector := make([]float32, dimensions)
+	for i := 0; i < dimensions; i++ {
+		vector[i] = (rng.Float32() * 2) - 1
+	}
+
+	normalized, ok := normalizeEmbedding(vector)
+	if !ok {
+		panic("failed to normalize synthetic vector")
+	}
+
+	return normalized
+}


### PR DESCRIPTION
Closes #88

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implemented pure-Go in-memory cosine similarity search to replace SQLite vector extension dependency. The new `Searcher` loads all memory chunk embeddings into RAM at startup and performs linear search with proper concurrency control via RWMutex.

**Key Changes:**
- Loads embeddings from `memory_chunks` table into RAM with flexible column name resolution
- Pre-normalizes embeddings for fast dot-product-based cosine similarity
- Supports both JSON and binary embedding formats for backward compatibility
- Configurable similarity threshold (default 0.75) and top-K results (default 5)
- Thread-safe with concurrent reads and exclusive writes
- Includes comprehensive test coverage with edge cases and performance benchmark

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The implementation is well-designed with proper thread-safety, defensive programming (NULL handling, malformed data skipping), comprehensive test coverage including edge cases, and graceful error handling throughout. No bugs or security issues identified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/memory/search.go | Implements in-RAM cosine similarity search with proper thread-safety, flexible schema resolution, and graceful error handling |
| internal/memory/search_test.go | Comprehensive test suite covering edge cases, defaults, custom options, error conditions, and includes performance benchmark |

</details>



<sub>Last reviewed commit: 1e3c0cf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->