### PR TITLE
TUI P1: Fix overlay dialogs — centering, sizing, clipping

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -79,6 +79,7 @@ type Model struct {
 	sessionCursor int
 	modelCursor   int
 	modelList     []string
+	modelFilter   string // live filter text for model picker
 
 	// misc
 	statusMsg string
@@ -236,6 +237,7 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 				} else {
 					m.screen = screenModels
 					m.modelCursor = 0
+					m.modelFilter = ""
 				}
 			} else if isBotCommand(text) {
 				m.sendCmd(controlserver.ClientMsg{
@@ -271,6 +273,7 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 		// Open model picker
 		m.screen = screenModels
 		m.modelCursor = 0
+		m.modelFilter = ""
 		return m, tea.Batch(cmds...)
 
 	case "ctrl+a":
@@ -364,17 +367,20 @@ func (m *Model) handleModelKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.C
 	switch msg.String() {
 	case "esc", "ctrl+m":
 		m.screen = screenChat
-	case "up", "k":
+		m.modelFilter = ""
+	case "up":
 		if m.modelCursor > 0 {
 			m.modelCursor--
 		}
-	case "down", "j":
-		if m.modelCursor < len(m.modelList)-1 {
+	case "down":
+		filtered := m.filteredModelList()
+		if m.modelCursor < len(filtered)-1 {
 			m.modelCursor++
 		}
 	case "enter":
-		if m.modelCursor < len(m.modelList) {
-			model := m.modelList[m.modelCursor]
+		filtered := m.filteredModelList()
+		if m.modelCursor < len(filtered) {
+			model := filtered[m.modelCursor]
 			m.sendCmd(controlserver.ClientMsg{
 				Type:      controlserver.CmdSetModel,
 				SessionID: m.activeSession,
@@ -383,8 +389,21 @@ func (m *Model) handleModelKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.C
 			m.setStatus("Model set to " + model)
 		}
 		m.screen = screenChat
+		m.modelFilter = ""
+	case "backspace":
+		if len(m.modelFilter) > 0 {
+			m.modelFilter = m.modelFilter[:len(m.modelFilter)-1]
+			m.modelCursor = 0
+		}
 	case "ctrl+c":
 		return m, tea.Quit
+	default:
+		// Single printable character → add to filter
+		s := msg.String()
+		if len(s) == 1 && s[0] >= ' ' && s[0] <= '~' {
+			m.modelFilter += s
+			m.modelCursor = 0
+		}
 	}
 	return m, tea.Batch(cmds...)
 }
@@ -721,23 +740,29 @@ func (m *Model) overlayApproval(base string) string {
 	buttons := lipgloss.JoinHorizontal(lipgloss.Top, yes, "  ", no)
 
 	content := lipgloss.JoinVertical(lipgloss.Left,
-		approvalTitleStyle.Render("Approval Required"),
+		dialogTitleStyle.Foreground(colorWarning).Render("⚠ Approval Required"),
 		"",
 		"Command:",
 		approvalCmdStyle.Render("  "+m.approvalCmd+"  "),
 		"",
 		buttons,
 		"",
-		lipgloss.NewStyle().Foreground(colorMuted).Render("← → to select · Enter to confirm · Esc to deny"),
+		dialogHelpStyle.Render("← → select · Enter confirm · Esc deny"),
 	)
 
-	box := approvalBoxStyle.Render(content)
-	return placeOverlay(m.width, m.height, base, box)
+	contentW := dialogContentWidth(lipgloss.Width(m.approvalCmd)+6, m.width)
+	box := approvalBoxStyle.Width(contentW).Render(content)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }
 
 // overlaySessionList renders the session picker overlay.
 func (m *Model) overlaySessionList(base string) string {
-	var items []string
+	type sessionLine struct {
+		raw   string
+		style lipgloss.Style
+	}
+	var lines []sessionLine
+	maxW := 0
 	for i, s := range m.sessions {
 		prefix := "  "
 		style := sessionItemStyle
@@ -747,54 +772,90 @@ func (m *Model) overlaySessionList(base string) string {
 		}
 		running := ""
 		if s.Running {
-			running = sessionRunningStyle.Render(" ●")
+			running = " ●"
 		}
-		label := prefix + s.Name + " [" + s.Model + "]" + running
+		active := ""
 		if s.ID == m.activeSession {
-			label += " ★"
+			active = " ★"
 		}
-		items = append(items, style.Render(label))
+		raw := prefix + s.Name + " · " + s.Model + running + active
+		if len(raw) > maxW {
+			maxW = len(raw)
+		}
+		lines = append(lines, sessionLine{raw, style})
 	}
-	items = append(items, lipgloss.NewStyle().Foreground(colorMuted).Render("  [n] new session"))
 
-	content := lipgloss.JoinVertical(lipgloss.Left,
-		sessionItemActiveStyle.Render("Sessions (Ctrl+P / Esc to close)"),
-		"",
-	)
-	content += strings.Join(items, "\n")
+	contentW := dialogContentWidth(maxW, m.width)
 
-	box := sessionListBorderStyle.Render(content)
-	return placeOverlay(m.width, m.height, base, box)
+	var items []string
+	for _, l := range lines {
+		items = append(items, l.style.Render(truncate(l.raw, contentW)))
+	}
+	items = append(items, dialogHelpStyle.Render("  [n] new session"))
+
+	title := dialogTitleStyle.Render("Sessions")
+	help := dialogHelpStyle.Render("↑↓ navigate · Enter select · Esc close")
+
+	parts := []string{title, ""}
+	parts = append(parts, items...)
+	parts = append(parts, "", help)
+	content := strings.Join(parts, "\n")
+
+	box := sessionListBorderStyle.Width(contentW).Render(content)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }
 
 // overlayModelList renders the model picker overlay.
 func (m *Model) overlayModelList(base string) string {
+	filtered := m.filteredModelList()
+
+	// Filter input line
+	filterPrompt := dialogFilterPromptStyle.Render("Filter: ")
+	filterText := m.modelFilter
+	if filterText == "" {
+		filterText = dialogFilterPlaceholderStyle.Render("type to filter…")
+	}
+	filterLine := filterPrompt + filterText
+
+	maxW := lipgloss.Width(filterLine)
 	var items []string
-	for i, model := range m.modelList {
+	for i, model := range filtered {
 		prefix := "  "
 		style := modelItemStyle
 		if i == m.modelCursor {
 			prefix = "▶ "
 			style = modelItemActiveStyle
 		}
-		items = append(items, style.Render(prefix+model))
+		raw := prefix + model
+		if len(raw) > maxW {
+			maxW = len(raw)
+		}
+		items = append(items, style.Render(raw))
+	}
+	if len(filtered) == 0 {
+		items = append(items, dialogHelpStyle.Render("  (no matches)"))
 	}
 
-	content := lipgloss.JoinVertical(lipgloss.Left,
-		modelItemActiveStyle.Render("Select Model (Ctrl+M / Esc to close)"),
-		"",
-	)
-	content += strings.Join(items, "\n")
+	contentW := dialogContentWidth(maxW, m.width)
 
-	box := modelListBorderStyle.Render(content)
-	return placeOverlay(m.width, m.height, base, box)
+	title := dialogTitleStyle.Render("Select Model")
+	help := dialogHelpStyle.Render("↑↓ navigate · Enter select · Esc close")
+
+	parts := []string{title, "", filterLine, ""}
+	parts = append(parts, items...)
+	parts = append(parts, "", help)
+	content := strings.Join(parts, "\n")
+
+	box := modelListBorderStyle.Width(contentW).Render(content)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }
 
 // overlaySpawnDialog renders the sub-agent spawn form over the base view.
 func (m *Model) overlaySpawnDialog(base string) string {
 	content := m.spawnDialog.View()
-	box := spawnDialogBoxStyle.Render(content)
-	return placeOverlay(m.width, m.height, base, box)
+	contentW := dialogContentWidth(60, m.width)
+	box := spawnDialogBoxStyle.Width(contentW).Render(content)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }
 
 // sendSpawnCmd sends a CmdSpawnSubagent message to the control server.
@@ -908,45 +969,43 @@ func tickEvery() tea.Cmd {
 	})
 }
 
-// placeOverlay centres a box string over the base.
-func placeOverlay(totalW, totalH int, base, box string) string {
-	boxW := lipgloss.Width(box)
-	boxH := lipgloss.Height(box)
-
-	x := (totalW - boxW) / 2
-	y := (totalH - boxH) / 2
-	if x < 0 {
-		x = 0
+// filteredModelList returns models matching the current filter.
+func (m *Model) filteredModelList() []string {
+	if m.modelFilter == "" {
+		return m.modelList
 	}
-	if y < 0 {
-		y = 0
+	filter := strings.ToLower(m.modelFilter)
+	var result []string
+	for _, model := range m.modelList {
+		if strings.Contains(strings.ToLower(model), filter) {
+			result = append(result, model)
+		}
 	}
+	return result
+}
 
-	baseLines := strings.Split(base, "\n")
-	boxLines := strings.Split(box, "\n")
-
-	for i, bLine := range boxLines {
-		row := y + i
-		if row >= len(baseLines) {
-			break
-		}
-		baseLine := baseLines[row]
-		baseRunes := []rune(baseLine)
-		// Pad base line if needed
-		for len(baseRunes) < totalW {
-			baseRunes = append(baseRunes, ' ')
-		}
-		// Overwrite the portion with boxLine
-		bRunes := []rune(bLine)
-		for j, r := range bRunes {
-			col := x + j
-			if col < len(baseRunes) {
-				baseRunes[col] = r
-			}
-		}
-		baseLines[row] = string(baseRunes)
+// dialogContentWidth returns a clamped content width for overlay dialogs.
+// The returned value is the inner content width (excluding border and padding).
+func dialogContentWidth(longestItem, termWidth int) int {
+	const (
+		minContent = 34 // min 40 total - 6 chrome
+		maxContent = 74 // max 80 total - 6 chrome
+		chrome     = 6  // border (2) + padding (4)
+	)
+	w := longestItem
+	if w < minContent {
+		w = minContent
 	}
-	return strings.Join(baseLines, "\n")
+	if w > maxContent {
+		w = maxContent
+	}
+	if w+chrome > termWidth-2 {
+		w = termWidth - chrome - 2
+	}
+	if w < 10 {
+		w = 10
+	}
+	return w
 }
 
 // wrapText word-wraps text to the given width.

--- a/internal/tui/overlay_test.go
+++ b/internal/tui/overlay_test.go
@@ -1,0 +1,116 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDialogContentWidth(t *testing.T) {
+	tests := []struct {
+		name        string
+		longestItem int
+		termWidth   int
+		want        int
+	}{
+		{"clamps to minimum", 10, 120, 34},
+		{"clamps to maximum", 100, 120, 74},
+		{"uses content width in range", 50, 120, 50},
+		{"respects terminal width", 74, 60, 52}, // 60 - 6 - 2 = 52
+		{"narrow terminal floor", 74, 16, 10},
+		{"exact minimum boundary", 34, 120, 34},
+		{"exact maximum boundary", 74, 120, 74},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dialogContentWidth(tt.longestItem, tt.termWidth)
+			if got != tt.want {
+				t.Errorf("dialogContentWidth(%d, %d) = %d, want %d",
+					tt.longestItem, tt.termWidth, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilteredModelList(t *testing.T) {
+	m := &Model{
+		modelList: []string{
+			"anthropic/claude-opus-4-5",
+			"anthropic/claude-sonnet-4-5",
+			"openai/gpt-4o",
+			"google/gemini-2.5-pro",
+			"deepseek/deepseek-chat-v3",
+		},
+	}
+
+	tests := []struct {
+		name   string
+		filter string
+		want   int
+		first  string
+	}{
+		{"empty filter returns all", "", 5, "anthropic/claude-opus-4-5"},
+		{"filter by provider", "anthropic", 2, "anthropic/claude-opus-4-5"},
+		{"filter by model name", "gemini", 1, "google/gemini-2.5-pro"},
+		{"case insensitive", "GPT", 1, "openai/gpt-4o"},
+		{"no matches", "llama", 0, ""},
+		{"partial match", "deep", 1, "deepseek/deepseek-chat-v3"},
+		{"filter by slash", "/claude", 2, "anthropic/claude-opus-4-5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m.modelFilter = tt.filter
+			got := m.filteredModelList()
+			if len(got) != tt.want {
+				t.Errorf("filteredModelList() with filter %q returned %d items, want %d",
+					tt.filter, len(got), tt.want)
+			}
+			if tt.want > 0 && got[0] != tt.first {
+				t.Errorf("filteredModelList() first item = %q, want %q", got[0], tt.first)
+			}
+		})
+	}
+}
+
+func TestOverlaySessionListContainsTitle(t *testing.T) {
+	m := &Model{
+		width:  100,
+		height: 40,
+	}
+
+	result := m.overlaySessionList("")
+	if !strings.Contains(result, "Sessions") {
+		t.Error("overlaySessionList should contain 'Sessions' title")
+	}
+}
+
+func TestOverlayModelListContainsFilterPrompt(t *testing.T) {
+	m := &Model{
+		width:     100,
+		height:    40,
+		modelList: []string{"anthropic/claude-opus", "openai/gpt-4o"},
+	}
+
+	result := m.overlayModelList("")
+	if !strings.Contains(result, "Filter") {
+		t.Error("overlayModelList should contain 'Filter' prompt")
+	}
+	if !strings.Contains(result, "Select Model") {
+		t.Error("overlayModelList should contain 'Select Model' title")
+	}
+}
+
+func TestOverlayModelListShowsNoMatches(t *testing.T) {
+	m := &Model{
+		width:       100,
+		height:      40,
+		modelList:   []string{"anthropic/claude-opus", "openai/gpt-4o"},
+		modelFilter: "zzzzz",
+	}
+
+	result := m.overlayModelList("")
+	if !strings.Contains(result, "no matches") {
+		t.Error("overlayModelList should show 'no matches' when filter has no results")
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -109,11 +109,11 @@ var (
 	// Session list overlay
 	sessionListBorderStyle = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(colorPrimary).
+				BorderForeground(colorSubtle).
 				Padding(1, 2)
 
 	sessionItemStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("252"))
+				Foreground(lipgloss.AdaptiveColor{Dark: "252", Light: "235"})
 
 	sessionItemActiveStyle = lipgloss.NewStyle().
 				Foreground(colorAccent).
@@ -146,15 +146,31 @@ var (
 	// Model picker
 	modelListBorderStyle = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(colorAccent).
+				BorderForeground(colorSubtle).
 				Padding(1, 2)
 
 	modelItemStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("252"))
+			Foreground(lipgloss.AdaptiveColor{Dark: "252", Light: "235"})
 
 	modelItemActiveStyle = lipgloss.NewStyle().
 				Foreground(colorAccent).
 				Bold(true)
+
+	// Dialog shared styles (reusable across overlay dialogs)
+	dialogTitleStyle = lipgloss.NewStyle().
+				Foreground(colorPrimary).
+				Bold(true)
+
+	dialogHelpStyle = lipgloss.NewStyle().
+			Foreground(colorMuted)
+
+	dialogFilterPromptStyle = lipgloss.NewStyle().
+				Foreground(colorAccent).
+				Bold(true)
+
+	dialogFilterPlaceholderStyle = lipgloss.NewStyle().
+					Foreground(colorMuted).
+					Italic(true)
 
 	// Spawn sub-agent dialog
 	spawnDialogBoxStyle = lipgloss.NewStyle().


### PR DESCRIPTION
## Summary
- Replace manual `placeOverlay` rune-splicing with `lipgloss.Place()` for correct centering without ANSI corruption
- Calculate dialog width dynamically (min 40, max 80 chars) based on content length and terminal size
- Add fuzzy filter input to model picker (type to filter, backspace to clear)
- Use subtle adaptive border colors and `AdaptiveColor` item text for better light-terminal readability
- Add proper dialog titles and help text to all overlays
- Truncate long session labels to fit dialog width

## Test plan
- [x] `dialogContentWidth` unit tests (7 cases: min/max clamping, terminal constraints)
- [x] `filteredModelList` unit tests (7 cases: empty/provider/name/case/no-match/partial/slash)
- [x] Overlay rendering smoke tests (title presence, filter prompt, no-matches message)
- [ ] Manual: open session picker (Ctrl+P), verify centered dialog with proper title
- [ ] Manual: open model picker (Ctrl+M), type to filter, verify results narrow
- [ ] Manual: verify dialogs render correctly on light terminal background

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors all four TUI overlay dialogs — replacing the hand-rolled `placeOverlay` rune-splicer with `lipgloss.Place`, adding dynamic width clamping via `dialogContentWidth`, and introducing a live fuzzy-filter input to the model picker. The changes also improve light-terminal readability by switching to `AdaptiveColor` item text and `colorSubtle` border colours.

**Key concerns:**
- **Overlay background is now blank** — `lipgloss.Place` positions the box in a fresh canvas of spaces; it does not composite onto `base`. All four overlay functions accept `base string` but silently ignore it, so the chat content becomes invisible whenever a dialog is open. If the blank-modal style is intentional, the `base` parameter should be removed from the signatures to avoid confusion.
- **Byte length used for visual width** — `overlaySessionList` uses `len(raw)` to find the widest session label, but labels contain multi-byte Unicode characters (`·`, `●`, `★`). `lipgloss.Width()` should be used instead to avoid over-estimating and rendering a wider-than-needed dialog. The same inconsistency appears in `overlayModelList` where `maxW` is seeded with `lipgloss.Width(filterLine)` but subsequent items are compared with `len(raw)`.
- **Dead style variables** — `approvalTitleStyle` and `sessionRunningStyle` in `styles.go` are no longer referenced after this refactor and should be removed.

<h3>Confidence Score: 3/5</h3>

- Safe to merge if blank-background modal style is the intended UX; the byte-vs-visual-width issue is a minor cosmetic defect.
- The `base` parameter being silently ignored is the most consequential change — it fundamentally alters how dialogs render (blank canvas vs. overlay on chat). Whether this is intentional or a regression should be confirmed. The `len()` vs `lipgloss.Width()` issue affects dialog sizing correctness for non-ASCII content. Neither blocks functionality, but the first warrants explicit confirmation before merging.
- internal/tui/model.go — specifically the four overlay render functions and the session-list width calculation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tui/model.go | Core TUI model — replaces manual placeOverlay with lipgloss.Place for dialog centering, adds fuzzy filter to model picker, and introduces dialogContentWidth for dynamic sizing. Two issues: (1) the `base` parameter is now ignored in all four overlay functions, so dialogs render on a blank canvas instead of over the chat; (2) len(raw) is used instead of lipgloss.Width in session/model list width calculations, overestimating width for labels with multi-byte Unicode characters. |
| internal/tui/overlay_test.go | New test file covering dialogContentWidth clamping (7 cases), filteredModelList behaviour (7 cases), and overlay smoke tests for title/filter prompt/no-matches. Tests are well-structured and cover the key edge cases; test for overlaySessionList only checks title presence, not the missing-sessions (empty list) case. |
| internal/tui/styles.go | Adds four new shared dialog styles (dialogTitleStyle, dialogHelpStyle, dialogFilterPromptStyle, dialogFilterPlaceholderStyle), moves border colors to colorSubtle/AdaptiveColor for light-terminal compatibility. Two previously-used styles (approvalTitleStyle, sessionRunningStyle) are now dead code after the refactor. |

</details>



<sub>Last reviewed commit: a7c45e7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->