### PR TITLE
feat: droid as AI backend via MCP bridge

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,12 +7,18 @@ telegram:
 
 # AI provider configuration
 ai:
-  provider: "openrouter"  # openrouter, openai, anthropic, or custom
+  provider: "openrouter"  # openrouter, openai, anthropic, droid, or custom
   api_key: "YOUR_API_KEY_HERE"
   model: "moonshotai/kimi-k2.5"
   base_url: ""  # For custom providers
   fallback_models: []
   default_thinking: ""  # Optional: off, low, medium, high, adaptive (provider/model dependent)
+  # Droid provider settings (factory.ai droid exec subprocess)
+  # Only used when provider: "droid"
+  # droid:
+  #   binary_path: "droid"   # Path to droid binary
+  #   auto_level: "low"      # Autonomy: low, medium, high
+  #   work_dir: ""           # Working directory for droid
 
 # Authentication configuration
 auth:

--- a/docs/ARCHITECTURE-v2.md
+++ b/docs/ARCHITECTURE-v2.md
@@ -82,6 +82,7 @@ single source of truth for configuration keys, types, defaults, and descriptions
             "openrouter",
             "openai",
             "anthropic",
+            "droid",
             "custom"
           ],
           "description": "AI provider backend."
@@ -115,6 +116,29 @@ single source of truth for configuration keys, types, defaults, and descriptions
           "type": "string",
           "default": "",
           "description": "Default thinking level for providers/models that support it."
+        },
+        "droid": {
+          "type": "object",
+          "default": {},
+          "description": "Settings for factory.ai droid provider (provider=droid).",
+          "properties": {
+            "binary_path": {
+              "type": "string",
+              "default": "droid",
+              "description": "Path to droid binary."
+            },
+            "auto_level": {
+              "type": "string",
+              "default": "",
+              "enum": ["", "low", "medium", "high"],
+              "description": "Droid autonomy level."
+            },
+            "work_dir": {
+              "type": "string",
+              "default": "",
+              "description": "Working directory for droid execution."
+            }
+          }
         }
       }
     },

