### PR TITLE
feat: Anthropic OAuth provider (claude.ai MAX subscription)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ telegram:
   token: "BOT_TOKEN"
 
 ai:
-  provider: "openrouter"
+  provider: "openrouter"  # openrouter | openai | anthropic | custom
   api_key: "sk-or-..."
   model: "moonshotai/kimi-k2.5"
   fallback_models:
@@ -175,6 +175,7 @@ ok-gobot config init              # Create default config
 ok-gobot config show              # Show config
 ok-gobot config set <key> <val>   # Set config value
 ok-gobot config models            # List available models
+ok-gobot auth anthropic login     # Anthropic OAuth login (Claude MAX)
 ok-gobot status                   # Show status
 ok-gobot doctor                   # Check config and dependencies
 ok-gobot daemon install|start|stop|status|logs|uninstall

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,7 +7,7 @@ telegram:
 
 # AI provider configuration
 ai:
-  provider: "openrouter"  # openrouter, openai, or custom
+  provider: "openrouter"  # openrouter, openai, anthropic, or custom
   api_key: "YOUR_API_KEY_HERE"
   model: "moonshotai/kimi-k2.5"
   base_url: ""  # For custom providers

--- a/config.schema.json
+++ b/config.schema.json
@@ -83,6 +83,7 @@
           "enum": [
             "openrouter",
             "openai",
+            "anthropic",
             "custom"
           ],
           "type": "string"

--- a/docs/ARCHITECTURE-v2.md
+++ b/docs/ARCHITECTURE-v2.md
@@ -81,6 +81,7 @@ single source of truth for configuration keys, types, defaults, and descriptions
           "enum": [
             "openrouter",
             "openai",
+            "anthropic",
             "custom"
           ],
           "description": "AI provider backend."

--- a/internal/ai/anthropic_client.go
+++ b/internal/ai/anthropic_client.go
@@ -1,20 +1,31 @@
 package ai
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"sort"
+	"strings"
 	"time"
 
 	"ok-gobot/internal/logger"
-	"strings"
 )
 
 const anthropicDefaultMaxTokens = 4096
 const claudeCodeIdentity = "You are Claude Code, Anthropic's official CLI for Claude."
+
+const (
+	anthropicVersionHeader        = "2023-06-01"
+	anthropicThinkingBetaHeader   = "interleaved-thinking-2025-05-14"
+	anthropicOAuthBetaHeader      = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+	anthropicSetupTokenBetaHeader = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14"
+	anthropicOAuthUserAgent       = "claude-cli/2.1.2 (external, cli)"
+)
 
 // thinkingForLevel maps a ThinkLevel string to an Anthropic ThinkingConfig.
 // Returns nil for "off" or empty (thinking disabled).
