### PR TITLE
TUI P1: Command autocomplete — type / to see completions

### DIFF
--- a/internal/tui/completion.go
+++ b/internal/tui/completion.go
@@ -1,0 +1,158 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+type completionCommand struct {
+	name        string
+	description string
+}
+
+type completionState struct {
+	visible  bool
+	query    string
+	items    []completionCommand
+	selected int
+}
+
+var commandCompletions = []completionCommand{
+	{name: "/status", description: "bot status, model, uptime"},
+	{name: "/usage", description: "token usage stats"},
+	{name: "/context", description: "context window info"},
+	{name: "/whoami", description: "your user info"},
+	{name: "/commands", description: "show available commands"},
+	{name: "/think", description: "set thinking level"},
+	{name: "/compact", description: "compact context window"},
+	{name: "/model", description: "set or pick model"},
+	{name: "/new", description: "start new session"},
+	{name: "/abort", description: "abort active run"},
+	{name: "/stop", description: "alias for /abort"},
+}
+
+func (m *Model) updateCompletion() {
+	query, ok := parseCompletionQuery(m.input.Value())
+	if !ok {
+		m.hideCompletion()
+		return
+	}
+
+	filtered := filterCommandCompletions(query)
+	m.completion.visible = true
+	m.completion.query = query
+	m.completion.items = filtered
+	if len(filtered) == 0 {
+		m.completion.selected = 0
+		return
+	}
+	if m.completion.selected >= len(filtered) {
+		m.completion.selected = 0
+	}
+}
+
+func (m *Model) hideCompletion() {
+	m.completion.visible = false
+	m.completion.query = ""
+	m.completion.items = nil
+	m.completion.selected = 0
+}
+
+func (m *Model) moveCompletion(delta int) {
+	if !m.completion.visible || len(m.completion.items) == 0 {
+		return
+	}
+	next := m.completion.selected + delta
+	if next < 0 {
+		next = len(m.completion.items) - 1
+	}
+	if next >= len(m.completion.items) {
+		next = 0
+	}
+	m.completion.selected = next
+}
+
+func (m *Model) applyCompletion() bool {
+	if !m.completion.visible || len(m.completion.items) == 0 {
+		return false
+	}
+	value := m.completion.items[m.completion.selected].name + " "
+	m.input.SetValue(value)
+	m.input.CursorEnd()
+	m.hideCompletion()
+	return true
+}
+
+func (m *Model) renderCompletionPopup() string {
+	if m.screen != screenChat || !m.completion.visible {
+		return ""
+	}
+
+	innerWidth := m.width - 6
+	if innerWidth < 20 {
+		innerWidth = 20
+	}
+
+	title := completionTitleStyle.Width(innerWidth).Render("Commands")
+
+	var rows []string
+	if len(m.completion.items) == 0 {
+		rows = append(rows, completionEmptyStyle.Width(innerWidth).Render("No matching commands"))
+	} else {
+		cmdWidth := 0
+		for _, item := range m.completion.items {
+			if w := lipgloss.Width(item.name); w > cmdWidth {
+				cmdWidth = w
+			}
+		}
+		descWidth := innerWidth - cmdWidth - 2
+		if descWidth < 10 {
+			descWidth = 10
+		}
+
+		for i, item := range m.completion.items {
+			cmdStyle := completionCommandStyle
+			descStyle := completionDescStyle
+			rowStyle := completionItemStyle
+			if i == m.completion.selected {
+				cmdStyle = completionCommandSelectedStyle
+				descStyle = completionDescSelectedStyle
+				rowStyle = completionItemSelectedStyle
+			}
+
+			cmd := cmdStyle.Width(cmdWidth).Render(item.name)
+			desc := descStyle.Width(descWidth).Render(truncate(item.description, descWidth))
+			row := rowStyle.Width(innerWidth).Render(lipgloss.JoinHorizontal(lipgloss.Top, cmd, "  ", desc))
+			rows = append(rows, row)
+		}
+	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left, append([]string{title}, rows...)...)
+	return completionPopupStyle.Width(m.width - 2).Render(content)
+}
+
+func parseCompletionQuery(input string) (string, bool) {
+	text := strings.TrimLeft(input, " \t")
+	if !strings.HasPrefix(text, "/") {
+		return "", false
+	}
+	if strings.ContainsAny(text, " \n\r\t") {
+		return "", false
+	}
+	return strings.ToLower(strings.TrimPrefix(text, "/")), true
+}
+
+func filterCommandCompletions(query string) []completionCommand {
+	if query == "" {
+		return append([]completionCommand(nil), commandCompletions...)
+	}
+	items := make([]completionCommand, 0, len(commandCompletions))
+	for _, cmd := range commandCompletions {
+		name := strings.TrimPrefix(strings.ToLower(cmd.name), "/")
+		if strings.HasPrefix(name, query) {
+			items = append(items, cmd)
+		}
+	}
+	return items
+}

