### PR TITLE
fix: /status and other commands silent-fail due to missing session_routes columns

### DIFF
--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -190,14 +190,22 @@ func (s *Store) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_session_messages_v2_key ON session_messages_v2(session_key);`,
 		// session_routes: maps canonical session_key → delivery channel details.
 		`CREATE TABLE IF NOT EXISTS session_routes (
-			session_key TEXT PRIMARY KEY,
-			channel     TEXT NOT NULL DEFAULT 'telegram',
-			chat_id     INTEGER DEFAULT 0,
-			thread_id   INTEGER DEFAULT 0,
-			user_id     INTEGER DEFAULT 0,
-			username    TEXT DEFAULT '',
-			updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP
-		);`,
+				session_key TEXT PRIMARY KEY,
+				channel     TEXT NOT NULL,
+				chat_id     INTEGER NOT NULL,
+				thread_id   INTEGER NOT NULL DEFAULT 0,
+				reply_to_message_id INTEGER NOT NULL DEFAULT 0,
+				user_id     INTEGER NOT NULL DEFAULT 0,
+				username    TEXT NOT NULL DEFAULT '',
+				updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+			);`,
+		`ALTER TABLE session_routes ADD COLUMN channel TEXT NOT NULL DEFAULT 'telegram';`,
+		`ALTER TABLE session_routes ADD COLUMN chat_id INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE session_routes ADD COLUMN thread_id INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE session_routes ADD COLUMN reply_to_message_id INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE session_routes ADD COLUMN user_id INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE session_routes ADD COLUMN username TEXT NOT NULL DEFAULT '';`,
+		`ALTER TABLE session_routes ADD COLUMN updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;`,
 	}
 
 	for _, migration := range migrations {

--- a/internal/storage/sqlite_schema_test.go
+++ b/internal/storage/sqlite_schema_test.go
@@ -124,6 +124,100 @@ func TestSessionRouteCRUD(t *testing.T) {
 	}
 }
 
