### PR TITLE
Memory v2: filesystem watcher + markdown indexer (fsnotify → chunks → embeddings)

### DIFF
--- a/internal/memory/embeddings.go
+++ b/internal/memory/embeddings.go
@@ -35,14 +35,15 @@ func NewEmbeddingClient(baseURL, apiKey, model string) *EmbeddingClient {
 
 // embeddingRequest represents the API request body
 type embeddingRequest struct {
-	Input string `json:"input"`
-	Model string `json:"model"`
+	Input interface{} `json:"input"`
+	Model string      `json:"model"`
 }
 
 // embeddingResponse represents the API response
 type embeddingResponse struct {
 	Data []struct {
 		Embedding []float32 `json:"embedding"`
+		Index     int       `json:"index"`
 	} `json:"data"`
 	Error *struct {
 		Message string `json:"message"`
@@ -52,8 +53,24 @@ type embeddingResponse struct {
 
 // GetEmbedding returns the embedding vector for the given text
 func (c *EmbeddingClient) GetEmbedding(ctx context.Context, text string) ([]float32, error) {
+	embeddings, err := c.GetEmbeddings(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) == 0 || len(embeddings[0]) == 0 {
+		return nil, fmt.Errorf("no embedding returned from API")
+	}
+	return embeddings[0], nil
+}
+
+// GetEmbeddings returns embedding vectors for the given texts.
+func (c *EmbeddingClient) GetEmbeddings(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
 	reqBody := embeddingRequest{
-		Input: text,
+		Input: texts,
 		Model: c.model,
 	}
 
@@ -103,5 +120,31 @@ func (c *EmbeddingClient) GetEmbedding(ctx context.Context, text string) ([]floa
 		return nil, fmt.Errorf("no embedding returned from API")
 	}
 
-	return result.Data[0].Embedding, nil
+	if len(result.Data) != len(texts) {
+		return nil, fmt.Errorf("embedding count mismatch: got %d, want %d", len(result.Data), len(texts))
+	}
+
+	embeddings := make([][]float32, len(texts))
+	allIndexed := true
+	for _, item := range result.Data {
+		if item.Index < 0 || item.Index >= len(texts) {
+			allIndexed = false
+			break
+		}
+		embeddings[item.Index] = item.Embedding
+	}
+
+	if !allIndexed {
+		for i := range result.Data {
+			embeddings[i] = result.Data[i].Embedding
+		}
+	}
+
+	for i := range embeddings {
+		if len(embeddings[i]) == 0 {
+			return nil, fmt.Errorf("missing embedding at index %d", i)
+		}
+	}
+
+	return embeddings, nil
 }

--- a/internal/memory/indexer.go
+++ b/internal/memory/indexer.go
@@ -1,0 +1,497 @@
+package memory
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	defaultEmbeddingBatchSize = 32
+	defaultChunkTokenLimit    = 512
+	defaultChunkTokenOverlap  = 64
+)
+
+var markdownHeaderLineRegexp = regexp.MustCompile(`^(#{1,6})\s+(.+?)\s*$`)
+
+// EmbeddingBatchClient produces embeddings for multiple inputs.
+type EmbeddingBatchClient interface {
+	GetEmbeddings(ctx context.Context, texts []string) ([][]float32, error)
+}
+
+type chunkKey struct {
+	headerPath string
+	ordinal    int
+}
+
+type indexedChunkRecord struct {
+	HeaderPath   string
+	ChunkOrdinal int
+	Content      string
+	ContentHash  string
+	Embedding    []float32
+}
+
+type textSection struct {
+	HeaderPath string
+	Content    string
+}
+
+// IndexerOption configures Indexer behavior.
+type IndexerOption func(*Indexer)
+
+// WithIndexerBatchSize overrides the embedding batch size.
+func WithIndexerBatchSize(size int) IndexerOption {
+	return func(i *Indexer) {
+		if size > 0 {
+			i.batchSize = size
+		}
+	}
+}
+
+// WithIndexerChunking overrides chunk size and overlap.
+func WithIndexerChunking(maxTokens, overlap int) IndexerOption {
+	return func(i *Indexer) {
+		if maxTokens > 0 {
+			i.chunkTokens = maxTokens
+		}
+		if overlap >= 0 {
+			i.chunkOverlap = overlap
+		}
+	}
+}
+
+// Indexer consumes file-change events and keeps memory_chunks synchronized.
+type Indexer struct {
+	rootPath string
+	store    *MemoryStore
+	embedder EmbeddingBatchClient
+
+	batchSize    int
+	chunkTokens  int
+	chunkOverlap int
+}
+
+// NewIndexer creates an indexer rooted at a workspace path.
+func NewIndexer(rootPath string, store *MemoryStore, embedder EmbeddingBatchClient, opts ...IndexerOption) *Indexer {
+	absRoot := strings.TrimSpace(rootPath)
+	if absRoot != "" {
+		if resolved, err := filepath.Abs(absRoot); err == nil {
+			absRoot = resolved
+		}
+		absRoot = filepath.Clean(absRoot)
+	}
+
+	indexer := &Indexer{
+		rootPath:     absRoot,
+		store:        store,
+		embedder:     embedder,
+		batchSize:    defaultEmbeddingBatchSize,
+		chunkTokens:  defaultChunkTokenLimit,
+		chunkOverlap: defaultChunkTokenOverlap,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(indexer)
+		}
+	}
+	if indexer.chunkOverlap >= indexer.chunkTokens {
+		indexer.chunkOverlap = 0
+	}
+	return indexer
+}
+
+// Consume reads file-change events until context cancellation or channel close.
+func (i *Indexer) Consume(ctx context.Context, events <-chan FileChangedEvent) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event, ok := <-events:
+			if !ok {
+				return nil
+			}
+			if err := i.HandleEvent(ctx, event); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// HandleEvent processes a single file-change event.
+func (i *Indexer) HandleEvent(ctx context.Context, event FileChangedEvent) error {
+	return i.IndexFile(ctx, event.Path, event.RelativePath)
+}
+
+// IndexFile indexes a single file into memory_chunks.
+func (i *Indexer) IndexFile(ctx context.Context, absPath, relativePath string) error {
+	if i == nil || i.store == nil || i.embedder == nil {
+		return fmt.Errorf("indexer is not fully configured")
+	}
+
+	sourceFile := normalizeSourceFile(i.rootPath, absPath, relativePath)
+	if sourceFile == "" {
+		return fmt.Errorf("source file is empty")
+	}
+
+	contentBytes, err := os.ReadFile(absPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return i.deleteBySourceFile(ctx, sourceFile)
+		}
+		return fmt.Errorf("read changed file %s: %w", absPath, err)
+	}
+
+	chunks := i.chunkFile(sourceFile, string(contentBytes))
+	if len(chunks) == 0 {
+		return i.deleteBySourceFile(ctx, sourceFile)
+	}
+
+	existingHashes, err := i.loadChunkHashes(ctx, sourceFile)
+	if err != nil {
+		return err
+	}
+
+	changedIndexes := make([]int, 0, len(chunks))
+	changedTexts := make([]string, 0, len(chunks))
+	for idx := range chunks {
+		key := chunkKey{headerPath: chunks[idx].HeaderPath, ordinal: chunks[idx].ChunkOrdinal}
+		if hash, exists := existingHashes[key]; exists && hash == chunks[idx].ContentHash {
+			delete(existingHashes, key)
+			continue
+		}
+		changedIndexes = append(changedIndexes, idx)
+		changedTexts = append(changedTexts, chunks[idx].Content)
+		delete(existingHashes, key)
+	}
+
+	if len(changedIndexes) > 0 {
+		embeddings, err := i.embedChangedChunks(ctx, changedTexts)
+		if err != nil {
+			return err
+		}
+		for pos, chunkIndex := range changedIndexes {
+			chunks[chunkIndex].Embedding = embeddings[pos]
+		}
+	}
+
+	return i.persistChunks(ctx, sourceFile, chunks, changedIndexes, existingHashes)
+}
+
+func (i *Indexer) embedChangedChunks(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	allEmbeddings := make([][]float32, 0, len(texts))
+	for start := 0; start < len(texts); start += i.batchSize {
+		end := start + i.batchSize
+		if end > len(texts) {
+			end = len(texts)
+		}
+
+		embeddings, err := i.embedder.GetEmbeddings(ctx, texts[start:end])
+		if err != nil {
+			return nil, fmt.Errorf("embed batch %d-%d: %w", start, end, err)
+		}
+		if len(embeddings) != end-start {
+			return nil, fmt.Errorf("embedding count mismatch: got %d, want %d", len(embeddings), end-start)
+		}
+		allEmbeddings = append(allEmbeddings, embeddings...)
+	}
+	return allEmbeddings, nil
+}
+
+func (i *Indexer) loadChunkHashes(ctx context.Context, sourceFile string) (map[chunkKey]string, error) {
+	rows, err := i.store.db.QueryContext(
+		ctx,
+		`SELECT header_path, chunk_ordinal, content_hash
+		 FROM memory_chunks
+		 WHERE source_file = ?`,
+		sourceFile,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query existing chunk hashes for %s: %w", sourceFile, err)
+	}
+	defer rows.Close()
+
+	hashes := make(map[chunkKey]string)
+	for rows.Next() {
+		var (
+			headerPath string
+			ordinal    int
+			hash       string
+		)
+		if err := rows.Scan(&headerPath, &ordinal, &hash); err != nil {
+			return nil, fmt.Errorf("scan chunk hash for %s: %w", sourceFile, err)
+		}
+		hashes[chunkKey{headerPath: headerPath, ordinal: ordinal}] = hash
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate chunk hashes for %s: %w", sourceFile, err)
+	}
+	return hashes, nil
+}
+
+func (i *Indexer) persistChunks(
+	ctx context.Context,
+	sourceFile string,
+	chunks []indexedChunkRecord,
+	changedIndexes []int,
+	stale map[chunkKey]string,
+) error {
+	if len(changedIndexes) == 0 && len(stale) == 0 {
+		return nil
+	}
+
+	tx, err := i.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin memory index transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	for _, idx := range changedIndexes {
+		embeddingBytes, err := encodeEmbedding(chunks[idx].Embedding)
+		if err != nil {
+			return fmt.Errorf("encode embedding: %w", err)
+		}
+
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO memory_chunks (
+				source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
+			) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+			ON CONFLICT(source_file, header_path, chunk_ordinal) DO UPDATE SET
+				content = excluded.content,
+				content_hash = excluded.content_hash,
+				embedding = excluded.embedding,
+				indexed_at = CURRENT_TIMESTAMP
+		`,
+			sourceFile,
+			chunks[idx].HeaderPath,
+			chunks[idx].ChunkOrdinal,
+			chunks[idx].Content,
+			chunks[idx].ContentHash,
+			embeddingBytes,
+		)
+		if err != nil {
+			return fmt.Errorf("upsert chunk (%s, %s, %d): %w",
+				sourceFile, chunks[idx].HeaderPath, chunks[idx].ChunkOrdinal, err)
+		}
+	}
+
+	for key := range stale {
+		if _, err := tx.ExecContext(
+			ctx,
+			`DELETE FROM memory_chunks
+			 WHERE source_file = ? AND header_path = ? AND chunk_ordinal = ?`,
+			sourceFile,
+			key.headerPath,
+			key.ordinal,
+		); err != nil {
+			return fmt.Errorf("delete stale chunk (%s, %s, %d): %w",
+				sourceFile, key.headerPath, key.ordinal, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit memory index transaction: %w", err)
+	}
+	return nil
+}
+
+func (i *Indexer) deleteBySourceFile(ctx context.Context, sourceFile string) error {
+	_, err := i.store.db.ExecContext(
+		ctx,
+		`DELETE FROM memory_chunks WHERE source_file = ?`,
+		sourceFile,
+	)
+	if err != nil {
+		return fmt.Errorf("delete chunks for %s: %w", sourceFile, err)
+	}
+	return nil
+}
+
+func (i *Indexer) chunkFile(sourceFile, content string) []indexedChunkRecord {
+	sections := splitIntoSections(sourceFile, content)
+	if len(sections) == 0 {
+		return nil
+	}
+
+	ordinals := make(map[string]int)
+	out := make([]indexedChunkRecord, 0, len(sections))
+	for _, section := range sections {
+		pieces := splitChunkText(section.Content, i.chunkTokens, i.chunkOverlap)
+		for _, piece := range pieces {
+			trimmed := strings.TrimSpace(piece)
+			if trimmed == "" {
+				continue
+			}
+
+			headerPath := strings.TrimSpace(section.HeaderPath)
+			if headerPath == "" {
+				headerPath = "root"
+			}
+
+			ordinal := ordinals[headerPath]
+			ordinals[headerPath] = ordinal + 1
+
+			out = append(out, indexedChunkRecord{
+				HeaderPath:   headerPath,
+				ChunkOrdinal: ordinal,
+				Content:      trimmed,
+				ContentHash:  hashChunkContent(trimmed),
+			})
+		}
+	}
+	return out
+}
+
+func splitIntoSections(sourceFile, content string) []textSection {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return nil
+	}
+
+	switch strings.ToLower(filepath.Ext(sourceFile)) {
+	case ".md":
+		return splitMarkdownSections(content)
+	case ".txt", ".yaml":
+		return []textSection{
+			{
+				HeaderPath: "root",
+				Content:    trimmed,
+			},
+		}
+	default:
+		return nil
+	}
+}
+
+func splitMarkdownSections(content string) []textSection {
+	lines := strings.Split(content, "\n")
+	stack := make([]string, 0, 6)
+	currentHeader := "root"
+	var buffer []string
+	sections := make([]textSection, 0)
+
+	flush := func() {
+		text := strings.TrimSpace(strings.Join(buffer, "\n"))
+		if text != "" {
+			sections = append(sections, textSection{
+				HeaderPath: currentHeader,
+				Content:    text,
+			})
+		}
+		buffer = nil
+	}
+
+	for _, line := range lines {
+		matches := markdownHeaderLineRegexp.FindStringSubmatch(line)
+		if len(matches) == 3 {
+			flush()
+
+			level := len(matches[1])
+			title := cleanMarkdownHeader(matches[2])
+			if level-1 < len(stack) {
+				stack = stack[:level-1]
+			}
+			stack = append(stack, title)
+
+			currentHeader = strings.Join(stack, " > ")
+			if currentHeader == "" {
+				currentHeader = "root"
+			}
+
+			buffer = append(buffer, strings.TrimSpace(line))
+			continue
+		}
+		buffer = append(buffer, line)
+	}
+
+	flush()
+	if len(sections) == 0 {
+		return []textSection{
+			{
+				HeaderPath: "root",
+				Content:    strings.TrimSpace(content),
+			},
+		}
+	}
+	return sections
+}
+
+func splitChunkText(text string, maxTokens, overlap int) []string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return nil
+	}
+	if maxTokens <= 0 {
+		return []string{strings.Join(words, " ")}
+	}
+	if overlap < 0 || overlap >= maxTokens {
+		overlap = 0
+	}
+
+	if len(words) <= maxTokens {
+		return []string{strings.Join(words, " ")}
+	}
+
+	step := maxTokens - overlap
+	chunks := make([]string, 0, len(words)/step+1)
+	for start := 0; start < len(words); start += step {
+		end := start + maxTokens
+		if end > len(words) {
+			end = len(words)
+		}
+		chunks = append(chunks, strings.Join(words[start:end], " "))
+		if end == len(words) {
+			break
+		}
+	}
+	return chunks
+}
+
+func hashChunkContent(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+func cleanMarkdownHeader(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimRight(raw, "#")
+	raw = strings.TrimSpace(raw)
+	return strings.Join(strings.Fields(raw), " ")
+}
+
+func normalizeSourceFile(rootPath, absPath, relativePath string) string {
+	trimmedRelative := strings.TrimSpace(relativePath)
+	if trimmedRelative != "" {
+		return filepath.ToSlash(filepath.Clean(trimmedRelative))
+	}
+
+	trimmedPath := strings.TrimSpace(absPath)
+	if trimmedPath == "" {
+		return ""
+	}
+
+	cleanPath := filepath.Clean(trimmedPath)
+	if rootPath == "" {
+		return filepath.ToSlash(cleanPath)
+	}
+
+	rel, err := filepath.Rel(rootPath, cleanPath)
+	if err != nil {
+		return filepath.ToSlash(cleanPath)
+	}
+	rel = filepath.Clean(rel)
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return filepath.ToSlash(cleanPath)
+	}
+	return filepath.ToSlash(rel)
+}

--- a/internal/memory/indexer_test.go
+++ b/internal/memory/indexer_test.go
@@ -1,0 +1,195 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestIndexerSkipsEmbeddingWhenContentHashUnchanged(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "MEMORY.md")
+	if err := os.WriteFile(filePath, []byte("# Memory\n\nThis is stable content."), 0o644); err != nil {
+		t.Fatalf("write file failed: %v", err)
+	}
+
+	embedder := &stubBatchEmbedder{}
+	indexer := NewIndexer(tmpDir, store, embedder, WithIndexerChunking(32, 0))
+	ctx := context.Background()
+
+	if err := indexer.IndexFile(ctx, filePath, "MEMORY.md"); err != nil {
+		t.Fatalf("first IndexFile failed: %v", err)
+	}
+	if calls := embedder.TotalCalls(); calls != 1 {
+		t.Fatalf("expected 1 embedding call after first index, got %d", calls)
+	}
+
+	if err := indexer.IndexFile(ctx, filePath, "MEMORY.md"); err != nil {
+		t.Fatalf("second IndexFile failed: %v", err)
+	}
+	if calls := embedder.TotalCalls(); calls != 1 {
+		t.Fatalf("expected unchanged content to skip embedding, got %d calls", calls)
+	}
+
+	if err := os.WriteFile(filePath, []byte("# Memory\n\nThis content has changed now."), 0o644); err != nil {
+		t.Fatalf("rewrite file failed: %v", err)
+	}
+	if err := indexer.IndexFile(ctx, filePath, "MEMORY.md"); err != nil {
+		t.Fatalf("third IndexFile failed: %v", err)
+	}
+	if calls := embedder.TotalCalls(); calls != 2 {
+		t.Fatalf("expected changed content to trigger embedding, got %d calls", calls)
+	}
+}
+
+func TestIndexerEmbedsInBatchesOfUpTo32(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "memory.txt")
+
+	words := make([]string, 0, 120)
+	for i := 0; i < 120; i++ {
+		words = append(words, fmt.Sprintf("w%d", i))
+	}
+	if err := os.WriteFile(filePath, []byte(strings.Join(words, " ")), 0o644); err != nil {
+		t.Fatalf("write file failed: %v", err)
+	}
+
+	embedder := &stubBatchEmbedder{}
+	indexer := NewIndexer(tmpDir, store, embedder, WithIndexerChunking(3, 0))
+
+	if err := indexer.IndexFile(context.Background(), filePath, "memory.txt"); err != nil {
+		t.Fatalf("IndexFile failed: %v", err)
+	}
+
+	batchSizes := embedder.BatchSizes()
+	if len(batchSizes) != 2 {
+		t.Fatalf("expected 2 embedding calls for 40 chunks, got %d (%v)", len(batchSizes), batchSizes)
+	}
+	if batchSizes[0] != 32 || batchSizes[1] != 8 {
+		t.Fatalf("unexpected batch sizes: got %v, want [32 8]", batchSizes)
+	}
+	for _, size := range batchSizes {
+		if size > 32 {
+			t.Fatalf("batch size exceeded 32: %d", size)
+		}
+	}
+}
+
+func TestIndexerDeletesStaleChunksWhenFileShrinks(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "notes.txt")
+
+	embedder := &stubBatchEmbedder{}
+	indexer := NewIndexer(tmpDir, store, embedder, WithIndexerChunking(4, 0))
+	ctx := context.Background()
+
+	if err := os.WriteFile(filePath, []byte("a b c d e f g h i j k l"), 0o644); err != nil {
+		t.Fatalf("write initial file failed: %v", err)
+	}
+	if err := indexer.IndexFile(ctx, filePath, "notes.txt"); err != nil {
+		t.Fatalf("initial IndexFile failed: %v", err)
+	}
+
+	if count := countSourceChunks(t, db, "notes.txt"); count != 3 {
+		t.Fatalf("expected 3 chunks after first index, got %d", count)
+	}
+
+	if err := os.WriteFile(filePath, []byte("a b c d"), 0o644); err != nil {
+		t.Fatalf("write smaller file failed: %v", err)
+	}
+	if err := indexer.IndexFile(ctx, filePath, "notes.txt"); err != nil {
+		t.Fatalf("second IndexFile failed: %v", err)
+	}
+
+	if count := countSourceChunks(t, db, "notes.txt"); count != 1 {
+		t.Fatalf("expected stale chunks to be deleted, got %d chunks", count)
+	}
+}
+
+func openIndexerTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite db failed: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	return db
+}
+
+func countSourceChunks(t *testing.T, db *sql.DB, sourceFile string) int {
+	t.Helper()
+
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM memory_chunks WHERE source_file = ?`,
+		sourceFile,
+	).Scan(&count); err != nil {
+		t.Fatalf("count source chunks failed: %v", err)
+	}
+	return count
+}
+
+type stubBatchEmbedder struct {
+	mu         sync.Mutex
+	callCount  int
+	batchSizes []int
+}
+
+func (s *stubBatchEmbedder) GetEmbeddings(_ context.Context, texts []string) ([][]float32, error) {
+	s.mu.Lock()
+	s.callCount++
+	s.batchSizes = append(s.batchSizes, len(texts))
+	s.mu.Unlock()
+
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{float32(len(texts[i])), float32(i + 1)}
+	}
+	return out, nil
+}
+
+func (s *stubBatchEmbedder) TotalCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.callCount
+}
+
+func (s *stubBatchEmbedder) BatchSizes() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]int, len(s.batchSizes))
+	copy(out, s.batchSizes)
+	return out
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -8,21 +8,35 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"time"
 )
 
