### PR TITLE
fix: show 'off' instead of 'default' for think level in /status

### DIFF
--- a/internal/bot/status.go
+++ b/internal/bot/status.go
@@ -68,8 +68,8 @@ func (b *Bot) handleStatusCommand(c telebot.Context) error {
 
 	// Runtime options
 	thinkLevel, _ := b.store.GetSessionOption(chatID, "think_level")
-	if thinkLevel == "" {
-		thinkLevel = "default"
+	if thinkLevel == "" || thinkLevel == "default" {
+		thinkLevel = "off"
 	}
 	queueMode, _ := b.store.GetSessionOption(chatID, "queue_mode")
 	if queueMode == "" {


### PR DESCRIPTION
When think_level is unset, /status showed `Think: default` which is misleading. The actual behavior is thinking disabled (off). Now shows `Think: off`.