@@ -77,16 +88,21 @@ func (c *AnthropicClient) Complete(ctx context.Context, messages []Message) (str
 	chatMessages := ConvertLegacyMessages(messages)
 	system, anthropicMsgs := translateMessages(chatMessages)
 
+	apiKey, err := c.resolveAPIKey(ctx)
+	if err != nil {
+		return "", err
+	}
+
 	thinking := thinkingForLevel(c.config.ThinkLevel)
 	reqBody := AnthropicRequest{
 		Model:     c.config.Model,
-		System:    c.buildSystem(system),
+		System:    c.buildSystem(system, apiKey),
 		Messages:  anthropicMsgs,
 		MaxTokens: maxTokensForThinking(thinking, anthropicDefaultMaxTokens),
 		Thinking:  thinking,
 	}
 
-	resp, err := c.doRequest(ctx, reqBody)
+	resp, err := c.doRequest(ctx, reqBody, apiKey)
 	if err != nil {
 		return "", err
 	}
@@ -103,17 +119,22 @@ func (c *AnthropicClient) CompleteWithTools(ctx context.Context, messages []Chat
 	system, anthropicMsgs := translateMessages(messages)
 	anthropicTools := translateTools(tools)
 
+	apiKey, err := c.resolveAPIKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	thinking := thinkingForLevel(c.config.ThinkLevel)
 	reqBody := AnthropicRequest{
 		Model:     c.config.Model,
-		System:    c.buildSystem(system),
+		System:    c.buildSystem(system, apiKey),
 		Messages:  anthropicMsgs,
 		Tools:     anthropicTools,
 		MaxTokens: maxTokensForThinking(thinking, anthropicDefaultMaxTokens),
 		Thinking:  thinking,
 	}
 
-	resp, err := c.doRequest(ctx, reqBody)
+	resp, err := c.doRequest(ctx, reqBody, apiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -123,49 +144,258 @@ func (c *AnthropicClient) CompleteWithTools(ctx context.Context, messages []Chat
 	return result, nil
 }
 
-func (c *AnthropicClient) doRequest(ctx context.Context, reqBody AnthropicRequest) (*AnthropicResponse, error) {
-	jsonData, err := json.Marshal(reqBody)
+// CompleteStream sends messages and returns streamed response chunks.
+func (c *AnthropicClient) CompleteStream(ctx context.Context, messages []Message) <-chan StreamChunk {
+	chatMessages := ConvertLegacyMessages(messages)
+	return c.CompleteStreamWithTools(ctx, chatMessages, nil)
+}
+
+// CompleteStreamWithTools sends messages/tools and returns streamed chunks.
+func (c *AnthropicClient) CompleteStreamWithTools(ctx context.Context, messages []ChatMessage, tools []ToolDefinition) <-chan StreamChunk {
+	ch := make(chan StreamChunk, 100)
+
+	go func() {
+		defer close(ch)
+
+		apiKey, err := c.resolveAPIKey(ctx)
+		if err != nil {
+			ch <- StreamChunk{Error: err}
+			return
+		}
+
+		system, anthropicMsgs := translateMessages(messages)
+		anthropicTools := translateTools(tools)
+		thinking := thinkingForLevel(c.config.ThinkLevel)
+		reqBody := AnthropicRequest{
+			Model:     c.config.Model,
+			System:    c.buildSystem(system, apiKey),
+			Messages:  anthropicMsgs,
+			Tools:     anthropicTools,
+			Stream:    true,
+			MaxTokens: maxTokensForThinking(thinking, anthropicDefaultMaxTokens),
+			Thinking:  thinking,
+		}
+
+		resp, err := c.startStreamRequest(ctx, reqBody, apiKey)
+		if err != nil {
+			ch <- StreamChunk{Error: fmt.Errorf("request failed: %w", err)}
+			return
+		}
+
+		if resp.StatusCode == http.StatusUnauthorized && isOAuthAccessToken(apiKey) {
+			_ = resp.Body.Close()
+			if refreshed, refreshErr := c.forceRefreshOAuthToken(ctx); refreshErr == nil && refreshed != "" && refreshed != apiKey {
+				apiKey = refreshed
+				c.config.APIKey = refreshed
+				resp, err = c.startStreamRequest(ctx, reqBody, apiKey)
+				if err != nil {
+					ch <- StreamChunk{Error: fmt.Errorf("request failed after OAuth refresh: %w", err)}
+					return
+				}
+			}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			ch <- StreamChunk{Error: fmt.Errorf("API error (status %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))}
+			return
+		}
+
+		toolCalls := make(map[int]*ToolCall)
+		toolCallArgs := make(map[int]*strings.Builder)
+		finishReason := ""
+
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+
+		var dataLines []string
+		handleEvent := func(data string) (bool, error) {
+			if data == "" {
+				return false, nil
+			}
+			if data == "[DONE]" {
+				return true, nil
+			}
+
+			var evt struct {
+				Type  string `json:"type"`
+				Index int    `json:"index,omitempty"`
+				Delta *struct {
+					Type        string `json:"type,omitempty"`
+					Text        string `json:"text,omitempty"`
+					PartialJSON string `json:"partial_json,omitempty"`
+					StopReason  string `json:"stop_reason,omitempty"`
+				} `json:"delta,omitempty"`
+				ContentBlock *ContentBlock `json:"content_block,omitempty"`
+				Error        *struct {
+					Type    string `json:"type"`
+					Message string `json:"message"`
+				} `json:"error,omitempty"`
+			}
+			if err := json.Unmarshal([]byte(data), &evt); err != nil {
+				// Ignore malformed keepalive chunks instead of killing stream.
+				return false, nil
+			}
+
+			switch evt.Type {
+			case "content_block_start":
+				if evt.ContentBlock != nil && evt.ContentBlock.Type == "tool_use" {
+					toolCalls[evt.Index] = &ToolCall{
+						ID:   evt.ContentBlock.ID,
+						Type: "function",
+						Function: FunctionCall{
+							Name: evt.ContentBlock.Name,
+						},
+					}
+					if args := normalizeRawJSON(evt.ContentBlock.Input); args != "" && args != "{}" {
+						toolCalls[evt.Index].Function.Arguments = args
+					}
+				}
+			case "content_block_delta":
+				if evt.Delta == nil {
+					return false, nil
+				}
+				switch evt.Delta.Type {
+				case "text_delta":
+					if evt.Delta.Text != "" {
+						ch <- StreamChunk{Content: evt.Delta.Text}
+					}
+				case "input_json_delta":
+					tc, ok := toolCalls[evt.Index]
+					if !ok {
+						return false, nil
+					}
+					sb, exists := toolCallArgs[evt.Index]
+					if !exists {
+						sb = &strings.Builder{}
+						if tc.Function.Arguments != "" {
+							sb.WriteString(tc.Function.Arguments)
+							tc.Function.Arguments = ""
+						}
+						toolCallArgs[evt.Index] = sb
+					}
+					sb.WriteString(evt.Delta.PartialJSON)
+				}
+			case "message_delta":
+				if evt.Delta != nil && evt.Delta.StopReason != "" {
+					finishReason = mapAnthropicStopReason(evt.Delta.StopReason)
+				}
+			case "error":
+				if evt.Error != nil {
+					return true, fmt.Errorf("Anthropic stream error: %s", evt.Error.Message)
+				}
+				return true, fmt.Errorf("Anthropic stream error")
+			case "message_stop":
+				return true, nil
+			}
+
+			return false, nil
+		}
+
+		flushData := func() (bool, error) {
+			if len(dataLines) == 0 {
+				return false, nil
+			}
+			joined := strings.Join(dataLines, "\n")
+			dataLines = dataLines[:0]
+			return handleEvent(joined)
+		}
+
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				ch <- StreamChunk{Error: ctx.Err(), Done: true}
+				return
+			default:
+			}
+
+			line := scanner.Text()
+			if line == "" {
+				stop, err := flushData()
+				if err != nil {
+					ch <- StreamChunk{Error: err, Done: true}
+					return
+				}
+				if stop {
+					break
+				}
+				continue
+			}
+
+			if strings.HasPrefix(line, "data:") {
+				dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+
+		if stop, err := flushData(); err != nil {
+			ch <- StreamChunk{Error: err, Done: true}
+			return
+		} else if stop {
+			// no-op
+		}
+
+		if err := scanner.Err(); err != nil {
+			ch <- StreamChunk{Error: fmt.Errorf("stream read error: %w", err), Done: true}
+			return
+		}
+
+		if len(toolCalls) > 0 {
+			indices := make([]int, 0, len(toolCalls))
+			for idx := range toolCalls {
+				indices = append(indices, idx)
+			}
+			sort.Ints(indices)
+
+			ordered := make([]ToolCall, 0, len(indices))
+			for _, idx := range indices {
+				tc := toolCalls[idx]
+				if tc == nil {
+					continue
+				}
+				if sb, ok := toolCallArgs[idx]; ok {
+					tc.Function.Arguments = strings.TrimSpace(sb.String())
+				}
+				if strings.TrimSpace(tc.Function.Arguments) == "" {
+					tc.Function.Arguments = "{}"
+				}
+				ordered = append(ordered, *tc)
+			}
+
+			toolCallsJSON, _ := json.Marshal(ordered)
+			ch <- StreamChunk{
+				Content:      "\n__TOOL_CALLS__:" + string(toolCallsJSON),
+				FinishReason: "tool_calls",
+				Done:         true,
+			}
+			return
+		}
+
+		ch <- StreamChunk{FinishReason: finishReason, Done: true}
+	}()
+
+	return ch
+}
+
+func (c *AnthropicClient) doRequest(ctx context.Context, reqBody AnthropicRequest, apiKey string) (*AnthropicResponse, error) {
+	statusCode, body, err := c.performRequest(ctx, reqBody, apiKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	logger.Tracef("Anthropic request body (%d bytes): %.3000s", len(jsonData), string(jsonData))
-
-	req, err := http.NewRequestWithContext(ctx, "POST", c.config.BaseURL+"/v1/messages", bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, err
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("anthropic-version", "2023-06-01")
-
-	if isOAuthToken(c.config.APIKey) {
-		// OAuth/setup-token: use Bearer auth + Claude Code headers
-		req.Header.Set("Authorization", "Bearer "+c.config.APIKey)
-		req.Header.Set("anthropic-beta", "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14")
-		req.Header.Set("user-agent", "claude-cli/2.1.2 (external, cli)")
-		req.Header.Set("x-app", "cli")
-	} else {
-		req.Header.Set("x-api-key", c.config.APIKey)
-		// Enable interleaved thinking beta for regular API keys when thinking is active.
-		if reqBody.Thinking != nil {
-			req.Header.Set("anthropic-beta", "interleaved-thinking-2025-05-14")
+	if statusCode == http.StatusUnauthorized && isOAuthAccessToken(apiKey) {
+		if refreshed, refreshErr := c.forceRefreshOAuthToken(ctx); refreshErr == nil && refreshed != "" && refreshed != apiKey {
+			apiKey = refreshed
+			c.config.APIKey = refreshed
+			statusCode, body, err = c.performRequest(ctx, reqBody, apiKey)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-	logger.Tracef("Anthropic response body (%d bytes): %.3000s", len(body), string(body))
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("API error (status %d): %s", statusCode, strings.TrimSpace(string(body)))
 	}
 
 	var result AnthropicResponse
@@ -178,6 +408,191 @@ func (c *AnthropicClient) doRequest(ctx context.Context, reqBody AnthropicReques
 	}
 
 	return &result, nil
+}
+
+func (c *AnthropicClient) performRequest(ctx context.Context, reqBody AnthropicRequest, apiKey string) (int, []byte, error) {
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	logger.Tracef("Anthropic request body (%d bytes): %.3000s", len(jsonData), string(jsonData))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.messagesURL(apiKey), bytes.NewBuffer(jsonData))
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	c.applyHeaders(req, apiKey, reqBody.Thinking, false)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	logger.Tracef("Anthropic response body (%d bytes): %.3000s", len(body), string(body))
+
+	return resp.StatusCode, body, nil
+}
+
+func (c *AnthropicClient) startStreamRequest(ctx context.Context, reqBody AnthropicRequest, apiKey string) (*http.Response, error) {
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	logger.Tracef("Anthropic stream request body (%d bytes): %.3000s", len(jsonData), string(jsonData))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.messagesURL(apiKey), bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	c.applyHeaders(req, apiKey, reqBody.Thinking, true)
+
+	// Streaming requests should not use the static client timeout.
+	streamClient := &http.Client{}
+	return streamClient.Do(req)
+}
+
+func (c *AnthropicClient) messagesURL(apiKey string) string {
+	base := strings.TrimRight(c.config.BaseURL, "/") + "/v1/messages"
+	if !isOAuthAccessToken(apiKey) {
+		return base
+	}
+
+	u, err := url.Parse(base)
+	if err != nil {
+		return base
+	}
+	q := u.Query()
+	q.Set("beta", "true")
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func (c *AnthropicClient) applyHeaders(req *http.Request, apiKey string, thinking *ThinkingConfig, stream bool) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-version", anthropicVersionHeader)
+	if stream {
+		req.Header.Set("Accept", "text/event-stream")
+	}
+
+	switch {
+	case isOAuthAccessToken(apiKey):
+		req.Header.Set("Authorization", "Bearer "+strings.TrimPrefix(apiKey, "oauth:"))
+		req.Header.Set("anthropic-beta", anthropicOAuthBetaHeader)
+		req.Header.Set("user-agent", anthropicOAuthUserAgent)
+		req.Header.Set("x-app", "cli")
+	case isOAuthSetupToken(apiKey):
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		req.Header.Set("anthropic-beta", anthropicSetupTokenBetaHeader)
+		req.Header.Set("user-agent", anthropicOAuthUserAgent)
+		req.Header.Set("x-app", "cli")
+	default:
+		req.Header.Set("x-api-key", apiKey)
+		// Enable interleaved thinking beta for regular API keys when thinking is active.
+		if thinking != nil {
+			req.Header.Set("anthropic-beta", anthropicThinkingBetaHeader)
+		}
+	}
+}
+
+func (c *AnthropicClient) resolveAPIKey(ctx context.Context) (string, error) {
+	apiKey := strings.TrimSpace(c.config.APIKey)
+	if apiKey == "" {
+		resolved, err := c.resolveOAuthKeyFromStore(ctx, "")
+		if err != nil {
+			return "", fmt.Errorf("anthropic API key is required: %w", err)
+		}
+		c.config.APIKey = resolved
+		return resolved, nil
+	}
+
+	if isOAuthAccessToken(apiKey) {
+		if resolved, err := c.resolveOAuthKeyFromStore(ctx, apiKey); err == nil && resolved != "" {
+			c.config.APIKey = resolved
+			return resolved, nil
+		}
+	}
+
+	return apiKey, nil
+}
+
+func (c *AnthropicClient) resolveOAuthKeyFromStore(ctx context.Context, fallback string) (string, error) {
+	path, err := resolveAnthropicOAuthStorePath(c.config.OAuthStorePath)
+	if err != nil {
+		if fallback != "" {
+			return fallback, nil
+		}
+		return "", err
+	}
+
+	creds, err := LoadAnthropicOAuthCredentials(path)
+	if err != nil {
+		if fallback != "" {
+			return fallback, nil
+		}
+		return "", err
+	}
+
+	now := time.Now()
+	if creds.IsExpiringSoon(now, 2*time.Minute) {
+		if strings.TrimSpace(creds.RefreshToken) == "" {
+			if creds.IsExpired(now) {
+				if fallback != "" {
+					return fallback, nil
+				}
+				return "", fmt.Errorf("Anthropic OAuth token expired and refresh token is missing")
+			}
+		} else {
+			refreshed, refreshErr := RefreshAnthropicOAuthCredentials(ctx, creds)
+			if refreshErr != nil {
+				if creds.IsExpired(now) {
+					if fallback != "" {
+						return fallback, nil
+					}
+					return "", fmt.Errorf("failed to refresh Anthropic OAuth token: %w", refreshErr)
+				}
+			} else {
+				creds = refreshed
+				if err := SaveAnthropicOAuthCredentials(path, creds); err != nil {
+					logger.Warnf("failed to persist refreshed Anthropic OAuth token: %v", err)
+				}
+			}
+		}
+	}
+
+	if strings.TrimSpace(creds.AccessToken) == "" {
+		if fallback != "" {
+			return fallback, nil
+		}
+		return "", fmt.Errorf("Anthropic OAuth credentials missing access token")
+	}
+
+	return "oauth:" + creds.AccessToken, nil
+}
+
+func (c *AnthropicClient) forceRefreshOAuthToken(ctx context.Context) (string, error) {
+	path, err := resolveAnthropicOAuthStorePath(c.config.OAuthStorePath)
+	if err != nil {
+		return "", err
+	}
+	creds, err := LoadAnthropicOAuthCredentials(path)
+	if err != nil {
+		return "", err
+	}
+	refreshed, err := RefreshAnthropicOAuthCredentials(ctx, creds)
+	if err != nil {
+		return "", err
+	}
+	if err := SaveAnthropicOAuthCredentials(path, refreshed); err != nil {
+		return "", err
+	}
+	return "oauth:" + refreshed.AccessToken, nil
 }
 
 // translateMessages converts ChatMessage slice to Anthropic format,
@@ -268,17 +683,6 @@ func translateResponse(resp *AnthropicResponse) *ChatCompletionResponse {
 		}
 	}
 
-	// Map stop_reason
-	finishReason := "stop"
-	switch resp.StopReason {
-	case "end_turn":
-		finishReason = "stop"
-	case "tool_use":
-		finishReason = "tool_calls"
-	case "max_tokens":
-		finishReason = "length"
-	}
-
 	totalTokens := resp.Usage.InputTokens + resp.Usage.OutputTokens
 
 	return &ChatCompletionResponse{
@@ -296,7 +700,7 @@ func translateResponse(resp *AnthropicResponse) *ChatCompletionResponse {
 					Content:   content,
 					ToolCalls: toolCalls,
 				},
-				FinishReason: finishReason,
+				FinishReason: mapAnthropicStopReason(resp.StopReason),
 			},
 		},
 		Usage: &struct {
@@ -311,14 +715,55 @@ func translateResponse(resp *AnthropicResponse) *ChatCompletionResponse {
 	}
 }
 
-// isOAuthToken checks if the key is an OAuth/setup-token (not a regular API key).
-func isOAuthToken(key string) bool {
-	return strings.Contains(key, "sk-ant-oat")
+func mapAnthropicStopReason(reason string) string {
+	switch reason {
+	case "end_turn":
+		return "stop"
+	case "tool_use":
+		return "tool_calls"
+	case "max_tokens":
+		return "length"
+	default:
+		if strings.TrimSpace(reason) == "" {
+			return "stop"
+		}
+		return reason
+	}
 }
 
-// buildSystem wraps the system prompt with Claude Code identity for OAuth tokens.
-func (c *AnthropicClient) buildSystem(system string) interface{} {
-	if !isOAuthToken(c.config.APIKey) {
+func normalizeRawJSON(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	var decoded interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return trimmed
+	}
+	compact, err := json.Marshal(decoded)
+	if err != nil {
+		return trimmed
+	}
+	return string(compact)
+}
+
+// isOAuthSetupToken checks if key is an OAuth setup-token from Claude Code.
+func isOAuthSetupToken(key string) bool {
+	return strings.Contains(strings.TrimSpace(key), "sk-ant-oat")
+}
+
+// isOAuthAccessToken checks whether key is a raw OAuth bearer token wrapper.
+func isOAuthAccessToken(key string) bool {
+	return strings.HasPrefix(strings.TrimSpace(key), "oauth:")
+}
+
+func isOAuthAuthKey(key string) bool {
+	return isOAuthSetupToken(key) || isOAuthAccessToken(key)
+}
+
+// buildSystem wraps the system prompt with Claude Code identity for OAuth auth.
+func (c *AnthropicClient) buildSystem(system string, apiKey string) interface{} {
+	if !isOAuthAuthKey(apiKey) {
 		return system
 	}
 	blocks := []SystemBlock{

--- a/internal/ai/anthropic_client_test.go
+++ b/internal/ai/anthropic_client_test.go
@@ -1,0 +1,166 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAnthropicClientCompleteStreamTextDeltas(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("x-api-key"); got != "test-key" {
+			t.Fatalf("unexpected x-api-key header: %q", got)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprint(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" world\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"message_stop\"}\n\n")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	client := NewAnthropicClient(ProviderConfig{
+		Name:    "anthropic",
+		APIKey:  "test-key",
+		BaseURL: srv.URL,
+		Model:   "claude-sonnet-4-5-20250929",
+	})
+
+	ch := client.CompleteStream(context.Background(), []Message{{Role: "user", Content: "hello"}})
+	var got strings.Builder
+	done := false
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("unexpected stream error: %v", chunk.Error)
+		}
+		got.WriteString(chunk.Content)
+		if chunk.Done {
+			done = true
+		}
+	}
+
+	if got.String() != "Hello world" {
+		t.Fatalf("unexpected stream text: %q", got.String())
+	}
+	if !done {
+		t.Fatal("expected done chunk")
+	}
+}
+
+func TestAnthropicClientCompleteStreamWithToolsMarker(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req AnthropicRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if !req.Stream {
+			t.Fatal("expected stream=true request")
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprint(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Working...\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"search\",\"input\":{}}}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"query\\\":\\\"tes\"}}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"t\\\"}\"}}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"}}\n\n")
+		fmt.Fprint(w, "data: {\"type\":\"message_stop\"}\n\n")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	client := NewAnthropicClient(ProviderConfig{
+		Name:    "anthropic",
+		APIKey:  "test-key",
+		BaseURL: srv.URL,
+		Model:   "claude-sonnet-4-5-20250929",
+	})
+
+	ch := client.CompleteStreamWithTools(context.Background(), []ChatMessage{{Role: RoleUser, Content: "find x"}}, nil)
+	var marker string
+	var text strings.Builder
+	for chunk := range ch {
+		if chunk.Error != nil {
+			t.Fatalf("unexpected stream error: %v", chunk.Error)
+		}
+		if strings.HasPrefix(chunk.Content, "\n__TOOL_CALLS__:") {
+			marker = chunk.Content
+		} else {
+			text.WriteString(chunk.Content)
+		}
+	}
+
+	if text.String() != "Working..." {
+		t.Fatalf("unexpected streamed text: %q", text.String())
+	}
+	if marker == "" {
+		t.Fatal("expected tool-calls marker chunk")
+	}
+
+	payload := strings.TrimPrefix(marker, "\n__TOOL_CALLS__:")
+	var calls []ToolCall
+	if err := json.Unmarshal([]byte(payload), &calls); err != nil {
+		t.Fatalf("failed to parse tool-calls marker: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected one tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "search" {
+		t.Fatalf("unexpected tool name: %s", calls[0].Function.Name)
+	}
+	if calls[0].Function.Arguments != `{"query":"test"}` {
+		t.Fatalf("unexpected tool args: %s", calls[0].Function.Arguments)
+	}
+}
+
+func TestAnthropicClientOAuthHeadersAndBetaQuery(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("beta"); got != "true" {
+			t.Fatalf("expected beta=true query, got %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-access" {
+			t.Fatalf("unexpected Authorization header: %q", got)
+		}
+		if !strings.Contains(r.Header.Get("anthropic-beta"), "oauth-2025-04-20") {
+			t.Fatalf("expected oauth anthropic-beta header, got %q", r.Header.Get("anthropic-beta"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-5-20250929","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer srv.Close()
+
+	client := NewAnthropicClient(ProviderConfig{
+		Name:    "anthropic",
+		APIKey:  "oauth:oauth-access",
+		BaseURL: srv.URL,
+		Model:   "claude-sonnet-4-5-20250929",
+	})
+
+	resp, err := client.Complete(context.Background(), []Message{{Role: "user", Content: "hello"}})
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if resp != "ok" {
+		t.Fatalf("unexpected response: %q", resp)
+	}
+}

--- a/internal/ai/anthropic_oauth.go
+++ b/internal/ai/anthropic_oauth.go
@@ -1,0 +1,381 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAnthropicOAuthClientID   = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+	defaultAnthropicOAuthAuthURL    = "https://claude.ai/oauth/authorize"
+	defaultAnthropicOAuthTokenURL   = "https://console.anthropic.com/v1/oauth/token"
+	defaultAnthropicOAuthRedirectURI = "https://console.anthropic.com/oauth/code/callback"
+	defaultAnthropicOAuthScopes     = "org:create_api_key user:profile user:inference"
+)
+
+const (
+	anthropicOAuthExpirySkew = 5 * time.Minute
+	anthropicOAuthMinTTL     = 60 * time.Minute
+)
+
+var (
+	anthropicOAuthClientID    = defaultAnthropicOAuthClientID
+	anthropicOAuthAuthURL     = defaultAnthropicOAuthAuthURL
+	anthropicOAuthTokenURL    = defaultAnthropicOAuthTokenURL
+	anthropicOAuthRedirectURI = defaultAnthropicOAuthRedirectURI
+	anthropicOAuthScopes      = defaultAnthropicOAuthScopes
+)
+
+// AnthropicOAuthAuthRequest contains browser URL and verifier data for PKCE flow.
+type AnthropicOAuthAuthRequest struct {
+	URL      string
+	Verifier string
+	State    string
+}
+
+// AnthropicOAuthCredentials stores OAuth tokens and metadata for Anthropic.
+type AnthropicOAuthCredentials struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresAt    int64  `json:"expires_at,omitempty"` // unix millis
+	TokenType    string `json:"token_type,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+	ClientID     string `json:"client_id,omitempty"`
+}
+
+// IsExpired returns true when access token is already expired.
+func (c *AnthropicOAuthCredentials) IsExpired(now time.Time) bool {
+	if c == nil || c.ExpiresAt <= 0 {
+		return false
+	}
+	return now.UnixMilli() >= c.ExpiresAt
+}
+
+// IsExpiringSoon returns true when access token is near expiration.
+func (c *AnthropicOAuthCredentials) IsExpiringSoon(now time.Time, within time.Duration) bool {
+	if c == nil || c.ExpiresAt <= 0 {
+		return false
+	}
+	return now.Add(within).UnixMilli() >= c.ExpiresAt
+}
+
+type anthropicOAuthTokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	ExpiresIn        int64  `json:"expires_in"`
+	TokenType        string `json:"token_type"`
+	Scope            string `json:"scope"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// NewAnthropicOAuthAuthRequest prepares a new PKCE auth request URL.
+func NewAnthropicOAuthAuthRequest() (*AnthropicOAuthAuthRequest, error) {
+	verifier, err := randomURLSafeString(64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate PKCE verifier: %w", err)
+	}
+	state, err := randomURLSafeString(32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate OAuth state: %w", err)
+	}
+
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	q := url.Values{}
+	q.Set("code", "true")
+	q.Set("client_id", anthropicOAuthClientID)
+	q.Set("response_type", "code")
+	q.Set("redirect_uri", anthropicOAuthRedirectURI)
+	q.Set("scope", anthropicOAuthScopes)
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", state)
+
+	return &AnthropicOAuthAuthRequest{
+		URL:      anthropicOAuthAuthURL + "?" + q.Encode(),
+		Verifier: verifier,
+		State:    state,
+	}, nil
+}
+
+// ExtractAnthropicOAuthCode accepts either a raw code or callback URL and returns only code value.
+func ExtractAnthropicOAuthCode(input string) string {
+	raw := strings.TrimSpace(input)
+	raw = strings.TrimSuffix(raw, "#")
+	if raw == "" {
+		return ""
+	}
+
+	if parsed, err := url.Parse(raw); err == nil {
+		if code := strings.TrimSpace(parsed.Query().Get("code")); code != "" {
+			return code
+		}
+	}
+
+	// Handle pasted "code=..." fragments.
+	if idx := strings.Index(raw, "code="); idx >= 0 {
+		fragment := raw[idx+len("code="):]
+		for i, r := range fragment {
+			if r == '&' || r == '#' || r == ' ' || r == '\n' || r == '\r' {
+				fragment = fragment[:i]
+				break
+			}
+		}
+		decoded, err := url.QueryUnescape(fragment)
+		if err == nil && strings.TrimSpace(decoded) != "" {
+			return strings.TrimSpace(decoded)
+		}
+	}
+
+	return raw
+}
+
+// ExchangeAnthropicOAuthCode exchanges authorization code for access/refresh tokens.
+func ExchangeAnthropicOAuthCode(ctx context.Context, code, verifier, state string) (*AnthropicOAuthCredentials, error) {
+	code = ExtractAnthropicOAuthCode(code)
+	if code == "" {
+		return nil, errors.New("authorization code is required")
+	}
+	if strings.TrimSpace(verifier) == "" {
+		return nil, errors.New("PKCE verifier is required")
+	}
+	if strings.TrimSpace(state) == "" {
+		return nil, errors.New("OAuth state is required")
+	}
+
+	payload := map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     anthropicOAuthClientID,
+		"code":          code,
+		"redirect_uri":  anthropicOAuthRedirectURI,
+		"code_verifier": verifier,
+		"state":         state,
+	}
+
+	resp, err := requestAnthropicOAuthToken(ctx, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return toAnthropicOAuthCredentials(resp), nil
+}
+
+// RefreshAnthropicOAuthCredentials refreshes an existing Anthropic OAuth credential.
+func RefreshAnthropicOAuthCredentials(ctx context.Context, creds *AnthropicOAuthCredentials) (*AnthropicOAuthCredentials, error) {
+	if creds == nil {
+		return nil, errors.New("credentials are required")
+	}
+	if strings.TrimSpace(creds.RefreshToken) == "" {
+		return nil, errors.New("refresh token is missing")
+	}
+
+	clientID := strings.TrimSpace(creds.ClientID)
+	if clientID == "" {
+		clientID = anthropicOAuthClientID
+	}
+
+	payload := map[string]any{
+		"grant_type":    "refresh_token",
+		"client_id":     clientID,
+		"refresh_token": creds.RefreshToken,
+	}
+
+	resp, err := requestAnthropicOAuthToken(ctx, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	next := toAnthropicOAuthCredentials(resp)
+	if next.RefreshToken == "" {
+		next.RefreshToken = creds.RefreshToken
+	}
+	if next.Scope == "" {
+		next.Scope = creds.Scope
+	}
+	if next.ClientID == "" {
+		next.ClientID = clientID
+	}
+	return next, nil
+}
+
+// DefaultAnthropicOAuthStorePath returns default path for Anthropic OAuth credentials.
+func DefaultAnthropicOAuthStorePath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".ok-gobot", "oauth", "anthropic.json"), nil
+}
+
+func resolveAnthropicOAuthStorePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path != "" {
+		return path, nil
+	}
+	return DefaultAnthropicOAuthStorePath()
+}
+
+// LoadAnthropicOAuthCredentials reads credentials from disk.
+func LoadAnthropicOAuthCredentials(path string) (*AnthropicOAuthCredentials, error) {
+	path, err := resolveAnthropicOAuthStorePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var creds AnthropicOAuthCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("failed to parse OAuth credentials: %w", err)
+	}
+	if strings.TrimSpace(creds.AccessToken) == "" {
+		return nil, errors.New("OAuth credentials are invalid: missing access_token")
+	}
+	if creds.ClientID == "" {
+		creds.ClientID = anthropicOAuthClientID
+	}
+	return &creds, nil
+}
+
+// SaveAnthropicOAuthCredentials persists credentials to disk with strict permissions.
+func SaveAnthropicOAuthCredentials(path string, creds *AnthropicOAuthCredentials) error {
+	if creds == nil {
+		return errors.New("credentials are required")
+	}
+	if strings.TrimSpace(creds.AccessToken) == "" {
+		return errors.New("access token is required")
+	}
+
+	path, err := resolveAnthropicOAuthStorePath(path)
+	if err != nil {
+		return err
+	}
+
+	if creds.ClientID == "" {
+		creds.ClientID = anthropicOAuthClientID
+	}
+
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode OAuth credentials: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("failed to create OAuth directory: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("failed to write OAuth credentials: %w", err)
+	}
+	return nil
+}
+
+// DeleteAnthropicOAuthCredentials removes stored credentials, ignoring missing file.
+func DeleteAnthropicOAuthCredentials(path string) error {
+	path, err := resolveAnthropicOAuthStorePath(path)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to delete OAuth credentials: %w", err)
+	}
+	return nil
+}
+
+func requestAnthropicOAuthToken(ctx context.Context, payload map[string]any) (*anthropicOAuthTokenResponse, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode OAuth payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicOAuthTokenURL, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OAuth request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("OAuth request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read OAuth response: %w", err)
+	}
+
+	var parsed anthropicOAuthTokenResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse OAuth response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(parsed.ErrorDescription)
+		if msg == "" {
+			msg = strings.TrimSpace(parsed.Error)
+		}
+		if msg == "" {
+			msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("OAuth token request failed: %s", msg)
+	}
+
+	if strings.TrimSpace(parsed.AccessToken) == "" {
+		return nil, errors.New("OAuth token response missing access_token")
+	}
+
+	return &parsed, nil
+}
+
+func toAnthropicOAuthCredentials(resp *anthropicOAuthTokenResponse) *AnthropicOAuthCredentials {
+	return &AnthropicOAuthCredentials{
+		AccessToken:  resp.AccessToken,
+		RefreshToken: resp.RefreshToken,
+		ExpiresAt:    expiresAtFromSeconds(resp.ExpiresIn),
+		TokenType:    resp.TokenType,
+		Scope:        resp.Scope,
+		ClientID:     anthropicOAuthClientID,
+	}
+}
+
+func expiresAtFromSeconds(expiresIn int64) int64 {
+	now := time.Now()
+	if expiresIn <= 0 {
+		return now.Add(anthropicOAuthMinTTL).UnixMilli()
+	}
+	expires := now.Add(time.Duration(expiresIn) * time.Second).Add(-anthropicOAuthExpirySkew)
+	if expires.Before(now) {
+		return now.Add(anthropicOAuthMinTTL).UnixMilli()
+	}
+	return expires.UnixMilli()
+}
+
+func randomURLSafeString(length int) (string, error) {
+	if length <= 0 {
+		length = 32
+	}
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/internal/ai/anthropic_oauth_test.go
+++ b/internal/ai/anthropic_oauth_test.go
@@ -1,0 +1,173 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewAnthropicOAuthAuthRequest(t *testing.T) {
+	req, err := NewAnthropicOAuthAuthRequest()
+	if err != nil {
+		t.Fatalf("NewAnthropicOAuthAuthRequest failed: %v", err)
+	}
+	if req.Verifier == "" {
+		t.Fatal("expected non-empty verifier")
+	}
+	if req.State == "" {
+		t.Fatal("expected non-empty state")
+	}
+	if !strings.HasPrefix(req.URL, anthropicOAuthAuthURL+"?") {
+		t.Fatalf("unexpected auth URL: %s", req.URL)
+	}
+	if !strings.Contains(req.URL, "code_challenge=") {
+		t.Fatalf("auth URL missing code_challenge: %s", req.URL)
+	}
+}
+
+func TestExtractAnthropicOAuthCode(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "raw code", input: "abc123", want: "abc123"},
+		{name: "query URL", input: "https://console.anthropic.com/oauth/code/callback?code=xyz789&state=s", want: "xyz789"},
+		{name: "fragment suffix", input: "xyz789#", want: "xyz789"},
+		{name: "code fragment", input: "code=hello%2Bworld&foo=bar", want: "hello+world"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractAnthropicOAuthCode(tt.input)
+			if got != tt.want {
+				t.Fatalf("ExtractAnthropicOAuthCode(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExchangeAnthropicOAuthCode(t *testing.T) {
+	t.Parallel()
+
+	oldURL := anthropicOAuthTokenURL
+	t.Cleanup(func() { anthropicOAuthTokenURL = oldURL })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if payload["grant_type"] != "authorization_code" {
+			t.Fatalf("unexpected grant_type: %v", payload["grant_type"])
+		}
+		if payload["code"] != "sample-code" {
+			t.Fatalf("unexpected code: %v", payload["code"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at_123","refresh_token":"rt_123","expires_in":3600,"token_type":"Bearer","scope":"scope1"}`))
+	}))
+	defer srv.Close()
+
+	anthropicOAuthTokenURL = srv.URL
+
+	creds, err := ExchangeAnthropicOAuthCode(context.Background(), "sample-code", "verifier", "state")
+	if err != nil {
+		t.Fatalf("ExchangeAnthropicOAuthCode failed: %v", err)
+	}
+	if creds.AccessToken != "at_123" {
+		t.Fatalf("unexpected access token: %s", creds.AccessToken)
+	}
+	if creds.RefreshToken != "rt_123" {
+		t.Fatalf("unexpected refresh token: %s", creds.RefreshToken)
+	}
+	if creds.ExpiresAt <= time.Now().UnixMilli() {
+		t.Fatalf("expected future expiry, got %d", creds.ExpiresAt)
+	}
+}
+
+func TestRefreshAnthropicOAuthCredentials(t *testing.T) {
+	t.Parallel()
+
+	oldURL := anthropicOAuthTokenURL
+	t.Cleanup(func() { anthropicOAuthTokenURL = oldURL })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+		if payload["grant_type"] != "refresh_token" {
+			t.Fatalf("unexpected grant_type: %v", payload["grant_type"])
+		}
+		if payload["refresh_token"] != "rt_old" {
+			t.Fatalf("unexpected refresh_token: %v", payload["refresh_token"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at_new","refresh_token":"","expires_in":1800,"token_type":"Bearer","scope":"scope2"}`))
+	}))
+	defer srv.Close()
+
+	anthropicOAuthTokenURL = srv.URL
+
+	now := time.Now().Add(-1 * time.Hour).UnixMilli()
+	creds, err := RefreshAnthropicOAuthCredentials(context.Background(), &AnthropicOAuthCredentials{
+		AccessToken:  "at_old",
+		RefreshToken: "rt_old",
+		ExpiresAt:    now,
+		Scope:        "scope_old",
+		ClientID:     anthropicOAuthClientID,
+	})
+	if err != nil {
+		t.Fatalf("RefreshAnthropicOAuthCredentials failed: %v", err)
+	}
+	if creds.AccessToken != "at_new" {
+		t.Fatalf("unexpected access token: %s", creds.AccessToken)
+	}
+	// Provider may return empty refresh token on refresh; keep previous token.
+	if creds.RefreshToken != "rt_old" {
+		t.Fatalf("unexpected refresh token: %s", creds.RefreshToken)
+	}
+	if creds.Scope != "scope2" {
+		t.Fatalf("unexpected scope: %s", creds.Scope)
+	}
+}
+
+func TestSaveLoadAnthropicOAuthCredentials(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "anthropic-oauth.json")
+
+	in := &AnthropicOAuthCredentials{
+		AccessToken:  "at_save",
+		RefreshToken: "rt_save",
+		ExpiresAt:    time.Now().Add(time.Hour).UnixMilli(),
+		TokenType:    "Bearer",
+		Scope:        "scope",
+	}
+	if err := SaveAnthropicOAuthCredentials(path, in); err != nil {
+		t.Fatalf("SaveAnthropicOAuthCredentials failed: %v", err)
+	}
+
+	out, err := LoadAnthropicOAuthCredentials(path)
+	if err != nil {
+		t.Fatalf("LoadAnthropicOAuthCredentials failed: %v", err)
+	}
+	if out.AccessToken != in.AccessToken {
+		t.Fatalf("access token mismatch: got %s want %s", out.AccessToken, in.AccessToken)
+	}
+	if out.RefreshToken != in.RefreshToken {
+		t.Fatalf("refresh token mismatch: got %s want %s", out.RefreshToken, in.RefreshToken)
+	}
+}

--- a/internal/ai/anthropic_types.go
+++ b/internal/ai/anthropic_types.go
@@ -15,6 +15,7 @@ type AnthropicRequest struct {
 	System    interface{}        `json:"system,omitempty"` // string or []SystemBlock for OAuth
 	Messages  []AnthropicMessage `json:"messages"`
 	Tools     []AnthropicTool    `json:"tools,omitempty"`
+	Stream    bool               `json:"stream,omitempty"`
 	MaxTokens int                `json:"max_tokens"`
 	Thinking  *ThinkingConfig    `json:"thinking,omitempty"`
 }

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -48,6 +48,9 @@ type ProviderConfig struct {
 	BaseURL    string
 	Model      string
 	ThinkLevel string // "off", "low", "medium", "high", "adaptive" — used by Anthropic client
+	// OAuthStorePath is used by providers with refreshable OAuth credentials (Anthropic).
+	// Empty means provider defaults are used.
+	OAuthStorePath string
 }
 
 // OpenAICompatibleClient implements Client for OpenAI-compatible APIs

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -158,12 +158,19 @@ func (a *App) Start(ctx context.Context) error {
 	// Initialize memory system
 	a.memory = agent.NewMemory(soulPath)
 
+	aiAPIKey := strings.TrimSpace(a.config.AI.APIKey)
+	if aiAPIKey == "" && a.config.AI.Provider == "anthropic" {
+		if creds, err := ai.LoadAnthropicOAuthCredentials(""); err == nil && creds != nil {
+			aiAPIKey = "oauth:" + creds.AccessToken
+		}
+	}
+
 	// Initialize AI client if configured
-	if a.config.AI.APIKey != "" {
+	if aiAPIKey != "" {
 		log.Printf("🤖 Initializing AI client (%s)...", a.config.AI.Provider)
 		primaryCfg := ai.ProviderConfig{
 			Name:    a.config.AI.Provider,
-			APIKey:  a.config.AI.APIKey,
+			APIKey:  aiAPIKey,
 			Model:   a.config.AI.Model,
 			BaseURL: a.config.AI.BaseURL,
 		}
@@ -228,7 +235,7 @@ func (a *App) Start(ctx context.Context) error {
 
 				metadataClient, err := ai.NewClient(ai.ProviderConfig{
 					Name:    a.config.AI.Provider,
-					APIKey:  a.config.AI.APIKey,
+					APIKey:  aiAPIKey,
 					BaseURL: a.config.AI.BaseURL,
 					Model:   metadataModel,
 				})
@@ -267,7 +274,7 @@ func (a *App) Start(ctx context.Context) error {
 	aiCfg := bot.AIConfig{
 		Provider:        a.config.AI.Provider,
 		Model:           a.config.AI.Model,
-		APIKey:          a.config.AI.APIKey,
+		APIKey:          aiAPIKey,
 		BaseURL:         a.config.AI.BaseURL,
 		FallbackModels:  a.config.AI.FallbackModels,
 		ModelAliases:    a.config.ModelAliases,

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -27,7 +27,7 @@ type Bot struct {
 	api              *telebot.Bot
 	store            *storage.Store
 	ai               ai.Client
-	streamingAI      *ai.OpenAICompatibleClient
+	streamingAI      ai.StreamingClient
 	aiConfig         AIConfig
 	personality      *agent.Personality
 	agentRegistry    *agent.AgentRegistry
@@ -91,7 +91,7 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 	toolRegistry, _ := tools.LoadFromConfigWithOptions(personality.BasePath, toolsConfig)
 
 	// Try to cast aiClient to streaming client
-	streamingClient, _ := aiClient.(*ai.OpenAICompatibleClient)
+	streamingClient, _ := aiClient.(ai.StreamingClient)
 
 	// Create auth manager
 	authManager := NewAuthManager(store, authCfg)

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"ok-gobot/internal/ai"
+	"ok-gobot/internal/config"
+)
+
+func newAuthCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Manage provider authentication",
+	}
+
+	cmd.AddCommand(newAuthAnthropicCommand(cfg))
+	return cmd
+}
+
+func newAuthAnthropicCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "anthropic",
+		Short: "Manage Anthropic OAuth authentication",
+	}
+
+	cmd.AddCommand(newAuthAnthropicLoginCommand(cfg))
+	cmd.AddCommand(newAuthAnthropicStatusCommand(cfg))
+	cmd.AddCommand(newAuthAnthropicLogoutCommand(cfg))
+	return cmd
+}
+
+func newAuthAnthropicLoginCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate Anthropic via OAuth (Claude MAX)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			req, err := ai.NewAnthropicOAuthAuthRequest()
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("Open this URL in your browser to authenticate with Anthropic:")
+			fmt.Println(req.URL)
+			fmt.Println()
+			if err := openBrowser(req.URL); err != nil {
+				fmt.Printf("Could not open browser automatically: %v\n", err)
+			}
+			fmt.Println("After approving access, copy the code from Anthropic and paste it below.")
+			fmt.Print("> OAuth code: ")
+
+			reader := bufio.NewReader(os.Stdin)
+			rawCode, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("failed to read OAuth code: %w", err)
+			}
+			code := ai.ExtractAnthropicOAuthCode(rawCode)
+			if code == "" {
+				return fmt.Errorf("OAuth code is empty")
+			}
+
+			creds, err := ai.ExchangeAnthropicOAuthCode(cmd.Context(), code, req.Verifier, req.State)
+			if err != nil {
+				return err
+			}
+
+			storePath, err := ai.DefaultAnthropicOAuthStorePath()
+			if err != nil {
+				return err
+			}
+			if err := ai.SaveAnthropicOAuthCredentials(storePath, creds); err != nil {
+				return err
+			}
+
+			if cfg.ConfigPath == "" {
+				configPath, err := defaultConfigPath()
+				if err != nil {
+					return fmt.Errorf("failed to resolve config path: %w", err)
+				}
+				if _, err := ensureDefaultConfig(configPath, cfg.GetSoulPath()); err != nil {
+					return fmt.Errorf("failed to initialize config: %w", err)
+				}
+				cfg.ConfigPath = configPath
+			}
+
+			cfg.AI.Provider = "anthropic"
+			cfg.AI.APIKey = "oauth:" + creds.AccessToken
+			if strings.TrimSpace(cfg.AI.Model) == "" {
+				cfg.AI.Model = "claude-sonnet-4-5-20250929"
+			}
+			if err := cfg.Save(); err != nil {
+				return fmt.Errorf("failed to save config: %w", err)
+			}
+
+			fmt.Printf("✅ Anthropic OAuth configured\n")
+			fmt.Printf("Credentials store: %s\n", storePath)
+			fmt.Println("Provider set to anthropic in your config.")
+			return nil
+		},
+	}
+}
+
+func newAuthAnthropicStatusCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show Anthropic OAuth credential status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			storePath, err := ai.DefaultAnthropicOAuthStorePath()
+			if err != nil {
+				return err
+			}
+			creds, err := ai.LoadAnthropicOAuthCredentials(storePath)
+			if err != nil {
+				fmt.Printf("Anthropic OAuth: not configured (%v)\n", err)
+				fmt.Printf("Store path: %s\n", storePath)
+				return nil
+			}
+
+			now := time.Now()
+			status := "valid"
+			switch {
+			case creds.IsExpired(now):
+				status = "expired"
+			case creds.IsExpiringSoon(now, 10*time.Minute):
+				status = "expiring_soon"
+			}
+
+			expiresAt := "not set"
+			if creds.ExpiresAt > 0 {
+				expiresAt = time.UnixMilli(creds.ExpiresAt).Format(time.RFC3339)
+			}
+
+			fmt.Printf("Anthropic OAuth status: %s\n", status)
+			fmt.Printf("Store path: %s\n", storePath)
+			fmt.Printf("Expires at: %s\n", expiresAt)
+			fmt.Printf("Refresh token: %v\n", strings.TrimSpace(creds.RefreshToken) != "")
+			fmt.Printf("Configured provider: %s\n", cfg.AI.Provider)
+			return nil
+		},
+	}
+}
+
+func newAuthAnthropicLogoutCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Remove saved Anthropic OAuth credentials",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			storePath, err := ai.DefaultAnthropicOAuthStorePath()
+			if err != nil {
+				return err
+			}
+			if err := ai.DeleteAnthropicOAuthCredentials(storePath); err != nil {
+				return err
+			}
+
+			if cfg.AI.Provider == "anthropic" && strings.HasPrefix(strings.TrimSpace(cfg.AI.APIKey), "oauth:") {
+				cfg.AI.APIKey = ""
+				if cfg.ConfigPath != "" {
+					if err := cfg.Save(); err != nil {
+						return fmt.Errorf("removed credentials but failed to save config: %w", err)
+					}
+				}
+			}
+
+			fmt.Printf("✅ Removed Anthropic OAuth credentials (%s)\n", storePath)
+			return nil
+		},
+	}
+}
+
+func openBrowser(rawURL string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", rawURL).Start()
+	case "linux":
+		return exec.Command("xdg-open", rawURL).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL).Start()
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -51,6 +51,7 @@ func newConfigInitCommand() *cobra.Command {
 			fmt.Println("\nNext steps:")
 			fmt.Println("1. Get a bot token from @BotFather on Telegram")
 			fmt.Println("2. Get an API key from openrouter.ai (free credits available)")
+			fmt.Println("   Or authenticate Anthropic OAuth: ok-gobot auth anthropic login")
 			fmt.Println("3. Edit the config: ok-gobot config set telegram.token <token>")
 			fmt.Println("4. Set AI key: ok-gobot config set ai.api_key <key>")
 			fmt.Println("5. Start the bot: ok-gobot start")
@@ -149,10 +150,18 @@ func newConfigModelsCommand() *cobra.Command {
 				fmt.Printf("    - %s\n", model)
 			}
 
+			fmt.Println("\nAnthropic:")
+			fmt.Println("  OAuth login: ok-gobot auth anthropic login")
+			fmt.Println("  Or get API key: https://console.anthropic.com/settings/keys")
+			for _, model := range models["anthropic"] {
+				fmt.Printf("    - %s\n", model)
+			}
+
 			fmt.Println("\nUsage:")
 			fmt.Println("  ok-gobot config set ai.provider openrouter")
 			fmt.Println("  ok-gobot config set ai.model moonshotai/kimi-k2.5")
 			fmt.Println("  ok-gobot config set ai.api_key <your-key>")
+			fmt.Println("  ok-gobot auth anthropic login")
 		},
 	}
 }
@@ -197,9 +206,9 @@ telegram:
   token: ""  # Your Telegram bot token
 
 # AI Provider Configuration
-# Supports: openrouter, openai, or any OpenAI-compatible API
+# Supports: openrouter, openai, anthropic, or any OpenAI-compatible API
 ai:
-  provider: "openrouter"  # "openrouter", "openai", or "custom"
+  provider: "openrouter"  # "openrouter", "openai", "anthropic", or "custom"
   api_key: ""            # Your API key (get from openrouter.ai or openai.com)
   model: "moonshotai/kimi-k2.5"  # Model ID
   # base_url: ""         # Optional: for custom providers

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"ok-gobot/internal/ai"
 	"ok-gobot/internal/config"
 )
 
@@ -176,8 +177,15 @@ func checkAIAPIKey(cfg *config.Config) checkResult {
 	}
 
 	if cfg.AI.APIKey == "" {
+		if cfg.AI.Provider == "anthropic" {
+			if creds, err := ai.LoadAnthropicOAuthCredentials(""); err == nil && creds != nil {
+				result.passed = true
+				result.message = fmt.Sprintf("Anthropic OAuth configured (model: %s)", cfg.AI.Model)
+				return result
+			}
+		}
 		result.passed = false
-		result.message = "Not set. Get key from openrouter.ai or openai.com and run: ok-gobot config set ai.api_key <key>"
+		result.message = "Not set. Configure key with `ok-gobot config set ai.api_key <key>` or run `ok-gobot auth anthropic login`"
 		return result
 	}
 
@@ -201,6 +209,8 @@ func checkAIBaseURL(cfg *config.Config) checkResult {
 			baseURL = "https://openrouter.ai"
 		case "openai":
 			baseURL = "https://api.openai.com"
+		case "anthropic":
+			baseURL = "https://api.anthropic.com"
 		default:
 			result.passed = true
 			result.message = "Skipping (custom provider without base_url)"

--- a/internal/cli/onboard.go
+++ b/internal/cli/onboard.go
@@ -19,7 +19,7 @@ func newOnboardCommand() *cobra.Command {
 This wizard will:
 1. Configure the agent's personality files location
 2. Help you set up Telegram bot token
-3. Configure AI provider (OpenRouter/OpenAI)
+3. Configure AI provider (OpenRouter/OpenAI/Anthropic)
 4. Set up Chrome browser for automation`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("🦞 Welcome to ok-gobot Setup!")
@@ -76,6 +76,7 @@ This wizard will:
 			fmt.Printf("  2. Edit %s/SOUL.md to define your personality\n", soulPath)
 			fmt.Println("  3. Run: ok-gobot config set telegram.token <token>")
 			fmt.Println("  4. Run: ok-gobot config set ai.api_key <key>")
+			fmt.Println("     Or:  ok-gobot auth anthropic login")
 			fmt.Println("  5. Run: ok-gobot doctor")
 			fmt.Println("  6. Run: ok-gobot start")
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,6 +33,7 @@ Supports Telegram bot integration with personality and memory.`,
 	root.AddCommand(newDoctorCommand(cfg))
 	root.AddCommand(newDaemonCommand(cfg))
 	root.AddCommand(newTUICommand(cfg))
+	root.AddCommand(newAuthCommand(cfg))
 	root.AddCommand(newOnboardCommand())
 	root.AddCommand(newMigrateCommand(cfg))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,10 +78,10 @@ type TelegramConfig struct {
 	Webhook string `mapstructure:"webhook"`
 }
 
-// AIConfig holds AI provider configuration
-// Supports: openrouter, openai, or any OpenAI-compatible API
+// AIConfig holds AI provider configuration.
+// Supports: openrouter, openai, anthropic, or custom OpenAI-compatible APIs.
 type AIConfig struct {
-	Provider        string   `mapstructure:"provider"` // "openrouter", "openai", "custom"
+	Provider        string   `mapstructure:"provider"` // "openrouter", "openai", "anthropic", "custom"
 	APIKey          string   `mapstructure:"api_key"`
 	Model           string   `mapstructure:"model"`
 	BaseURL         string   `mapstructure:"base_url"`         // For custom providers


### PR DESCRIPTION
Closes #114

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Anthropic OAuth authentication support for Claude MAX subscriptions with PKCE flow, automatic token refresh, and SSE streaming.

**Key Changes:**
- Implements OAuth 2.0 with PKCE (SHA256) for secure authentication
- Adds automatic token refresh with 2-minute expiry buffer
- Implements SSE streaming support for Anthropic API  
- Stores credentials securely with `0o600` file permissions in `~/.ok-gobot/oauth/anthropic.json`
- Adds CLI commands: `auth anthropic login/logout/status`
- Updates `AnthropicClient` to support both OAuth and API key authentication
- Integrates OAuth credential loading in app startup

**Critical Issue:**
- OAuth state parameter is never validated in the CLI login flow (line 56-69 in `auth.go`), creating a CSRF vulnerability where an attacker could trick users into authenticating with the attacker's account

**Implementation Quality:**
- Well-structured OAuth implementation with proper PKCE flow
- Good separation of concerns between OAuth logic and client
- Comprehensive test coverage for OAuth functions
- Handles token refresh gracefully with fallback logic
- Proper error handling throughout

<h3>Confidence Score: 3/5</h3>

- This PR has a critical OAuth security vulnerability that must be fixed before merging
- Score reflects one critical security issue (missing OAuth state validation) that creates a CSRF vulnerability. The rest of the implementation is solid with good test coverage, proper PKCE flow, secure credential storage, and well-designed token refresh logic. Once the state validation is added, this would be a 4-5/5.
- Pay close attention to `internal/cli/auth.go` - the OAuth state validation issue must be fixed

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/ai/anthropic_oauth.go | New OAuth implementation with PKCE flow, token refresh, and secure credential storage |
| internal/cli/auth.go | CLI commands for OAuth login/logout/status - missing state validation creates CSRF vulnerability |
| internal/ai/anthropic_client.go | Enhanced client with OAuth support, streaming, automatic token refresh, and proper error handling |
| internal/app/app.go | Updated to auto-load OAuth credentials from storage when API key is empty |
| internal/bot/bot.go | Updated to use StreamingClient interface for better abstraction |

</details>



<sub>Last reviewed commit: 3c0b867</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->