### PR TITLE
TUI P2: Split layout — sessions sidebar + chat pane

### DIFF
--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -29,9 +29,11 @@ By default this command connects to the running bot control server.
 You can point the TUI at a different control server with --server.
 
 Key bindings:
-  Enter         Send message
+  Enter         Send message (chat pane) / switch session (sessions pane)
   Shift+Enter   Insert newline (Alt+Enter also works)
-  Ctrl+P        Open session picker
+  Tab/Ctrl+]    Switch focus between sessions/chat panes
+  Ctrl+P        Focus sessions pane
+  ↑/↓           Move in sessions pane (when focused)
   Ctrl+M        Open model picker
   Ctrl+A        Abort active run
   Ctrl+N        Spawn sub-agent

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -328,7 +328,9 @@ func (s *Server) executeBotCommand(text string) string {
 /abort     — abort active run
 
 *TUI shortcuts:*
-Ctrl+P     — session picker
+Tab/Ctrl+] — switch focus (sessions/chat)
+↑/↓        — move sessions cursor (sessions pane)
+Enter      — switch session (sessions pane)
 Ctrl+M     — model picker
 Ctrl+A     — abort run
 Ctrl+N     — spawn sub-agent

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -25,10 +25,17 @@ type screen int
 
 const (
 	screenChat     screen = iota
-	screenSessions        // session picker overlay
 	screenModels          // model picker overlay
 	screenApproval        // approval prompt overlay
 	screenSpawn           // sub-agent spawn dialog
+)
+
+// paneFocus tracks whether the sessions sidebar or chat input is focused.
+type paneFocus int
+
+const (
+	focusChat paneFocus = iota
+	focusSessions
 )
 
 // chatEntry is one logical item in the chat log.
