### PR TITLE
TUI P3: Timestamps and message metadata

### DIFF
--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -112,11 +112,14 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 			SessionID: sessionID,
 			Role:      "user",
 			Content:   text,
+			Timestamp: time.Now().Format(time.RFC3339),
 		})
 		s.hub.BroadcastTUI(ServerMsg{
 			Type:      MsgTypeEvent,
 			Kind:      KindRunStart,
 			SessionID: sessionID,
+			Model:     snapshot.model,
+			Timestamp: time.Now().Format(time.RFC3339),
 		})
 
 		// Append user message to history before the run
@@ -173,15 +176,18 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 				Kind:      KindError,
 				SessionID: sessionID,
 				Message:   "tui runtime returned no events",
+				Timestamp: time.Now().Format(time.RFC3339),
 			})
 			s.hub.BroadcastTUI(ServerMsg{
 				Type:      MsgTypeEvent,
 				Kind:      KindRunEnd,
 				SessionID: sessionID,
+				Model:     snapshot.model,
+				Timestamp: time.Now().Format(time.RFC3339),
 			})
 			return
 		}
-		go s.consumeTUIRunEvents(sessionID, text, events)
+		go s.consumeTUIRunEvents(sessionID, text, snapshot.model, events)
 		c.tuiSessionID = sessionID
 
 	case CmdAbort:
@@ -293,6 +299,8 @@ func (s *Server) handleTUIBotCommand(c *client, cmd ClientMsg) {
 		SessionID: sessionID,
 		Role:      "assistant",
 		Content:   result,
+		Model:     s.sessionModel(sessionID),
+		Timestamp: time.Now().Format(time.RFC3339),
 	})
 }
 
@@ -402,8 +410,9 @@ func (s *Server) resolveTUISession(c *client, requestedID string, sessions []TUI
 	return sessionID, true
 }
 
