### PR TITLE
TUI P1: Command autocomplete — type / to see completions

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -42,6 +42,24 @@ type chatEntry struct {
 	streaming bool // true while tokens are still arriving
 }
 
+type commandCompletion struct {
+	name string
+	desc string
+}
+
+var commandCompletions = []commandCompletion{
+	{name: "/status", desc: "bot status, model, uptime"},
+	{name: "/usage", desc: "token usage stats"},
+	{name: "/context", desc: "context window info"},
+	{name: "/whoami", desc: "your user info"},
+	{name: "/commands", desc: "show available commands"},
+	{name: "/think", desc: "set thinking level"},
+	{name: "/compact", desc: "compact context window"},
+	{name: "/model", desc: "set model (or open picker)"},
+	{name: "/new", desc: "start a new session"},
+	{name: "/abort", desc: "abort active run"},
+}
+
 // Model is the root Bubble Tea model.
 type Model struct {
 	// layout
@@ -79,6 +97,12 @@ type Model struct {
 	sessionCursor int
 	modelCursor   int
 	modelList     []string
+
+	// command completion popup (chat input slash commands)
+	completionVisible      bool
+	completionCursor       int
+	completionItems        []commandCompletion
+	completionDismissedFor string
 
 	// misc
 	statusMsg string
@@ -193,6 +217,36 @@ func (m *Model) handleKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	if m.completionVisible {
+		switch msg.String() {
+		case "up":
+			if m.completionCursor > 0 {
+				m.completionCursor--
+			}
+			return m, tea.Batch(cmds...)
+
+		case "down":
+			if m.completionCursor < len(m.completionItems)-1 {
+				m.completionCursor++
+			}
+			return m, tea.Batch(cmds...)
+
+		case "tab":
+			m.applySelectedCompletion()
+			return m, tea.Batch(cmds...)
+
+		case "enter":
+			if !msg.Alt {
+				m.applySelectedCompletion()
+				return m, tea.Batch(cmds...)
+			}
+
+		case "esc":
+			m.dismissCompletions()
+			return m, tea.Batch(cmds...)
+		}
+	}
+
 	switch msg.String() {
 	case "ctrl+c":
 		return m, tea.Quit
@@ -252,6 +306,7 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 			}
 			m.input.Reset()
 			m.recalcInputHeight()
+			m.clearCompletions()
 			return m, tea.Batch(cmds...)
 		}
 
@@ -259,18 +314,21 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 		// Open sub-agent spawn dialog
 		m.spawnDialog = NewSpawnDialog()
 		m.screen = screenSpawn
+		m.clearCompletions()
 		return m, tea.Batch(append(cmds, m.spawnDialog.Init())...)
 
 	case "ctrl+p":
 		// Open session picker
 		m.screen = screenSessions
 		m.sessionCursor = 0
+		m.clearCompletions()
 		return m, tea.Batch(cmds...)
 
 	case "ctrl+m":
 		// Open model picker
 		m.screen = screenModels
 		m.modelCursor = 0
+		m.clearCompletions()
 		return m, tea.Batch(cmds...)
 
 	case "ctrl+a":
@@ -304,6 +362,7 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 	m.input, inputCmd = m.input.Update(msg)
 	cmds = append(cmds, inputCmd)
 	m.recalcInputHeight()
+	m.refreshCompletions()
 	return m, tea.Batch(cmds...)
 }
 
