### PR TITLE
Memory v2: header-aware markdown chunker

### DIFF
--- a/internal/memory/chunker.go
+++ b/internal/memory/chunker.go
@@ -1,0 +1,362 @@
+package memory
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	// DefaultChunkSoftTargetTokens is the preferred chunk size target.
+	DefaultChunkSoftTargetTokens = 512
+	// DefaultChunkHardMaxTokens is the maximum allowed chunk size.
+	DefaultChunkHardMaxTokens = 800
+	approxCharsPerToken       = 4
+)
+
+var (
+	atxHeaderRE = regexp.MustCompile(`^ {0,3}(#{1,3})[ \t]+(.+?)\s*$`)
+	fenceStart  = regexp.MustCompile(`^ {0,3}(` + "```|~~~" + `)`)
+)
+
+// MarkdownChunk stores a single chunk of markdown memory text with indexing metadata.
+type MarkdownChunk struct {
+	SourceFile   string   `json:"source_file"`
+	HeaderPath   []string `json:"header_path"`
+	ChunkOrdinal int      `json:"chunk_ordinal"`
+	Content      string   `json:"content"`
+}
+
+// ChunkerConfig configures markdown chunking behavior.
+type ChunkerConfig struct {
+	SoftTargetChars int
+	HardMaxChars    int
+}
+
+// DefaultChunkerConfig returns the default chunking limits.
+func DefaultChunkerConfig() ChunkerConfig {
+	return ChunkerConfig{
+		SoftTargetChars: DefaultChunkSoftTargetTokens * approxCharsPerToken,
+		HardMaxChars:    DefaultChunkHardMaxTokens * approxCharsPerToken,
+	}
+}
+
+// MarkdownChunker splits markdown files into header-aware chunks.
+type MarkdownChunker struct {
+	softTargetChars int
+	hardMaxChars    int
+}
+
+// NewMarkdownChunker creates a chunker using default limits.
+func NewMarkdownChunker() *MarkdownChunker {
+	return NewMarkdownChunkerWithConfig(DefaultChunkerConfig())
+}
+
+// NewMarkdownChunkerWithConfig creates a chunker with custom limits.
+func NewMarkdownChunkerWithConfig(cfg ChunkerConfig) *MarkdownChunker {
+	defaults := DefaultChunkerConfig()
+	if cfg.SoftTargetChars <= 0 {
+		cfg.SoftTargetChars = defaults.SoftTargetChars
+	}
+	if cfg.HardMaxChars <= 0 {
+		cfg.HardMaxChars = defaults.HardMaxChars
+	}
+	if cfg.HardMaxChars < cfg.SoftTargetChars {
+		cfg.HardMaxChars = cfg.SoftTargetChars
+	}
+	return &MarkdownChunker{
+		softTargetChars: cfg.SoftTargetChars,
+		hardMaxChars:    cfg.HardMaxChars,
+	}
+}
+
+// ChunkMarkdown chunks markdown with default chunker settings.
+func ChunkMarkdown(sourceFile, markdown string) []MarkdownChunk {
+	return NewMarkdownChunker().Chunk(sourceFile, markdown)
+}
+
+// Chunk splits markdown into header-aware chunks.
+//
+// A section starts at a header (#, ##, ###) and includes all text until the
+// next same-or-higher header.
+func (c *MarkdownChunker) Chunk(sourceFile, markdown string) []MarkdownChunk {
+	normalized := strings.ReplaceAll(markdown, "\r\n", "\n")
+	lines := strings.Split(normalized, "\n")
+	sections := buildSections(lines)
+
+	var chunks []MarkdownChunk
+	for _, section := range sections {
+		parts := c.splitSection(section)
+		for _, part := range parts {
+			if strings.TrimSpace(part) == "" {
+				continue
+			}
+			chunks = append(chunks, MarkdownChunk{
+				SourceFile: sourceFile,
+				HeaderPath: append([]string(nil), section.headerPath...),
+				Content:    part,
+			})
+		}
+	}
+
+	for i := range chunks {
+		chunks[i].ChunkOrdinal = i
+	}
+
+	return chunks
+}
+
+type markdownHeader struct {
+	line  int
+	level int
+	title string
+	path  []string
+}
+
+type markdownSection struct {
+	headerLine string
+	headerPath []string
+	body       string
+}
+
+func buildSections(lines []string) []markdownSection {
+	headers := collectHeaders(lines)
+	if len(headers) == 0 {
+		body := strings.TrimSpace(strings.Join(lines, "\n"))
+		if body == "" {
+			return nil
+		}
+		return []markdownSection{{body: body}}
+	}
+
+	var sections []markdownSection
+	if headers[0].line > 0 {
+		preamble := strings.TrimSpace(strings.Join(lines[:headers[0].line], "\n"))
+		if preamble != "" {
+			sections = append(sections, markdownSection{body: preamble})
+		}
+	}
+
+	for i, h := range headers {
+		end := len(lines)
+		for j := i + 1; j < len(headers); j++ {
+			if headers[j].level <= h.level {
+				end = headers[j].line
+				break
+			}
+		}
+
+		bodyLines := ""
+		if h.line+1 < end {
+			bodyLines = strings.TrimSpace(strings.Join(lines[h.line+1:end], "\n"))
+		}
+
+		sections = append(sections, markdownSection{
+			headerLine: strings.TrimSpace(lines[h.line]),
+			headerPath: append([]string(nil), h.path...),
+			body:       bodyLines,
+		})
+	}
+
+	return sections
+}
+
+func collectHeaders(lines []string) []markdownHeader {
+	var headers []markdownHeader
+	var stack []markdownHeader
+	inFence := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if fenceStart.MatchString(trimmed) {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+
+		matches := atxHeaderRE.FindStringSubmatch(line)
+		if len(matches) != 3 {
+			continue
+		}
+
+		level := len(matches[1])
+		title := normalizeHeaderTitle(matches[2])
+		if title == "" {
+			continue
+		}
+
+		for len(stack) > 0 && stack[len(stack)-1].level >= level {
+			stack = stack[:len(stack)-1]
+		}
+
+		header := markdownHeader{
+			line:  i,
+			level: level,
+			title: title,
+		}
+		stack = append(stack, header)
+		header.path = make([]string, len(stack))
+		for idx := range stack {
+			header.path[idx] = stack[idx].title
+		}
+		headers = append(headers, header)
+	}
+
+	return headers
+}
+
+func normalizeHeaderTitle(raw string) string {
+	title := strings.TrimSpace(raw)
+	title = strings.TrimRight(title, "#")
+	return strings.TrimSpace(title)
+}
+
+func (c *MarkdownChunker) splitSection(section markdownSection) []string {
+	headerLine := strings.TrimSpace(section.headerLine)
+	body := strings.TrimSpace(section.body)
+
+	if headerLine == "" {
+		return c.packBody("", body)
+	}
+	if body == "" {
+		return []string{headerLine}
+	}
+	return c.packBody(headerLine, body)
+}
+
+func (c *MarkdownChunker) packBody(headerLine, body string) []string {
+	separator := ""
+	if headerLine != "" {
+		separator = "\n\n"
+	}
+
+	prefixLen := len(headerLine) + len(separator)
+	softBodyLimit := c.softTargetChars - prefixLen
+	hardBodyLimit := c.hardMaxChars - prefixLen
+	if softBodyLimit <= 0 {
+		softBodyLimit = 1
+	}
+	if hardBodyLimit <= 0 {
+		hardBodyLimit = 1
+	}
+	if hardBodyLimit < softBodyLimit {
+		hardBodyLimit = softBodyLimit
+	}
+
+	paragraphs := splitParagraphs(body)
+	if len(paragraphs) == 0 {
+		if headerLine == "" {
+			return nil
+		}
+		return []string{headerLine}
+	}
+
+	var bodyParts []string
+	current := ""
+	appendCurrent := func() {
+		if strings.TrimSpace(current) == "" {
+			return
+		}
+		bodyParts = append(bodyParts, current)
+		current = ""
+	}
+
+	for _, paragraph := range paragraphs {
+		segments := []string{paragraph}
+		if len(paragraph) > hardBodyLimit {
+			segments = splitByHardLimit(paragraph, hardBodyLimit)
+		}
+
+		for _, segment := range segments {
+			if current == "" {
+				current = segment
+				continue
+			}
+
+			candidate := current + "\n\n" + segment
+			if len(candidate) <= softBodyLimit {
+				current = candidate
+				continue
+			}
+
+			appendCurrent()
+			current = segment
+		}
+	}
+	appendCurrent()
+
+	var chunks []string
+	for _, part := range bodyParts {
+		if headerLine == "" {
+			chunks = append(chunks, part)
+			continue
+		}
+		chunks = append(chunks, headerLine+separator+part)
+	}
+	if len(chunks) == 0 && headerLine != "" {
+		chunks = append(chunks, headerLine)
+	}
+	return chunks
+}
+
+func splitParagraphs(body string) []string {
+	parts := strings.Split(body, "\n\n")
+	paragraphs := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		paragraphs = append(paragraphs, trimmed)
+	}
+	return paragraphs
+}
+
+func splitByHardLimit(text string, hardLimit int) []string {
+	if hardLimit <= 0 || len(text) <= hardLimit {
+		return []string{strings.TrimSpace(text)}
+	}
+
+	remaining := strings.TrimSpace(text)
+	var out []string
+	for len(remaining) > hardLimit {
+		cut := pickSplitPoint(remaining, hardLimit)
+		part := strings.TrimSpace(remaining[:cut])
+		if part == "" {
+			cut = hardLimit
+			part = strings.TrimSpace(remaining[:cut])
+		}
+		if part != "" {
+			out = append(out, part)
+		}
+		remaining = strings.TrimSpace(remaining[cut:])
+	}
+	if remaining != "" {
+		out = append(out, remaining)
+	}
+	return out
+}
+
+func pickSplitPoint(text string, hardLimit int) int {
+	if hardLimit >= len(text) {
+		return len(text)
+	}
+	min := hardLimit / 2
+	if min < 1 {
+		min = 1
+	}
+
+	for i := hardLimit; i > min; i-- {
+		if text[i] == '\n' {
+			return i
+		}
+	}
+	for i := hardLimit; i > min; i-- {
+		if text[i] == ' ' {
+			return i
+		}
+	}
+
+	return hardLimit
+}

