### PR TITLE
fix: TUI must connect to running bot's control server (port 8787), not spawn its own

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -42,8 +42,9 @@ type App struct {
 
 // stateAdapter bridges bot/storage to the control.StateProvider interface.
 type stateAdapter struct {
-	b     *bot.Bot
-	store *storage.Store
+	b            *bot.Bot
+	store        *storage.Store
+	defaultModel string
 }
 
 func (a *stateAdapter) GetStatus() map[string]interface{} {
@@ -58,8 +59,13 @@ func (a *stateAdapter) ListSessions() ([]control.SessionInfo, error) {
 	out := make([]control.SessionInfo, 0, len(rows))
 	for _, r := range rows {
 		chatID, _ := r["chat_id"].(int64)
+		model, err := a.store.GetModelOverride(chatID)
+		if err != nil || model == "" {
+			model = a.defaultModel
+		}
 		out = append(out, control.SessionInfo{
 			ChatID: chatID,
+			Model:  model,
 			State:  "idle",
 		})
 	}
@@ -315,7 +321,11 @@ func (a *App) Start(ctx context.Context) error {
 			Token:                     a.config.Control.Token,
 			AllowLoopbackWithoutToken: a.config.Control.AllowLoopbackWithoutToken,
 		}
-		adapter := &stateAdapter{b: a.bot, store: a.store}
+		adapter := &stateAdapter{
+			b:            a.bot,
+			store:        a.store,
+			defaultModel: a.config.AI.Model,
+		}
 		a.controlServer = control.New(ctrlCfg, adapter)
 		a.bot.SetControlHub(a.controlServer.Hub())
 		go func() {

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -63,6 +63,12 @@ func (b *Bot) processViaHub(ctx context.Context, c telebot.Context, sessionKey a
 		}
 		onDelta = func(delta string) {
 			liveEditor.AppendDelta(delta)
+			if ctrlHub != nil && delta != "" {
+				ctrlHub.Emit(control.EvtRunDelta, control.RunDeltaPayload{
+					ChatID: chatID,
+					Delta:  delta,
+				})
+			}
 		}
 		onDeltaReset = func() {
 			liveEditor.ResetContent()
@@ -84,6 +90,15 @@ func (b *Bot) processViaHub(ctx context.Context, c telebot.Context, sessionKey a
 				}
 				ctrlHub.Emit(control.EvtToolFinished, p)
 			}
+		}
+		onDelta = func(delta string) {
+			if delta == "" {
+				return
+			}
+			ctrlHub.Emit(control.EvtRunDelta, control.RunDeltaPayload{
+				ChatID: chatID,
+				Delta:  delta,
+			})
 		}
 	}
 

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -1,36 +1,32 @@
 package cli
 
 import (
-	"context"
 	"fmt"
-	"log"
-	"time"
 
 	"github.com/spf13/cobra"
 
-	"ok-gobot/internal/ai"
 	"ok-gobot/internal/config"
-	controlserver "ok-gobot/internal/control"
 	"ok-gobot/internal/tui"
 )
-
-const defaultControlServerAddr = "127.0.0.1:9099"
 
 func newTUICommand(cfg *config.Config) *cobra.Command {
 	var (
 		serverAddr string
-		noServer   bool
 		modelList  []string
 	)
+
+	defaultControlServerAddr := fmt.Sprintf("127.0.0.1:%d", cfg.Control.Port)
+	if cfg.Control.Port == 0 {
+		defaultControlServerAddr = "127.0.0.1:8787"
+	}
 
 	cmd := &cobra.Command{
 		Use:   "tui",
 		Short: "Launch the interactive terminal UI",
 		Long: `Launch the Bubble Tea terminal UI for ok-gobot.
 
-By default this command starts a local control server and connects
-the TUI to it. You can point the TUI at an existing control server
-with --server.
+By default this command connects to the running bot control server.
+You can point the TUI at a different control server with --server.
 
 Key bindings:
   Enter       Send message
@@ -46,42 +42,8 @@ In-chat commands:
   /model <name>     Switch to a named model
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			if ctx == nil {
-				ctx = context.Background()
-			}
-
 			if serverAddr == "" {
 				serverAddr = defaultControlServerAddr
-			}
-
-			if !noServer {
-				// Start an embedded control server
-				aiCfg := ai.ProviderConfig{
-					Name:    cfg.AI.Provider,
-					APIKey:  cfg.AI.APIKey,
-					Model:   cfg.AI.Model,
-					BaseURL: cfg.AI.BaseURL,
-				}
-
-				srv := controlserver.NewTUIServer(controlserver.TUIConfig{
-					Addr:  serverAddr,
-					AICfg: aiCfg,
-				})
-
-				srvCtx, srvCancel := context.WithCancel(ctx)
-				defer srvCancel()
-
-				go func() {
-					if err := srv.Start(srvCtx); err != nil && srvCtx.Err() == nil {
-						log.Printf("[tui] control server error: %v", err)
-					}
-				}()
-
-				// Wait for the server to be ready (up to 3 s)
-				if err := controlserver.WaitTUIReady(serverAddr, 3*time.Second); err != nil {
-					return fmt.Errorf("control server did not start: %w", err)
-				}
 			}
 
 			return tui.Run(tui.Options{
@@ -92,7 +54,6 @@ In-chat commands:
 	}
 
 	cmd.Flags().StringVar(&serverAddr, "server", "", fmt.Sprintf("control server address (default %s)", defaultControlServerAddr))
-	cmd.Flags().BoolVar(&noServer, "no-server", false, "do not start an embedded control server (use --server to point at one)")
 	cmd.Flags().StringSliceVar(&modelList, "models", nil, "comma-separated list of models for the model picker")
 
 	return cmd

--- a/internal/control/hub.go
+++ b/internal/control/hub.go
@@ -12,10 +12,12 @@ import (
 
 // client represents a single connected WebSocket client.
 type client struct {
-	hub  *Hub
-	conn net.Conn
-	send chan []byte
-	done chan struct{}
+	hub          *Hub
+	conn         net.Conn
+	send         chan []byte
+	done         chan struct{}
+	tuiConnected bool
+	tuiSessionID string
 }
 
 // Hub manages all active WebSocket connections and event broadcasting.
@@ -82,11 +84,33 @@ func (h *Hub) Emit(evtType string, payload interface{}) {
 		log.Printf("[control/hub] failed to encode event %s: %v", evtType, err)
 		return
 	}
+
+	h.BroadcastRaw(data)
+
+	// Also mirror legacy events to the TUI websocket protocol so the Bubble Tea
+	// client can consume runtime updates from the main control server.
+	for _, tuiMsg := range legacyEventToTUI(evtType, payload) {
+		h.BroadcastTUI(tuiMsg)
+	}
+}
+
+// BroadcastRaw sends a pre-encoded websocket text frame payload to all clients.
+func (h *Hub) BroadcastRaw(data []byte) {
 	select {
 	case h.broadcast <- data:
 	default:
-		log.Printf("[control/hub] broadcast channel full, dropping event %s", evtType)
+		log.Printf("[control/hub] broadcast channel full, dropping message")
 	}
+}
+
+// BroadcastTUI encodes and broadcasts a TUI protocol message to all clients.
+func (h *Hub) BroadcastTUI(msg ServerMsg) {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		log.Printf("[control/hub] failed to encode TUI message %s: %v", msg.Type, err)
+		return
+	}
+	h.BroadcastRaw(data)
 }
 
 // addClient registers c and starts its read/write pumps.
@@ -132,6 +156,12 @@ func (c *client) readPump(srv *Server) {
 			continue
 		}
 
+		var tuiReq ClientMsg
+		if err := json.Unmarshal(data, &tuiReq); err == nil && isTUICommand(tuiReq.Type) {
+			srv.handleTUIRequest(c, tuiReq)
+			continue
+		}
+
 		var req Message
 		if err := json.Unmarshal(data, &req); err != nil {
 			c.sendError("", "parse", "invalid JSON: "+err.Error())
@@ -142,26 +172,40 @@ func (c *client) readPump(srv *Server) {
 		if resp == nil {
 			continue
 		}
-		out, err := json.Marshal(resp)
-		if err != nil {
-			log.Printf("[control/hub] marshal response error: %v", err)
-			continue
-		}
-		select {
-		case c.send <- out:
-		case <-c.done:
-			return
-		}
+		c.sendMessage(*resp)
 	}
 }
 
 func (c *client) sendError(id, reqType, msg string) {
-	resp := ErrorResponse(id, reqType, msg)
-	out, _ := json.Marshal(resp)
+	c.sendMessage(ErrorResponse(id, reqType, msg))
+}
+
+func (c *client) sendMessage(msg Message) {
+	out, err := json.Marshal(msg)
+	if err != nil {
+		log.Printf("[control/hub] marshal response error: %v", err)
+		return
+	}
 	select {
 	case c.send <- out:
 	default:
 	}
+}
+
+func (c *client) sendTUIMsg(msg ServerMsg) {
+	out, err := json.Marshal(msg)
+	if err != nil {
+		log.Printf("[control/hub] marshal TUI response error: %v", err)
+		return
+	}
+	select {
+	case c.send <- out:
+	case <-c.done:
+	}
+}
+
+func (c *client) sendTUIError(msg string) {
+	c.sendTUIMsg(ServerMsg{Type: MsgTypeError, Message: msg})
 }
 
 func isClosedErr(err error) bool {

--- a/internal/control/protocol.go
+++ b/internal/control/protocol.go
@@ -91,6 +91,7 @@ type ApprovalRespondPayload struct {
 type SessionInfo struct {
 	ChatID   int64  `json:"chat_id"`
 	Username string `json:"username,omitempty"`
+	Model    string `json:"model,omitempty"`
 	State    string `json:"state"`
 }
 

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 
 	"github.com/gobwas/ws"
+
+	runtimepkg "ok-gobot/internal/runtime"
 )
 
 // StateProvider is the interface the control server uses to interact with the
@@ -76,10 +78,11 @@ func DefaultConfig() Config {
 
 // Server is the loopback WebSocket control server.
 type Server struct {
-	cfg     Config
-	hub     *Hub
-	state   StateProvider
-	httpSrv *http.Server
+	cfg        Config
+	hub        *Hub
+	state      StateProvider
+	httpSrv    *http.Server
+	runtimeHub *runtimepkg.Hub
 }
 
 // New creates a new Server.  Call Start to begin accepting connections.
@@ -102,6 +105,7 @@ func (s *Server) Hub() *Hub {
 // cancelled.
 func (s *Server) Start(ctx context.Context) error {
 	go s.hub.Run()
+	s.initTUIRuntime(ctx)
 
 	addr := fmt.Sprintf("127.0.0.1:%d", s.cfg.Port)
 	mux := http.NewServeMux()

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -1,0 +1,309 @@
+package control
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	runtimepkg "ok-gobot/internal/runtime"
+)
+
+func isTUICommand(cmdType string) bool {
+	switch cmdType {
+	case CmdSend,
+		CmdAbort,
+		CmdApprove,
+		CmdSetModel,
+		CmdListSessions,
+		CmdNewSession,
+		CmdSwitch,
+		CmdSpawnSubagent:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Server) initTUIRuntime(ctx context.Context) {
+	s.runtimeHub = runtimepkg.NewHub(ctx, 64)
+	evCh := make(chan runtimepkg.RuntimeEvent, 128)
+	s.runtimeHub.Subscribe(evCh)
+	go s.bridgeRuntimeEvents(ctx, evCh)
+}
+
+func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
+	sessions, ok := s.ensureTUIConnected(c, cmd.SessionID)
+	if !ok {
+		return
+	}
+
+	switch cmd.Type {
+	case CmdListSessions:
+		c.sendTUIMsg(ServerMsg{
+			Type:     MsgTypeSessions,
+			Sessions: sessions,
+		})
+
+	case CmdSwitch:
+		target := strings.TrimSpace(cmd.SessionID)
+		if target == "" {
+			c.sendTUIError("session_id is required")
+			return
+		}
+		if !hasSessionID(sessions, target) {
+			c.sendTUIError("session not found")
+			return
+		}
+		c.tuiSessionID = target
+		c.sendTUIMsg(ServerMsg{
+			Type:      MsgTypeConnected,
+			SessionID: c.tuiSessionID,
+			Sessions:  sessions,
+		})
+
+	case CmdNewSession:
+		c.sendTUIError("new_session is not supported on bot control sessions")
+
+	case CmdSend:
+		sessionID, chatID, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
+		if !ok {
+			return
+		}
+		text := strings.TrimSpace(cmd.Text)
+		if text == "" {
+			c.sendTUIError("text is required")
+			return
+		}
+		s.hub.BroadcastTUI(ServerMsg{
+			Type:      MsgTypeEvent,
+			Kind:      KindMessage,
+			SessionID: sessionID,
+			Role:      "user",
+			Content:   text,
+		})
+		if err := s.state.SendChat(chatID, text); err != nil {
+			c.sendTUIError(err.Error())
+			return
+		}
+		c.tuiSessionID = sessionID
+
+	case CmdAbort:
+		_, chatID, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
+		if !ok {
+			return
+		}
+		if err := s.state.AbortRun(chatID); err != nil {
+			c.sendTUIError(err.Error())
+			return
+		}
+
+	case CmdApprove:
+		if strings.TrimSpace(cmd.ApprovalID) == "" {
+			c.sendTUIError("approval_id is required")
+			return
+		}
+		if err := s.state.RespondToApproval(cmd.ApprovalID, cmd.Approved); err != nil {
+			c.sendTUIError(err.Error())
+			return
+		}
+
+	case CmdSetModel:
+		sessionID, chatID, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
+		if !ok {
+			return
+		}
+		model := strings.TrimSpace(cmd.Model)
+		if model == "" {
+			c.sendTUIError("model is required")
+			return
+		}
+		if err := s.state.SetModel(chatID, model); err != nil {
+			c.sendTUIError(err.Error())
+			return
+		}
+		c.tuiSessionID = sessionID
+		updated, err := s.listTUISessions()
+		if err != nil {
+			c.sendTUIError(err.Error())
+			return
+		}
+		c.sendTUIMsg(ServerMsg{
+			Type:     MsgTypeSessions,
+			Sessions: updated,
+		})
+
+	case CmdSpawnSubagent:
+		sessionID, _, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
+		if !ok {
+			return
+		}
+		task := strings.TrimSpace(cmd.Task)
+		if task == "" {
+			c.sendTUIError("task is required")
+			return
+		}
+		if s.runtimeHub == nil {
+			c.sendTUIError("runtime hub not ready")
+			return
+		}
+
+		parentKey := "agent:tui:" + sessionID
+		req := runtimepkg.SubagentSpawnRequest{
+			ParentSessionKey: parentKey,
+			Task:             task,
+			Model:            cmd.Model,
+			Thinking:         cmd.Thinking,
+			ToolAllowlist:    cmd.ToolAllowlist,
+			WorkspaceRoot:    cmd.WorkspaceRoot,
+			DeliverBack:      true,
+		}
+
+		handle, err := s.runtimeHub.SpawnSubagent(req, func(ctx context.Context, ack runtimepkg.AckHandle) {
+			log.Printf("[control] subagent started for session %s: %q", sessionID, task)
+			ack.Close(nil)
+		})
+		if err != nil {
+			c.sendTUIError(fmt.Sprintf("spawn subagent: %v", err))
+			return
+		}
+
+		c.sendTUIMsg(ServerMsg{
+			Type:            MsgTypeEvent,
+			Kind:            KindRunStart,
+			SessionID:       sessionID,
+			ChildSessionKey: handle.SessionKey,
+		})
+
+	default:
+		c.sendTUIError("unknown command type: " + cmd.Type)
+	}
+}
+
+func (s *Server) ensureTUIConnected(c *client, requestedID string) ([]TUISessionInfo, bool) {
+	sessions, err := s.listTUISessions()
+	if err != nil {
+		c.sendTUIError(err.Error())
+		return nil, false
+	}
+
+	if !c.tuiConnected {
+		c.tuiConnected = true
+		c.tuiSessionID = selectSessionID(sessions, requestedID, c.tuiSessionID)
+		c.sendTUIMsg(ServerMsg{
+			Type:      MsgTypeConnected,
+			SessionID: c.tuiSessionID,
+			Sessions:  sessions,
+		})
+	}
+
+	return sessions, true
+}
+
+func (s *Server) resolveTUISession(c *client, requestedID string, sessions []TUISessionInfo) (string, int64, bool) {
+	sessionID := selectSessionID(sessions, requestedID, c.tuiSessionID)
+	if sessionID == "" {
+		c.sendTUIError("no sessions available")
+		return "", 0, false
+	}
+	chatID, err := strconv.ParseInt(sessionID, 10, 64)
+	if err != nil {
+		c.sendTUIError("invalid session_id")
+		return "", 0, false
+	}
+	if !hasSessionID(sessions, sessionID) {
+		c.sendTUIError("session not found")
+		return "", 0, false
+	}
+	c.tuiSessionID = sessionID
+	return sessionID, chatID, true
+}
+
+func (s *Server) listTUISessions() ([]TUISessionInfo, error) {
+	sessions, err := s.state.ListSessions()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]TUISessionInfo, 0, len(sessions))
+	for _, sess := range sessions {
+		name := strings.TrimSpace(sess.Username)
+		if name == "" {
+			name = fmt.Sprintf("Chat %d", sess.ChatID)
+		}
+		out = append(out, TUISessionInfo{
+			ID:      sessionIDForChat(sess.ChatID),
+			Name:    name,
+			Model:   sess.Model,
+			Running: sess.State == "running" || sess.State == "queued",
+		})
+	}
+	return out, nil
+}
+
+func hasSessionID(sessions []TUISessionInfo, id string) bool {
+	for _, s := range sessions {
+		if s.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func selectSessionID(sessions []TUISessionInfo, requestedID, fallbackID string) string {
+	req := strings.TrimSpace(requestedID)
+	if req != "" && hasSessionID(sessions, req) {
+		return req
+	}
+	fallback := strings.TrimSpace(fallbackID)
+	if fallback != "" && hasSessionID(sessions, fallback) {
+		return fallback
+	}
+	if len(sessions) > 0 {
+		return sessions[0].ID
+	}
+	return ""
+}
+
+func (s *Server) bridgeRuntimeEvents(ctx context.Context, evCh <-chan runtimepkg.RuntimeEvent) {
+	const parentPrefix = "agent:tui:"
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-evCh:
+			if !ok {
+				return
+			}
+			if ev.Type != runtimepkg.EventChildDone && ev.Type != runtimepkg.EventChildFailed {
+				continue
+			}
+			if !strings.HasPrefix(ev.SessionKey, parentPrefix) {
+				continue
+			}
+
+			sessionID := strings.TrimPrefix(ev.SessionKey, parentPrefix)
+			payload, ok := ev.Payload.(runtimepkg.ChildCompletionPayload)
+			if !ok {
+				continue
+			}
+
+			kind := KindChildDone
+			msg := ""
+			if ev.Type == runtimepkg.EventChildFailed {
+				kind = KindChildFailed
+				if payload.Err != nil {
+					msg = payload.Err.Error()
+				}
+			}
+
+			s.hub.BroadcastTUI(ServerMsg{
+				Type:            MsgTypeEvent,
+				Kind:            kind,
+				SessionID:       sessionID,
+				ChildSessionKey: payload.ChildSessionKey,
+				Message:         msg,
+			})
+		}
+	}
+}

--- a/internal/control/server_tui_test.go
+++ b/internal/control/server_tui_test.go
@@ -1,0 +1,247 @@
+package control_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+
+	"ok-gobot/internal/control"
+)
+
+type mockTUIState struct {
+	mu       sync.Mutex
+	sessions []control.SessionInfo
+	sent     []struct {
+		chatID int64
+		text   string
+	}
+	modelSet []struct {
+		chatID int64
+		model  string
+	}
+}
+
+func (m *mockTUIState) GetStatus() map[string]interface{} {
+	return map[string]interface{}{"ok": true}
+}
+
+func (m *mockTUIState) ListSessions() ([]control.SessionInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]control.SessionInfo, len(m.sessions))
+	copy(out, m.sessions)
+	return out, nil
+}
+
+func (m *mockTUIState) SendChat(chatID int64, text string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sent = append(m.sent, struct {
+		chatID int64
+		text   string
+	}{chatID: chatID, text: text})
+	return nil
+}
+
+func (m *mockTUIState) AbortRun(_ int64) error                   { return nil }
+func (m *mockTUIState) RespondToApproval(_ string, _ bool) error { return nil }
+func (m *mockTUIState) SetAgent(_ int64, _ string) error         { return nil }
+func (m *mockTUIState) SpawnSubagent(_ int64, _, _ string) error { return nil }
+
+func (m *mockTUIState) SetModel(chatID int64, model string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.modelSet = append(m.modelSet, struct {
+		chatID int64
+		model  string
+	}{chatID: chatID, model: model})
+	for i := range m.sessions {
+		if m.sessions[i].ChatID == chatID {
+			m.sessions[i].Model = model
+		}
+	}
+	return nil
+}
+
+func startServerWithHandle(t *testing.T, state control.StateProvider) (*control.Server, string, context.CancelFunc) {
+	t.Helper()
+	port := freePort(t)
+	cfg := control.Config{
+		Enabled:                   true,
+		Port:                      port,
+		AllowLoopbackWithoutToken: true,
+	}
+	srv := control.New(cfg, state)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		if err := srv.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Errorf("server error: %v", err)
+		}
+	}()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond); err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	return srv, addr, cancel
+}
+
+func sendTUIRequest(t *testing.T, conn net.Conn, msg control.ClientMsg) {
+	t.Helper()
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if err := wsutil.WriteClientText(conn, data); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+}
+
+func readTUIMessage(t *testing.T, conn net.Conn) control.ServerMsg {
+	t.Helper()
+	conn.SetDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	data, op, err := wsutil.ReadServerData(conn)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if op != ws.OpText {
+		t.Fatalf("expected text frame, got %v", op)
+	}
+	var msg control.ServerMsg
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	return msg
+}
+
+func TestControlServerHandlesTUISessionCommands(t *testing.T) {
+	state := &mockTUIState{
+		sessions: []control.SessionInfo{
+			{ChatID: 42, Username: "alice", Model: "model-a", State: "idle"},
+		},
+	}
+	_, addr, cancel := startServerWithHandle(t, state)
+	defer cancel()
+
+	conn := wsConnect(t, addr)
+
+	sendTUIRequest(t, conn, control.ClientMsg{Type: control.CmdListSessions})
+
+	connected := readTUIMessage(t, conn)
+	if connected.Type != control.MsgTypeConnected {
+		t.Fatalf("expected %q, got %q", control.MsgTypeConnected, connected.Type)
+	}
+	if connected.SessionID != "42" {
+		t.Fatalf("expected active session_id 42, got %q", connected.SessionID)
+	}
+
+	sessions := readTUIMessage(t, conn)
+	if sessions.Type != control.MsgTypeSessions {
+		t.Fatalf("expected %q, got %q", control.MsgTypeSessions, sessions.Type)
+	}
+	if len(sessions.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions.Sessions))
+	}
+	if sessions.Sessions[0].Model != "model-a" {
+		t.Fatalf("expected model model-a, got %q", sessions.Sessions[0].Model)
+	}
+
+	sendTUIRequest(t, conn, control.ClientMsg{
+		Type:      control.CmdSetModel,
+		SessionID: "42",
+		Model:     "model-b",
+	})
+	updated := readTUIMessage(t, conn)
+	if updated.Type != control.MsgTypeSessions {
+		t.Fatalf("expected %q after set_model, got %q", control.MsgTypeSessions, updated.Type)
+	}
+	if len(updated.Sessions) != 1 || updated.Sessions[0].Model != "model-b" {
+		t.Fatalf("expected updated model model-b, got %#v", updated.Sessions)
+	}
+}
+
+func TestControlServerHandlesTUISend(t *testing.T) {
+	state := &mockTUIState{
+		sessions: []control.SessionInfo{
+			{ChatID: 777, Model: "model-a", State: "idle"},
+		},
+	}
+	_, addr, cancel := startServerWithHandle(t, state)
+	defer cancel()
+
+	conn := wsConnect(t, addr)
+
+	sendTUIRequest(t, conn, control.ClientMsg{Type: control.CmdListSessions})
+	_ = readTUIMessage(t, conn) // connected
+	_ = readTUIMessage(t, conn) // sessions
+
+	sendTUIRequest(t, conn, control.ClientMsg{
+		Type:      control.CmdSend,
+		SessionID: "777",
+		Text:      "hello from tui",
+	})
+
+	event := readTUIMessage(t, conn)
+	if event.Type != control.MsgTypeEvent || event.Kind != control.KindMessage {
+		t.Fatalf("expected user message event, got type=%q kind=%q", event.Type, event.Kind)
+	}
+	if event.SessionID != "777" {
+		t.Fatalf("expected session_id 777, got %q", event.SessionID)
+	}
+	if event.Role != "user" || event.Content != "hello from tui" {
+		t.Fatalf("unexpected message payload: role=%q content=%q", event.Role, event.Content)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.sent) != 1 {
+		t.Fatalf("expected exactly 1 SendChat call, got %d", len(state.sent))
+	}
+	if state.sent[0].chatID != 777 || state.sent[0].text != "hello from tui" {
+		t.Fatalf("unexpected SendChat call: %+v", state.sent[0])
+	}
+}
+
+func TestHubEmitMirrorsLegacyRunEventsToTUI(t *testing.T) {
+	state := &mockTUIState{
+		sessions: []control.SessionInfo{
+			{ChatID: 99, Model: "model-a", State: "idle"},
+		},
+	}
+	srv, addr, cancel := startServerWithHandle(t, state)
+	defer cancel()
+
+	conn := wsConnect(t, addr)
+
+	// Initialize TUI state for this connection.
+	sendTUIRequest(t, conn, control.ClientMsg{Type: control.CmdListSessions})
+	_ = readTUIMessage(t, conn)
+	_ = readTUIMessage(t, conn)
+
+	srv.Hub().Emit(control.EvtRunStarted, control.RunEventPayload{ChatID: 99})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		msg := readTUIMessage(t, conn)
+		if msg.Type == control.MsgTypeEvent && msg.Kind == control.KindRunStart {
+			if msg.SessionID != "99" {
+				t.Fatalf("expected session_id 99, got %q", msg.SessionID)
+			}
+			return
+		}
+	}
+	t.Fatal("did not receive mirrored TUI run_start event")
+}

--- a/internal/control/tui_bridge.go
+++ b/internal/control/tui_bridge.go
@@ -1,0 +1,184 @@
+package control
+
+import "strconv"
+
+// legacyEventToTUI converts legacy control events into TUI websocket messages.
+func legacyEventToTUI(evtType string, payload interface{}) []ServerMsg {
+	switch evtType {
+	case EvtRunStarted:
+		p, ok := asRunEventPayload(payload)
+		if !ok {
+			return nil
+		}
+		return []ServerMsg{{
+			Type:      MsgTypeEvent,
+			Kind:      KindRunStart,
+			SessionID: sessionIDForChat(p.ChatID),
+		}}
+	case EvtRunDelta:
+		p, ok := asRunDeltaPayload(payload)
+		if !ok {
+			return nil
+		}
+		return []ServerMsg{{
+			Type:      MsgTypeEvent,
+			Kind:      KindToken,
+			SessionID: sessionIDForChat(p.ChatID),
+			Content:   p.Delta,
+		}}
+	case EvtRunCompleted:
+		p, ok := asRunEventPayload(payload)
+		if !ok {
+			return nil
+		}
+		return []ServerMsg{{
+			Type:      MsgTypeEvent,
+			Kind:      KindRunEnd,
+			SessionID: sessionIDForChat(p.ChatID),
+		}}
+	case EvtRunFailed:
+		p, ok := asRunEventPayload(payload)
+		if !ok {
+			return nil
+		}
+		msgs := make([]ServerMsg, 0, 2)
+		if p.Error != "" {
+			msgs = append(msgs, ServerMsg{
+				Type:      MsgTypeEvent,
+				Kind:      KindError,
+				SessionID: sessionIDForChat(p.ChatID),
+				Message:   p.Error,
+			})
+		}
+		msgs = append(msgs, ServerMsg{
+			Type:      MsgTypeEvent,
+			Kind:      KindRunEnd,
+			SessionID: sessionIDForChat(p.ChatID),
+		})
+		return msgs
+	case EvtToolStarted:
+		p, ok := asToolEventPayload(payload)
+		if !ok {
+			return nil
+		}
+		return []ServerMsg{{
+			Type:      MsgTypeEvent,
+			Kind:      KindToolStart,
+			SessionID: sessionIDForChat(p.ChatID),
+			ToolName:  p.ToolName,
+			ToolArgs:  p.Input,
+		}}
+	case EvtToolFinished:
+		p, ok := asToolEventPayload(payload)
+		if !ok {
+			return nil
+		}
+		return []ServerMsg{{
+			Type:       MsgTypeEvent,
+			Kind:       KindToolEnd,
+			SessionID:  sessionIDForChat(p.ChatID),
+			ToolName:   p.ToolName,
+			ToolResult: p.Output,
+			ToolError:  p.Error,
+		}}
+	case EvtApprovalRequest:
+		p, ok := asApprovalRequestPayload(payload)
+		if !ok {
+			return nil
+		}
+		return []ServerMsg{{
+			Type:       MsgTypeEvent,
+			Kind:       KindApproval,
+			SessionID:  sessionIDForChat(p.ChatID),
+			ApprovalID: p.ApprovalID,
+			Command:    p.Command,
+		}}
+	case EvtSessionQueued:
+		p, ok := asSessionInfo(payload)
+		if !ok {
+			return nil
+		}
+		return []ServerMsg{{
+			Type:       MsgTypeEvent,
+			Kind:       KindQueue,
+			SessionID:  sessionIDForChat(p.ChatID),
+			QueueDepth: 1,
+		}}
+	default:
+		return nil
+	}
+}
+
+func asRunEventPayload(payload interface{}) (RunEventPayload, bool) {
+	switch p := payload.(type) {
+	case RunEventPayload:
+		return p, true
+	case *RunEventPayload:
+		if p == nil {
+			return RunEventPayload{}, false
+		}
+		return *p, true
+	default:
+		return RunEventPayload{}, false
+	}
+}
+
+func asRunDeltaPayload(payload interface{}) (RunDeltaPayload, bool) {
+	switch p := payload.(type) {
+	case RunDeltaPayload:
+		return p, true
+	case *RunDeltaPayload:
+		if p == nil {
+			return RunDeltaPayload{}, false
+		}
+		return *p, true
+	default:
+		return RunDeltaPayload{}, false
+	}
+}
+
+func asToolEventPayload(payload interface{}) (ToolEventPayload, bool) {
+	switch p := payload.(type) {
+	case ToolEventPayload:
+		return p, true
+	case *ToolEventPayload:
+		if p == nil {
+			return ToolEventPayload{}, false
+		}
+		return *p, true
+	default:
+		return ToolEventPayload{}, false
+	}
+}
+
+func asApprovalRequestPayload(payload interface{}) (ApprovalRequestPayload, bool) {
+	switch p := payload.(type) {
+	case ApprovalRequestPayload:
+		return p, true
+	case *ApprovalRequestPayload:
+		if p == nil {
+			return ApprovalRequestPayload{}, false
+		}
+		return *p, true
+	default:
+		return ApprovalRequestPayload{}, false
+	}
+}
+
+func asSessionInfo(payload interface{}) (SessionInfo, bool) {
+	switch p := payload.(type) {
+	case SessionInfo:
+		return p, true
+	case *SessionInfo:
+		if p == nil {
+			return SessionInfo{}, false
+		}
+		return *p, true
+	default:
+		return SessionInfo{}, false
+	}
+}
+
+func sessionIDForChat(chatID int64) string {
+	return strconv.FormatInt(chatID, 10)
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -28,7 +28,7 @@ var defaultModelList = []string{
 
 // Options configures the TUI startup.
 type Options struct {
-	// ServerAddr is the address of the control server (e.g. "127.0.0.1:9099").
+	// ServerAddr is the address of the control server (e.g. "127.0.0.1:8787").
 	ServerAddr string
 	// ModelList overrides the built-in model picker list.
 	ModelList []string


### PR DESCRIPTION
Closes #116

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored TUI to connect to the running bot's control server instead of spawning its own embedded server, correctly implementing the fix for issue #116.

Key changes:
- Removed embedded control server logic from `internal/cli/tui.go` and the `--no-server` flag
- Added TUI protocol support to the main control server with bidirectional message routing
- Implemented event bridging to convert legacy control events to TUI websocket messages
- Added model tracking to session info for proper per-chat model display
- Added runtime hub integration for TUI subagent spawning support

The implementation is well-structured with comprehensive test coverage, though there's one message ordering issue in the send handler that should be addressed.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the message broadcast ordering issue
- Score reflects solid architecture and comprehensive tests, reduced by 1 point due to the message ordering bug in `CmdSend` handler that could cause UI inconsistency if SendChat fails
- Pay close attention to `internal/control/server_tui.go` - fix the broadcast-before-send ordering in the CmdSend handler (lines 79-89)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/cli/tui.go | Removed embedded control server logic, TUI now connects to existing bot control server on configured port |
| internal/app/app.go | Added model tracking to sessions via store.GetModelOverride with proper fallback to defaultModel |
| internal/control/hub.go | Added TUI protocol support with BroadcastTUI, message routing, and legacy event mirroring |
| internal/control/server_tui.go | New file implementing TUI command handlers and runtime event bridging; broadcasts user message before SendChat validation |
| internal/bot/hub_handler.go | Added EvtRunDelta emission to control hub in both live editor and non-live-editor code paths |

</details>



<sub>Last reviewed commit: a9363e1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->