@@ -527,10 +586,15 @@ func (m *Model) View() string {
 
 	header := m.renderHeader()
 	status := m.renderStatus()
+	completion := m.renderCompletionPopup()
+	completionHeight := 0
+	if completion != "" {
+		completionHeight = lipgloss.Height(completion)
+	}
 
 	// Reserve lines for header (1), status (1), input border + textarea
 	inputHeight := m.inputAreaHeight()
-	chatHeight := m.height - lipgloss.Height(header) - lipgloss.Height(status) - inputHeight
+	chatHeight := m.height - lipgloss.Height(header) - lipgloss.Height(status) - inputHeight - completionHeight
 
 	if chatHeight < 2 {
 		chatHeight = 2
@@ -540,12 +604,12 @@ func (m *Model) View() string {
 	chat := m.viewport.View()
 	input := m.renderInput()
 
-	base := lipgloss.JoinVertical(lipgloss.Left,
-		header,
-		chat,
-		input,
-		status,
-	)
+	parts := []string{header, chat}
+	if completion != "" {
+		parts = append(parts, completion)
+	}
+	parts = append(parts, input, status)
+	base := lipgloss.JoinVertical(lipgloss.Left, parts...)
 
 	// Overlay screens
 	switch m.screen {
@@ -639,6 +703,58 @@ func (m *Model) renderInput() string {
 		borderStyle = inputBorderFocusStyle
 	}
 	return borderStyle.Width(m.width - 2).Render(m.input.View())
+}
+
+// renderCompletionPopup renders the slash-command completion popup above input.
+func (m *Model) renderCompletionPopup() string {
+	if m.screen != screenChat || !m.completionVisible || len(m.completionItems) == 0 {
+		return ""
+	}
+
+	innerWidth := m.width - 8
+	maxInnerWidth := m.width - 4
+	if maxInnerWidth < 18 {
+		maxInnerWidth = 18
+	}
+	if innerWidth > maxInnerWidth {
+		innerWidth = maxInnerWidth
+	}
+	if innerWidth < 18 {
+		innerWidth = 18
+	}
+
+	cmdWidth := 12
+	for _, item := range m.completionItems {
+		if w := lipgloss.Width(item.name); w > cmdWidth {
+			cmdWidth = w
+		}
+	}
+	if cmdWidth > innerWidth/2 {
+		cmdWidth = innerWidth / 2
+	}
+	descWidth := innerWidth - cmdWidth - 1
+	if descWidth < 10 {
+		descWidth = 10
+	}
+
+	var lines []string
+	lines = append(lines, completionTitleStyle.Width(innerWidth).Render("Command autocomplete"))
+
+	for i, item := range m.completionItems {
+		cmdPart := completionCmdStyle.Width(cmdWidth).Render(item.name)
+		descPart := completionDescStyle.Width(descWidth).Render(truncate(item.desc, descWidth))
+		line := cmdPart + " " + descPart
+
+		rowStyle := completionRowStyle
+		if i == m.completionCursor {
+			rowStyle = completionRowSelectedStyle
+		}
+		lines = append(lines, rowStyle.Width(innerWidth).Render(line))
+	}
+
+	lines = append(lines, completionHintStyle.Width(innerWidth).Render("↑/↓ navigate · Tab/Enter complete · Esc dismiss"))
+
+	return completionPopupStyle.Render(strings.Join(lines, "\n"))
 }
 
 // renderChatLog builds the full chat log string for the viewport.
@@ -885,6 +1001,102 @@ func (m *Model) recalcInputHeight() {
 func (m *Model) setStatus(s string) {
 	m.statusMsg = s
 	m.statusAt = time.Now()
+}
+
+// clearCompletions hides the command completion popup and resets selection state.
+func (m *Model) clearCompletions() {
+	m.completionVisible = false
+	m.completionCursor = 0
+	m.completionItems = nil
+	m.completionDismissedFor = ""
+}
+
+// dismissCompletions hides completions and keeps them dismissed until input changes.
+func (m *Model) dismissCompletions() {
+	m.completionVisible = false
+	m.completionCursor = 0
+	m.completionItems = nil
+	m.completionDismissedFor = m.input.Value()
+}
+
+// refreshCompletions updates the completion list from the current input text.
+func (m *Model) refreshCompletions() {
+	value := m.input.Value()
+	if m.completionDismissedFor != "" {
+		if value == m.completionDismissedFor {
+			m.completionVisible = false
+			m.completionCursor = 0
+			m.completionItems = nil
+			return
+		}
+		m.completionDismissedFor = ""
+	}
+
+	prefix, ok := slashCommandPrefix(value)
+	if !ok {
+		m.clearCompletions()
+		return
+	}
+
+	matches := filterCommandCompletions(prefix)
+	if len(matches) == 0 {
+		m.clearCompletions()
+		return
+	}
+
+	selected := ""
+	if m.completionVisible && m.completionCursor >= 0 && m.completionCursor < len(m.completionItems) {
+		selected = m.completionItems[m.completionCursor].name
+	}
+
+	m.completionVisible = true
+	m.completionItems = matches
+	m.completionCursor = 0
+
+	if selected != "" {
+		for i, item := range matches {
+			if item.name == selected {
+				m.completionCursor = i
+				break
+			}
+		}
+	}
+}
+
+// applySelectedCompletion inserts the currently selected command into input.
+func (m *Model) applySelectedCompletion() {
+	if !m.completionVisible || len(m.completionItems) == 0 {
+		return
+	}
+	if m.completionCursor < 0 || m.completionCursor >= len(m.completionItems) {
+		m.completionCursor = 0
+	}
+
+	m.input.SetValue(m.completionItems[m.completionCursor].name + " ")
+	m.input.CursorEnd()
+	m.clearCompletions()
+}
+
+// slashCommandPrefix returns text after "/" when input is in command-typing mode.
+func slashCommandPrefix(value string) (string, bool) {
+	if value == "" || !strings.HasPrefix(value, "/") {
+		return "", false
+	}
+	if strings.ContainsAny(value, " \t\r\n") {
+		return "", false
+	}
+	return strings.ToLower(strings.TrimPrefix(value, "/")), true
+}
+
+// filterCommandCompletions returns command completions that match the prefix.
+func filterCommandCompletions(prefix string) []commandCompletion {
+	var out []commandCompletion
+	for _, item := range commandCompletions {
+		if strings.HasPrefix(strings.TrimPrefix(strings.ToLower(item.name), "/"), prefix) {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 // submitApproval sends the approval response to the server.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // newTestModel builds a minimal Model suitable for unit tests (no WebSocket).
@@ -18,8 +19,20 @@ func newTestModel() *Model {
 	return &Model{
 		width:     120,
 		height:    40,
+		screen:    screenChat,
 		input:     ta,
 		streamIdx: -1,
+	}
+}
+
+func newCompletionTestModel() Model {
+	ta := textarea.New()
+	ta.SetWidth(80)
+	ta.SetHeight(3)
+
+	return Model{
+		screen: screenChat,
+		input:  ta,
 	}
 }
 
@@ -70,5 +83,104 @@ func TestInputAreaHeight_IncludesBorder(t *testing.T) {
 	// 3 lines + 2 for top/bottom border
 	if got != 5 {
 		t.Errorf("expected inputAreaHeight 5, got %d", got)
+	}
+}
+
+func TestRefreshCompletionsShowsAllForSlash(t *testing.T) {
+	m := newCompletionTestModel()
+	m.input.SetValue("/")
+
+	m.refreshCompletions()
+
+	if !m.completionVisible {
+		t.Fatalf("expected completion popup to be visible")
+	}
+	if got, want := len(m.completionItems), len(commandCompletions); got != want {
+		t.Fatalf("expected %d completion items, got %d", want, got)
+	}
+}
+
+func TestRefreshCompletionsFiltersByPrefix(t *testing.T) {
+	m := newCompletionTestModel()
+	m.input.SetValue("/mo")
+
+	m.refreshCompletions()
+
+	if !m.completionVisible {
+		t.Fatalf("expected completion popup to be visible")
+	}
+	if got, want := len(m.completionItems), 1; got != want {
+		t.Fatalf("expected %d completion item, got %d", want, got)
+	}
+	if got, want := m.completionItems[0].name, "/model"; got != want {
+		t.Fatalf("expected first completion to be %q, got %q", want, got)
+	}
+}
+
+func TestEscDismissesCompletionPopup(t *testing.T) {
+	m := newCompletionTestModel()
+	m.input.SetValue("/st")
+	m.refreshCompletions()
+
+	_, _ = m.handleChatKey(tea.KeyMsg{Type: tea.KeyEsc}, nil)
+
+	if m.completionVisible {
+		t.Fatalf("expected completion popup to be hidden after esc")
+	}
+	if got, want := m.input.Value(), "/st"; got != want {
+		t.Fatalf("expected input to stay %q, got %q", want, got)
+	}
+
+	m.refreshCompletions()
+	if m.completionVisible {
+		t.Fatalf("expected completion popup to remain hidden until input changes")
+	}
+
+	m.input.SetValue("/sta")
+	m.refreshCompletions()
+	if !m.completionVisible {
+		t.Fatalf("expected completion popup to reopen after input change")
+	}
+}
+
+func TestEnterCompletesSelectedCommand(t *testing.T) {
+	m := newCompletionTestModel()
+	m.input.SetValue("/st")
+	m.refreshCompletions()
+
+	_, _ = m.handleChatKey(tea.KeyMsg{Type: tea.KeyEnter}, nil)
+
+	if got, want := m.input.Value(), "/status "; got != want {
+		t.Fatalf("expected input to be %q, got %q", want, got)
+	}
+	if m.completionVisible {
+		t.Fatalf("expected completion popup to be hidden after completion")
+	}
+}
+
+func TestSlashCommandPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		want   string
+		okWant bool
+	}{
+		{name: "slash only", input: "/", want: "", okWant: true},
+		{name: "typed prefix", input: "/co", want: "co", okWant: true},
+		{name: "uppercase normalised", input: "/TH", want: "th", okWant: true},
+		{name: "command with args disabled", input: "/new test", okWant: false},
+		{name: "plain text", input: "hello", okWant: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := slashCommandPrefix(tc.input)
+			if ok != tc.okWant {
+				t.Fatalf("expected ok=%v, got %v", tc.okWant, ok)
+			}
+			if got != tc.want {
+				t.Fatalf("expected prefix %q, got %q", tc.want, got)
+			}
+		})
 	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -156,6 +156,36 @@ var (
 				Foreground(colorAccent).
 				Bold(true)
 
+	// Command autocomplete popup above input
+	completionPopupStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("241")).
+				Background(lipgloss.Color("235")).
+				Padding(0, 1)
+
+	completionTitleStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("250")).
+				Background(lipgloss.Color("236")).
+				Bold(true)
+
+	completionRowStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("252")).
+				Background(lipgloss.Color("235"))
+
+	completionRowSelectedStyle = lipgloss.NewStyle().
+					Background(lipgloss.Color("24")).
+					Bold(true)
+
+	completionCmdStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("255")).
+				Bold(true)
+
+	completionDescStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("245"))
+
+	completionHintStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("242"))
+
 	// Spawn sub-agent dialog
 	spawnDialogBoxStyle = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).