--- a/internal/memory/chunker_test.go
+++ b/internal/memory/chunker_test.go
@@ -1,0 +1,220 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestChunkMarkdownNoHeaders(t *testing.T) {
+	input := "This is a note.\n\nIt has two paragraphs."
+
+	chunks := ChunkMarkdown("MEMORY.md", input)
+
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+
+	chunk := chunks[0]
+	if chunk.SourceFile != "MEMORY.md" {
+		t.Fatalf("unexpected source_file: %q", chunk.SourceFile)
+	}
+	if chunk.ChunkOrdinal != 0 {
+		t.Fatalf("unexpected chunk_ordinal: %d", chunk.ChunkOrdinal)
+	}
+	if len(chunk.HeaderPath) != 0 {
+		t.Fatalf("expected empty header_path, got %v", chunk.HeaderPath)
+	}
+	if chunk.Content != input {
+		t.Fatalf("unexpected content:\n%q", chunk.Content)
+	}
+}
+
+func TestChunkMarkdownNestedHeadersAndPaths(t *testing.T) {
+	input := strings.Join([]string{
+		"# Alpha",
+		"alpha body",
+		"",
+		"## Beta",
+		"beta body",
+		"",
+		"### Gamma",
+		"gamma body",
+		"",
+		"## Delta",
+		"delta body",
+		"",
+		"# Epsilon",
+		"epsilon body",
+	}, "\n")
+
+	chunks := ChunkMarkdown("memory/2026-03-04.md", input)
+
+	if len(chunks) != 5 {
+		t.Fatalf("expected 5 chunks, got %d", len(chunks))
+	}
+
+	wantPaths := [][]string{
+		{"Alpha"},
+		{"Alpha", "Beta"},
+		{"Alpha", "Beta", "Gamma"},
+		{"Alpha", "Delta"},
+		{"Epsilon"},
+	}
+	for i, chunk := range chunks {
+		if chunk.ChunkOrdinal != i {
+			t.Fatalf("chunk %d has wrong ordinal %d", i, chunk.ChunkOrdinal)
+		}
+		if chunk.SourceFile != "memory/2026-03-04.md" {
+			t.Fatalf("chunk %d source_file mismatch: %q", i, chunk.SourceFile)
+		}
+		if !equalStrings(chunk.HeaderPath, wantPaths[i]) {
+			t.Fatalf("chunk %d header_path mismatch: got %v want %v", i, chunk.HeaderPath, wantPaths[i])
+		}
+	}
+
+	if !strings.Contains(chunks[0].Content, "## Beta") || !strings.Contains(chunks[0].Content, "## Delta") {
+		t.Fatalf("top-level chunk should extend until next # header, got:\n%s", chunks[0].Content)
+	}
+	if strings.Contains(chunks[1].Content, "## Delta") {
+		t.Fatalf("second-level chunk should stop before next ## header, got:\n%s", chunks[1].Content)
+	}
+}
+
+func TestChunkMarkdownIncludesPreamble(t *testing.T) {
+	input := strings.Join([]string{
+		"Standalone intro line.",
+		"",
+		"# Header",
+		"Body text.",
+	}, "\n")
+
+	chunks := ChunkMarkdown("MEMORY.md", input)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks (preamble + header), got %d", len(chunks))
+	}
+	if len(chunks[0].HeaderPath) != 0 {
+		t.Fatalf("preamble header_path should be empty, got %v", chunks[0].HeaderPath)
+	}
+	if !strings.Contains(chunks[1].Content, "# Header") {
+		t.Fatalf("header chunk should contain header line, got:\n%s", chunks[1].Content)
+	}
+}
+
+func TestChunkMarkdownSplitsAtParagraphBoundaries(t *testing.T) {
+	chunker := NewMarkdownChunkerWithConfig(ChunkerConfig{
+		SoftTargetChars: 80,
+		HardMaxChars:    120,
+	})
+
+	para1 := strings.Repeat("a", 45)
+	para2 := strings.Repeat("b", 45)
+	para3 := strings.Repeat("c", 20)
+	input := "# Title\n\n" + para1 + "\n\n" + para2 + "\n\n" + para3
+
+	chunks := chunker.Chunk("MEMORY.md", input)
+
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for _, chunk := range chunks {
+		if !strings.HasPrefix(chunk.Content, "# Title\n\n") {
+			t.Fatalf("split chunk should preserve header prefix, got:\n%s", chunk.Content)
+		}
+		if len(chunk.Content) > 120 {
+			t.Fatalf("chunk exceeds hard max chars: %d", len(chunk.Content))
+		}
+	}
+	if !containsChunkWithText(chunks, para1) {
+		t.Fatalf("paragraph 1 was not preserved in a chunk")
+	}
+	if !containsChunkWithText(chunks, para2) {
+		t.Fatalf("paragraph 2 was not preserved in a chunk")
+	}
+}
+
+func TestChunkMarkdownEnforcesHardLimitForLongParagraph(t *testing.T) {
+	chunker := NewMarkdownChunkerWithConfig(ChunkerConfig{
+		SoftTargetChars: 70,
+		HardMaxChars:    90,
+	})
+
+	longParagraph := strings.Repeat("word ", 80)
+	input := "# Header\n\n" + strings.TrimSpace(longParagraph)
+
+	chunks := chunker.Chunk("MEMORY.md", input)
+	if len(chunks) < 2 {
+		t.Fatalf("expected long paragraph to split, got %d chunk(s)", len(chunks))
+	}
+
+	for _, chunk := range chunks {
+		if len(chunk.Content) > 90 {
+			t.Fatalf("chunk length %d exceeds hard max", len(chunk.Content))
+		}
+	}
+}
+
+func TestChunkMarkdownIgnoresHeadersInsideFencedCode(t *testing.T) {
+	input := strings.Join([]string{
+		"# Top",
+		"text before code",
+		"```",
+		"## not a real header",
+		"```",
+		"",
+		"## Real child",
+		"child text",
+	}, "\n")
+
+	chunks := ChunkMarkdown("MEMORY.md", input)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if !equalStrings(chunks[1].HeaderPath, []string{"Top", "Real child"}) {
+		t.Fatalf("unexpected path for child chunk: %v", chunks[1].HeaderPath)
+	}
+	if strings.Contains(chunks[0].Content, "not a real header\n\n") {
+		t.Fatalf("fenced-code header should not produce a separate chunk")
+	}
+}
+
+func TestSplitByHardLimit(t *testing.T) {
+	input := "one two three four five six seven eight"
+	parts := splitByHardLimit(input, 10)
+
+	if len(parts) < 2 {
+		t.Fatalf("expected text to split into multiple parts, got %d", len(parts))
+	}
+	for _, part := range parts {
+		if len(part) > 10 {
+			t.Fatalf("part exceeds hard limit: %q (%d)", part, len(part))
+		}
+	}
+}
+
+func TestNormalizeHeaderTitle(t *testing.T) {
+	got := normalizeHeaderTitle("Title ### ")
+	if got != "Title" {
+		t.Fatalf("unexpected normalized title: %q", got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsChunkWithText(chunks []MarkdownChunk, text string) bool {
+	for _, chunk := range chunks {
+		if strings.Contains(chunk.Content, text) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #87

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a header-aware markdown chunker for memory management that splits markdown files into chunks while preserving header hierarchy context.

**Key Features:**
- Configurable soft target (512 tokens) and hard max (800 tokens) limits
- Tracks nested header paths up to 3 levels (e.g., `["Alpha", "Beta", "Gamma"]`)
- Splits at paragraph boundaries when possible, enforces hard limit for oversized paragraphs
- Ignores headers inside fenced code blocks (` ``` ` and `~~~`)
- Handles preamble text before first header

**Implementation Notes:**
- Only recognizes headers with 1-3 hashes (`#`, `##`, `###`) - levels 4-6 are intentionally excluded
- Fence detection toggles on any ` ``` ` or `~~~` marker (simplified vs. full CommonMark spec)
- Comprehensive test coverage validates all core functionality

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - new code with comprehensive test coverage and no integration risk
- This is entirely new code (not modifying existing functionality) with excellent test coverage covering all major use cases. The implementation is clean, well-structured, and all tests pass. No integration concerns since `MarkdownChunk` is only used within these new files.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/memory/chunker.go | Implements header-aware markdown chunker with configurable soft/hard token limits, nested header path tracking, and fenced code block handling |
| internal/memory/chunker_test.go | Comprehensive test coverage for chunker including no headers, nested headers, preambles, splitting logic, hard limits, and fenced code blocks |

</details>



<sub>Last reviewed commit: dfe8bff</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->