@@ -57,6 +64,7 @@ type Model struct {
 	sessions      []controlserver.TUISessionInfo
 	activeSession string
 	running       bool
+	paneFocus     paneFocus
 
 	// chat log
 	entries   []chatEntry
@@ -77,8 +85,13 @@ type Model struct {
 
 	// session/model pickers
 	sessionCursor int
+	sessionOffset int
 	modelCursor   int
 	modelList     []string
+
+	// split-pane layout
+	sessionPaneWidth int
+	chatPaneWidth    int
 
 	// misc
 	statusMsg string
@@ -181,8 +194,6 @@ func (m *Model) handleKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	switch m.screen {
 	case screenApproval:
 		return m.handleApprovalKey(msg, cmds)
-	case screenSessions:
-		return m.handleSessionKey(msg, cmds)
 	case screenModels:
 		return m.handleModelKey(msg, cmds)
 	case screenSpawn:
@@ -197,10 +208,28 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 	case "ctrl+c":
 		return m, tea.Quit
 
-	case "esc":
-		// do nothing in chat mode, esc closes overlays
+	case "tab", "ctrl+]":
+		m.togglePaneFocus()
 		return m, tea.Batch(cmds...)
 
+	case "ctrl+p":
+		// Keep backward compatibility with old shortcut.
+		m.setPaneFocus(focusSessions)
+		return m, tea.Batch(cmds...)
+
+	case "esc":
+		if m.paneFocus == focusSessions {
+			m.setPaneFocus(focusChat)
+		}
+		// do nothing in chat mode, esc closes overlays
+		return m, tea.Batch(cmds...)
+	}
+
+	if m.paneFocus == focusSessions {
+		return m.handleSessionPaneKey(msg, cmds)
+	}
+
+	switch msg.String() {
 	case "ctrl+s", "enter":
 		if msg.String() == "enter" && !msg.Alt {
 			// Enter without Alt sends message (textarea handles Alt+Enter for newlines)
@@ -261,12 +290,6 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 		m.screen = screenSpawn
 		return m, tea.Batch(append(cmds, m.spawnDialog.Init())...)
 
-	case "ctrl+p":
-		// Open session picker
-		m.screen = screenSessions
-		m.sessionCursor = 0
-		return m, tea.Batch(cmds...)
-
 	case "ctrl+m":
 		// Open model picker
 		m.screen = screenModels
@@ -307,6 +330,56 @@ func (m *Model) handleChatKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cm
 	return m, tea.Batch(cmds...)
 }
 
+func (m *Model) handleSessionPaneKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.setPaneFocus(focusChat)
+	case "up", "k":
+		m.moveSessionCursor(-1)
+	case "down", "j":
+		m.moveSessionCursor(1)
+	case "enter":
+		if m.sessionCursor < len(m.sessions) {
+			target := m.sessions[m.sessionCursor]
+			m.sendCmd(controlserver.ClientMsg{
+				Type:      controlserver.CmdSwitch,
+				SessionID: target.ID,
+			})
+		}
+	case "n":
+		m.sendCmd(controlserver.ClientMsg{
+			Type: controlserver.CmdNewSession,
+			Name: fmt.Sprintf("Chat %d", len(m.sessions)+1),
+		})
+	case "ctrl+a":
+		m.sendCmd(controlserver.ClientMsg{
+			Type:      controlserver.CmdAbort,
+			SessionID: m.activeSession,
+		})
+		m.setStatus("Abort sent")
+	case "ctrl+m":
+		m.screen = screenModels
+		m.modelCursor = 0
+	case "ctrl+n":
+		m.spawnDialog = NewSpawnDialog()
+		m.screen = screenSpawn
+		return m, tea.Batch(append(cmds, m.spawnDialog.Init())...)
+	case "ctrl+y":
+		if text := m.lastAssistantText(); text != "" {
+			if err := copyToClipboard(text); err != nil {
+				m.setStatus("Copy failed: " + err.Error())
+			} else {
+				m.setStatus("✓ Copied to clipboard")
+			}
+		}
+	case "pgup":
+		m.viewport.HalfViewUp()
+	case "pgdown":
+		m.viewport.HalfViewDown()
+	}
+	return m, tea.Batch(cmds...)
+}
+
 func (m *Model) handleApprovalKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "left", "h":
@@ -321,39 +394,6 @@ func (m *Model) handleApprovalKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, te
 		m.submitApproval()
 	case "enter":
 		m.submitApproval()
-	case "ctrl+c":
-		return m, tea.Quit
-	}
-	return m, tea.Batch(cmds...)
-}
-
-func (m *Model) handleSessionKey(msg tea.KeyMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc", "ctrl+p":
-		m.screen = screenChat
-	case "up", "k":
-		if m.sessionCursor > 0 {
-			m.sessionCursor--
-		}
-	case "down", "j":
-		if m.sessionCursor < len(m.sessions)-1 {
-			m.sessionCursor++
-		}
-	case "enter":
-		if m.sessionCursor < len(m.sessions) {
-			target := m.sessions[m.sessionCursor]
-			m.sendCmd(controlserver.ClientMsg{
-				Type:      controlserver.CmdSwitch,
-				SessionID: target.ID,
-			})
-		}
-		m.screen = screenChat
-	case "n":
-		m.sendCmd(controlserver.ClientMsg{
-			Type: controlserver.CmdNewSession,
-			Name: fmt.Sprintf("Chat %d", len(m.sessions)+1),
-		})
-		m.screen = screenChat
 	case "ctrl+c":
 		return m, tea.Quit
 	}