--- a/internal/tui/completion_test.go
+++ b/internal/tui/completion_test.go
@@ -1,0 +1,155 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func newTestChatModel() *Model {
+	ta := textarea.New()
+	ta.SetWidth(80)
+	ta.SetHeight(3)
+	ta.Focus()
+	return &Model{
+		screen: screenChat,
+		input:  ta,
+		width:  120,
+		height: 40,
+	}
+}
+
+func TestParseCompletionQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		ok    bool
+	}{
+		{name: "slash only", input: "/", want: "", ok: true},
+		{name: "command prefix", input: "/st", want: "st", ok: true},
+		{name: "ignores leading spaces", input: "   /mo", want: "mo", ok: true},
+		{name: "not a command", input: "hello", want: "", ok: false},
+		{name: "has args", input: "/status now", want: "", ok: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseCompletionQuery(tc.input)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("parseCompletionQuery(%q) = (%q, %v), want (%q, %v)", tc.input, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestFilterCommandCompletions(t *testing.T) {
+	t.Parallel()
+
+	all := filterCommandCompletions("")
+	if len(all) != len(commandCompletions) {
+		t.Fatalf("expected %d commands, got %d", len(commandCompletions), len(all))
+	}
+
+	st := filterCommandCompletions("st")
+	if len(st) != 2 {
+		t.Fatalf("expected 2 /st matches, got %d", len(st))
+	}
+	if st[0].name != "/status" || st[1].name != "/stop" {
+		t.Fatalf("unexpected /st matches: %+v", st)
+	}
+
+	none := filterCommandCompletions("does-not-exist")
+	if len(none) != 0 {
+		t.Fatalf("expected no matches, got %d", len(none))
+	}
+}
+
+func TestUpdateCompletionVisibility(t *testing.T) {
+	t.Parallel()
+
+	m := newTestChatModel()
+
+	m.input.SetValue("/")
+	m.updateCompletion()
+	if !m.completion.visible {
+		t.Fatal("expected completion to be visible for /")
+	}
+	if len(m.completion.items) != len(commandCompletions) {
+		t.Fatalf("expected %d items, got %d", len(commandCompletions), len(m.completion.items))
+	}
+
+	m.input.SetValue("/status now")
+	m.updateCompletion()
+	if m.completion.visible {
+		t.Fatal("expected completion to hide when args are present")
+	}
+
+	m.input.SetValue("plain text")
+	m.updateCompletion()
+	if m.completion.visible {
+		t.Fatal("expected completion to hide for non-command input")
+	}
+}
+
+func TestHandleChatKeyCompletionNavigationAndTabApply(t *testing.T) {
+	t.Parallel()
+
+	m := newTestChatModel()
+	m.input.SetValue("/")
+	m.updateCompletion()
+
+	if m.completion.selected != 0 {
+		t.Fatalf("expected initial selection 0, got %d", m.completion.selected)
+	}
+
+	m.handleChatKey(tea.KeyMsg{Type: tea.KeyDown}, nil)
+	if m.completion.selected != 1 {
+		t.Fatalf("expected selection 1 after down, got %d", m.completion.selected)
+	}
+
+	m.handleChatKey(tea.KeyMsg{Type: tea.KeyTab}, nil)
+	if m.completion.visible {
+		t.Fatal("expected completion popup to be hidden after apply")
+	}
+	if m.input.Value() != "/usage " {
+		t.Fatalf("expected tab apply to set /usage, got %q", m.input.Value())
+	}
+}
+
+func TestHandleChatKeyEscDismissesCompletion(t *testing.T) {
+	t.Parallel()
+
+	m := newTestChatModel()
+	m.input.SetValue("/")
+	m.updateCompletion()
+
+	m.handleChatKey(tea.KeyMsg{Type: tea.KeyEsc}, nil)
+	if m.completion.visible {
+		t.Fatal("expected esc to dismiss completion")
+	}
+	if m.input.Value() != "/" {
+		t.Fatalf("expected input to remain unchanged, got %q", m.input.Value())
+	}
+}
+
+func TestHandleChatKeyEnterCompletesCommand(t *testing.T) {
+	t.Parallel()
+
+	m := newTestChatModel()
+	m.input.SetValue("/st")
+	m.updateCompletion()
+
+	m.handleChatKey(tea.KeyMsg{Type: tea.KeyEnter}, nil)
+	if m.completion.visible {
+		t.Fatal("expected enter to apply completion and hide popup")
+	}
+	if m.input.Value() != "/status " {
+		t.Fatalf("expected enter to complete /status, got %q", m.input.Value())
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -84,6 +84,9 @@ type Model struct {
 	// markdown renderer for assistant messages
 	md *mdRenderer
 
+	// slash command completion
+	completion completionState
+
 	// misc
 	statusMsg string
 	statusAt  time.Time
@@ -198,6 +201,28 @@ func (m *Model) handleKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	if m.completion.visible {
+		switch msg.String() {
+		case "esc":
+			m.hideCompletion()
+			return m, tea.Batch(cmds...)
+		case "up":
+			m.moveCompletion(-1)
+			return m, tea.Batch(cmds...)
+		case "down":
+			m.moveCompletion(1)
+			return m, tea.Batch(cmds...)
+		case "tab":
+			if m.applyCompletion() {
+				return m, tea.Batch(cmds...)
+			}
+		case "enter":
+			if !msg.Alt && m.applyCompletion() {
+				return m, tea.Batch(cmds...)
+			}
+		}
+	}
+
 	switch msg.String() {
 	case "ctrl+c":
 		return m, tea.Quit
@@ -213,13 +238,14 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 			if text == "" {
 				break
 			}
-			if strings.HasPrefix(text, "/abort") {
+			switch commandToken(text) {
+			case "/abort", "/stop":
 				m.sendCmd(controlserver.ClientMsg{
 					Type:      controlserver.CmdAbort,
 					SessionID: m.activeSession,
 				})
 				m.setStatus("Abort sent")
-			} else if strings.HasPrefix(text, "/new") {
+			case "/new":
 				parts := strings.Fields(text)
 				name := ""
 				if len(parts) > 1 {
@@ -229,7 +255,7 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 					Type: controlserver.CmdNewSession,
 					Name: name,
 				})
-			} else if strings.HasPrefix(text, "/model") {
+			case "/model":
 				parts := strings.Fields(text)
 				if len(parts) == 2 {
 					m.sendCmd(controlserver.ClientMsg{
@@ -243,21 +269,24 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 					m.modelCursor = 0
 					m.modelFilter = ""
 				}
-			} else if isBotCommand(text) {
-				m.sendCmd(controlserver.ClientMsg{
-					Type:      controlserver.CmdBotCommand,
-					SessionID: m.activeSession,
-					Text:      text,
-				})
-			} else {
-				m.sendCmd(controlserver.ClientMsg{
-					Type:      controlserver.CmdSend,
-					SessionID: m.activeSession,
-					Text:      text,
-				})
+			default:
+				if isBotCommand(text) {
+					m.sendCmd(controlserver.ClientMsg{
+						Type:      controlserver.CmdBotCommand,
+						SessionID: m.activeSession,
+						Text:      text,
+					})
+				} else {
+					m.sendCmd(controlserver.ClientMsg{
+						Type:      controlserver.CmdSend,
+						SessionID: m.activeSession,
+						Text:      text,
+					})
+				}
 			}
 			m.input.Reset()
 			m.recalcInputHeight()
+			m.hideCompletion()
 			return m, tea.Batch(cmds...)
 		}
 
@@ -265,12 +294,14 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 		// Open sub-agent spawn dialog
 		m.spawnDialog = NewSpawnDialog()
 		m.screen = screenSpawn
+		m.hideCompletion()
 		return m, tea.Batch(append(cmds, m.spawnDialog.Init())...)
 
 	case "ctrl+p":
 		// Open session picker
 		m.screen = screenSessions
 		m.sessionCursor = 0
+		m.hideCompletion()
 		return m, tea.Batch(cmds...)
 
 	case "ctrl+m":
@@ -278,6 +309,7 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 		m.screen = screenModels
 		m.modelCursor = 0
 		m.modelFilter = ""
+		m.hideCompletion()
 		return m, tea.Batch(cmds...)
 
 	case "ctrl+a":
@@ -309,6 +341,7 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 	// Forward to textarea
 	var inputCmd tea.Cmd
 	m.input, inputCmd = m.input.Update(msg)
+	m.updateCompletion()
 	cmds = append(cmds, inputCmd)
 	m.recalcInputHeight()
 	return m, tea.Batch(cmds...)
@@ -550,10 +583,12 @@ func (m *Model) View() string {
 
 	header := m.renderHeader()
 	status := m.renderStatus()
+	completion := m.renderCompletionPopup()
+	completionHeight := lipgloss.Height(completion)
 
 	// Reserve lines for header (1), status (1), input border + textarea
 	inputHeight := m.inputAreaHeight()
-	chatHeight := m.height - lipgloss.Height(header) - lipgloss.Height(status) - inputHeight
+	chatHeight := m.height - lipgloss.Height(header) - lipgloss.Height(status) - inputHeight - completionHeight
 
 	if chatHeight < 2 {
 		chatHeight = 2
@@ -562,13 +597,23 @@ func (m *Model) View() string {
 
 	chat := m.viewport.View()
 	input := m.renderInput()
-
-	base := lipgloss.JoinVertical(lipgloss.Left,
-		header,
-		chat,
-		input,
-		status,
-	)
+	var base string
+	if completion != "" {
+		base = lipgloss.JoinVertical(lipgloss.Left,
+			header,
+			chat,
+			completion,
+			input,
+			status,
+		)
+	} else {
+		base = lipgloss.JoinVertical(lipgloss.Left,
+			header,
+			chat,
+			input,
+			status,
+		)
+	}
 
 	// Overlay screens
 	switch m.screen {
@@ -646,7 +691,7 @@ func (m *Model) renderStatus() string {
 
 	statusText := m.statusMsg
 	if statusText == "" {
-		statusText = "/abort · /new · /commands · Ctrl+Y copy · Ctrl+N spawn · enter to send"
+		statusText = "/abort · /new · /commands · type / for completions · Ctrl+Y copy · Ctrl+N spawn · enter to send"
 	}
 	fixedWidth := lipgloss.Width(left) + lipgloss.Width(leftVal) + lipgloss.Width(charPart) + lipgloss.Width(errPart)
 	hint := statusBarStyle.Width(m.width - fixedWidth).
@@ -1068,13 +1113,22 @@ func copyToClipboard(text string) error {
 // directly to the bot handler rather than the AI.
 func isBotCommand(text string) bool {
 	botCmds := []string{"/status", "/usage", "/context", "/whoami", "/commands"}
-	lower := strings.ToLower(strings.Fields(text)[0])
+	lower := commandToken(text)
 	for _, c := range botCmds {
 		if lower == c {
 			return true
 		}
 	}
 	return false
+}
+
+// commandToken returns the first lower-cased token from text.
+func commandToken(text string) string {
+	fields := strings.Fields(strings.ToLower(strings.TrimSpace(text)))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }
 
 // truncate shortens a string to at most n runes.

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -133,6 +133,46 @@ var (
 				BorderForeground(colorAccent).
 				Padding(0, 1)
 
+	// Slash command completion popup
+	completionPopupStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("243")).
+				Background(lipgloss.Color("235")).
+				Padding(0, 1)
+
+	completionTitleStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("250")).
+				Background(lipgloss.Color("236")).
+				Padding(0, 1).
+				Bold(true)
+
+	completionItemStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("252")).
+				Padding(0, 1)
+
+	completionItemSelectedStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("255")).
+					Background(lipgloss.Color("24")).
+					Padding(0, 1)
+
+	completionCommandStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("87")).
+				Bold(true)
+
+	completionCommandSelectedStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("230")).
+					Bold(true)
+
+	completionDescStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("245"))
+
+	completionDescSelectedStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("252"))
+
+	completionEmptyStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("245")).
+				Italic(true)
+
 	// Streaming cursor
 	streamingCursorStyle = lipgloss.NewStyle().
 				Foreground(colorAccent).


### PR DESCRIPTION
Closes #136

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds slash-command autocomplete to the TUI chat screen. The implementation is clean and well-structured, but there are four issues that need to be addressed before merging:

1. **Bug: Viewport height miscalculation** — `lipgloss.Height("")` returns 1 instead of 0, so the chat viewport permanently loses one line of height between popup appearances. The layout join correctly skips empty strings, but the height budget calculation does not.

2. **Unhandled completions** — `/think` and `/compact` are surfaced as completions in `commandCompletions` but have no corresponding handlers in the command dispatch switch (lines 242-271) or in `isBotCommand`, so selecting either will silently dispatch to the AI as a plain `CmdSend` message rather than executing the intended bot command.

3. **Enter falls through on empty matches** — When the completion popup is visible but has no matching items (showing "No matching commands"), pressing Enter causes `applyCompletion()` to return false, which allows the `case "enter"` block to fall through to the outer `case "enter"` handler that sends the partial input (e.g. `/zzzz`) as a plain message while the "No matching commands" popup is still on screen.

4. **Brittle tests** — Several tests hardcode command names, positions, and result counts (e.g., the test asserts exactly 2 matches for `/st`, and assumes `/usage` is at index 1 in the completion list). These will produce confusing failures if `commandCompletions` is reordered or extended with new commands like `/stats` or `/stream`.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — multiple logic bugs cause persistent visual glitches, silent command misrouting, and confusing UX.
- All four verified findings are real bugs with user-visible impact: (1) viewport height miscalculation causes a persistent 1-line layout glitch every time the popup is shown/hidden; (2) `/think` and `/compact` completions silently dispatch as AI messages instead of executing bot commands; (3) Enter key with no matching items sends incomplete commands while the "No matching commands" popup is still visible; (4) brittle tests hardcode positions and counts, guaranteeing CI failures when commands are added or reordered. These are not trivial issues and should be addressed before merging.
- internal/tui/model.go (viewport height calculation and Enter key fall-through), internal/tui/completion.go (missing command handlers), internal/tui/completion_test.go (hardcoded test assumptions)

<sub>Last reviewed commit: 07a7506</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->