--- a/internal/agent/tokens.go
+++ b/internal/agent/tokens.go
@@ -73,14 +73,14 @@ func ModelLimits(model string) int {
 		"anthropic/claude-3-sonnet":   200000,
 
 		// Anthropic native
-		"claude-sonnet-4-5":   200000,
-		"claude-opus-4-5":     200000,
-		"claude-haiku-4-5":    200000,
-		"claude-3-5-sonnet":   200000,
-		"claude-3-5-haiku":    200000,
-		"claude-3-opus":       200000,
-		"claude-3-sonnet":     200000,
-		"claude-3-haiku":      200000,
+		"claude-sonnet-4-5": 200000,
+		"claude-opus-4-5":   200000,
+		"claude-haiku-4-5":  200000,
+		"claude-3-5-sonnet": 200000,
+		"claude-3-5-haiku":  200000,
+		"claude-3-opus":     200000,
+		"claude-3-sonnet":   200000,
+		"claude-3-haiku":    200000,
 
 		// Google
 		"google/gemini-pro-1.5": 1000000,
@@ -91,6 +91,12 @@ func ModelLimits(model string) int {
 
 		// Kimi
 		"moonshotai/kimi-k2.5": 131072,
+
+		// Droid models (factory.ai)
+		"glm-5":        128000,
+		"glm-4.7":      128000,
+		"kimi-k2.5":    131072,
+		"minimax-m2.5": 128000,
 
 		// Default for unknown models
 		"default": 8192,

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -63,6 +63,19 @@ type OpenAICompatibleClient struct {
 // NewClient creates a new AI client from provider configuration.
 // Returns Client interface — use type assertion for streaming support.
 func NewClient(config ProviderConfig) (Client, error) {
+	return NewClientWithDroid(config, DroidConfig{})
+}
+
+// NewClientWithDroid creates a new AI client, accepting optional DroidConfig
+// for the "droid" provider.
+func NewClientWithDroid(config ProviderConfig, droidCfg DroidConfig) (Client, error) {
+	if config.Name == "droid" {
+		if config.Model == "" {
+			config.Model = "glm-5"
+		}
+		return NewDroidClient(config, droidCfg), nil
+	}
+
 	if config.Name == "anthropic" {
 		if config.BaseURL == "" {
 			config.BaseURL = "https://api.anthropic.com"
@@ -562,6 +575,12 @@ func AvailableModels() map[string][]string {
 			"claude-sonnet-4-5-20250929",
 			"claude-sonnet-4-20250514",
 			"claude-haiku-3-5-20241022",
+		},
+		"droid": {
+			"glm-5",        // GLM-5 (Zhipu AI)
+			"kimi-k2.5",    // Kimi K2.5 (Moonshot)
+			"minimax-m2.5", // MiniMax M2.5
+			"glm-4.7",      // GLM-4.7
 		},
 	}
 }

--- a/internal/ai/droid_client.go
+++ b/internal/ai/droid_client.go
@@ -1,0 +1,330 @@
+package ai
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"ok-gobot/internal/logger"
+)
+
+// DroidConfig holds droid-specific configuration.
+type DroidConfig struct {
+	BinaryPath string `mapstructure:"binary_path"` // Path to droid binary (default: "droid")
+	AutoLevel  string `mapstructure:"auto_level"`  // Autonomy level: "", "low", "medium", "high"
+	WorkDir    string `mapstructure:"work_dir"`    // Working directory for droid execution
+}
+
+// DroidClient implements Client and StreamingClient for factory.ai droid exec.
+//
+// Architecture: ok-gobot spawns `droid exec` as a subprocess per request.
+// Droid runs the model and handles tool execution internally, including MCP
+// tools registered with droid (e.g. ok-gobot's memory MCP server).
+//
+// Tool definitions passed via CompleteWithTools are ignored — droid discovers
+// tools from its own MCP server configuration, not from per-request definitions.
+//
+// For multi-turn context, the full message history is formatted into a single
+// prompt. Droid session management (--session-id) is not used yet; each request
+// starts a fresh droid session.
+type DroidClient struct {
+	config   ProviderConfig
+	droidCfg DroidConfig
+}
+
+// NewDroidClient creates a new droid subprocess client.
+func NewDroidClient(config ProviderConfig, droidCfg DroidConfig) *DroidClient {
+	if droidCfg.BinaryPath == "" {
+		droidCfg.BinaryPath = "droid"
+	}
+	return &DroidClient{
+		config:   config,
+		droidCfg: droidCfg,
+	}
+}
+
+// droidStreamEvent represents a single event from droid's stream-json output.
+type droidStreamEvent struct {
+	Type    string `json:"type"`
+	Content string `json:"content,omitempty"`
+	Text    string `json:"text,omitempty"`
+	// completion fields
+	Result    string `json:"result,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	IsError   bool   `json:"is_error,omitempty"`
+	// tool event fields (informational — droid handles tools internally)
+	ToolName string          `json:"tool_name,omitempty"`
+	Input    json.RawMessage `json:"input,omitempty"`
+}
+
+// buildArgs constructs the droid exec command arguments.
+func (c *DroidClient) buildArgs(prompt string, outputFmt string) []string {
+	args := []string{"exec"}
+
+	if c.config.Model != "" {
+		args = append(args, "-m", c.config.Model)
+	}
+
+	args = append(args, "-o", outputFmt)
+
+	if c.droidCfg.AutoLevel != "" {
+		args = append(args, "--auto", c.droidCfg.AutoLevel)
+	}
+
+	if c.droidCfg.WorkDir != "" {
+		args = append(args, "--cwd", c.droidCfg.WorkDir)
+	}
+
+	args = append(args, prompt)
+	return args
+}
+
+// formatDroidPrompt converts a legacy message history into a single prompt string.
+func formatDroidPrompt(messages []Message) string {
+	var sb strings.Builder
+	for _, msg := range messages {
+		switch msg.Role {
+		case "system":
+			sb.WriteString("[System]\n")
+			sb.WriteString(msg.Content)
+			sb.WriteString("\n\n")
+		case "user":
+			sb.WriteString(msg.Content)
+			sb.WriteString("\n")
+		case "assistant":
+			sb.WriteString("[Previous response]\n")
+			sb.WriteString(msg.Content)
+			sb.WriteString("\n\n")
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+// formatDroidChatPrompt converts ChatMessage history into a prompt string.
+func formatDroidChatPrompt(messages []ChatMessage) string {
+	var sb strings.Builder
+	for _, msg := range messages {
+		switch msg.Role {
+		case RoleSystem:
+			sb.WriteString("[System]\n")
+			sb.WriteString(msg.Content)
+			sb.WriteString("\n\n")
+		case RoleUser:
+			sb.WriteString(msg.Content)
+			sb.WriteString("\n")
+		case RoleAssistant:
+			if msg.Content != "" {
+				sb.WriteString("[Previous response]\n")
+				sb.WriteString(msg.Content)
+				sb.WriteString("\n\n")
+			}
+		case RoleTool:
+			sb.WriteString(fmt.Sprintf("[Tool result: %s]\n", msg.Name))
+			sb.WriteString(msg.Content)
+			sb.WriteString("\n\n")
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+// Complete sends messages and returns the response.
+func (c *DroidClient) Complete(ctx context.Context, messages []Message) (string, error) {
+	prompt := formatDroidPrompt(messages)
+	logger.Debugf("Droid Complete: model=%s prompt_len=%d", c.config.Model, len(prompt))
+
+	args := c.buildArgs(prompt, "json")
+	cmd := exec.CommandContext(ctx, c.droidCfg.BinaryPath, args...)
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("droid exec failed (exit %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		return "", fmt.Errorf("droid exec failed: %w", err)
+	}
+
+	var result struct {
+		Result    string `json:"result"`
+		IsError   bool   `json:"is_error"`
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(output, &result); err != nil {
+		// If JSON parse fails, return raw output as text.
+		return strings.TrimSpace(string(output)), nil
+	}
+
+	if result.IsError {
+		return "", fmt.Errorf("droid error: %s", result.Result)
+	}
+
+	logger.Debugf("Droid Complete response: len=%d session=%s", len(result.Result), result.SessionID)
+	return result.Result, nil
+}
+
+// CompleteWithTools sends messages with tool definitions and returns the full response.
+// Tool definitions are ignored — droid discovers tools via its MCP server configuration.
+func (c *DroidClient) CompleteWithTools(ctx context.Context, messages []ChatMessage, tools []ToolDefinition) (*ChatCompletionResponse, error) {
+	prompt := formatDroidChatPrompt(messages)
+	logger.Debugf("Droid CompleteWithTools: model=%s prompt_len=%d tools=%d (ignored, droid uses MCP)",
+		c.config.Model, len(prompt), len(tools))
+
+	args := c.buildArgs(prompt, "json")
+	cmd := exec.CommandContext(ctx, c.droidCfg.BinaryPath, args...)
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("droid exec failed (exit %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("droid exec failed: %w", err)
+	}
+
+	var result struct {
+		Result    string `json:"result"`
+		IsError   bool   `json:"is_error"`
+		SessionID string `json:"session_id"`
+		NumTurns  int    `json:"num_turns"`
+	}
+	if err := json.Unmarshal(output, &result); err != nil {
+		result.Result = strings.TrimSpace(string(output))
+	}
+
+	if result.IsError {
+		return nil, fmt.Errorf("droid error: %s", result.Result)
+	}
+
+	return &ChatCompletionResponse{
+		ID:    result.SessionID,
+		Model: c.config.Model,
+		Choices: []struct {
+			Index        int         `json:"index"`
+			Message      ChatMessage `json:"message"`
+			FinishReason string      `json:"finish_reason"`
+		}{
+			{
+				Index: 0,
+				Message: ChatMessage{
+					Role:    RoleAssistant,
+					Content: result.Result,
+				},
+				FinishReason: "stop",
+			},
+		},
+	}, nil
+}
+
+// CompleteStream sends messages and returns a channel of streamed chunks.
+func (c *DroidClient) CompleteStream(ctx context.Context, messages []Message) <-chan StreamChunk {
+	chatMessages := ConvertLegacyMessages(messages)
+	return c.CompleteStreamWithTools(ctx, chatMessages, nil)
+}
+
+// CompleteStreamWithTools streams the droid response as chunks.
+// Tool definitions are ignored — droid discovers tools via MCP.
+func (c *DroidClient) CompleteStreamWithTools(ctx context.Context, messages []ChatMessage, tools []ToolDefinition) <-chan StreamChunk {
+	ch := make(chan StreamChunk, 100)
+
+	go func() {
+		defer close(ch)
+
+		prompt := formatDroidChatPrompt(messages)
+		logger.Debugf("Droid stream: model=%s prompt_len=%d", c.config.Model, len(prompt))
+
+		args := c.buildArgs(prompt, "stream-json")
+		cmd := exec.CommandContext(ctx, c.droidCfg.BinaryPath, args...)
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			ch <- StreamChunk{Error: fmt.Errorf("failed to create stdout pipe: %w", err)}
+			return
+		}
+
+		if err := cmd.Start(); err != nil {
+			ch <- StreamChunk{Error: fmt.Errorf("failed to start droid: %w", err)}
+			return
+		}
+
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				_ = cmd.Process.Kill()
+				ch <- StreamChunk{Error: ctx.Err(), Done: true}
+				return
+			default:
+			}
+
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+
+			var evt droidStreamEvent
+			if err := json.Unmarshal([]byte(line), &evt); err != nil {
+				continue
+			}
+
+			switch evt.Type {
+			case "message":
+				text := evt.Content
+				if text == "" {
+					text = evt.Text
+				}
+				if text != "" {
+					ch <- StreamChunk{Content: text}
+				}
+
+			case "completion":
+				text := evt.Result
+				if text == "" {
+					text = evt.Content
+				}
+				if text != "" {
+					ch <- StreamChunk{Content: text}
+				}
+				ch <- StreamChunk{Done: true, FinishReason: "stop"}
+				_ = cmd.Wait()
+				return
+
+			case "error":
+				errMsg := evt.Content
+				if errMsg == "" {
+					errMsg = evt.Result
+				}
+				if errMsg == "" {
+					errMsg = "unknown droid error"
+				}
+				ch <- StreamChunk{Error: fmt.Errorf("droid: %s", errMsg), Done: true}
+				_ = cmd.Wait()
+				return
+
+			case "tool_call", "tool_result":
+				// Informational — droid handles tools internally.
+				logger.Debugf("Droid stream tool event: type=%s tool=%s", evt.Type, evt.ToolName)
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			ch <- StreamChunk{Error: fmt.Errorf("stream read error: %w", err), Done: true}
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				ch <- StreamChunk{
+					Error: fmt.Errorf("droid exited with code %d: %s",
+						exitErr.ExitCode(), string(exitErr.Stderr)),
+					Done: true,
+				}
+			}
+		} else {
+			ch <- StreamChunk{Done: true, FinishReason: "stop"}
+		}
+	}()
+
+	return ch
+}

--- a/internal/ai/droid_client_test.go
+++ b/internal/ai/droid_client_test.go
@@ -1,0 +1,452 @@
+package ai
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestNewDroidClient_Defaults(t *testing.T) {
+	client := NewDroidClient(ProviderConfig{Name: "droid"}, DroidConfig{})
+	if client.droidCfg.BinaryPath != "droid" {
+		t.Errorf("expected default binary_path 'droid', got %q", client.droidCfg.BinaryPath)
+	}
+}
+
+func TestNewDroidClient_CustomBinary(t *testing.T) {
+	client := NewDroidClient(ProviderConfig{Name: "droid"}, DroidConfig{BinaryPath: "/usr/local/bin/droid"})
+	if client.droidCfg.BinaryPath != "/usr/local/bin/droid" {
+		t.Errorf("expected custom binary_path, got %q", client.droidCfg.BinaryPath)
+	}
+}
+
+func TestDroidClient_BuildArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    ProviderConfig
+		droidCfg  DroidConfig
+		prompt    string
+		outputFmt string
+		wantArgs  []string
+	}{
+		{
+			name:      "minimal",
+			config:    ProviderConfig{Model: "glm-5"},
+			droidCfg:  DroidConfig{BinaryPath: "droid"},
+			prompt:    "hello",
+			outputFmt: "json",
+			wantArgs:  []string{"exec", "-m", "glm-5", "-o", "json", "hello"},
+		},
+		{
+			name:      "with auto level",
+			config:    ProviderConfig{Model: "kimi-k2.5"},
+			droidCfg:  DroidConfig{BinaryPath: "droid", AutoLevel: "low"},
+			prompt:    "test prompt",
+			outputFmt: "stream-json",
+			wantArgs:  []string{"exec", "-m", "kimi-k2.5", "-o", "stream-json", "--auto", "low", "test prompt"},
+		},
+		{
+			name:      "with work dir",
+			config:    ProviderConfig{Model: "glm-5"},
+			droidCfg:  DroidConfig{BinaryPath: "droid", WorkDir: "/tmp/work"},
+			prompt:    "prompt",
+			outputFmt: "json",
+			wantArgs:  []string{"exec", "-m", "glm-5", "-o", "json", "--cwd", "/tmp/work", "prompt"},
+		},
+		{
+			name:      "no model",
+			config:    ProviderConfig{},
+			droidCfg:  DroidConfig{BinaryPath: "droid"},
+			prompt:    "prompt",
+			outputFmt: "json",
+			wantArgs:  []string{"exec", "-o", "json", "prompt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewDroidClient(tt.config, tt.droidCfg)
+			got := client.buildArgs(tt.prompt, tt.outputFmt)
+
+			if len(got) != len(tt.wantArgs) {
+				t.Fatalf("arg count: got %d, want %d\n  got:  %v\n  want: %v", len(got), len(tt.wantArgs), got, tt.wantArgs)
+			}
+			for i, g := range got {
+				if g != tt.wantArgs[i] {
+					t.Errorf("arg[%d]: got %q, want %q", i, g, tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFormatDroidPrompt(t *testing.T) {
+	messages := []Message{
+		{Role: "system", Content: "You are a helpful assistant."},
+		{Role: "user", Content: "Hello!"},
+		{Role: "assistant", Content: "Hi there!"},
+		{Role: "user", Content: "How are you?"},
+	}
+
+	got := formatDroidPrompt(messages)
+
+	// Check key sections are present
+	if got == "" {
+		t.Fatal("empty prompt")
+	}
+	if !contains(got, "[System]") {
+		t.Error("missing [System] section")
+	}
+	if !contains(got, "You are a helpful assistant.") {
+		t.Error("missing system content")
+	}
+	if !contains(got, "[Previous response]") {
+		t.Error("missing [Previous response] section")
+	}
+	if !contains(got, "How are you?") {
+		t.Error("missing latest user message")
+	}
+}
+
+func TestFormatDroidChatPrompt(t *testing.T) {
+	messages := []ChatMessage{
+		{Role: RoleSystem, Content: "System prompt"},
+		{Role: RoleUser, Content: "Question"},
+		{Role: RoleAssistant, Content: "Answer"},
+		{Role: RoleTool, Name: "memory_search", Content: `{"results":[]}`, ToolCallID: "tc1"},
+		{Role: RoleUser, Content: "Follow-up"},
+	}
+
+	got := formatDroidChatPrompt(messages)
+
+	if !contains(got, "[System]") {
+		t.Error("missing [System] section")
+	}
+	if !contains(got, "[Tool result: memory_search]") {
+		t.Error("missing tool result section")
+	}
+	if !contains(got, "Follow-up") {
+		t.Error("missing follow-up message")
+	}
+}
+
+func TestNewClientWithDroid_Factory(t *testing.T) {
+	client, err := NewClientWithDroid(ProviderConfig{Name: "droid", Model: "glm-5"}, DroidConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := client.(*DroidClient); !ok {
+		t.Error("expected *DroidClient")
+	}
+}
+
+func TestNewClient_DroidDefaultModel(t *testing.T) {
+	client, err := NewClient(ProviderConfig{Name: "droid"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dc, ok := client.(*DroidClient)
+	if !ok {
+		t.Fatal("expected *DroidClient")
+	}
+	if dc.config.Model != "glm-5" {
+		t.Errorf("expected default model 'glm-5', got %q", dc.config.Model)
+	}
+}
+
+func TestDroidClient_Complete_BinaryNotFound(t *testing.T) {
+	client := NewDroidClient(
+		ProviderConfig{Name: "droid", Model: "glm-5"},
+		DroidConfig{BinaryPath: "/nonexistent/droid-binary-12345"},
+	)
+
+	_, err := client.Complete(context.Background(), []Message{
+		{Role: "user", Content: "test"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	if !contains(err.Error(), "droid exec failed") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestDroidClient_CompleteWithTools_BinaryNotFound(t *testing.T) {
+	client := NewDroidClient(
+		ProviderConfig{Name: "droid", Model: "glm-5"},
+		DroidConfig{BinaryPath: "/nonexistent/droid-binary-12345"},
+	)
+
+	_, err := client.CompleteWithTools(context.Background(), []ChatMessage{
+		{Role: RoleUser, Content: "test"},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+}
+
+// TestDroidClient_Complete_MockScript uses a mock shell script to test the
+// complete flow without requiring the actual droid binary.
+func TestDroidClient_Complete_MockScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	// Create a mock "droid" script that outputs valid JSON
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "droid")
+	mockScript := `#!/bin/sh
+echo '{"type":"completion","result":"Hello from mock droid","is_error":false,"session_id":"sess-123"}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	client := NewDroidClient(
+		ProviderConfig{Name: "droid", Model: "glm-5"},
+		DroidConfig{BinaryPath: mockBinary},
+	)
+
+	result, err := client.Complete(context.Background(), []Message{
+		{Role: "user", Content: "test"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "Hello from mock droid" {
+		t.Errorf("expected 'Hello from mock droid', got %q", result)
+	}
+}
+
+// TestDroidClient_CompleteWithTools_MockScript tests CompleteWithTools with mock.
+func TestDroidClient_CompleteWithTools_MockScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "droid")
+	mockScript := `#!/bin/sh
+echo '{"type":"completion","result":"Tool response","is_error":false,"session_id":"sess-456","num_turns":2}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	client := NewDroidClient(
+		ProviderConfig{Name: "droid", Model: "glm-5"},
+		DroidConfig{BinaryPath: mockBinary},
+	)
+
+	resp, err := client.CompleteWithTools(context.Background(), []ChatMessage{
+		{Role: RoleSystem, Content: "You are helpful"},
+		{Role: RoleUser, Content: "search memory"},
+	}, []ToolDefinition{
+		{Type: "function", Function: FunctionDefinition{Name: "memory_search"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	if resp.Choices[0].Message.Content != "Tool response" {
+		t.Errorf("unexpected content: %q", resp.Choices[0].Message.Content)
+	}
+	if resp.Choices[0].FinishReason != "stop" {
+		t.Errorf("unexpected finish_reason: %q", resp.Choices[0].FinishReason)
+	}
+	if resp.ID != "sess-456" {
+		t.Errorf("expected session_id 'sess-456', got %q", resp.ID)
+	}
+}
+
+// TestDroidClient_CompleteStream_MockScript tests streaming with mock.
+func TestDroidClient_CompleteStream_MockScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "droid")
+	mockScript := `#!/bin/sh
+echo '{"type":"message","content":"Hello "}'
+echo '{"type":"message","content":"world!"}'
+echo '{"type":"completion","result":"","session_id":"sess-789"}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	client := NewDroidClient(
+		ProviderConfig{Name: "droid", Model: "glm-5"},
+		DroidConfig{BinaryPath: mockBinary},
+	)
+
+	ch := client.CompleteStream(context.Background(), []Message{
+		{Role: "user", Content: "test"},
+	})
+
+	var chunks []StreamChunk
+	for chunk := range ch {
+		chunks = append(chunks, chunk)
+	}
+
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+	}
+
+	// First two should be content chunks
+	if chunks[0].Content != "Hello " {
+		t.Errorf("chunk[0] content: got %q, want 'Hello '", chunks[0].Content)
+	}
+	if chunks[1].Content != "world!" {
+		t.Errorf("chunk[1] content: got %q, want 'world!'", chunks[1].Content)
+	}
+
+	// Last chunk should be done
+	lastChunk := chunks[len(chunks)-1]
+	if !lastChunk.Done {
+		t.Error("expected last chunk to be done")
+	}
+}
+
+// TestDroidClient_Complete_ErrorResponse tests error handling.
+func TestDroidClient_Complete_ErrorResponse(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "droid")
+	mockScript := `#!/bin/sh
+echo '{"type":"error","result":"model not found","is_error":true}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	client := NewDroidClient(
+		ProviderConfig{Name: "droid", Model: "nonexistent-model"},
+		DroidConfig{BinaryPath: mockBinary},
+	)
+
+	_, err := client.Complete(context.Background(), []Message{
+		{Role: "user", Content: "test"},
+	})
+	if err == nil {
+		t.Fatal("expected error for error response")
+	}
+	if !contains(err.Error(), "model not found") {
+		t.Errorf("expected 'model not found' in error, got: %v", err)
+	}
+}
+
+// TestDroidClient_CompleteStream_ErrorEvent tests stream error handling.
+func TestDroidClient_CompleteStream_ErrorEvent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "droid")
+	mockScript := `#!/bin/sh
+echo '{"type":"message","content":"partial "}'
+echo '{"type":"error","content":"rate limit exceeded"}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	client := NewDroidClient(
+		ProviderConfig{Name: "droid", Model: "glm-5"},
+		DroidConfig{BinaryPath: mockBinary},
+	)
+
+	ch := client.CompleteStreamWithTools(context.Background(), []ChatMessage{
+		{Role: RoleUser, Content: "test"},
+	}, nil)
+
+	var gotError bool
+	for chunk := range ch {
+		if chunk.Error != nil {
+			gotError = true
+			if !contains(chunk.Error.Error(), "rate limit exceeded") {
+				t.Errorf("unexpected error: %v", chunk.Error)
+			}
+		}
+	}
+	if !gotError {
+		t.Error("expected error chunk in stream")
+	}
+}
+
+// TestDroidClient_ContextCancellation tests that context cancellation is respected.
+func TestDroidClient_ContextCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "droid")
+	// Script that sleeps — will be killed by context cancellation
+	mockScript := `#!/bin/sh
+sleep 30
+echo '{"type":"completion","result":"should not reach"}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	client := NewDroidClient(
+		ProviderConfig{Name: "droid", Model: "glm-5"},
+		DroidConfig{BinaryPath: mockBinary},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := client.Complete(ctx, []Message{
+		{Role: "user", Content: "test"},
+	})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestAvailableModels_IncludesDroid(t *testing.T) {
+	models := AvailableModels()
+	droidModels, ok := models["droid"]
+	if !ok {
+		t.Fatal("missing 'droid' in AvailableModels")
+	}
+	if len(droidModels) == 0 {
+		t.Fatal("empty droid model list")
+	}
+
+	// Check key models are present
+	found := make(map[string]bool)
+	for _, m := range droidModels {
+		found[m] = true
+	}
+	for _, expected := range []string{"glm-5", "kimi-k2.5", "minimax-m2.5"} {
+		if !found[expected] {
+			t.Errorf("missing droid model: %s", expected)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -180,13 +180,18 @@ func (a *App) Start(ctx context.Context) error {
 	}
 
 	// Initialize AI client if configured
-	if aiAPIKey != "" {
+	if aiAPIKey != "" || a.config.AI.Provider == "droid" {
 		log.Printf("🤖 Initializing AI client (%s)...", a.config.AI.Provider)
 		primaryCfg := ai.ProviderConfig{
 			Name:    a.config.AI.Provider,
 			APIKey:  aiAPIKey,
 			Model:   a.config.AI.Model,
 			BaseURL: a.config.AI.BaseURL,
+		}
+		droidCfg := ai.DroidConfig{
+			BinaryPath: a.config.AI.Droid.BinaryPath,
+			AutoLevel:  a.config.AI.Droid.AutoLevel,
+			WorkDir:    a.config.AI.Droid.WorkDir,
 		}
 		if len(a.config.AI.FallbackModels) > 0 {
 			log.Printf("🔄 Failover enabled: %d fallback model(s) configured", len(a.config.AI.FallbackModels))
@@ -196,7 +201,7 @@ func (a *App) Start(ctx context.Context) error {
 			}
 			a.ai = aiClient
 		} else {
-			aiClient, err := ai.NewClient(primaryCfg)
+			aiClient, err := ai.NewClientWithDroid(primaryCfg, droidCfg)
 			if err != nil {
 				return fmt.Errorf("failed to initialize AI client: %w", err)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,8 @@ var DefaultModelAliases = map[string]string{
 	"gemini":   "google/gemini-2.5-pro",
 	"flash":    "google/gemini-2.5-flash",
 	"deepseek": "deepseek/deepseek-chat-v3-0324",
+	"glm":      "glm-5",
+	"minimax":  "minimax-m2.5",
 }
 
 // ControlConfig holds configuration for the loopback WebSocket control server.
@@ -79,14 +81,22 @@ type TelegramConfig struct {
 }
 
 // AIConfig holds AI provider configuration.
-// Supports: openrouter, openai, anthropic, or custom OpenAI-compatible APIs.
+// Supports: openrouter, openai, anthropic, droid, or custom OpenAI-compatible APIs.
 type AIConfig struct {
-	Provider        string   `mapstructure:"provider"` // "openrouter", "openai", "anthropic", "custom"
-	APIKey          string   `mapstructure:"api_key"`
-	Model           string   `mapstructure:"model"`
-	BaseURL         string   `mapstructure:"base_url"`         // For custom providers
-	FallbackModels  []string `mapstructure:"fallback_models"`  // Models to try if primary fails
-	DefaultThinking string   `mapstructure:"default_thinking"` // Default thinking level: "off", "low", "medium", "high", "adaptive"
+	Provider        string      `mapstructure:"provider"` // "openrouter", "openai", "anthropic", "droid", "custom"
+	APIKey          string      `mapstructure:"api_key"`
+	Model           string      `mapstructure:"model"`
+	BaseURL         string      `mapstructure:"base_url"`         // For custom providers
+	FallbackModels  []string    `mapstructure:"fallback_models"`  // Models to try if primary fails
+	DefaultThinking string      `mapstructure:"default_thinking"` // Default thinking level: "off", "low", "medium", "high", "adaptive"
+	Droid           DroidConfig `mapstructure:"droid"`            // Droid-specific settings (provider=droid)
+}
+
+// DroidConfig holds configuration for the factory.ai droid provider.
+type DroidConfig struct {
+	BinaryPath string `mapstructure:"binary_path"` // Path to droid binary (default: "droid")
+	AutoLevel  string `mapstructure:"auto_level"`  // Autonomy level: "", "low", "medium", "high"
+	WorkDir    string `mapstructure:"work_dir"`    // Working directory for droid execution
 }
 
 // AuthConfig holds authorization configuration
@@ -159,6 +169,9 @@ func Load() (*Config, error) {
 	v.SetDefault("soul_path", bootstrap.DefaultPath) // Default to visible directory
 	v.SetDefault("ai.provider", "openrouter")
 	v.SetDefault("ai.model", "moonshotai/kimi-k2.5")
+	v.SetDefault("ai.droid.binary_path", "droid")
+	v.SetDefault("ai.droid.auto_level", "")
+	v.SetDefault("ai.droid.work_dir", "")
 	v.SetDefault("auth.mode", "open")
 	v.SetDefault("auth.allowed_users", []int64{})
 	v.SetDefault("auth.admin_id", int64(0))
@@ -254,6 +267,9 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("soul_path", bootstrap.DefaultPath)
 	v.SetDefault("ai.provider", "openrouter")
 	v.SetDefault("ai.model", "moonshotai/kimi-k2.5")
+	v.SetDefault("ai.droid.binary_path", "droid")
+	v.SetDefault("ai.droid.auto_level", "")
+	v.SetDefault("ai.droid.work_dir", "")
 	v.SetDefault("auth.mode", "open")
 	v.SetDefault("auth.allowed_users", []int64{})
 	v.SetDefault("auth.admin_id", int64(0))
@@ -328,7 +344,7 @@ func (c *Config) Validate() error {
 	}
 
 	// Check AI configuration
-	if c.AI.APIKey == "" {
+	if c.AI.APIKey == "" && c.AI.Provider != "droid" {
 		return fmt.Errorf("ai.api_key is required")
 	}
 
@@ -382,6 +398,9 @@ func (c *Config) Save() error {
 	v.Set("ai.model", c.AI.Model)
 	v.Set("ai.base_url", c.AI.BaseURL)
 	v.Set("ai.fallback_models", c.AI.FallbackModels)
+	v.Set("ai.droid.binary_path", c.AI.Droid.BinaryPath)
+	v.Set("ai.droid.auto_level", c.AI.Droid.AutoLevel)
+	v.Set("ai.droid.work_dir", c.AI.Droid.WorkDir)
 	v.Set("auth.mode", c.Auth.Mode)
 	v.Set("auth.allowed_users", c.Auth.AllowedUsers)
 	v.Set("auth.admin_id", c.Auth.AdminID)


### PR DESCRIPTION
## Summary

- Adds `DroidClient` AI provider that spawns `droid exec` (factory.ai CLI) as a subprocess to access models like `glm-5`, `kimi-k2.5`, `minimax-m2.5` not available via OpenRouter
- Implements `Client` + `StreamingClient` interfaces with subprocess lifecycle management, stream-json parsing, and error handling
- Droid handles tool execution internally — ok-gobot's MCP server provides memory tools to droid via MCP bridge

## Architecture

```
Telegram → ok-gobot → droid exec -m glm-5 -o stream-json
                         ↓
                    model runs with:
                      - droid built-in tools
                      - [MCP] memory_search ← ok-gobot MCP server
                      - [MCP] memory_get    ← ok-gobot MCP server
                         ↓
                    streamed response → ok-gobot → Telegram