-func (s *Server) consumeTUIRunEvents(sessionID, userText string, events <-chan agent.RunEvent) {
+func (s *Server) consumeTUIRunEvents(sessionID, userText, model string, events <-chan agent.RunEvent) {
 	var finalMessage string
+	var promptTokens, completionTokens, totalTokens int
 	defer func() {
 		s.finishTUIRun(sessionID, finalMessage)
 		// Log the exchange if the provider supports it
@@ -412,17 +421,24 @@ func (s *Server) consumeTUIRunEvents(sessionID, userText string, events <-chan a
 		}
 		if strings.TrimSpace(finalMessage) != "" {
 			s.hub.BroadcastTUI(ServerMsg{
-				Type:      MsgTypeEvent,
-				Kind:      KindMessage,
-				SessionID: sessionID,
-				Role:      "assistant",
-				Content:   finalMessage,
+				Type:             MsgTypeEvent,
+				Kind:             KindMessage,
+				SessionID:        sessionID,
+				Role:             "assistant",
+				Content:          finalMessage,
+				Model:            model,
+				PromptTokens:     promptTokens,
+				CompletionTokens: completionTokens,
+				TotalTokens:      totalTokens,
+				Timestamp:        time.Now().Format(time.RFC3339),
 			})
 		}
 		s.hub.BroadcastTUI(ServerMsg{
 			Type:      MsgTypeEvent,
 			Kind:      KindRunEnd,
 			SessionID: sessionID,
+			Model:     model,
+			Timestamp: time.Now().Format(time.RFC3339),
 		})
 	}()
 
@@ -431,6 +447,9 @@ func (s *Server) consumeTUIRunEvents(sessionID, userText string, events <-chan a
 		case agent.RunEventDone:
 			if ev.Result != nil {
 				finalMessage = ev.Result.Message
+				promptTokens = ev.Result.PromptTokens
+				completionTokens = ev.Result.CompletionTokens
+				totalTokens = ev.Result.TotalTokens
 			}
 		case agent.RunEventError:
 			if ev.Err != nil && !errors.Is(ev.Err, context.Canceled) {
@@ -439,6 +458,7 @@ func (s *Server) consumeTUIRunEvents(sessionID, userText string, events <-chan a
 					Kind:      KindError,
 					SessionID: sessionID,
 					Message:   ev.Err.Error(),
+					Timestamp: time.Now().Format(time.RFC3339),
 				})
 			}
 		}
@@ -541,6 +561,7 @@ func (s *Server) setTUIModel(sessionID, model string) error {
 type tuiRunSnapshot struct {
 	lastAssistant string
 	modelOverride string
+	model         string
 	history       []ai.ChatMessage
 }
 
@@ -562,6 +583,7 @@ func (s *Server) startTUIRun(sessionID string) (tuiRunSnapshot, error) {
 	return tuiRunSnapshot{
 		lastAssistant: session.LastAssistant,
 		modelOverride: session.ModelOverride,
+		model:         session.Model,
 		history:       hist,
 	}, nil
 }
@@ -587,6 +609,18 @@ func (s *Server) appendTUIHistory(sessionID string, msg ai.ChatMessage) {
 	if session, ok := s.tuiState.byID[sessionID]; ok {
 		session.History = append(session.History, msg)
 	}
+}
+
+func (s *Server) sessionModel(sessionID string) string {
+	s.tuiMu.Lock()
+	defer s.tuiMu.Unlock()
+
+	if session, ok := s.tuiState.byID[sessionID]; ok {
+		if model := strings.TrimSpace(session.Model); model != "" {
+			return model
+		}
+	}
+	return s.defaultTUIModel()
 }
 
 func (s *Server) defaultTUIModel() string {

--- a/internal/control/server_tui_test.go
+++ b/internal/control/server_tui_test.go
@@ -92,7 +92,10 @@ func (m *mockTUIState) SubmitTUIRun(_ context.Context, req control.TUIRunRequest
 		ch <- agent.RunEvent{
 			Type: agent.RunEventDone,
 			Result: &agent.AgentResponse{
-				Message: "assistant reply",
+				Message:          "assistant reply",
+				PromptTokens:     11,
+				CompletionTokens: 7,
+				TotalTokens:      18,
 			},
 		}
 		close(ch)
@@ -105,6 +108,10 @@ func (m *mockTUIState) AbortTUIRun(sessionKey string) {
 	defer m.mu.Unlock()
 	m.tuiAbortKey = append(m.tuiAbortKey, sessionKey)
 }
+
+func (m *mockTUIState) LogTUIExchange(_, _ string) {}
+
+func (m *mockTUIState) GetStatusText(_ string) string { return "ok" }
 
 func startServerWithHandle(t *testing.T, state control.StateProvider) (*control.Server, string, context.CancelFunc) {
 	t.Helper()
@@ -252,12 +259,13 @@ func TestControlServerHandlesTUISend(t *testing.T) {
 	})
 
 	var (
-		gotUser   bool
-		gotStart  bool
-		gotToken  bool
-		gotAssist bool
-		gotRunEnd bool
-		deadline  = time.Now().Add(2 * time.Second)
+		gotUser       bool
+		gotStart      bool
+		gotToken      bool
+		gotAssist     bool
+		gotAssistMeta bool
+		gotRunEnd     bool
+		deadline      = time.Now().Add(2 * time.Second)
 	)
 
 	for time.Now().Before(deadline) {
@@ -267,14 +275,19 @@ func TestControlServerHandlesTUISend(t *testing.T) {
 		}
 		switch msg.Kind {
 		case control.KindMessage:
-			if msg.Role == "user" && msg.Content == "hello from tui" && msg.SessionID == "main" {
+			if msg.Role == "user" && msg.Content == "hello from tui" && msg.SessionID == "main" && msg.Timestamp != "" {
 				gotUser = true
 			}
 			if msg.Role == "assistant" && msg.Content == "assistant reply" && msg.SessionID == "main" {
 				gotAssist = true
+				if msg.Model == "model-a" && msg.PromptTokens == 11 && msg.CompletionTokens == 7 && msg.TotalTokens == 18 && msg.Timestamp != "" {
+					if _, err := time.Parse(time.RFC3339, msg.Timestamp); err == nil {
+						gotAssistMeta = true
+					}
+				}
 			}
 		case control.KindRunStart:
-			if msg.SessionID == "main" {
+			if msg.SessionID == "main" && msg.Model == "model-a" && msg.Timestamp != "" {
 				gotStart = true
 			}
 		case control.KindToken:
@@ -282,17 +295,17 @@ func TestControlServerHandlesTUISend(t *testing.T) {
 				gotToken = true
 			}
 		case control.KindRunEnd:
-			if msg.SessionID == "main" {
+			if msg.SessionID == "main" && msg.Model == "model-a" && msg.Timestamp != "" {
 				gotRunEnd = true
 			}
 		}
-		if gotUser && gotStart && gotToken && gotAssist && gotRunEnd {
+		if gotUser && gotStart && gotToken && gotAssist && gotAssistMeta && gotRunEnd {
 			break
 		}
 	}
 
-	if !gotUser || !gotStart || !gotToken || !gotAssist || !gotRunEnd {
-		t.Fatalf("missing expected TUI run events user=%v start=%v token=%v assistant=%v run_end=%v", gotUser, gotStart, gotToken, gotAssist, gotRunEnd)
+	if !gotUser || !gotStart || !gotToken || !gotAssist || !gotAssistMeta || !gotRunEnd {
+		t.Fatalf("missing expected TUI run events user=%v start=%v token=%v assistant=%v assistant_meta=%v run_end=%v", gotUser, gotStart, gotToken, gotAssist, gotAssistMeta, gotRunEnd)
 	}
 
 	state.mu.Lock()

--- a/internal/control/tui_types.go
+++ b/internal/control/tui_types.go
@@ -38,20 +38,25 @@ const (
 
 // ServerMsg is sent from the control server to TUI clients.
 type ServerMsg struct {
-	Type       string           `json:"type"`
-	Kind       string           `json:"kind,omitempty"`
-	SessionID  string           `json:"session_id,omitempty"`
-	Content    string           `json:"content,omitempty"`
-	Role       string           `json:"role,omitempty"`
-	ToolName   string           `json:"tool_name,omitempty"`
-	ToolArgs   string           `json:"tool_args,omitempty"`
-	ToolResult string           `json:"tool_result,omitempty"`
-	ToolError  string           `json:"tool_error,omitempty"`
-	ApprovalID string           `json:"approval_id,omitempty"`
-	Command    string           `json:"command,omitempty"`
-	QueueDepth int              `json:"queue_depth,omitempty"`
-	Sessions   []TUISessionInfo `json:"sessions,omitempty"`
-	Message    string           `json:"message,omitempty"`
+	Type             string           `json:"type"`
+	Kind             string           `json:"kind,omitempty"`
+	SessionID        string           `json:"session_id,omitempty"`
+	Content          string           `json:"content,omitempty"`
+	Timestamp        string           `json:"timestamp,omitempty"` // RFC3339 timestamp
+	Role             string           `json:"role,omitempty"`
+	Model            string           `json:"model,omitempty"`
+	PromptTokens     int              `json:"prompt_tokens,omitempty"`
+	CompletionTokens int              `json:"completion_tokens,omitempty"`
+	TotalTokens      int              `json:"total_tokens,omitempty"`
+	ToolName         string           `json:"tool_name,omitempty"`
+	ToolArgs         string           `json:"tool_args,omitempty"`
+	ToolResult       string           `json:"tool_result,omitempty"`
+	ToolError        string           `json:"tool_error,omitempty"`
+	ApprovalID       string           `json:"approval_id,omitempty"`
+	Command          string           `json:"command,omitempty"`
+	QueueDepth       int              `json:"queue_depth,omitempty"`
+	Sessions         []TUISessionInfo `json:"sessions,omitempty"`
+	Message          string           `json:"message,omitempty"`
 	// Sub-agent spawn fields.
 	ChildSessionKey string `json:"child_session_key,omitempty"`
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -40,6 +40,9 @@ type chatEntry struct {
 	toolRes   string
 	toolErr   string
 	streaming bool // true while tokens are still arriving
+	timestamp time.Time
+	model     string
+	tokens    int
 }
 
 // Model is the root Bubble Tea model.
@@ -482,9 +485,11 @@ func (m *Model) handleEvent(msg controlserver.ServerMsg) tea.Cmd {
 		// start a streaming entry
 		m.streamBuf.Reset()
 		m.streamIdx = len(m.entries)
-		m.entries = append(m.entries, chatEntry{
+		m.addEntry(chatEntry{
 			role:      "assistant",
 			streaming: true,
+			model:     firstNonEmpty(msg.Model, m.activeSessionModel()),
+			timestamp: parseServerTimestamp(msg.Timestamp),
 		})
 		m.refreshViewport()
 
@@ -506,19 +511,36 @@ func (m *Model) handleEvent(msg controlserver.ServerMsg) tea.Cmd {
 
 	case controlserver.KindMessage:
 		if msg.Role == "assistant" {
+			entryModel := firstNonEmpty(msg.Model, m.activeSessionModel())
+			entryTime := parseServerTimestamp(msg.Timestamp)
 			if m.streamIdx >= 0 {
 				// finalise the active streaming entry
 				if m.streamIdx < len(m.entries) {
 					m.entries[m.streamIdx].content = msg.Content
 					m.entries[m.streamIdx].streaming = false
+					m.entries[m.streamIdx].model = firstNonEmpty(msg.Model, m.entries[m.streamIdx].model)
+					m.entries[m.streamIdx].tokens = msg.TotalTokens
+					if !entryTime.IsZero() {
+						m.entries[m.streamIdx].timestamp = entryTime
+					}
 				}
 				m.streamIdx = -1
 			} else {
 				// direct (non-streaming) assistant message — e.g. /status response
-				m.addEntry(chatEntry{role: "assistant", content: msg.Content})
+				m.addEntry(chatEntry{
+					role:      "assistant",
+					content:   msg.Content,
+					model:     entryModel,
+					tokens:    msg.TotalTokens,
+					timestamp: entryTime,
+				})
 			}
 		} else if msg.Role == "user" {
-			m.addEntry(chatEntry{role: "user", content: msg.Content})
+			m.addEntry(chatEntry{
+				role:      "user",
+				content:   msg.Content,
+				timestamp: parseServerTimestamp(msg.Timestamp),
+			})
 		}
 		m.refreshViewport()
 
@@ -632,13 +654,9 @@ func (m *Model) View() string {
 
 // renderHeader renders the top status bar.
 func (m *Model) renderHeader() string {
-	// Model info
-	model := "unknown"
-	for _, s := range m.sessions {
-		if s.ID == m.activeSession {
-			model = s.Model
-			break
-		}
+	model := m.activeSessionModel()
+	if model == "" {
+		model = "unknown"
 	}
 
 	runIndicator := ""
@@ -666,16 +684,29 @@ func (m *Model) renderHeader() string {
 
 // renderStatus renders the bottom status bar.
 func (m *Model) renderStatus() string {
-	sessionName := ""
-	for _, s := range m.sessions {
-		if s.ID == m.activeSession {
-			sessionName = s.Name
-			break
-		}
+	sessionName := m.activeSessionName()
+	if sessionName == "" {
+		sessionName = "unknown"
+	}
+	model := m.activeSessionModel()
+	if model == "" {
+		model = "unknown"
+	}
+	stateLabel := "idle"
+	stateStyle := statusRunIdleStyle
+	if m.running {
+		stateLabel = "running"
+		stateStyle = statusRunBusyStyle
 	}
 
-	left := statusKeyStyle.Render("session")
-	leftVal := statusValueStyle.Render(" " + sessionName + " ")
+	left := lipgloss.JoinHorizontal(lipgloss.Top,
+		statusKeyStyle.Render("session"),
+		statusValueStyle.Render(" "+sessionName+" "),
+		statusKeyStyle.Render("model"),
+		statusValueStyle.Render(" "+model+" "),
+		statusKeyStyle.Render("state"),
+		stateStyle.Render(" "+stateLabel+" "),
+	)
 
 	// Character count for the current input.
 	charCount := utf8.RuneCountInString(m.input.Value())
@@ -693,11 +724,15 @@ func (m *Model) renderStatus() string {
 	if statusText == "" {
 		statusText = "/abort · /new · /commands · type / for completions · Ctrl+Y copy · Ctrl+N spawn · enter to send"
 	}
-	fixedWidth := lipgloss.Width(left) + lipgloss.Width(leftVal) + lipgloss.Width(charPart) + lipgloss.Width(errPart)
-	hint := statusBarStyle.Width(m.width - fixedWidth).
+	fixedWidth := lipgloss.Width(left) + lipgloss.Width(charPart) + lipgloss.Width(errPart)
+	hintWidth := m.width - fixedWidth
+	if hintWidth < 0 {
+		hintWidth = 0
+	}
+	hint := statusBarStyle.Width(hintWidth).
 		Render(statusText)
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, left, leftVal, hint, charPart, errPart)
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, hint, charPart, errPart)
 }
 
 // renderInput renders the text input area.
@@ -725,27 +760,34 @@ func (m *Model) renderChatLog() string {
 func (m *Model) renderEntry(e chatEntry) string {
 	switch e.role {
 	case "user":
-		label := userLabelStyle.Render("You")
-		msg := userMsgStyle.Render(wrapText(e.content, m.width-6))
-		return label + "\n" + msg
+		header := m.renderEntryHeader(userLabelStyle.Render("You"), e.timestamp)
+		msg := userMsgStyle.Render(wrapText(e.content, m.chatWrapWidth()))
+		return header + "\n" + msg
 
 	case "assistant":
-		label := botLabelStyle.Render("Bot")
+		header := m.renderEntryHeader(botLabelStyle.Render("Bot"), e.timestamp)
 		cursor := ""
 		if e.streaming {
 			cursor = streamingCursorStyle.Render("█")
 		}
 		msg := m.md.render(e.content)
-		return label + "\n" + msg + cursor
+		parts := []string{header, msg + cursor}
+		if meta := m.renderAssistantMeta(e); meta != "" {
+			parts = append(parts, messageMetaStyle.Render(meta))
+		}
+		return strings.Join(parts, "\n")
 
 	case "tool":
-		return m.renderToolCard(e)
+		header := m.renderEntryHeader(toolNameStyle.Render("Tool"), e.timestamp)
+		return header + "\n" + m.renderToolCard(e)
 
 	case "system":
-		return systemMsgStyle.Render("ℹ " + e.content)
+		header := m.renderEntryHeader(systemMsgStyle.Render("System"), e.timestamp)
+		return header + "\n" + systemMsgStyle.Render("ℹ "+e.content)
 
 	case "error":
-		return inlineErrorStyle.Render("⚠ " + e.content)
+		header := m.renderEntryHeader(inlineErrorStyle.Render("Error"), e.timestamp)
+		return header + "\n" + inlineErrorStyle.Render("⚠ "+e.content)
 	}
 	return e.content
 }
@@ -774,7 +816,7 @@ func (m *Model) renderToolCard(e chatEntry) string {
 		sb.WriteString("\n" + toolErrorStyle.Render("  ✗ "+e.toolErr))
 	}
 	inner := sb.String()
-	return toolCardBorderStyle.Width(m.width - 4).Render(inner)
+	return toolCardBorderStyle.Width(m.chatLineWidth()).Render(inner)
 }
 
 // overlayApproval renders the approval dialog over the base view.
@@ -940,8 +982,79 @@ func (m *Model) sendCmd(msg controlserver.ClientMsg) {
 	}
 }
 
+func (m *Model) activeSessionInfo() *controlserver.TUISessionInfo {
+	for i := range m.sessions {
+		if m.sessions[i].ID == m.activeSession {
+			return &m.sessions[i]
+		}
+	}
+	return nil
+}
+
+func (m *Model) activeSessionName() string {
+	if info := m.activeSessionInfo(); info != nil {
+		return strings.TrimSpace(info.Name)
+	}
+	return ""
+}
+
+func (m *Model) activeSessionModel() string {
+	if info := m.activeSessionInfo(); info != nil {
+		return strings.TrimSpace(info.Model)
+	}
+	return ""
+}
+
+func (m *Model) chatLineWidth() int {
+	width := m.width - 4
+	if width < 8 {
+		return 8
+	}
+	return width
+}
+
+func (m *Model) chatWrapWidth() int {
+	width := m.chatLineWidth() - 2
+	if width < 8 {
+		return 8
+	}
+	return width
+}
+
+func (m *Model) renderEntryHeader(label string, ts time.Time) string {
+	timestamp := ""
+	if !ts.IsZero() {
+		timestamp = messageTimeStyle.Render(ts.Format("15:04"))
+	}
+
+	width := m.chatLineWidth()
+	if timestamp == "" {
+		return label
+	}
+
+	space := width - lipgloss.Width(label) - lipgloss.Width(timestamp)
+	if space < 1 {
+		space = 1
+	}
+	return label + strings.Repeat(" ", space) + timestamp
+}
+
+func (m *Model) renderAssistantMeta(e chatEntry) string {
+	parts := make([]string, 0, 2)
+	if e.model != "" {
+		parts = append(parts, e.model)
+	}
+	if e.tokens > 0 {
+		parts = append(parts, fmt.Sprintf("%d tok", e.tokens))
+	}
+	return strings.Join(parts, " · ")
+}
+
 // addEntry appends a chat entry.
 func (m *Model) addEntry(e chatEntry) {
+	if e.timestamp.IsZero() {
+		e.timestamp = time.Now()
+	}
 	m.entries = append(m.entries, e)
 }
 
@@ -1129,6 +1242,30 @@ func commandToken(text string) string {
 		return ""
 	}
 	return fields[0]
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func parseServerTimestamp(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	if ts, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return ts
+	}
+	if ts, err := time.Parse(time.RFC3339, raw); err == nil {
+		return ts
+	}
+	return time.Time{}
 }
 
 // truncate shortens a string to at most n runes.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,9 +1,14 @@
 package tui
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/viewport"
+
+	controlserver "ok-gobot/internal/control"
 )
 
 // newTestModel builds a minimal Model suitable for unit tests (no WebSocket).
@@ -70,5 +75,93 @@ func TestInputAreaHeight_IncludesBorder(t *testing.T) {
 	// 3 lines + 2 for top/bottom border
 	if got != 5 {
 		t.Errorf("expected inputAreaHeight 5, got %d", got)
+	}
+}
+
+func TestHandleEventAssistantMessageMetadata(t *testing.T) {
+	m := &Model{
+		width:         120,
+		viewport:      viewport.New(120, 20),
+		streamIdx:     -1,
+		activeSession: "main",
+		sessions: []controlserver.TUISessionInfo{{
+			ID:    "main",
+			Name:  "Main",
+			Model: "model-fallback",
+		}},
+	}
+
+	msg := controlserver.ServerMsg{
+		Kind:        controlserver.KindMessage,
+		Role:        "assistant",
+		Content:     "hello",
+		Model:       "model-x",
+		TotalTokens: 42,
+		Timestamp:   "2026-03-05T09:07:00Z",
+	}
+
+	m.handleEvent(msg)
+
+	if len(m.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(m.entries))
+	}
+	entry := m.entries[0]
+	if entry.role != "assistant" {
+		t.Fatalf("expected assistant role, got %q", entry.role)
+	}
+	if entry.model != "model-x" {
+		t.Fatalf("expected model metadata, got %q", entry.model)
+	}
+	if entry.tokens != 42 {
+		t.Fatalf("expected token metadata 42, got %d", entry.tokens)
+	}
+	if got := entry.timestamp.Format("15:04"); got != "09:07" {
+		t.Fatalf("expected timestamp 09:07, got %q", got)
+	}
+}
+
+func TestRenderEntryAssistantShowsTimeAndMeta(t *testing.T) {
+	m := &Model{width: 100}
+	entry := chatEntry{
+		role:      "assistant",
+		content:   "test response",
+		model:     "model-y",
+		tokens:    73,
+		timestamp: time.Date(2026, time.March, 5, 14, 22, 0, 0, time.UTC),
+	}
+
+	out := m.renderEntry(entry)
+
+	if !strings.Contains(out, "14:22") {
+		t.Fatalf("expected rendered timestamp in entry, output=%q", out)
+	}
+	if !strings.Contains(out, "model-y") || !strings.Contains(out, "73 tok") {
+		t.Fatalf("expected rendered assistant metadata, output=%q", out)
+	}
+}
+
+func TestRenderStatusShowsSessionModelAndState(t *testing.T) {
+	m := &Model{
+		width:         140,
+		activeSession: "main",
+		running:       true,
+		sessions: []controlserver.TUISessionInfo{{
+			ID:    "main",
+			Name:  "Main Session",
+			Model: "model-a",
+		}},
+	}
+
+	out := m.renderStatus()
+	for _, want := range []string{"session", "Main Session", "model", "model-a", "state", "running"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected status to contain %q, output=%q", want, out)
+		}
+	}
+
+	m.running = false
+	out = m.renderStatus()
+	if !strings.Contains(out, "idle") {
+		t.Fatalf("expected idle state in status, output=%q", out)
 	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -31,6 +31,17 @@ var (
 				Foreground(lipgloss.Color("252")).
 				Padding(0, 1)
 
+	statusRunIdleStyle = lipgloss.NewStyle().
+				Background(lipgloss.Color("236")).
+				Foreground(lipgloss.Color("252")).
+				Padding(0, 1)
+
+	statusRunBusyStyle = lipgloss.NewStyle().
+				Background(lipgloss.Color("52")).
+				Foreground(lipgloss.Color("230")).
+				Padding(0, 1).
+				Bold(true)
+
 	// Header bar
 	headerStyle = lipgloss.NewStyle().
 			Background(lipgloss.Color("17")).
@@ -59,6 +70,13 @@ var (
 	botLabelStyle = lipgloss.NewStyle().
 			Foreground(colorBot).
 			Bold(true)
+
+	messageTimeStyle = lipgloss.NewStyle().
+				Foreground(colorMuted)
+
+	messageMetaStyle = lipgloss.NewStyle().
+				Foreground(colorMuted).
+				Italic(true)
 
 	// Tool event card
 	toolCardBorderStyle = lipgloss.NewStyle().


### PR DESCRIPTION
Closes #132

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enriches the TUI with per-message timestamps and metadata (model name, token counts) for assistant messages, and expands the bottom status bar to show the active session model and run state. The work spans the server-side broadcast path (`server_tui.go`, `tui_types.go`) and the client-side rendering layer (`model.go`, `styles.go`), with good test coverage added for all new behaviours.

Key changes:
- `ServerMsg` gains `Timestamp`, `Model`, `PromptTokens`, `CompletionTokens`, and `TotalTokens` fields; all relevant broadcast events are stamped accordingly.
- `consumeTUIRunEvents` now accepts and propagates the session model and captures token counts from `agent.RunEventDone`.
- A new `sessionModel()` helper centralises model resolution with proper mutex handling.
- `chatEntry` grows `timestamp`, `model`, and `tokens` fields; `renderEntryHeader` aligns the label and timestamp across the chat width; `renderAssistantMeta` shows model and token footer for assistant messages.
- The status bar is expanded to show session name, model, and idle/running state with a distinct busy style.
- Two minor style notes: the RFC3339 fallback in `parseServerTimestamp` is unreachable in practice, and the model-name meta footer appears during active streaming before token counts are available.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — changes are purely additive metadata propagation with no behavioural regressions and solid test coverage.
- All new fields are optional (`omitempty`), existing event flow is preserved, locking patterns follow established conventions, and both server-side and TUI-side behaviour are covered by updated/new tests. The two flagged points are cosmetic style suggestions, not correctness issues.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/control/tui_types.go | Adds Timestamp, Model, PromptTokens, CompletionTokens, and TotalTokens fields to ServerMsg. Clean, additive change with no issues. |
| internal/control/server_tui.go | Adds model and timestamp propagation to broadcast events, extracts model into tuiRunSnapshot, adds sessionModel() helper, and threads token counts through consumeTUIRunEvents. Logic is sound and consistent with existing locking patterns. |
| internal/tui/model.go | Adds timestamp/model/token fields to chatEntry, renderEntryHeader, renderAssistantMeta, and related helpers. Minor issue: RFC3339 fallback in parseServerTimestamp is dead code; also renderAssistantMeta renders a model-only footer during active streaming before tokens are available. |
| internal/tui/styles.go | Adds statusRunIdleStyle, statusRunBusyStyle, messageTimeStyle, and messageMetaStyle. Straightforward style definitions, consistent with existing patterns. |
| internal/control/server_tui_test.go | Updates mock to satisfy the expanded TUIRunProvider interface (LogTUIExchange, GetStatusText) and extends the send-test to assert on new metadata fields (Model, token counts, Timestamp). Tests are thorough and cover the new contract. |
| internal/tui/model_test.go | Adds unit tests for metadata handling (TestHandleEventAssistantMessageMetadata), rendering (TestRenderEntryAssistantShowsTimeAndMeta), and the new status bar layout (TestRenderStatusShowsSessionModelAndState). Well-structured and covers the key new behaviours. |

</details>



<sub>Last reviewed commit: 5dd481f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->