### PR TITLE
fix: strip #fragment from OAuth code input

### DIFF
--- a/internal/ai/anthropic_oauth.go
+++ b/internal/ai/anthropic_oauth.go
@@ -116,7 +116,11 @@ func NewAnthropicOAuthAuthRequest() (*AnthropicOAuthAuthRequest, error) {
 // ExtractAnthropicOAuthCode accepts either a raw code or callback URL and returns only code value.
 func ExtractAnthropicOAuthCode(input string) string {
 	raw := strings.TrimSpace(input)
-	raw = strings.TrimSuffix(raw, "#")
+	// Strip fragment (e.g. "code#state" → "code")
+	if idx := strings.Index(raw, "#"); idx >= 0 {
+		raw = raw[:idx]
+	}
+	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return ""
 	}


### PR DESCRIPTION
Anthropic callback returns `code#state` — the `#state` fragment was passed to the token endpoint causing `Invalid 'code'` error.

Fix: strip everything after `#` before using the code.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in `ExtractAnthropicOAuthCode` where the Anthropic callback delivers the authorization code in the form `code#state`, and the old `strings.TrimSuffix(raw, "#")` call only removed a bare trailing `#` — leaving the `#state` suffix intact and causing the token endpoint to reject the code with `Invalid 'code'`.

The fix is correct: `strings.Index(raw, "#")` finds the first `#` and truncates there, properly stripping any fragment regardless of what follows it.

**Key points:**
- The root cause and fix are both clearly described and accurately implemented.
- The extra `strings.TrimSpace(raw)` after truncation is a harmless defensive improvement (handles whitespace immediately before a `#`).
- One minor follow-on: the `r == '#'` guard inside the inner `code=...` fallback loop (line 138) is now dead code — `raw` can never contain a literal `#` at that point since it was already stripped above. This can be cleaned up for better code clarity.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the fix is minimal, targeted, and correctly resolves the `Invalid 'code'` error. Only suggestion is a minor dead-code cleanup with no impact on correctness.
- The fix is well-scoped and correct: replacing `TrimSuffix(raw, "#")` with `Index`-based truncation properly handles the `code#state` format. The change introduces no new dependencies or risky control flow. The identified finding (dead code at line 138) is a valid code quality observation — the condition is unreachable after the fragment-stripping fix — but its removal is optional and does not affect correctness or safety. This is a straightforward, low-risk bug fix.
- No files require special attention. The optional cleanup suggestion (removing the dead `r == '#'` condition at line 138) can be addressed if the author prefers; the code is already correct and safe as-is.

<sub>Last reviewed commit: abad88c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->