@@ -404,9 +444,11 @@ func (m *Model) handleServerMsg(msg controlserver.ServerMsg) tea.Cmd {
 		if len(msg.Sessions) > 0 {
 			m.sessions = msg.Sessions
 		}
+		m.syncSessionSelection(true)
 
 	case controlserver.MsgTypeSessions:
 		m.sessions = msg.Sessions
+		m.syncSessionSelection(false)
 
 	case controlserver.MsgTypeError:
 		m.addEntry(chatEntry{role: "error", content: msg.Message})
@@ -528,21 +570,19 @@ func (m *Model) View() string {
 	header := m.renderHeader()
 	status := m.renderStatus()
 
-	// Reserve lines for header (1), status (1), input border + textarea
+	// Reserve lines for header (1), status (1), input border + textarea.
 	inputHeight := m.inputAreaHeight()
-	chatHeight := m.height - lipgloss.Height(header) - lipgloss.Height(status) - inputHeight
-
-	if chatHeight < 2 {
-		chatHeight = 2
+	mainHeight := m.height - lipgloss.Height(header) - lipgloss.Height(status) - inputHeight
+	if mainHeight < 2 {
+		mainHeight = 2
 	}
-	m.viewport.Height = chatHeight
 
-	chat := m.viewport.View()
+	mainArea := m.renderMainArea(mainHeight)
 	input := m.renderInput()
 
 	base := lipgloss.JoinVertical(lipgloss.Left,
 		header,
-		chat,
+		mainArea,
 		input,
 		status,
 	)
@@ -551,8 +591,6 @@ func (m *Model) View() string {
 	switch m.screen {
 	case screenApproval:
 		return m.overlayApproval(base)
-	case screenSessions:
-		return m.overlaySessionList(base)
 	case screenModels:
 		return m.overlayModelList(base)
 	case screenSpawn:
@@ -581,7 +619,7 @@ func (m *Model) renderHeader() string {
 
 	left := headerStyle.Render("🦞 ok-gobot" + runIndicator)
 	mid := headerDimStyle.Render("model: " + model)
-	right := headerDimStyle.Render("Ctrl+P sessions · Ctrl+M model · Ctrl+A abort")
+	right := headerDimStyle.Render("Tab/Ctrl+] focus · Ctrl+M model · Ctrl+A abort")
 
 	midWidth := m.width - lipgloss.Width(left) - lipgloss.Width(right)
 	if midWidth < 0 {
@@ -623,7 +661,7 @@ func (m *Model) renderStatus() string {
 
 	statusText := m.statusMsg
 	if statusText == "" {
-		statusText = "/abort · /new · /commands · Ctrl+Y copy · Ctrl+N spawn · enter to send"
+		statusText = "/abort · /new · /commands · Ctrl+Y copy · Ctrl+N spawn · Tab focus · enter to send"
 	}
 	fixedWidth := lipgloss.Width(left) + lipgloss.Width(leftVal) + lipgloss.Width(charPart) + lipgloss.Width(errPart)
 	hint := statusBarStyle.Width(m.width - fixedWidth).
@@ -635,10 +673,93 @@ func (m *Model) renderStatus() string {
 // renderInput renders the text input area.
 func (m *Model) renderInput() string {
 	borderStyle := inputBorderStyle
-	if m.screen == screenChat {
+	if m.screen == screenChat && m.paneFocus == focusChat {
 		borderStyle = inputBorderFocusStyle
 	}
 	return borderStyle.Width(m.width - 2).Render(m.input.View())
+}
+
+func (m *Model) renderMainArea(height int) string {
+	if height < 1 {
+		height = 1
+	}
+
+	m.sessionPaneWidth, m.chatPaneWidth = m.computePaneWidths()
+	m.viewport.Width = m.chatPaneWidth
+	m.viewport.Height = height
+	m.syncSessionSelection(false)
+
+	sidebar := m.renderSessionSidebar(height)
+	separator := lipgloss.NewStyle().Foreground(colorSubtle).Render("│")
+	chat := lipgloss.NewStyle().
+		Width(m.chatPaneWidth).
+		Height(height).
+		Render(m.viewport.View())
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, sidebar, separator, chat)
+}
+
+func (m *Model) renderSessionSidebar(height int) string {
+	sidebarStyle := lipgloss.NewStyle().
+		Width(m.sessionPaneWidth).
+		Height(height)
+
+	if height < 2 || m.sessionPaneWidth < 1 {
+		return sidebarStyle.Render("")
+	}
+
+	titleStyle := lipgloss.NewStyle().Foreground(colorMuted)
+	if m.paneFocus == focusSessions {
+		titleStyle = titleStyle.Foreground(colorAccent).Bold(true)
+	}
+
+	headerLine := truncate(" Sessions ", m.sessionPaneWidth)
+	hintLine := truncate(" ↑↓ select · Enter switch ", m.sessionPaneWidth)
+	lines := []string{
+		titleStyle.Render(headerLine),
+		lipgloss.NewStyle().Foreground(colorMuted).Render(hintLine),
+	}
+
+	visibleRows := height - len(lines)
+	if visibleRows < 1 {
+		return sidebarStyle.Render(strings.Join(lines, "\n"))
+	}
+	m.ensureSessionOffset(visibleRows)
+
+	if len(m.sessions) == 0 {
+		lines = append(lines, lipgloss.NewStyle().Foreground(colorMuted).Render(" (no sessions)"))
+		for len(lines) < height {
+			lines = append(lines, "")
+		}
+		return sidebarStyle.Render(strings.Join(lines, "\n"))
+	}
+
+	for row := 0; row < visibleRows; row++ {
+		idx := m.sessionOffset + row
+		if idx >= len(m.sessions) {
+			lines = append(lines, "")
+			continue
+		}
+
+		s := m.sessions[idx]
+		prefix := "  "
+		style := sessionItemStyle
+		if idx == m.sessionCursor {
+			prefix = "> "
+			style = sessionItemActiveStyle
+		}
+
+		line := prefix + s.Name
+		if s.ID == m.activeSession {
+			line += " *"
+		}
+		if s.Running {
+			line += " ●"
+		}
+		lines = append(lines, style.Render(truncate(line, m.sessionPaneWidth)))
+	}
+
+	return sidebarStyle.Render(strings.Join(lines, "\n"))
 }
 
 // renderChatLog builds the full chat log string for the viewport.
@@ -655,10 +776,11 @@ func (m *Model) renderChatLog() string {
 
 // renderEntry renders one chat entry.
 func (m *Model) renderEntry(e chatEntry) string {
+	contentWidth := m.chatContentWidth()
 	switch e.role {
 	case "user":
 		label := userLabelStyle.Render("You")
-		msg := userMsgStyle.Render(wrapText(e.content, m.width-6))
+		msg := userMsgStyle.Render(wrapText(e.content, contentWidth))
 		return label + "\n" + msg
 
 	case "assistant":
@@ -668,7 +790,7 @@ func (m *Model) renderEntry(e chatEntry) string {
 		if e.streaming {
 			cursor = streamingCursorStyle.Render("█")
 		}
-		msg := botMsgStyle.Render(wrapText(text, m.width-6))
+		msg := botMsgStyle.Render(wrapText(text, contentWidth))
 		return label + "\n" + msg + cursor
 
 	case "tool":
@@ -707,7 +829,11 @@ func (m *Model) renderToolCard(e chatEntry) string {
 		sb.WriteString("\n" + toolErrorStyle.Render("  ✗ "+e.toolErr))
 	}
 	inner := sb.String()
-	return toolCardBorderStyle.Width(m.width - 4).Render(inner)
+	width := m.chatContentWidth() + 2
+	if width < 10 {
+		width = 10
+	}
+	return toolCardBorderStyle.Width(width).Render(inner)
 }
 
 // overlayApproval renders the approval dialog over the base view.
@@ -732,38 +858,6 @@ func (m *Model) overlayApproval(base string) string {
 	)
 
 	box := approvalBoxStyle.Render(content)
-	return placeOverlay(m.width, m.height, base, box)
-}
-
-// overlaySessionList renders the session picker overlay.
-func (m *Model) overlaySessionList(base string) string {
-	var items []string
-	for i, s := range m.sessions {
-		prefix := "  "
-		style := sessionItemStyle
-		if i == m.sessionCursor {
-			prefix = "▶ "
-			style = sessionItemActiveStyle
-		}
-		running := ""
-		if s.Running {
-			running = sessionRunningStyle.Render(" ●")
-		}
-		label := prefix + s.Name + " [" + s.Model + "]" + running
-		if s.ID == m.activeSession {
-			label += " ★"
-		}
-		items = append(items, style.Render(label))
-	}
-	items = append(items, lipgloss.NewStyle().Foreground(colorMuted).Render("  [n] new session"))
-
-	content := lipgloss.JoinVertical(lipgloss.Left,
-		sessionItemActiveStyle.Render("Sessions (Ctrl+P / Esc to close)"),
-		"",
-	)
-	content += strings.Join(items, "\n")
-
-	box := sessionListBorderStyle.Render(content)
 	return placeOverlay(m.width, m.height, base, box)
 }
 
@@ -826,6 +920,10 @@ func (m *Model) listenCmd() tea.Cmd {
 
 // sendCmd sends a ClientMsg over WebSocket (fire and forget).
 func (m *Model) sendCmd(msg controlserver.ClientMsg) {
+	if m.conn == nil {
+		m.lastErr = "send error: no active connection"
+		return
+	}
 	if err := m.conn.send(msg); err != nil {
 		m.lastErr = fmt.Sprintf("send error: %v", err)
 	}
@@ -848,12 +946,16 @@ func (m *Model) resizeComponents() {
 	inputHeight := m.inputAreaHeight()
 	headerH := 1
 	statusH := 1
-	chatH := m.height - headerH - statusH - inputHeight
-	if chatH < 2 {
-		chatH = 2
+	mainH := m.height - headerH - statusH - inputHeight
+	if mainH < 2 {
+		mainH = 2
 	}
-	m.viewport.Width = m.width
-	m.viewport.Height = chatH
+
+	m.sessionPaneWidth, m.chatPaneWidth = m.computePaneWidths()
+	m.viewport.Width = m.chatPaneWidth
+	m.viewport.Height = mainH
+	m.ensureSessionOffset(mainH - 2)
+
 	m.input.SetWidth(m.width - 4) // account for border padding
 	m.refreshViewport()
 }
@@ -885,6 +987,145 @@ func (m *Model) recalcInputHeight() {
 func (m *Model) setStatus(s string) {
 	m.statusMsg = s
 	m.statusAt = time.Now()
+}
+
+func (m *Model) setPaneFocus(f paneFocus) {
+	m.paneFocus = f
+	if f == focusChat {
+		m.input.Focus()
+		return
+	}
+	m.input.Blur()
+}
+
+func (m *Model) togglePaneFocus() {
+	if m.paneFocus == focusChat {
+		m.setPaneFocus(focusSessions)
+		return
+	}
+	m.setPaneFocus(focusChat)
+}
+
+func (m *Model) moveSessionCursor(delta int) {
+	if len(m.sessions) == 0 {
+		m.sessionCursor = 0
+		m.sessionOffset = 0
+		return
+	}
+	m.sessionCursor += delta
+	if m.sessionCursor < 0 {
+		m.sessionCursor = 0
+	}
+	if m.sessionCursor >= len(m.sessions) {
+		m.sessionCursor = len(m.sessions) - 1
+	}
+	visible := m.viewport.Height - 2
+	if visible < 1 {
+		visible = 1
+	}
+	m.ensureSessionOffset(visible)
+}
+
+func (m *Model) syncSessionSelection(preferActive bool) {
+	if len(m.sessions) == 0 {
+		m.sessionCursor = 0
+		m.sessionOffset = 0
+		return
+	}
+
+	if preferActive {
+		activeIdx := -1
+		for i, s := range m.sessions {
+			if s.ID == m.activeSession {
+				activeIdx = i
+				break
+			}
+		}
+		if activeIdx >= 0 {
+			m.sessionCursor = activeIdx
+		}
+	}
+
+	if m.sessionCursor >= len(m.sessions) {
+		m.sessionCursor = len(m.sessions) - 1
+	}
+	if m.sessionCursor < 0 {
+		m.sessionCursor = 0
+	}
+
+	if m.activeSession == "" && len(m.sessions) > 0 {
+		m.activeSession = m.sessions[0].ID
+	}
+
+	visible := m.viewport.Height - 2
+	if visible < 1 {
+		visible = 1
+	}
+	m.ensureSessionOffset(visible)
+}
+
+func (m *Model) ensureSessionOffset(visibleRows int) {
+	if visibleRows < 1 {
+		visibleRows = 1
+	}
+	if len(m.sessions) == 0 {
+		m.sessionOffset = 0
+		return
+	}
+	if m.sessionCursor < m.sessionOffset {
+		m.sessionOffset = m.sessionCursor
+	}
+	if m.sessionCursor >= m.sessionOffset+visibleRows {
+		m.sessionOffset = m.sessionCursor - visibleRows + 1
+	}
+	maxOffset := len(m.sessions) - visibleRows
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if m.sessionOffset > maxOffset {
+		m.sessionOffset = maxOffset
+	}
+	if m.sessionOffset < 0 {
+		m.sessionOffset = 0
+	}
+}
+
+func (m *Model) computePaneWidths() (int, int) {
+	total := m.width
+	if total <= 3 {
+		return 1, 1
+	}
+
+	// ~20% sessions pane, with a practical minimum where possible.
+	sessionW := total / 5
+	if sessionW < 12 {
+		sessionW = 12
+	}
+	maxSession := total - 2 // reserve separator and at least 1 col for chat
+	if sessionW > maxSession {
+		sessionW = maxSession
+	}
+	if sessionW < 1 {
+		sessionW = 1
+	}
+
+	chatW := total - sessionW - 1 // 1 column separator
+	if chatW < 1 {
+		chatW = 1
+		sessionW = total - chatW - 1
+	}
+	if sessionW < 1 {
+		sessionW = 1
+	}
+	return sessionW, chatW
+}
+
+func (m *Model) chatContentWidth() int {
+	w := m.chatPaneWidth - 4
+	if w < 1 {
+		return 1
+	}
+	return w
 }
 
 // submitApproval sends the approval response to the server.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,13 +1,18 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+
+	controlserver "ok-gobot/internal/control"
 )
 
-// newTestModel builds a minimal Model suitable for unit tests (no WebSocket).
-func newTestModel() *Model {
+// newInputHeightTestModel builds a minimal model for textarea auto-height tests.
+func newInputHeightTestModel() *Model {
 	ta := textarea.New()
 	ta.SetHeight(1)
 	ta.SetWidth(80)
@@ -24,7 +29,7 @@ func newTestModel() *Model {
 }
 
 func TestRecalcInputHeight_EmptyInput(t *testing.T) {
-	m := newTestModel()
+	m := newInputHeightTestModel()
 	m.recalcInputHeight()
 	if m.input.Height() != minInputLines {
 		t.Errorf("expected height %d for empty input, got %d", minInputLines, m.input.Height())
@@ -32,7 +37,7 @@ func TestRecalcInputHeight_EmptyInput(t *testing.T) {
 }
 
 func TestRecalcInputHeight_MultipleLines(t *testing.T) {
-	m := newTestModel()
+	m := newInputHeightTestModel()
 	m.input.SetValue("line1\nline2\nline3")
 	m.recalcInputHeight()
 	if m.input.Height() != 3 {
@@ -41,7 +46,7 @@ func TestRecalcInputHeight_MultipleLines(t *testing.T) {
 }
 
 func TestRecalcInputHeight_CapsAtMax(t *testing.T) {
-	m := newTestModel()
+	m := newInputHeightTestModel()
 	m.input.SetValue("1\n2\n3\n4\n5\n6\n7\n8")
 	m.recalcInputHeight()
 	if m.input.Height() != maxInputLines {
@@ -50,7 +55,7 @@ func TestRecalcInputHeight_CapsAtMax(t *testing.T) {
 }
 
 func TestRecalcInputHeight_ShrinksAfterReset(t *testing.T) {
-	m := newTestModel()
+	m := newInputHeightTestModel()
 	m.input.SetValue("a\nb\nc\nd")
 	m.recalcInputHeight()
 	if m.input.Height() != 4 {
@@ -64,11 +69,129 @@ func TestRecalcInputHeight_ShrinksAfterReset(t *testing.T) {
 }
 
 func TestInputAreaHeight_IncludesBorder(t *testing.T) {
-	m := newTestModel()
+	m := newInputHeightTestModel()
 	m.input.SetHeight(3)
 	got := m.inputAreaHeight()
 	// 3 lines + 2 for top/bottom border
 	if got != 5 {
 		t.Errorf("expected inputAreaHeight 5, got %d", got)
+	}
+}
+
+func newSplitLayoutTestModel() *Model {
+	ta := textarea.New()
+	ta.Focus()
+	ta.SetHeight(3)
+	ta.SetWidth(80)
+	ta.CharLimit = 4096
+	ta.ShowLineNumbers = false
+	ta.KeyMap.InsertNewline.SetKeys("shift+enter", "alt+enter")
+
+	vp := viewport.New(80, 20)
+	vp.SetContent("")
+
+	return &Model{
+		screen:           screenChat,
+		streamIdx:        -1,
+		viewport:         vp,
+		input:            ta,
+		paneFocus:        focusChat,
+		sessionPaneWidth: 20,
+		chatPaneWidth:    59,
+		modelList:        defaultModelList,
+	}
+}
+
+func TestTabTogglesPaneFocus(t *testing.T) {
+	m := newSplitLayoutTestModel()
+	m.width = 120
+	m.height = 30
+	m.resizeComponents()
+
+	if !m.input.Focused() {
+		t.Fatal("expected chat input focused initially")
+	}
+
+	m.handleChatKey(tea.KeyMsg{Type: tea.KeyTab}, nil)
+	if m.paneFocus != focusSessions {
+		t.Fatalf("expected focusSessions, got %v", m.paneFocus)
+	}
+	if m.input.Focused() {
+		t.Fatal("expected input to be blurred when sessions pane is focused")
+	}
+
+	m.handleChatKey(tea.KeyMsg{Type: tea.KeyTab}, nil)
+	if m.paneFocus != focusChat {
+		t.Fatalf("expected focusChat, got %v", m.paneFocus)
+	}
+	if !m.input.Focused() {
+		t.Fatal("expected input to be focused again after toggling back")
+	}
+}
+
+func TestSessionPaneNavigationAndEnterSendsSwitch(t *testing.T) {
+	m := newSplitLayoutTestModel()
+	m.width = 100
+	m.height = 24
+	m.sessions = []controlserver.TUISessionInfo{
+		{ID: "s1", Name: "default"},
+		{ID: "s2", Name: "work"},
+		{ID: "s3", Name: "coding"},
+	}
+	m.activeSession = "s1"
+	m.resizeComponents()
+	m.syncSessionSelection(true)
+	m.setPaneFocus(focusSessions)
+
+	m.handleChatKey(tea.KeyMsg{Type: tea.KeyDown}, nil)
+	if m.sessionCursor != 1 {
+		t.Fatalf("expected session cursor at 1, got %d", m.sessionCursor)
+	}
+
+	m.handleChatKey(tea.KeyMsg{Type: tea.KeyEnter}, nil)
+	if m.lastErr != "send error: no active connection" {
+		t.Fatalf("expected send to be attempted on Enter, got lastErr=%q", m.lastErr)
+	}
+}
+
+func TestSessionPaneScrollsWithCursor(t *testing.T) {
+	m := newSplitLayoutTestModel()
+	m.width = 90
+	m.height = 12
+	for i := 0; i < 12; i++ {
+		m.sessions = append(m.sessions, controlserver.TUISessionInfo{ID: "s" + strings.Repeat("x", i+1), Name: "session"})
+	}
+	m.activeSession = m.sessions[0].ID
+	m.resizeComponents()
+	m.syncSessionSelection(true)
+	m.setPaneFocus(focusSessions)
+
+	for i := 0; i < 8; i++ {
+		m.handleChatKey(tea.KeyMsg{Type: tea.KeyDown}, nil)
+	}
+
+	if m.sessionCursor != 8 {
+		t.Fatalf("expected cursor at 8, got %d", m.sessionCursor)
+	}
+	if m.sessionOffset == 0 {
+		t.Fatal("expected non-zero sessionOffset after moving past visible rows")
+	}
+}
+
+func TestViewRendersSplitWithSessionsAndChat(t *testing.T) {
+	m := newSplitLayoutTestModel()
+	m.width = 110
+	m.height = 26
+	m.sessions = []controlserver.TUISessionInfo{{ID: "s1", Name: "default"}, {ID: "s2", Name: "work"}}
+	m.activeSession = "s1"
+	m.entries = []chatEntry{{role: "user", content: "hi"}, {role: "assistant", content: "hello"}}
+	m.resizeComponents()
+	m.refreshViewport()
+
+	view := m.View()
+	for _, want := range []string{"Sessions", "You", "Bot", "│"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected view to contain %q", want)
+		}
 	}
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -81,11 +81,14 @@ func newModel(conn *wsConn, addr string, models []string) *Model {
 	_ = conn.send(controlserver.ClientMsg{Type: controlserver.CmdListSessions})
 
 	return &Model{
-		conn:       conn,
-		serverAddr: addr,
-		streamIdx:  -1,
-		viewport:   vp,
-		input:      ta,
-		modelList:  models,
+		conn:             conn,
+		serverAddr:       addr,
+		streamIdx:        -1,
+		viewport:         vp,
+		input:            ta,
+		modelList:        models,
+		paneFocus:        focusChat,
+		sessionPaneWidth: 20,
+		chatPaneWidth:    59,
 	}
 }


### PR DESCRIPTION
Closes #129

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the modal session-picker overlay with a persistent split-pane layout: a sessions sidebar on the left (~20% width) and the chat viewport on the right. Focus switches between the two panes via `Tab`/`Ctrl+]`, and session navigation (`↑`/`↓`/`Enter`/`n`) is only active when the sidebar is focused. The change is well-scoped and comes with a solid new test suite.

Three issues were found in `internal/tui/model.go`:

- **State mutation inside `View()`** — `renderMainArea` (called on every render) reassigns `m.sessionPaneWidth`, `m.chatPaneWidth`, `m.viewport.Width/Height`, and calls `syncSessionSelection`, which can mutate `m.sessionCursor`, `m.sessionOffset`, and even `m.activeSession`. In Bubble Tea, `View()` must be a pure read-only function; these side-effects should be confined to `resizeComponents()` and `Update()` handlers.
- **`truncate` off-by-one** — when a string exceeds `n` runes the function returns `n` runes + `"…"`, yielding `n+1` runes total. Every call site passes the sidebar width as the cap, so text can overflow the pane by one column.
- **`computePaneWidths` narrow-terminal edge case** — the early return `(1, 1)` for `total ≤ 3` still produces a 3-column layout (`sidebar + separator + chat`), which overflows a 1- or 2-column terminal.

<h3>Confidence Score: 2/5</h3>

- The PR introduces state mutation inside View() that violates Bubble Tea's architecture and a truncate off-by-one that can corrupt sidebar rendering; resolve before merging.
- The feature logic and keybinding wiring are sound and the new tests cover the happy path well, but the state-mutation-in-View() issue is a structural correctness problem (can silently change activeSession on every render frame), and the truncate off-by-one will visibly overflow the sidebar for any session name that exactly fills or exceeds the pane width. Both affect normal usage, not just edge cases.
- internal/tui/model.go — specifically renderMainArea, truncate, and computePaneWidths

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tui/model.go | Core model refactored to replace the sessions overlay with a persistent sidebar; contains three notable issues: state mutation inside View() via renderMainArea, an off-by-one in truncate that overflows the sidebar by one column, and a narrow-terminal edge case in computePaneWidths. |
| internal/tui/model_test.go | Adds a well-structured suite of new tests covering tab-toggle focus, session pane navigation/enter, scroll-offset behaviour, and full split-layout rendering; existing input-height tests updated to use a renamed helper. |
| internal/tui/tui.go | Minor update to newModel initialiser: adds paneFocus, sessionPaneWidth, and chatPaneWidth fields with sensible defaults. No issues found. |
| internal/cli/tui.go | Help text updated to reflect new split-pane keybindings (Tab/Ctrl+], Ctrl+P, ↑/↓). Accurate and no issues found. |
| internal/control/server_tui.go | In-app /commands help text updated to match new TUI keybindings. No issues found. |

</details>



<sub>Last reviewed commit: 38b95b4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->