-const memoryChunksTable = "memory_chunks"
+const (
+	memoryChunksTable     = "memory_chunks"
+	defaultMigratedSource = "legacy://migrated"
+	defaultHeaderPath     = "root"
+)
 
 // MemoryResult represents an indexed markdown memory search result.
+// Some fields are aliases kept for compatibility with existing callers.
 type MemoryResult struct {
-	ID         int64     `json:"id"`
-	Source     string    `json:"source"`
-	HeaderPath string    `json:"header_path"`
-	StartLine  int       `json:"start_line"`
-	EndLine    int       `json:"end_line"`
-	Content    string    `json:"content"`
-	Similarity float32   `json:"similarity"`
-	UpdatedAt  time.Time `json:"updated_at"`
+	ID int64 `json:"id"`
+
+	Source     string `json:"source"`
+	SourceFile string `json:"source_file"`
+	HeaderPath string `json:"header_path"`
+
+	StartLine    int `json:"start_line"`
+	EndLine      int `json:"end_line"`
+	ChunkOrdinal int `json:"chunk_ordinal"`
+
+	Content     string  `json:"content"`
+	ContentHash string  `json:"content_hash"`
+	Similarity  float32 `json:"similarity"`
+
+	UpdatedAt time.Time `json:"updated_at"`
+	IndexedAt time.Time `json:"indexed_at"`
 }
 
 // MemoryStore handles storage and retrieval of memory chunks with embeddings.