```

## Config

```yaml
ai:
  provider: "droid"
  model: "glm-5"
  droid:
    binary_path: "droid"
    auto_level: "low"
    work_dir: ""
```

## Changes

- `internal/ai/droid_client.go` — DroidClient with Complete, CompleteWithTools, streaming
- `internal/ai/client.go` — `NewClientWithDroid()` factory, droid in AvailableModels
- `internal/config/config.go` — `DroidConfig` struct, defaults, validation (api_key not required)
- `internal/app/app.go` — Pass droid config to AI client initialization
- `internal/agent/tokens.go` — Model limits for droid models
- `docs/ARCHITECTURE-v2.md` — Canonical schema updated with droid provider + config
- `config.example.yaml` — Droid provider example

## Test plan

- [x] 17 unit tests with mock shell scripts for subprocess integration
- [x] Tests cover: arg building, prompt formatting, Complete, CompleteWithTools, streaming, error handling, context cancellation
- [x] `go build ./...` passes
- [x] `go vet` passes
- [ ] Manual testing with actual `droid` binary (requires factory.ai CLI installed)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR integrates `factory.ai`'s `droid` CLI as a new AI backend by spawning it as a subprocess per request, enabling access to models (`glm-5`, `kimi-k2.5`, `minimax-m2.5`) not available via OpenRouter. The architecture is sound and the test coverage with mock shell scripts is thorough, but there are six issues that should be addressed before production use:

**Key changes:**
- `internal/ai/droid_client.go` — new `DroidClient` implementing `Client` + `StreamingClient` via subprocess lifecycle management and stream-json parsing
- `internal/config/config.go` — `DroidConfig` struct, defaults, and API-key-free validation path
- `internal/app/app.go` — wires `DroidConfig` into client initialisation for non-failover path
- `internal/agent/tokens.go` — token limits for droid models
- `internal/ai/client.go` — `NewClientWithDroid` factory and droid models in `AvailableModels`

**Issues found:**
- **[logic]** Prompt is passed as a positional CLI argument, exposing user messages in process listings (`ps aux`, `/proc/<pid>/cmdline`) and risking hard failure via OS `ARG_MAX` on long conversations — consider passing via stdin
- **[logic]** Zombie process leak when context is cancelled mid-stream; `cmd.Process.Kill()` is called but `cmd.Wait()` is never invoked, leaving zombie process entries
- **[logic]** `DroidConfig` is silently dropped in failover mode; custom `binary_path`, `auto_level`, and `work_dir` are ignored when `fallback_models` is configured
- **[style]** `DroidConfig` is defined identically in both `internal/ai/droid_client.go` and `internal/config/config.go`, with `app.go` manually copying fields — future field additions won't be caught at compile time
- **[style]** `ai.droid.auto_level` is not validated in `Validate()` against its documented enum (`low`, `medium`, `high`)
- **[style]** Test-only `contains`/`containsStr` helpers re-implement `strings.Contains`

<h3>Confidence Score: 1/5</h3>

- Not safe to merge as-is: critical issues with prompt exposure in process listings, zombie process leaks, and silent config drops in failover mode.
- The core logic is well-structured and test coverage is solid, but three critical issues significantly lower confidence for production use: (1) passing the full conversation prompt as a CLI argument exposes all user messages in process listings and can hard-fail on long conversations hitting ARG_MAX; (2) context cancellation leaks zombie processes due to missing Wait() call; (3) DroidConfig is silently dropped when fallover is enabled, causing custom binary_path and settings to be silently ignored. For a Telegram bot handling private user messages, these issues present real security, reliability, and usability concerns. Three additional minor issues (DroidConfig duplication, missing auto_level validation, test helpers) are also present.
- internal/ai/droid_client.go (prompt argument exposure, zombie leak), internal/app/app.go (droidCfg dropped in failover), internal/config/config.go (missing auto_level validation)

<sub>Last reviewed commit: 1c2caa3</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))

<!-- /greptile_comment -->