### PR DESCRIPTION
Closes #136

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a slash-command autocomplete popup to the TUI chat input. When the user types `/`, a floating popup appears above the input box showing matching commands with descriptions; users can navigate with `↑`/`↓`, accept with `Tab`/`Enter`, and dismiss with `Esc`. The feature integrates cleanly into the existing Bubble Tea model loop: completions are refreshed on every keystroke via `refreshCompletions`, layout height is adjusted dynamically to include the popup, and all navigation shortcuts (`Ctrl+N`, `Ctrl+P`, `Ctrl+M`) correctly clear the popup on transition.

**Findings:**
- `completionRowSelectedStyle` in `styles.go` does not specify a foreground color, while the unselected `completionRowStyle` sets `Foreground("252")`. When the selected row style is applied with `.Width()` and padding is needed, the padding will render in the terminal's default foreground color on the blue background, producing inconsistent appearance across terminal themes.
- In `renderCompletionPopup`, the `descWidth` floor of 10 can push the total row content width (`cmdWidth + 1 + descWidth`) above `innerWidth` at its minimum of 18. Since lipgloss `Width` is a _minimum_ width setter, not a clamp, rows overflow the popup border on narrow terminals (≤ 26 columns).

**Test coverage** is comprehensive: five new tests exercise the primary flows (display, filtering, Esc dismiss/re-show, Enter completion, prefix parsing).

<h3>Confidence Score: 3/5</h3>

- The PR is safe to merge from a functional standpoint, but two verified visual/layout issues should be addressed for correctness and consistency.
- The core autocomplete logic is well-structured with comprehensive test coverage. However, two real issues are present: (1) missing foreground color in the selected row style causes padding to render in terminal default colors (theme-dependent inconsistency), and (2) the descWidth floor logic can cause row overflow on narrow terminals (≤ 26 columns). Both issues are verifiable in the code and affect the visual correctness of the feature. Neither affects functionality on typical terminal sizes, but both should be fixed before merge.
- internal/tui/model.go (width overflow logic) and internal/tui/styles.go (selected row foreground color)

<sub>Last reviewed commit: 3645841</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->