### PR TITLE
fix: TUI CmdSend routes through Telegram session instead of isolated TUI session

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -97,6 +97,14 @@ func (a *stateAdapter) SpawnSubagent(parentChatID int64, task, agentName string)
 	return a.b.SendMessage(parentChatID, msg)
 }
 
+func (a *stateAdapter) SubmitTUIRun(ctx context.Context, req control.TUIRunRequest) <-chan agent.RunEvent {
+	return a.b.SubmitTUIRun(ctx, req)
+}
+
+func (a *stateAdapter) AbortTUIRun(sessionKey string) {
+	a.b.AbortTUIRun(sessionKey)
+}
+
 // New creates a new application instance
 func New(cfg *config.Config, store *storage.Store) *App {
 	return &App{

--- a/internal/bot/tui_runtime.go
+++ b/internal/bot/tui_runtime.go
@@ -1,0 +1,39 @@
+package bot
+
+import (
+	"context"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/control"
+)
+
+// SubmitTUIRun submits an isolated TUI run through the bot's RuntimeHub.
+// TUI runs intentionally use ChatID=0 so they stay independent from Telegram
+// chat sessions while still reusing the same resolver, tools, and personality.
+func (b *Bot) SubmitTUIRun(ctx context.Context, req control.TUIRunRequest) <-chan agent.RunEvent {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var overrides *agent.RunOverrides
+	if req.Model != "" {
+		overrides = &agent.RunOverrides{Model: req.Model}
+	}
+
+	return b.hub.Submit(agent.RunRequest{
+		SessionKey:   agent.SessionKey(req.SessionKey),
+		ChatID:       0,
+		Content:      req.Content,
+		Session:      req.Session,
+		Context:      ctx,
+		OnToolEvent:  req.OnToolEvent,
+		OnDelta:      req.OnDelta,
+		OnDeltaReset: req.OnDeltaReset,
+		Overrides:    overrides,
+	})
+}
+
+// AbortTUIRun cancels the active isolated TUI run for the provided session key.
+func (b *Bot) AbortTUIRun(sessionKey string) {
+	b.hub.Cancel(agent.SessionKey(sessionKey))
+}

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"sync"
 
 	"github.com/gobwas/ws"
 
@@ -83,6 +84,8 @@ type Server struct {
 	state      StateProvider
 	httpSrv    *http.Server
 	runtimeHub *runtimepkg.Hub
+	tuiMu      sync.Mutex
+	tuiState   *tuiSessionStore
 }
 
 // New creates a new Server.  Call Start to begin accepting connections.
@@ -92,6 +95,9 @@ func New(cfg Config, state StateProvider) *Server {
 		cfg:   cfg,
 		hub:   hub,
 		state: state,
+		tuiState: &tuiSessionStore{
+			byID: make(map[string]*tuiSessionState),
+		},
 	}
 }
 

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -2,12 +2,20 @@ package control
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
+	"time"
 
+	"ok-gobot/internal/agent"
 	runtimepkg "ok-gobot/internal/runtime"
+)
+
+const (
+	defaultTUISessionID   = "main"
+	defaultTUISessionName = "Main"
+	tuiSessionKeyPrefix   = "agent:default:tui:"
 )
 
 func isTUICommand(cmdType string) bool {
@@ -27,6 +35,7 @@ func isTUICommand(cmdType string) bool {
 }
 
 func (s *Server) initTUIRuntime(ctx context.Context) {
+	s.ensureDefaultTUISession()
 	s.runtimeHub = runtimepkg.NewHub(ctx, 64)
 	evCh := make(chan runtimepkg.RuntimeEvent, 128)
 	s.runtimeHub.Subscribe(evCh)
@@ -64,10 +73,16 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 		})
 
 	case CmdNewSession:
