### PR TITLE
fix: escape underscores in masked API key for Telegram Markdown v1

### DIFF
--- a/internal/bot/status.go
+++ b/internal/bot/status.go
@@ -33,7 +33,7 @@ func (b *Bot) handleStatusCommand(c telebot.Context) error {
 
 	// Model and provider
 	if b.aiConfig.APIKey != "" {
-		maskedKey := maskAPIKey(b.aiConfig.APIKey)
+		maskedKey := strings.ReplaceAll(maskAPIKey(b.aiConfig.APIKey), "_", "\\_")
 		sb.WriteString(fmt.Sprintf("🧠 Model: `%s` · 🔑 %s (%s)\n", b.aiConfig.Model, maskedKey, b.aiConfig.Provider))
 	} else {
 		sb.WriteString("⚠️ AI not configured\n")
@@ -97,7 +97,7 @@ func maskAPIKey(key string) string {
 	if len(key) <= 8 {
 		return "***"
 	}
-	return key[:6] + "…" + key[len(key)-4:]
+	return key[:6] + "..." + key[len(key)-4:]
 }
 
 func formatTimeAgo(timestamp string) string {


### PR DESCRIPTION
Fixes silent 400 error in `/status` command.

**Root cause:** `maskAPIKey()` returned keys with `_` (e.g. `fw_XxP...ADAX`). Telegram Markdown v1 interprets `_` as italic delimiter — unclosed italic caused `can't parse entities` 400 error.

**Fix:**
- Escape `_` in masked key output with `\_`  
- Replace unicode `…` with ASCII `...` to avoid similar edge cases

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes silent 400 error in `/status` command by escaping underscores in masked API keys to prevent Telegram Markdown v1 from interpreting them as italic delimiters. Also replaces unicode ellipsis with ASCII for better compatibility.

- Escaped `_` with `\_` in masked API key output (line 36)
- Replaced unicode `…` with ASCII `...` in `maskAPIKey()` function (line 100)

This is a clean, targeted fix that addresses the root cause of the parsing error without over-engineering the solution.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal, focused, and directly fix a documented bug. The escaping is applied at the correct location (after masking, before Telegram parsing), and the unicode-to-ASCII change is safe and backwards-compatible. No logic changes, no new dependencies, and the fix is isolated to the display layer.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/status.go | Escapes underscores in masked API keys for Telegram Markdown v1 compatibility and replaces unicode ellipsis with ASCII |

</details>



<sub>Last reviewed commit: f454470</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->