+func TestCanonicalMigrationRepairsLegacySessionRoutesSchema(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "legacy-routes.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+
+	stmts := []string{
+		`CREATE TABLE sessions_v2 (
+			session_key TEXT PRIMARY KEY,
+			agent_id TEXT NOT NULL DEFAULT 'default',
+			parent_session_key TEXT NOT NULL DEFAULT '',
+			state TEXT NOT NULL DEFAULT '',
+			model_override TEXT NOT NULL DEFAULT '',
+			think_level TEXT NOT NULL DEFAULT '',
+			usage_mode TEXT NOT NULL DEFAULT 'off',
+			verbose INTEGER NOT NULL DEFAULT 0,
+			deliver INTEGER NOT NULL DEFAULT 0,
+			queue_depth INTEGER NOT NULL DEFAULT 0,
+			queue_mode TEXT NOT NULL DEFAULT 'collect',
+			queue_debounce_ms INTEGER NOT NULL DEFAULT 1500,
+			input_tokens INTEGER NOT NULL DEFAULT 0,
+			output_tokens INTEGER NOT NULL DEFAULT 0,
+			total_tokens INTEGER NOT NULL DEFAULT 0,
+			context_tokens INTEGER NOT NULL DEFAULT 0,
+			message_count INTEGER NOT NULL DEFAULT 0,
+			compaction_count INTEGER NOT NULL DEFAULT 0,
+			last_summary TEXT NOT NULL DEFAULT '',
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);`,
+		`CREATE TABLE session_routes (
+			session_key TEXT PRIMARY KEY,
+			channel TEXT NOT NULL DEFAULT 'telegram',
+			chat_id INTEGER DEFAULT 0,
+			thread_id INTEGER DEFAULT 0,
+			user_id INTEGER DEFAULT 0,
+			username TEXT DEFAULT '',
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed stmt failed: %v\nSQL: %s", err, stmt)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close failed: %v", err)
+	}
+
+	store, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	var columnCount int
+	err = store.DB().QueryRow(`
+		SELECT COUNT(*)
+		FROM pragma_table_info('session_routes')
+		WHERE name = 'reply_to_message_id'
+	`).Scan(&columnCount)
+	if err != nil {
+		t.Fatalf("failed to inspect session_routes columns: %v", err)
+	}
+	if columnCount != 1 {
+		t.Fatalf("expected reply_to_message_id column to be added, got count=%d", columnCount)
+	}
+
+	route := SessionRoute{
+		SessionKey:       "agent:default:telegram:group:777",
+		Channel:          "telegram",
+		ChatID:           777,
+		ThreadID:         3,
+		ReplyToMessageID: 444,
+		UserID:           1001,
+		Username:         "route_user",
+	}
+	if err := store.SaveSessionRoute(route); err != nil {
+		t.Fatalf("SaveSessionRoute failed after migration: %v", err)
+	}
+	got, err := store.GetSessionRoute(route.SessionKey)
+	if err != nil {
+		t.Fatalf("GetSessionRoute failed after migration: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected route, got nil")
+	}
+	if got.ReplyToMessageID != route.ReplyToMessageID {
+		t.Fatalf("ReplyToMessageID mismatch: got %d want %d", got.ReplyToMessageID, route.ReplyToMessageID)
+	}
+}
+
 func TestRecordSubagentSpawnSetsCanonicalColumns(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/sqlite_v2_test.go
+++ b/internal/storage/sqlite_v2_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-// newTestStore creates a temporary SQLite store for testing.
-func newTestStore(t *testing.T) *Store {
+// newV2TestStore creates a temporary SQLite store for testing.
+func newV2TestStore(t *testing.T) *Store {
 	t.Helper()
 	dir := t.TempDir()
 	s, err := New(filepath.Join(dir, "test.db"))
@@ -19,7 +19,7 @@ func newTestStore(t *testing.T) *Store {
 
 // TestV2TablesCreated verifies that the v2 tables are created by the migration.
 func TestV2TablesCreated(t *testing.T) {
-	s := newTestStore(t)
+	s := newV2TestStore(t)
 
 	tables := []string{"sessions_v2", "session_messages_v2", "session_routes"}
 	for _, tbl := range tables {
@@ -35,7 +35,7 @@ func TestV2TablesCreated(t *testing.T) {
 
 // TestUpsertAndGetSessionV2 verifies basic insert/read of sessions_v2.
 func TestUpsertAndGetSessionV2(t *testing.T) {
-	s := newTestStore(t)
+	s := newV2TestStore(t)
 
 	sess := &SessionV2{
 		SessionKey:      "agent:bot:telegram:group:-100",
@@ -75,7 +75,7 @@ func TestUpsertAndGetSessionV2(t *testing.T) {
 
 // TestGetSessionV2NotFound verifies that missing keys return nil without error.
 func TestGetSessionV2NotFound(t *testing.T) {
-	s := newTestStore(t)
+	s := newV2TestStore(t)
 
 	got, err := s.GetSessionV2("nonexistent")
 	if err != nil {
@@ -88,7 +88,7 @@ func TestGetSessionV2NotFound(t *testing.T) {
 
 // TestSaveAndGetSessionMessagesV2 verifies message storage and retrieval.
 func TestSaveAndGetSessionMessagesV2(t *testing.T) {
-	s := newTestStore(t)
+	s := newV2TestStore(t)
 	key := "agent:bot:main"
 
 	// Seed a v2 session so message_count updates work.
@@ -133,7 +133,7 @@ func TestSaveAndGetSessionMessagesV2(t *testing.T) {
 
 // TestUpsertAndGetSessionRoute verifies session_routes CRUD.
 func TestUpsertAndGetSessionRoute(t *testing.T) {
-	s := newTestStore(t)
+	s := newV2TestStore(t)
 
 	route := SessionRoute{
 		SessionKey: "agent:bot:telegram:group:-100",
@@ -164,7 +164,7 @@ func TestUpsertAndGetSessionRoute(t *testing.T) {
 
 // TestGetSessionRouteNotFound verifies missing keys return nil without error.
 func TestGetSessionRouteNotFound(t *testing.T) {
-	s := newTestStore(t)
+	s := newV2TestStore(t)
 
 	got, err := s.GetSessionRoute("nonexistent")
 	if err != nil {
@@ -178,7 +178,7 @@ func TestGetSessionRouteNotFound(t *testing.T) {
 // TestPromoteLegacySession_NoLegacy verifies that promotion creates a bare v2
 // session even when there is no legacy data for chatID.
 func TestPromoteLegacySession_NoLegacy(t *testing.T) {
-	s := newTestStore(t)
+	s := newV2TestStore(t)
 
 	key := "agent:bot:telegram:group:-200"
 	if err := s.PromoteLegacySession(key, "bot", "telegram", -200); err != nil {
@@ -208,7 +208,7 @@ func TestPromoteLegacySession_NoLegacy(t *testing.T) {
 // TestPromoteLegacySession_WithLegacy verifies that promotion copies metadata
 // and messages from the legacy tables, leaving the originals intact.
 func TestPromoteLegacySession_WithLegacy(t *testing.T) {
-	s := newTestStore(t)
+	s := newV2TestStore(t)
 
 	chatID := int64(-300)
 
@@ -274,7 +274,7 @@ func TestPromoteLegacySession_WithLegacy(t *testing.T) {
 
 // TestPromoteLegacySession_Idempotent verifies that a second call is a no-op.
 func TestPromoteLegacySession_Idempotent(t *testing.T) {
-	s := newTestStore(t)
+	s := newV2TestStore(t)
 
 	key := "agent:bot:telegram:group:-400"
 	chatID := int64(-400)
@@ -294,4 +294,3 @@ func TestPromoteLegacySession_Idempotent(t *testing.T) {
 		t.Errorf("expected 1 sessions_v2 row, got %d", count)
 	}
 }
-


### PR DESCRIPTION
Closes #119

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes silent failures in `/status` and other commands by adding the missing `reply_to_message_id` column to the `session_routes` table schema. The code was already attempting to use this column in SQL queries, causing operations to fail on databases created with the old schema.

- Added `reply_to_message_id INTEGER NOT NULL DEFAULT 0` to the table schema
- Implemented backward-compatible migration using ALTER TABLE statements for all columns
- Added comprehensive test (`TestCanonicalMigrationRepairsLegacySessionRoutesSchema`) that verifies migration works on legacy databases
- Renamed test helper function for better clarity

The migration strategy is idempotent and handles both new and existing databases correctly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses a critical bug using standard SQLite migration patterns. The ALTER TABLE approach safely adds the missing column to existing databases while handling duplicate column errors appropriately. The new test validates that the migration works for legacy schemas, and all changes are backward-compatible.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/storage/sqlite.go | Added `reply_to_message_id` column to `session_routes` table schema and ALTER TABLE statements for backward compatibility migration |
| internal/storage/sqlite_schema_test.go | Added test verifying migration correctly adds missing column to legacy databases |
| internal/storage/sqlite_v2_test.go | Renamed helper function from `newTestStore` to `newV2TestStore` for clarity |

</details>



<sub>Last reviewed commit: 022b7b1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->