-		c.sendTUIError("new_session is not supported on bot control sessions")
+		created := s.newTUISession(cmd.Name, cmd.Model)
+		c.tuiSessionID = created.ID
+		c.sendTUIMsg(ServerMsg{
+			Type:      MsgTypeConnected,
+			SessionID: created.ID,
+			Sessions:  s.listTUISessions(),
+		})
 
 	case CmdSend:
-		sessionID, chatID, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
+		sessionID, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
 		if !ok {
 			return
 		}
@@ -76,6 +91,19 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 			c.sendTUIError("text is required")
 			return
 		}
+
+		provider, ok := s.state.(TUIRunProvider)
+		if !ok {
+			c.sendTUIError("tui runtime provider not configured")
+			return
+		}
+
+		snapshot, err := s.startTUIRun(sessionID)
+		if err != nil {
+			c.sendTUIError(err.Error())
+			return
+		}
+
 		s.hub.BroadcastTUI(ServerMsg{
 			Type:      MsgTypeEvent,
 			Kind:      KindMessage,
@@ -83,21 +111,82 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 			Role:      "user",
 			Content:   text,
 		})
-		if err := s.state.SendChat(chatID, text); err != nil {
-			c.sendTUIError(err.Error())
+		s.hub.BroadcastTUI(ServerMsg{
+			Type:      MsgTypeEvent,
+			Kind:      KindRunStart,
+			SessionID: sessionID,
+		})
+
+		req := TUIRunRequest{
+			SessionKey: tuiSessionKeyForID(sessionID),
+			Content:    text,
+			Session:    snapshot.lastAssistant,
+			Model:      snapshot.modelOverride,
+			OnDelta: func(delta string) {
+				if delta == "" {
+					return
+				}
+				s.hub.BroadcastTUI(ServerMsg{
+					Type:      MsgTypeEvent,
+					Kind:      KindToken,
+					SessionID: sessionID,
+					Content:   delta,
+				})
+			},
+			OnToolEvent: func(event agent.ToolEvent) {
+				switch event.Type {
+				case agent.ToolEventStarted:
+					s.hub.BroadcastTUI(ServerMsg{
+						Type:      MsgTypeEvent,
+						Kind:      KindToolStart,
+						SessionID: sessionID,
+						ToolName:  event.ToolName,
+					})
+				case agent.ToolEventFinished:
+					msg := ServerMsg{
+						Type:      MsgTypeEvent,
+						Kind:      KindToolEnd,
+						SessionID: sessionID,
+						ToolName:  event.ToolName,
+					}
+					if event.Err != nil {
+						msg.ToolError = event.Err.Error()
+					}
+					s.hub.BroadcastTUI(msg)
+				}
+			},
+		}
+
+		events := provider.SubmitTUIRun(context.Background(), req)
+		if events == nil {
+			s.finishTUIRun(sessionID, "")
+			s.hub.BroadcastTUI(ServerMsg{
+				Type:      MsgTypeEvent,
+				Kind:      KindError,
+				SessionID: sessionID,
+				Message:   "tui runtime returned no events",
+			})
+			s.hub.BroadcastTUI(ServerMsg{
+				Type:      MsgTypeEvent,
+				Kind:      KindRunEnd,
+				SessionID: sessionID,
+			})
 			return
 		}
+		go s.consumeTUIRunEvents(sessionID, events)
 		c.tuiSessionID = sessionID
 
 	case CmdAbort:
-		_, chatID, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
+		sessionID, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
 		if !ok {
 			return
 		}
-		if err := s.state.AbortRun(chatID); err != nil {
-			c.sendTUIError(err.Error())
+		provider, ok := s.state.(TUIRunProvider)
+		if !ok {
+			c.sendTUIError("tui runtime provider not configured")
 			return
 		}
+		provider.AbortTUIRun(tuiSessionKeyForID(sessionID))
 
 	case CmdApprove:
 		if strings.TrimSpace(cmd.ApprovalID) == "" {
@@ -110,7 +199,7 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 		}
 
 	case CmdSetModel:
-		sessionID, chatID, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
+		sessionID, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
 		if !ok {
 			return
 		}
@@ -119,23 +208,18 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 			c.sendTUIError("model is required")
 			return
 		}
-		if err := s.state.SetModel(chatID, model); err != nil {
+		if err := s.setTUIModel(sessionID, model); err != nil {
 			c.sendTUIError(err.Error())
 			return
 		}
 		c.tuiSessionID = sessionID
-		updated, err := s.listTUISessions()
-		if err != nil {
-			c.sendTUIError(err.Error())
-			return
-		}
 		c.sendTUIMsg(ServerMsg{
 			Type:     MsgTypeSessions,
-			Sessions: updated,
+			Sessions: s.listTUISessions(),
 		})
 
 	case CmdSpawnSubagent:
-		sessionID, _, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
+		sessionID, ok := s.resolveTUISession(c, cmd.SessionID, sessions)
 		if !ok {
 			return
 		}
@@ -182,11 +266,7 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 }
 
 func (s *Server) ensureTUIConnected(c *client, requestedID string) ([]TUISessionInfo, bool) {
-	sessions, err := s.listTUISessions()
-	if err != nil {
-		c.sendTUIError(err.Error())
-		return nil, false
-	}
+	sessions := s.listTUISessions()
 
 	if !c.tuiConnected {
 		c.tuiConnected = true
@@ -201,44 +281,209 @@ func (s *Server) ensureTUIConnected(c *client, requestedID string) ([]TUISession
 	return sessions, true
 }
 
-func (s *Server) resolveTUISession(c *client, requestedID string, sessions []TUISessionInfo) (string, int64, bool) {
+func (s *Server) resolveTUISession(c *client, requestedID string, sessions []TUISessionInfo) (string, bool) {
 	sessionID := selectSessionID(sessions, requestedID, c.tuiSessionID)
 	if sessionID == "" {
 		c.sendTUIError("no sessions available")
-		return "", 0, false
-	}
-	chatID, err := strconv.ParseInt(sessionID, 10, 64)
-	if err != nil {
-		c.sendTUIError("invalid session_id")
-		return "", 0, false
+		return "", false
 	}
 	if !hasSessionID(sessions, sessionID) {
 		c.sendTUIError("session not found")
-		return "", 0, false
+		return "", false
 	}
 	c.tuiSessionID = sessionID
-	return sessionID, chatID, true
+	return sessionID, true
 }
 
-func (s *Server) listTUISessions() ([]TUISessionInfo, error) {
-	sessions, err := s.state.ListSessions()
-	if err != nil {
-		return nil, err
+func (s *Server) consumeTUIRunEvents(sessionID string, events <-chan agent.RunEvent) {
+	var finalMessage string
+	defer func() {
+		s.finishTUIRun(sessionID, finalMessage)
+		if strings.TrimSpace(finalMessage) != "" {
+			s.hub.BroadcastTUI(ServerMsg{
+				Type:      MsgTypeEvent,
+				Kind:      KindMessage,
+				SessionID: sessionID,
+				Role:      "assistant",
+				Content:   finalMessage,
+			})
+		}
+		s.hub.BroadcastTUI(ServerMsg{
+			Type:      MsgTypeEvent,
+			Kind:      KindRunEnd,
+			SessionID: sessionID,
+		})
+	}()
+
+	for ev := range events {
+		switch ev.Type {
+		case agent.RunEventDone:
+			if ev.Result != nil {
+				finalMessage = ev.Result.Message
+			}
+		case agent.RunEventError:
+			if ev.Err != nil && !errors.Is(ev.Err, context.Canceled) {
+				s.hub.BroadcastTUI(ServerMsg{
+					Type:      MsgTypeEvent,
+					Kind:      KindError,
+					SessionID: sessionID,
+					Message:   ev.Err.Error(),
+				})
+			}
+		}
 	}
-	out := make([]TUISessionInfo, 0, len(sessions))
-	for _, sess := range sessions {
-		name := strings.TrimSpace(sess.Username)
-		if name == "" {
-			name = fmt.Sprintf("Chat %d", sess.ChatID)
+}
+
+func (s *Server) ensureDefaultTUISession() {
+	s.tuiMu.Lock()
+	defer s.tuiMu.Unlock()
+
+	if s.tuiState == nil {
+		s.tuiState = &tuiSessionStore{byID: make(map[string]*tuiSessionState)}
+	}
+	if len(s.tuiState.byID) > 0 {
+		return
+	}
+
+	s.tuiState.byID[defaultTUISessionID] = &tuiSessionState{
+		ID:        defaultTUISessionID,
+		Name:      defaultTUISessionName,
+		Model:     s.defaultTUIModel(),
+		CreatedAt: time.Now(),
+	}
+	s.tuiState.order = []string{defaultTUISessionID}
+}
+
+func (s *Server) newTUISession(name, model string) TUISessionInfo {
+	s.ensureDefaultTUISession()
+
+	s.tuiMu.Lock()
+	defer s.tuiMu.Unlock()
+
+	for {
+		s.tuiState.nextID++
+		id := fmt.Sprintf("tui-%d", s.tuiState.nextID)
+		if _, exists := s.tuiState.byID[id]; exists {
+			continue
+		}
+		displayName := strings.TrimSpace(name)
+		if displayName == "" {
+			displayName = fmt.Sprintf("Chat %d", len(s.tuiState.order)+1)
+		}
+		displayModel := strings.TrimSpace(model)
+		if displayModel == "" {
+			displayModel = s.defaultTUIModel()
+		}
+		session := &tuiSessionState{
+			ID:            id,
+			Name:          displayName,
+			Model:         displayModel,
+			ModelOverride: strings.TrimSpace(model),
+			CreatedAt:     time.Now(),
+		}
+		s.tuiState.byID[id] = session
+		s.tuiState.order = append(s.tuiState.order, id)
+		return TUISessionInfo{
+			ID:      session.ID,
+			Name:    session.Name,
+			Model:   session.Model,
+			Running: session.Running,
+		}
+	}
+}
+
+func (s *Server) listTUISessions() []TUISessionInfo {
+	s.ensureDefaultTUISession()
+
+	s.tuiMu.Lock()
+	defer s.tuiMu.Unlock()
+
+	out := make([]TUISessionInfo, 0, len(s.tuiState.order))
+	for _, id := range s.tuiState.order {
+		session, ok := s.tuiState.byID[id]
+		if !ok {
+			continue
 		}
 		out = append(out, TUISessionInfo{
-			ID:      sessionIDForChat(sess.ChatID),
-			Name:    name,
-			Model:   sess.Model,
-			Running: sess.State == "running" || sess.State == "queued",
+			ID:      session.ID,
+			Name:    session.Name,
+			Model:   session.Model,
+			Running: session.Running,
 		})
 	}
-	return out, nil
+	return out
+}
+
+func (s *Server) setTUIModel(sessionID, model string) error {
+	s.tuiMu.Lock()
+	defer s.tuiMu.Unlock()
+
+	session, ok := s.tuiState.byID[sessionID]
+	if !ok {
+		return fmt.Errorf("session not found")
+	}
+	session.Model = model
+	session.ModelOverride = model
+	return nil
+}
+
+type tuiRunSnapshot struct {
+	lastAssistant string
+	modelOverride string
+}
+
+func (s *Server) startTUIRun(sessionID string) (tuiRunSnapshot, error) {
+	s.tuiMu.Lock()
+	defer s.tuiMu.Unlock()
+
+	session, ok := s.tuiState.byID[sessionID]
+	if !ok {
+		return tuiRunSnapshot{}, fmt.Errorf("session not found")
+	}
+	if session.Running {
+		return tuiRunSnapshot{}, fmt.Errorf("A run is already in progress. Use /abort first.")
+	}
+	session.Running = true
+	return tuiRunSnapshot{
+		lastAssistant: session.LastAssistant,
+		modelOverride: session.ModelOverride,
+	}, nil
+}
+
+func (s *Server) finishTUIRun(sessionID, assistant string) {
+	s.tuiMu.Lock()
+	defer s.tuiMu.Unlock()
+
+	session, ok := s.tuiState.byID[sessionID]
+	if !ok {
+		return
+	}
+	session.Running = false
+	if strings.TrimSpace(assistant) != "" {
+		session.LastAssistant = assistant
+	}
+}
+
+func (s *Server) defaultTUIModel() string {
+	status := s.state.GetStatus()
+	if status == nil {
+		return ""
+	}
+
+	aiRaw, ok := status["ai"]
+	if !ok {
+		return ""
+	}
+
+	switch aiMap := aiRaw.(type) {
+	case map[string]string:
+		return strings.TrimSpace(aiMap["model"])
+	case map[string]interface{}:
+		if model, ok := aiMap["model"].(string); ok {
+			return strings.TrimSpace(model)
+		}
+	}
+	return ""
 }
 
 func hasSessionID(sessions []TUISessionInfo, id string) bool {
@@ -263,6 +508,10 @@ func selectSessionID(sessions []TUISessionInfo, requestedID, fallbackID string) 
 		return sessions[0].ID
 	}
 	return ""
+}
+
+func tuiSessionKeyForID(sessionID string) string {
+	return tuiSessionKeyPrefix + sessionID
 }
 
 func (s *Server) bridgeRuntimeEvents(ctx context.Context, evCh <-chan runtimepkg.RuntimeEvent) {

--- a/internal/control/server_tui_test.go
+++ b/internal/control/server_tui_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gobwas/ws"
 	"github.com/gobwas/ws/wsutil"
 
+	"ok-gobot/internal/agent"
 	"ok-gobot/internal/control"
 )
 
@@ -26,10 +27,18 @@ type mockTUIState struct {
 		chatID int64
 		model  string
 	}
+	tuiRunReqs  []control.TUIRunRequest
+	tuiAbortKey []string
+	tuiSubmitFn func(control.TUIRunRequest) <-chan agent.RunEvent
 }
 
 func (m *mockTUIState) GetStatus() map[string]interface{} {
-	return map[string]interface{}{"ok": true}
+	return map[string]interface{}{
+		"ok": true,
+		"ai": map[string]interface{}{
+			"model": "model-a",
+		},
+	}
 }
 
 func (m *mockTUIState) ListSessions() ([]control.SessionInfo, error) {
@@ -62,12 +71,39 @@ func (m *mockTUIState) SetModel(chatID int64, model string) error {
 		chatID int64
 		model  string
 	}{chatID: chatID, model: model})
-	for i := range m.sessions {
-		if m.sessions[i].ChatID == chatID {
-			m.sessions[i].Model = model
-		}
-	}
 	return nil
+}
+
+func (m *mockTUIState) SubmitTUIRun(_ context.Context, req control.TUIRunRequest) <-chan agent.RunEvent {
+	m.mu.Lock()
+	m.tuiRunReqs = append(m.tuiRunReqs, req)
+	submitFn := m.tuiSubmitFn
+	m.mu.Unlock()
+
+	if submitFn != nil {
+		return submitFn(req)
+	}
+
+	ch := make(chan agent.RunEvent, 1)
+	go func() {
+		if req.OnDelta != nil {
+			req.OnDelta("token")
+		}
+		ch <- agent.RunEvent{
+			Type: agent.RunEventDone,
+			Result: &agent.AgentResponse{
+				Message: "assistant reply",
+			},
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+func (m *mockTUIState) AbortTUIRun(sessionKey string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tuiAbortKey = append(m.tuiAbortKey, sessionKey)
 }
 
 func startServerWithHandle(t *testing.T, state control.StateProvider) (*control.Server, string, context.CancelFunc) {
@@ -128,11 +164,7 @@ func readTUIMessage(t *testing.T, conn net.Conn) control.ServerMsg {
 }
 
 func TestControlServerHandlesTUISessionCommands(t *testing.T) {
-	state := &mockTUIState{
-		sessions: []control.SessionInfo{
-			{ChatID: 42, Username: "alice", Model: "model-a", State: "idle"},
-		},
-	}
+	state := &mockTUIState{}
 	_, addr, cancel := startServerWithHandle(t, state)
 	defer cancel()
 
@@ -144,8 +176,8 @@ func TestControlServerHandlesTUISessionCommands(t *testing.T) {
 	if connected.Type != control.MsgTypeConnected {
 		t.Fatalf("expected %q, got %q", control.MsgTypeConnected, connected.Type)
 	}
-	if connected.SessionID != "42" {
-		t.Fatalf("expected active session_id 42, got %q", connected.SessionID)
+	if connected.SessionID != "main" {
+		t.Fatalf("expected active session_id main, got %q", connected.SessionID)
 	}
 
 	sessions := readTUIMessage(t, conn)
@@ -153,32 +185,57 @@ func TestControlServerHandlesTUISessionCommands(t *testing.T) {
 		t.Fatalf("expected %q, got %q", control.MsgTypeSessions, sessions.Type)
 	}
 	if len(sessions.Sessions) != 1 {
-		t.Fatalf("expected 1 session, got %d", len(sessions.Sessions))
+		t.Fatalf("expected 1 default TUI session, got %d", len(sessions.Sessions))
 	}
 	if sessions.Sessions[0].Model != "model-a" {
-		t.Fatalf("expected model model-a, got %q", sessions.Sessions[0].Model)
+		t.Fatalf("expected default model model-a, got %q", sessions.Sessions[0].Model)
+	}
+
+	sendTUIRequest(t, conn, control.ClientMsg{
+		Type:  control.CmdNewSession,
+		Name:  "Scratch",
+		Model: "model-x",
+	})
+	created := readTUIMessage(t, conn)
+	if created.Type != control.MsgTypeConnected {
+		t.Fatalf("expected %q after new_session, got %q", control.MsgTypeConnected, created.Type)
+	}
+	if created.SessionID == "main" {
+		t.Fatal("expected a distinct new TUI session ID")
+	}
+	if len(created.Sessions) != 2 {
+		t.Fatalf("expected 2 sessions after new_session, got %d", len(created.Sessions))
 	}
 
 	sendTUIRequest(t, conn, control.ClientMsg{
 		Type:      control.CmdSetModel,
-		SessionID: "42",
+		SessionID: created.SessionID,
 		Model:     "model-b",
 	})
 	updated := readTUIMessage(t, conn)
 	if updated.Type != control.MsgTypeSessions {
 		t.Fatalf("expected %q after set_model, got %q", control.MsgTypeSessions, updated.Type)
 	}
-	if len(updated.Sessions) != 1 || updated.Sessions[0].Model != "model-b" {
-		t.Fatalf("expected updated model model-b, got %#v", updated.Sessions)
+	var gotModel string
+	for _, s := range updated.Sessions {
+		if s.ID == created.SessionID {
+			gotModel = s.Model
+			break
+		}
+	}
+	if gotModel != "model-b" {
+		t.Fatalf("expected updated model model-b, got %q", gotModel)
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.modelSet) != 0 {
+		t.Fatalf("expected no Telegram SetModel calls for TUI sessions, got %d", len(state.modelSet))
 	}
 }
 
 func TestControlServerHandlesTUISend(t *testing.T) {
-	state := &mockTUIState{
-		sessions: []control.SessionInfo{
-			{ChatID: 777, Model: "model-a", State: "idle"},
-		},
-	}
+	state := &mockTUIState{}
 	_, addr, cancel := startServerWithHandle(t, state)
 	defer cancel()
 
@@ -190,37 +247,106 @@ func TestControlServerHandlesTUISend(t *testing.T) {
 
 	sendTUIRequest(t, conn, control.ClientMsg{
 		Type:      control.CmdSend,
-		SessionID: "777",
+		SessionID: "main",
 		Text:      "hello from tui",
 	})
 
-	event := readTUIMessage(t, conn)
-	if event.Type != control.MsgTypeEvent || event.Kind != control.KindMessage {
-		t.Fatalf("expected user message event, got type=%q kind=%q", event.Type, event.Kind)
+	var (
+		gotUser   bool
+		gotStart  bool
+		gotToken  bool
+		gotAssist bool
+		gotRunEnd bool
+		deadline  = time.Now().Add(2 * time.Second)
+	)
+
+	for time.Now().Before(deadline) {
+		msg := readTUIMessage(t, conn)
+		if msg.Type != control.MsgTypeEvent {
+			continue
+		}
+		switch msg.Kind {
+		case control.KindMessage:
+			if msg.Role == "user" && msg.Content == "hello from tui" && msg.SessionID == "main" {
+				gotUser = true
+			}
+			if msg.Role == "assistant" && msg.Content == "assistant reply" && msg.SessionID == "main" {
+				gotAssist = true
+			}
+		case control.KindRunStart:
+			if msg.SessionID == "main" {
+				gotStart = true
+			}
+		case control.KindToken:
+			if msg.Content == "token" && msg.SessionID == "main" {
+				gotToken = true
+			}
+		case control.KindRunEnd:
+			if msg.SessionID == "main" {
+				gotRunEnd = true
+			}
+		}
+		if gotUser && gotStart && gotToken && gotAssist && gotRunEnd {
+			break
+		}
 	}
-	if event.SessionID != "777" {
-		t.Fatalf("expected session_id 777, got %q", event.SessionID)
-	}
-	if event.Role != "user" || event.Content != "hello from tui" {
-		t.Fatalf("unexpected message payload: role=%q content=%q", event.Role, event.Content)
+
+	if !gotUser || !gotStart || !gotToken || !gotAssist || !gotRunEnd {
+		t.Fatalf("missing expected TUI run events user=%v start=%v token=%v assistant=%v run_end=%v", gotUser, gotStart, gotToken, gotAssist, gotRunEnd)
 	}
 
 	state.mu.Lock()
 	defer state.mu.Unlock()
-	if len(state.sent) != 1 {
-		t.Fatalf("expected exactly 1 SendChat call, got %d", len(state.sent))
+	if len(state.sent) != 0 {
+		t.Fatalf("expected no SendChat calls, got %d", len(state.sent))
 	}
-	if state.sent[0].chatID != 777 || state.sent[0].text != "hello from tui" {
-		t.Fatalf("unexpected SendChat call: %+v", state.sent[0])
+	if len(state.tuiRunReqs) != 1 {
+		t.Fatalf("expected one SubmitTUIRun call, got %d", len(state.tuiRunReqs))
+	}
+	gotReq := state.tuiRunReqs[0]
+	if gotReq.SessionKey != "agent:default:tui:main" {
+		t.Fatalf("unexpected session key: %q", gotReq.SessionKey)
+	}
+	if gotReq.Content != "hello from tui" {
+		t.Fatalf("unexpected content: %q", gotReq.Content)
 	}
 }
 
-func TestHubEmitMirrorsLegacyRunEventsToTUI(t *testing.T) {
-	state := &mockTUIState{
-		sessions: []control.SessionInfo{
-			{ChatID: 99, Model: "model-a", State: "idle"},
-		},
+func TestControlServerAbortRoutesToTUIRuntimeProvider(t *testing.T) {
+	state := &mockTUIState{}
+	_, addr, cancel := startServerWithHandle(t, state)
+	defer cancel()
+
+	conn := wsConnect(t, addr)
+
+	sendTUIRequest(t, conn, control.ClientMsg{Type: control.CmdListSessions})
+	_ = readTUIMessage(t, conn) // connected
+	_ = readTUIMessage(t, conn) // sessions
+
+	sendTUIRequest(t, conn, control.ClientMsg{
+		Type:      control.CmdAbort,
+		SessionID: "main",
+	})
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		state.mu.Lock()
+		if len(state.tuiAbortKey) > 0 {
+			key := state.tuiAbortKey[0]
+			state.mu.Unlock()
+			if key != "agent:default:tui:main" {
+				t.Fatalf("unexpected abort key: %q", key)
+			}
+			return
+		}
+		state.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
 	}
+	t.Fatal("expected AbortTUIRun to be called")
+}
+
+func TestHubEmitMirrorsLegacyRunEventsToTUI(t *testing.T) {
+	state := &mockTUIState{}
 	srv, addr, cancel := startServerWithHandle(t, state)
 	defer cancel()
 

--- a/internal/control/tui_runtime.go
+++ b/internal/control/tui_runtime.go
@@ -1,0 +1,42 @@
+package control
+
+import (
+	"context"
+	"time"
+
+	"ok-gobot/internal/agent"
+)
+
+// TUIRunRequest describes one isolated TUI run routed through the bot runtime hub.
+type TUIRunRequest struct {
+	SessionKey   string
+	Content      string
+	Session      string
+	Model        string
+	OnToolEvent  func(agent.ToolEvent)
+	OnDelta      func(string)
+	OnDeltaReset func()
+}
+
+// TUIRunProvider is an optional state extension used by the control server TUI
+// command path. Implementations submit isolated TUI runs to the bot runtime hub.
+type TUIRunProvider interface {
+	SubmitTUIRun(ctx context.Context, req TUIRunRequest) <-chan agent.RunEvent
+	AbortTUIRun(sessionKey string)
+}
+
+type tuiSessionState struct {
+	ID            string
+	Name          string
+	Model         string
+	ModelOverride string
+	LastAssistant string
+	Running       bool
+	CreatedAt     time.Time
+}
+
+type tuiSessionStore struct {
+	byID   map[string]*tuiSessionState
+	order  []string
+	nextID int
+}


### PR DESCRIPTION
Closes #118

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully refactors TUI command handling to use isolated sessions (ChatID=0) instead of sharing Telegram chat sessions. The implementation provides proper separation between TUI and Telegram interactions while reusing the bot's runtime infrastructure.

**Key changes:**
- Introduced `TUIRunProvider` interface for routing TUI runs through the bot's RuntimeHub
- Added dedicated TUI session management with in-memory state storage
- Refactored `CmdSend` and `CmdAbort` to use isolated TUI sessions instead of Telegram ChatID-based sessions
- Implemented proper concurrency control with mutex protection for TUI session state
- Added comprehensive event handling and broadcasting for TUI runs
- Updated tests to verify new behavior and ensure no Telegram state is affected by TUI operations

**Architecture improvements:**
- Clean separation of concerns between TUI and Telegram sessions
- Proper event streaming with callbacks for deltas and tool events
- Defensive programming with nil checks and proper error handling
- Well-structured defer usage ensures session cleanup even on errors

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The changes are well-structured with proper concurrency control (mutex protection), comprehensive error handling, thorough test coverage, and clean separation of concerns. The refactoring from Telegram sessions to isolated TUI sessions is implemented correctly with no breaking changes to existing functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/tui_runtime.go | New file implementing isolated TUI runs with ChatID=0, properly routing through bot's RuntimeHub |
| internal/control/server_tui.go | Refactored TUI commands from Telegram sessions to isolated TUI sessions with proper concurrency control, event handling, and session management |
| internal/control/tui_runtime.go | New file defining TUIRunProvider interface and session state structs for isolated TUI runtime |

</details>



<sub>Last reviewed commit: 61fdc3b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->