@@ -41,9 +55,56 @@ func NewMemoryStore(db *sql.DB) (*MemoryStore, error) {
 }
 
 // migrate creates/updates memory index tables.
-// The legacy memories table is retained only for rollback compatibility and kept empty.
 func (s *MemoryStore) migrate() error {
-	legacyMigrations := []string{
+	if err := s.ensureLegacyMemoriesTable(); err != nil {
+		return err
+	}
+
+	hasChunksTable, err := s.tableExists(memoryChunksTable)
+	if err != nil {
+		return fmt.Errorf("failed to inspect %s table: %w", memoryChunksTable, err)
+	}
+
+	if hasChunksTable && !s.hasMemoryChunksV2Shape() {
+		legacyBackup := fmt.Sprintf("memory_chunks_legacy_%d", time.Now().UnixNano())
+		tx, err := s.db.Begin()
+		if err != nil {
+			return fmt.Errorf("begin memory table recreation: %w", err)
+		}
+		defer tx.Rollback() //nolint:errcheck
+
+		if _, err := tx.Exec(fmt.Sprintf(`ALTER TABLE %s RENAME TO %s`, memoryChunksTable, legacyBackup)); err != nil {
+			return fmt.Errorf("backup legacy memory_chunks table: %w", err)
+		}
+		if err := createChunksSchemaTx(tx); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit memory table recreation: %w", err)
+		}
+
+		_ = s.importLegacyRows(legacyBackup)
+	} else if !hasChunksTable {
+		if err := s.createChunksSchema(); err != nil {
+			return err
+		}
+	}
+
+	if hasLegacyTable, err := s.tableExists("memories"); err == nil && hasLegacyTable {
+		_ = s.importLegacyRows("memories")
+		if _, err := s.db.Exec(`DELETE FROM memories`); err != nil {
+			return fmt.Errorf("clear legacy memories table: %w", err)
+		}
+	}
+
+	if err := s.ensureChunksIndexes(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *MemoryStore) ensureLegacyMemoriesTable() error {
+	statements := []string{
 		`CREATE TABLE IF NOT EXISTS memories (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			content TEXT NOT NULL,
@@ -54,69 +115,236 @@ func (s *MemoryStore) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);`,
 		`CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at);`,
 	}
-	for _, migration := range legacyMigrations {
-		if _, err := s.db.Exec(migration); err != nil {
+	for _, stmt := range statements {
+		if _, err := s.db.Exec(stmt); err != nil {
 			return fmt.Errorf("legacy migration failed: %w", err)
 		}
 	}
+	return nil
+}
 
-	hasChunksTable, err := s.tableExists(memoryChunksTable)
+func (s *MemoryStore) createChunksSchema() error {
+	tx, err := s.db.Begin()
 	if err != nil {
-		return fmt.Errorf("failed to inspect %s table: %w", memoryChunksTable, err)
+		return fmt.Errorf("begin memory schema migration: %w", err)
 	}
+	defer tx.Rollback() //nolint:errcheck
 
-	if hasChunksTable {
-		hasSourceColumn, err := s.columnExists(memoryChunksTable, "source")
-		if err != nil {
-			return fmt.Errorf("failed to inspect %s schema: %w", memoryChunksTable, err)
-		}
-		if !hasSourceColumn {
-			if _, err := s.db.Exec(`ALTER TABLE memory_chunks RENAME TO memory_chunks_legacy_v1`); err != nil {
-				return fmt.Errorf("failed to rename legacy memory_chunks table: %w", err)
-			}
-			hasChunksTable = false
-		}
+	if err := createChunksSchemaTx(tx); err != nil {
+		return err
 	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit memory schema migration: %w", err)
+	}
+	return nil
+}
 
-	if !hasChunksTable {
-		if _, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS memory_chunks (
+func createChunksSchemaTx(tx *sql.Tx) error {
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS memory_chunks (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			source TEXT NOT NULL,
-			header_path TEXT NOT NULL DEFAULT '',
-			start_line INTEGER NOT NULL DEFAULT 1,
-			end_line INTEGER NOT NULL DEFAULT 1,
+			source_file TEXT NOT NULL,
+			header_path TEXT NOT NULL,
+			chunk_ordinal INTEGER NOT NULL DEFAULT 0,
 			content TEXT NOT NULL,
+			content_hash TEXT NOT NULL,
 			embedding BLOB NOT NULL,
-			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-		);`); err != nil {
-			return fmt.Errorf("failed to create memory_chunks table: %w", err)
+			indexed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(source_file, header_path, chunk_ordinal)
+		);`,
+		`CREATE INDEX IF NOT EXISTS idx_memory_chunks_source_file ON memory_chunks(source_file);`,
+		`CREATE INDEX IF NOT EXISTS idx_memory_chunks_indexed_at ON memory_chunks(indexed_at);`,
+	}
+
+	for _, statement := range statements {
+		if _, err := tx.Exec(statement); err != nil {
+			return fmt.Errorf("memory migration failed: %w", err)
 		}
 	}
+	return nil
+}
 
-	chunkIndexes := []string{
-		`CREATE INDEX IF NOT EXISTS idx_memory_chunks_source ON memory_chunks(source);`,
-		`CREATE INDEX IF NOT EXISTS idx_memory_chunks_header_path ON memory_chunks(header_path);`,
-		`CREATE INDEX IF NOT EXISTS idx_memory_chunks_updated_at ON memory_chunks(updated_at);`,
+func (s *MemoryStore) ensureChunksIndexes() error {
+	statements := []string{
+		`CREATE INDEX IF NOT EXISTS idx_memory_chunks_source_file ON memory_chunks(source_file);`,
+		`CREATE INDEX IF NOT EXISTS idx_memory_chunks_indexed_at ON memory_chunks(indexed_at);`,
 	}
-	for _, stmt := range chunkIndexes {
-		if _, err := s.db.Exec(stmt); err != nil {
-			return fmt.Errorf("failed to create memory_chunks index: %w", err)
+	for _, statement := range statements {
+		if _, err := s.db.Exec(statement); err != nil {
+			return fmt.Errorf("create memory index failed: %w", err)
 		}
 	}
+	return nil
+}
 
-	if _, err := s.db.Exec(`DROP TABLE IF EXISTS memory_chunks_legacy_v1`); err != nil {
-		return fmt.Errorf("failed to drop legacy memory_chunks table: %w", err)
+func (s *MemoryStore) hasMemoryChunksV2Shape() bool {
+	required := []string{
+		"id",
+		"source_file",
+		"header_path",
+		"chunk_ordinal",
+		"content",
+		"content_hash",
+		"embedding",
+		"indexed_at",
+	}
+	for _, column := range required {
+		ok, err := s.columnExists(memoryChunksTable, column)
+		if err != nil || !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *MemoryStore) importLegacyRows(table string) error {
+	hasContent, err := s.columnExists(table, "content")
+	if err != nil || !hasContent {
+		return nil
+	}
+	hasEmbedding, err := s.columnExists(table, "embedding")
+	if err != nil || !hasEmbedding {
+		return nil
 	}
 
-	if _, err := s.db.Exec(`DELETE FROM memories`); err != nil {
-		return fmt.Errorf("failed to clear legacy memories table: %w", err)
+	hasSourceFile, _ := s.columnExists(table, "source_file")
+	hasSource, _ := s.columnExists(table, "source")
+	hasHeaderPath, _ := s.columnExists(table, "header_path")
+	hasCategory, _ := s.columnExists(table, "category")
+	hasChunkOrdinal, _ := s.columnExists(table, "chunk_ordinal")
+	hasStartLine, _ := s.columnExists(table, "start_line")
+
+	fields := []string{"content", "embedding"}
+	includeSource := hasSourceFile || hasSource
+	includeHeader := hasHeaderPath || hasCategory
+	includeOrdinal := hasChunkOrdinal || hasStartLine
+
+	if hasSourceFile {
+		fields = append(fields, "source_file")
+	} else if hasSource {
+		fields = append(fields, "source")
+	}
+	if hasHeaderPath {
+		fields = append(fields, "header_path")
+	} else if hasCategory {
+		fields = append(fields, "category")
+	}
+	if hasChunkOrdinal {
+		fields = append(fields, "chunk_ordinal")
+	} else if hasStartLine {
+		fields = append(fields, "start_line")
+	}
+
+	query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(fields, ", "), table)
+	rows, err := s.db.Query(query)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	type legacyRow struct {
+		source     string
+		headerPath string
+		ordinal    int
+		hasOrdinal bool
+		content    string
+		embedding  []byte
+	}
+
+	collected := make([]legacyRow, 0, 64)
+	for rows.Next() {
+		var (
+			content   string
+			embedding []byte
+			source    sql.NullString
+			header    sql.NullString
+			ordinal   sql.NullInt64
+		)
+
+		args := []interface{}{&content, &embedding}
+		if includeSource {
+			args = append(args, &source)
+		}
+		if includeHeader {
+			args = append(args, &header)
+		}
+		if includeOrdinal {
+			args = append(args, &ordinal)
+		}
+		if err := rows.Scan(args...); err != nil {
+			continue
+		}
+
+		sourceValue := strings.TrimSpace(source.String)
+		if sourceValue == "" {
+			sourceValue = defaultMigratedSource
+		}
+		headerPathValue := strings.TrimSpace(header.String)
+		if headerPathValue == "" {
+			headerPathValue = defaultHeaderPath
+		}
+
+		collected = append(collected, legacyRow{
+			source:     sourceValue,
+			headerPath: headerPathValue,
+			ordinal:    int(ordinal.Int64),
+			hasOrdinal: ordinal.Valid,
+			content:    content,
+			embedding:  embedding,
+		})
+	}
+	if len(collected) == 0 {
+		return nil
+	}
+
+	nextOrdinalByKey := make(map[string]int)
+	for _, row := range collected {
+		ordinal := row.ordinal
+		if !row.hasOrdinal || ordinal < 0 {
+			key := row.source + "\x00" + row.headerPath
+			ordinal = nextOrdinalByKey[key]
+			nextOrdinalByKey[key] = ordinal + 1
+		}
+
+		_, _ = s.db.Exec(`
+			INSERT OR IGNORE INTO memory_chunks
+				(source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at)
+			VALUES
+				(?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		`, row.source, row.headerPath, ordinal, row.content, hashChunkContent(row.content), row.embedding)
 	}
 
 	return nil
 }
 
-// IndexChunk stores a markdown chunk and its embedding in the index table.
+// IndexChunk stores or updates a markdown chunk in the index table.
 func (s *MemoryStore) IndexChunk(ctx context.Context, source, headerPath string, startLine, endLine int, content string, embedding []float32) error {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return fmt.Errorf("source is required")
+	}
+
+	headerPath = strings.TrimSpace(headerPath)
+	if headerPath == "" {
+		headerPath = defaultHeaderPath
+	}
+
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return fmt.Errorf("content is empty")
+	}
+
+	_ = endLine // line ranges are currently represented by chunk ordinal in v2 schema.
+
+	ordinal := startLine
+	if ordinal <= 0 {
+		nextOrdinal, err := s.nextOrdinal(ctx, source, headerPath)
+		if err != nil {
+			return fmt.Errorf("resolve next chunk ordinal: %w", err)
+		}
+		ordinal = nextOrdinal
+	}
+
 	embeddingBytes, err := encodeEmbedding(embedding)
 	if err != nil {
 		return fmt.Errorf("failed to encode embedding: %w", err)
@@ -124,11 +352,36 @@ func (s *MemoryStore) IndexChunk(ctx context.Context, source, headerPath string,
 
 	_, err = s.db.ExecContext(
 		ctx,
-		`INSERT INTO memory_chunks (source, header_path, start_line, end_line, content, embedding, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
-		source, headerPath, startLine, endLine, content, embeddingBytes,
+		`INSERT INTO memory_chunks
+			(source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at)
+		VALUES
+			(?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(source_file, header_path, chunk_ordinal) DO UPDATE SET
+			content = excluded.content,
+			content_hash = excluded.content_hash,
+			embedding = excluded.embedding,
+			indexed_at = CURRENT_TIMESTAMP`,
+		source,
+		headerPath,
+		ordinal,
+		content,
+		hashChunkContent(content),
+		embeddingBytes,
 	)
 	return err
+}
+
+func (s *MemoryStore) nextOrdinal(ctx context.Context, sourceFile, headerPath string) (int, error) {
+	var next int
+	err := s.db.QueryRowContext(
+		ctx,
+		`SELECT COALESCE(MAX(chunk_ordinal), -1) + 1
+		 FROM memory_chunks
+		 WHERE source_file = ? AND header_path = ?`,
+		sourceFile,
+		headerPath,
+	).Scan(&next)
+	return next, err
 }
 
 // SearchChunks finds the most similar indexed chunks using cosine similarity.
@@ -138,9 +391,9 @@ func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32
 	}
 
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, source, header_path, start_line, end_line, content, embedding, updated_at
+		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
 		FROM memory_chunks
-		ORDER BY updated_at DESC
+		ORDER BY indexed_at DESC
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query memory chunks: %w", err)
@@ -149,32 +402,49 @@ func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32
 
 	var results []MemoryResult
 	for rows.Next() {
-		var id int64
-		var source, headerPath, content string
-		var startLine, endLine int
-		var embeddingBytes []byte
-		var updatedAt time.Time
+		var (
+			id           int64
+			sourceFile   string
+			headerPath   string
+			chunkOrdinal int
+			content      string
+			contentHash  string
+			embeddingRaw []byte
+			indexedAt    time.Time
+		)
 
-		if err := rows.Scan(&id, &source, &headerPath, &startLine, &endLine, &content, &embeddingBytes, &updatedAt); err != nil {
+		if err := rows.Scan(
+			&id,
+			&sourceFile,
+			&headerPath,
+			&chunkOrdinal,
+			&content,
+			&contentHash,
+			&embeddingRaw,
+			&indexedAt,
+		); err != nil {
 			continue
 		}
 
-		embedding, err := decodeEmbedding(embeddingBytes)
+		embedding, err := decodeEmbedding(embeddingRaw)
 		if err != nil {
 			continue
 		}
 
 		similarity := cosineSimilarity(queryEmbedding, embedding)
-
 		results = append(results, MemoryResult{
-			ID:         id,
-			Source:     source,
-			HeaderPath: headerPath,
-			StartLine:  startLine,
-			EndLine:    endLine,
-			Content:    content,
-			Similarity: similarity,
-			UpdatedAt:  updatedAt,
+			ID:           id,
+			Source:       sourceFile,
+			SourceFile:   sourceFile,
+			HeaderPath:   headerPath,
+			StartLine:    chunkOrdinal,
+			EndLine:      chunkOrdinal,
+			ChunkOrdinal: chunkOrdinal,
+			Content:      content,
+			ContentHash:  contentHash,
+			Similarity:   similarity,
+			UpdatedAt:    indexedAt,
+			IndexedAt:    indexedAt,
 		})
 	}
 
@@ -185,7 +455,6 @@ func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32
 	if len(results) > topK {
 		results = results[:topK]
 	}
-
 	return results, nil
 }
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -130,7 +131,7 @@ func TestEncodeDecodeEmbedding(t *testing.T) {
 	}
 }
 
-func TestMemoryStoreMigrateCreatesMemoryChunksAndClearsLegacyMemories(t *testing.T) {
+func TestMemoryStoreMigrateCreatesV2SchemaAndClearsLegacyMemories(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
@@ -158,19 +159,25 @@ func TestMemoryStoreMigrateCreatesMemoryChunksAndClearsLegacyMemories(t *testing
 		t.Fatalf("failed to seed legacy memories table: %v", err)
 	}
 
-	if _, err := NewMemoryStore(db); err != nil {
+	store, err := NewMemoryStore(db)
+	if err != nil {
 		t.Fatalf("NewMemoryStore failed: %v", err)
 	}
 
-	var chunkTableCount int
-	if err := db.QueryRow(`
-		SELECT COUNT(*) FROM sqlite_master
-		WHERE type='table' AND name='memory_chunks'
-	`).Scan(&chunkTableCount); err != nil {
-		t.Fatalf("failed to check memory_chunks table: %v", err)
-	}
-	if chunkTableCount != 1 {
-		t.Fatalf("expected memory_chunks table to exist")
+	for _, column := range []string{
+		"source_file",
+		"header_path",
+		"chunk_ordinal",
+		"content_hash",
+		"indexed_at",
+	} {
+		ok, err := store.columnExists(memoryChunksTable, column)
+		if err != nil {
+			t.Fatalf("columnExists(%q) failed: %v", column, err)
+		}
+		if !ok {
+			t.Fatalf("expected v2 column %q to exist", column)
+		}
 	}
 
 	var legacyRows int
@@ -180,6 +187,14 @@ func TestMemoryStoreMigrateCreatesMemoryChunksAndClearsLegacyMemories(t *testing
 	if legacyRows != 0 {
 		t.Fatalf("expected legacy memories table to be empty, got %d row(s)", legacyRows)
 	}
+
+	var migratedRows int
+	if err := db.QueryRow("SELECT COUNT(*) FROM memory_chunks WHERE source_file = ?", defaultMigratedSource).Scan(&migratedRows); err != nil {
+		t.Fatalf("failed to count migrated chunks: %v", err)
+	}
+	if migratedRows != 1 {
+		t.Fatalf("expected 1 migrated chunk, got %d", migratedRows)
+	}
 }
 
 func TestMemoryStoreMigrateRecreatesLegacyMemoryChunksSchema(t *testing.T) {
@@ -188,13 +203,26 @@ func TestMemoryStoreMigrateRecreatesLegacyMemoryChunksSchema(t *testing.T) {
 
 	if _, err := db.Exec(`CREATE TABLE memory_chunks (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		source TEXT NOT NULL,
+		header_path TEXT NOT NULL DEFAULT '',
+		start_line INTEGER NOT NULL DEFAULT 1,
+		end_line INTEGER NOT NULL DEFAULT 1,
 		content TEXT NOT NULL,
 		embedding BLOB NOT NULL,
-		category TEXT,
-		metadata TEXT NOT NULL DEFAULT '{}',
-		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);`); err != nil {
 		t.Fatalf("failed to create legacy memory_chunks table: %v", err)
+	}
+
+	embeddingBytes, err := encodeEmbedding([]float32{0.3, 0.7})
+	if err != nil {
+		t.Fatalf("failed to encode legacy embedding: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO memory_chunks (source, header_path, start_line, end_line, content, embedding)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, "MEMORY.md", "root", 1, 2, "legacy chunk", embeddingBytes); err != nil {
+		t.Fatalf("failed to seed legacy memory_chunks table: %v", err)
 	}
 
 	store, err := NewMemoryStore(db)
@@ -206,14 +234,14 @@ func TestMemoryStoreMigrateRecreatesLegacyMemoryChunksSchema(t *testing.T) {
 		t.Fatalf("IndexChunk failed after migration: %v", err)
 	}
 
-	var hasSource int
+	var hasSourceFile int
 	if err := db.QueryRow(`
-		SELECT COUNT(*) FROM pragma_table_info('memory_chunks') WHERE name='source'
-	`).Scan(&hasSource); err != nil {
+		SELECT COUNT(*) FROM pragma_table_info('memory_chunks') WHERE name='source_file'
+	`).Scan(&hasSourceFile); err != nil {
 		t.Fatalf("failed to inspect migrated memory_chunks columns: %v", err)
 	}
-	if hasSource != 1 {
-		t.Fatalf("expected migrated memory_chunks table to contain source column")
+	if hasSourceFile != 1 {
+		t.Fatalf("expected migrated memory_chunks table to contain source_file column")
 	}
 }
 
@@ -263,14 +291,40 @@ func TestMemoryStoreSearchChunks(t *testing.T) {
 	if got.Source != "MEMORY.md" {
 		t.Fatalf("unexpected source: got %q", got.Source)
 	}
+	if got.SourceFile != "MEMORY.md" {
+		t.Fatalf("unexpected source_file: got %q", got.SourceFile)
+	}
 	if got.HeaderPath != "projects > ok-gobot" {
 		t.Fatalf("unexpected header path: got %q", got.HeaderPath)
 	}
-	if got.StartLine != 12 || got.EndLine != 16 {
-		t.Fatalf("unexpected line range: got %d-%d", got.StartLine, got.EndLine)
+	if got.ChunkOrdinal != 12 {
+		t.Fatalf("unexpected chunk ordinal: got %d", got.ChunkOrdinal)
+	}
+	if got.ContentHash == "" {
+		t.Fatal("expected content hash to be populated")
 	}
 	if got.Similarity <= 0 {
 		t.Fatalf("expected positive similarity, got %f", got.Similarity)
+	}
+}
+
+func TestMemoryStoreLegacyMutationsAreDeprecated(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	if err := store.Save(context.Background(), "x", "general", []float32{1}); err == nil || !strings.Contains(err.Error(), "deprecated") {
+		t.Fatalf("expected deprecated save error, got %v", err)
+	}
+	if err := store.Delete(1); err == nil || !strings.Contains(err.Error(), "deprecated") {
+		t.Fatalf("expected deprecated delete error, got %v", err)
+	}
+	if _, err := store.List(10); err == nil || !strings.Contains(err.Error(), "deprecated") {
+		t.Fatalf("expected deprecated list error, got %v", err)
 	}
 }
 
@@ -280,5 +334,6 @@ func openTestDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("failed to open sqlite db: %v", err)
 	}
+	db.SetMaxOpenConns(1)
 	return db
 }

--- a/internal/memory/watcher.go
+++ b/internal/memory/watcher.go
@@ -1,0 +1,305 @@
+package memory
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const (
+	defaultWatcherDebounceDelay = 500 * time.Millisecond
+)
+
+var trackedMemoryExtensions = map[string]struct{}{
+	".md":   {},
+	".txt":  {},
+	".yaml": {},
+}
+
+var ignoredMemoryDirectories = map[string]struct{}{
+	".git":         {},
+	"node_modules": {},
+}
+
+// FileChangedEvent is emitted by Watcher when a tracked file changes.
+type FileChangedEvent struct {
+	Path         string
+	RelativePath string
+	Op           fsnotify.Op
+}
+
+type pendingFileEvent struct {
+	op    fsnotify.Op
+	timer *time.Timer
+}
+
+// Watcher watches a full workspace tree for memory-source file changes.
+type Watcher struct {
+	rootPath string
+	watcher  *fsnotify.Watcher
+	debounce time.Duration
+
+	events chan FileChangedEvent
+	errors chan error
+	stopCh chan struct{}
+
+	mu       sync.Mutex
+	pending  map[string]*pendingFileEvent
+	watched  map[string]struct{}
+	stopOnce sync.Once
+}
+
+// NewWatcher creates a recursive filesystem watcher for the workspace.
+func NewWatcher(rootPath string) (*Watcher, error) {
+	if strings.TrimSpace(rootPath) == "" {
+		return nil, fmt.Errorf("root path is empty")
+	}
+
+	absRoot, err := filepath.Abs(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve root path: %w", err)
+	}
+
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create fsnotify watcher: %w", err)
+	}
+
+	w := &Watcher{
+		rootPath: filepath.Clean(absRoot),
+		watcher:  fsWatcher,
+		debounce: defaultWatcherDebounceDelay,
+		events:   make(chan FileChangedEvent, 256),
+		errors:   make(chan error, 32),
+		stopCh:   make(chan struct{}),
+		pending:  make(map[string]*pendingFileEvent),
+		watched:  make(map[string]struct{}),
+	}
+
+	if err := w.addRecursive(w.rootPath); err != nil {
+		_ = fsWatcher.Close()
+		return nil, err
+	}
+
+	go w.loop()
+	return w, nil
+}
+
+// Events returns the stream of debounced file-change events.
+func (w *Watcher) Events() <-chan FileChangedEvent {
+	return w.events
+}
+
+// Errors returns asynchronous watcher errors.
+func (w *Watcher) Errors() <-chan error {
+	return w.errors
+}
+
+// Stop stops the watcher and releases resources.
+func (w *Watcher) Stop() {
+	if w == nil {
+		return
+	}
+
+	w.stopOnce.Do(func() {
+		close(w.stopCh)
+
+		w.mu.Lock()
+		for key, pending := range w.pending {
+			if pending != nil && pending.timer != nil {
+				pending.timer.Stop()
+			}
+			delete(w.pending, key)
+		}
+		w.mu.Unlock()
+
+		_ = w.watcher.Close()
+	})
+}
+
+func (w *Watcher) loop() {
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+			w.handleEvent(event)
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+			select {
+			case w.errors <- err:
+			default:
+			}
+		}
+	}
+}
+
+func (w *Watcher) handleEvent(event fsnotify.Event) {
+	if event.Op&fsnotify.Create == fsnotify.Create {
+		info, err := os.Stat(event.Name)
+		if err == nil && info.IsDir() && !isIgnoredMemoryPath(w.rootPath, event.Name) {
+			_ = w.addRecursive(event.Name)
+			return
+		}
+	}
+
+	if !isTrackedMemoryEvent(w.rootPath, event.Name, event.Op) {
+		return
+	}
+	w.debounceEvent(event.Name, event.Op)
+}
+
+func (w *Watcher) debounceEvent(path string, op fsnotify.Op) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return
+	}
+	absPath = filepath.Clean(absPath)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if pending := w.pending[absPath]; pending != nil {
+		pending.op |= op
+		if pending.timer != nil {
+			pending.timer.Reset(w.debounce)
+		}
+		return
+	}
+
+	pending := &pendingFileEvent{
+		op: op,
+	}
+	pending.timer = time.AfterFunc(w.debounce, func() {
+		w.emit(absPath)
+	})
+	w.pending[absPath] = pending
+}
+
+func (w *Watcher) emit(absPath string) {
+	w.mu.Lock()
+	pending := w.pending[absPath]
+	if pending == nil {
+		w.mu.Unlock()
+		return
+	}
+	op := pending.op
+	delete(w.pending, absPath)
+	w.mu.Unlock()
+
+	rel, err := filepath.Rel(w.rootPath, absPath)
+	if err != nil {
+		return
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." || strings.HasPrefix(rel, "../") {
+		return
+	}
+
+	event := FileChangedEvent{
+		Path:         absPath,
+		RelativePath: rel,
+		Op:           op,
+	}
+
+	select {
+	case <-w.stopCh:
+		return
+	case w.events <- event:
+	}
+}
+
+func (w *Watcher) addRecursive(path string) error {
+	return filepath.WalkDir(path, func(current string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+
+		if current != w.rootPath && isIgnoredMemoryPath(w.rootPath, current) {
+			return filepath.SkipDir
+		}
+
+		return w.addDirectory(current)
+	})
+}
+
+func (w *Watcher) addDirectory(path string) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	absPath = filepath.Clean(absPath)
+
+	w.mu.Lock()
+	if _, exists := w.watched[absPath]; exists {
+		w.mu.Unlock()
+		return nil
+	}
+	w.mu.Unlock()
+
+	if err := w.watcher.Add(absPath); err != nil {
+		return fmt.Errorf("watch directory %s: %w", absPath, err)
+	}
+
+	w.mu.Lock()
+	w.watched[absPath] = struct{}{}
+	w.mu.Unlock()
+	return nil
+}
+
+func isTrackedMemoryEvent(rootPath, path string, op fsnotify.Op) bool {
+	if op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename) == 0 {
+		return false
+	}
+	if isIgnoredMemoryPath(rootPath, path) {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	_, ok := trackedMemoryExtensions[ext]
+	return ok
+}
+
+func isIgnoredMemoryPath(rootPath, path string) bool {
+	absRoot, err := filepath.Abs(rootPath)
+	if err != nil {
+		return true
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return true
+	}
+	absRoot = filepath.Clean(absRoot)
+	absPath = filepath.Clean(absPath)
+
+	rel, err := filepath.Rel(absRoot, absPath)
+	if err != nil {
+		return true
+	}
+	if rel == "." {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return true
+	}
+
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if _, ignored := ignoredMemoryDirectories[part]; ignored {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/memory/watcher_test.go
+++ b/internal/memory/watcher_test.go
@@ -1,0 +1,111 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWatcherDebouncesTrackedFileChanges(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	watcher, err := NewWatcher(tmpDir)
+	if err != nil {
+		t.Fatalf("NewWatcher failed: %v", err)
+	}
+	defer watcher.Stop()
+
+	filePath := filepath.Join(tmpDir, "notes.md")
+	if err := os.WriteFile(filePath, []byte("one"), 0o644); err != nil {
+		t.Fatalf("write #1 failed: %v", err)
+	}
+	time.Sleep(120 * time.Millisecond)
+	if err := os.WriteFile(filePath, []byte("two"), 0o644); err != nil {
+		t.Fatalf("write #2 failed: %v", err)
+	}
+	time.Sleep(120 * time.Millisecond)
+	if err := os.WriteFile(filePath, []byte("three"), 0o644); err != nil {
+		t.Fatalf("write #3 failed: %v", err)
+	}
+
+	select {
+	case event := <-watcher.Events():
+		if event.RelativePath != "notes.md" {
+			t.Fatalf("unexpected relative path: got %q", event.RelativePath)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("timed out waiting for debounced watcher event")
+	}
+
+	select {
+	case event := <-watcher.Events():
+		t.Fatalf("expected one debounced event, got extra event: %+v", event)
+	case <-time.After(1100 * time.Millisecond):
+	}
+}
+
+func TestWatcherIgnoresNonTrackedFilesAndIgnoredDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	watcher, err := NewWatcher(tmpDir)
+	if err != nil {
+		t.Fatalf("NewWatcher failed: %v", err)
+	}
+	defer watcher.Stop()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "data.json"), []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatalf("write json failed: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".git", "ignored.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write .git file failed: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, "node_modules"), 0o755); err != nil {
+		t.Fatalf("mkdir node_modules failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "node_modules", "ignored.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write node_modules file failed: %v", err)
+	}
+
+	select {
+	case event := <-watcher.Events():
+		t.Fatalf("expected no events for ignored files, got %+v", event)
+	case <-time.After(1300 * time.Millisecond):
+	}
+}
+
+func TestWatcherTracksNewDirectoriesRecursively(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	watcher, err := NewWatcher(tmpDir)
+	if err != nil {
+		t.Fatalf("NewWatcher failed: %v", err)
+	}
+	defer watcher.Stop()
+
+	dynamicDir := filepath.Join(tmpDir, "docs", "nested")
+	if err := os.MkdirAll(dynamicDir, 0o755); err != nil {
+		t.Fatalf("mkdir dynamic dir failed: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	targetFile := filepath.Join(dynamicDir, "context.yaml")
+	if err := os.WriteFile(targetFile, []byte("x: 1"), 0o644); err != nil {
+		t.Fatalf("write tracked file failed: %v", err)
+	}
+
+	select {
+	case event := <-watcher.Events():
+		if event.RelativePath != filepath.ToSlash(filepath.Join("docs", "nested", "context.yaml")) {
+			t.Fatalf("unexpected relative path: got %q", event.RelativePath)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("timed out waiting for recursive watcher event")
+	}
+}


### PR DESCRIPTION
Closes #86

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements a complete filesystem-based memory indexing pipeline: `fsnotify` watches workspace directories for `.md`, `.txt`, and `.yaml` changes, the indexer splits files into header-aware chunks with content-hash deduplication, and embeddings are generated in batches of 32. The v2 schema migration properly handles legacy data.

**Key Changes:**
- Added `GetEmbeddings` batch API in `embeddings.go` with indexed/sequential response handling
- New recursive filesystem watcher with 500ms debouncing and `.git`/`node_modules` filtering
- Markdown chunker splits by headers (e.g., "Projects > ok-gobot") with configurable token limits and overlap
- Content-hash optimization skips re-embedding unchanged chunks
- Comprehensive test coverage for all new components

**Issue Found:**
- Watcher doesn't track `fsnotify.Remove` events, leaving stale database entries when files are deleted

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the Remove event handling to prevent stale data accumulation
- Well-structured implementation with good test coverage and defensive programming. The missing Remove event tracking is the only significant issue that could cause production problems (stale database entries). Once fixed, this is production-ready.
- internal/memory/watcher.go - must add fsnotify.Remove event tracking

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/memory/watcher.go | Implements recursive filesystem watcher with debouncing and directory filtering. Missing Remove event tracking causes stale data when files are deleted. |
| internal/memory/embeddings.go | Added batch embedding support with proper index handling and fallback logic. Refactored single embedding method to use batch API. |
| internal/memory/indexer.go | Implements markdown-aware chunking with content-hash-based change detection and batch embedding. Properly handles file deletion and chunk cleanup. |
| internal/memory/store.go | Updated schema to v2 with comprehensive migration logic from legacy formats. Properly deprecates old mutation APIs. |

</details>



<sub>Last reviewed commit: b4e37ef</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->