### PR TITLE
feat: pass photo bytes as vision content to AI (multimodal)

### DIFF
--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -45,16 +45,17 @@ type RunEvent struct {
 // The hub owns agent creation via its RunResolver — callers no longer
 // supply a pre-built ToolCallingAgent.
 type RunRequest struct {
-	SessionKey      SessionKey
-	ChatID          int64
-	Content         string
-	Session         string           // legacy: last assistant text (single turn)
-	History         []ai.ChatMessage // full conversation history (preferred over Session)
-	Context         context.Context
-	OnToolEvent     func(ToolEvent) // optional callback for tool status updates
-	OnDelta         func(string)    // optional callback for streamed text tokens
-	OnDeltaReset    func()          // optional callback when tool calls follow text
-	Overrides       *RunOverrides   // optional explicit model/thinking overrides
+	SessionKey   SessionKey
+	ChatID       int64
+	Content      string
+	UserContent  []ai.ContentBlock // optional multimodal user blocks (e.g. image + text)
+	Session      string            // legacy: last assistant text (single turn)
+	History      []ai.ChatMessage  // full conversation history (preferred over Session)
+	Context      context.Context
+	OnToolEvent  func(ToolEvent) // optional callback for tool status updates
+	OnDelta      func(string)    // optional callback for streamed text tokens
+	OnDeltaReset func()          // optional callback when tool calls follow text
+	Overrides    *RunOverrides   // optional explicit model/thinking overrides
 }
 
 // runSlot holds the state of a single active run.
@@ -137,7 +138,7 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 		}()
 
 		log.Printf("[hub] starting run for session %s (agent: %s)", req.SessionKey, profileName)
-		result, err := components.Agent.ProcessRequestWithHistory(ctx, req.Content, req.Session, req.History)
+		result, err := components.Agent.ProcessRequestWithContent(ctx, req.Content, req.UserContent, req.Session, req.History)
 		if err != nil {
 			if ctx.Err() != nil {
 				log.Printf("[hub] run for session %s was cancelled", req.SessionKey)

--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -88,12 +88,28 @@ func (a *ToolCallingAgent) SetModelAliases(aliases map[string]string) {
 
 // ProcessRequest handles a user request, potentially invoking tools
 func (a *ToolCallingAgent) ProcessRequest(ctx context.Context, userMessage string, session string) (*AgentResponse, error) {
-	return a.ProcessRequestWithHistory(ctx, userMessage, session, nil)
+	return a.ProcessRequestWithContent(ctx, userMessage, nil, session, nil)
 }
 
 // ProcessRequestWithHistory handles a user request with full conversation history.
 func (a *ToolCallingAgent) ProcessRequestWithHistory(ctx context.Context, userMessage string, session string, history []ai.ChatMessage) (*AgentResponse, error) {
-	logger.Debugf("ToolAgent: processing request, message len=%d, history=%d", len(userMessage), len(history))
+	return a.ProcessRequestWithContent(ctx, userMessage, nil, session, history)
+}
+
+// ProcessRequestWithContent handles a user request with optional multimodal user blocks.
+func (a *ToolCallingAgent) ProcessRequestWithContent(
+	ctx context.Context,
+	userMessage string,
+	userContent []ai.ContentBlock,
+	session string,
+	history []ai.ChatMessage,
+) (*AgentResponse, error) {
+	logger.Debugf(
+		"ToolAgent: processing request, message len=%d, blocks=%d, history=%d",
+		len(userMessage),
+		len(userContent),
+		len(history),
+	)
 
 	// Build system prompt
 	systemPrompt := a.buildSystemPrompt()
@@ -112,7 +128,11 @@ func (a *ToolCallingAgent) ProcessRequestWithHistory(ctx context.Context, userMe
 		messages = append(messages, ai.ChatMessage{Role: ai.RoleAssistant, Content: session})
 	}
 
-	messages = append(messages, ai.ChatMessage{Role: ai.RoleUser, Content: userMessage})
+	userMsg := ai.ChatMessage{Role: ai.RoleUser, Content: userMessage}
+	if len(userContent) > 0 && ai.SupportsVision(a.aiClient) {
+		userMsg.ContentBlocks = userContent
+	}
+	messages = append(messages, userMsg)
 
 	// Get tool definitions
 	toolDefinitions := tools.ToOpenAITools(a.tools.List())

--- a/internal/agent/tool_agent_test.go
+++ b/internal/agent/tool_agent_test.go
@@ -24,6 +24,36 @@ func (m *mockAIClient) Complete(ctx context.Context, messages []ai.Message) (str
 	return m.finalText, nil
 }
 
+type recordingAIClient struct {
+	finalText      string
+	supportsVision bool
+	lastMessages   []ai.ChatMessage
+}
+
+func (c *recordingAIClient) Complete(_ context.Context, _ []ai.Message) (string, error) {
+	return c.finalText, nil
+}
+
+func (c *recordingAIClient) CompleteWithTools(_ context.Context, messages []ai.ChatMessage, _ []ai.ToolDefinition) (*ai.ChatCompletionResponse, error) {
+	c.lastMessages = append([]ai.ChatMessage(nil), messages...)
+	return &ai.ChatCompletionResponse{
+		Choices: []struct {
+			Index        int            `json:"index"`
+			Message      ai.ChatMessage `json:"message"`
+			FinishReason string         `json:"finish_reason"`
+		}{
+			{
+				Message:      ai.ChatMessage{Role: ai.RoleAssistant, Content: c.finalText},
+				FinishReason: "stop",
+			},
+		},
+	}, nil
+}
+
+func (c *recordingAIClient) SupportsVision() bool {
+	return c.supportsVision
+}
+
 func (m *mockAIClient) CompleteWithTools(ctx context.Context, messages []ai.ChatMessage, toolDefs []ai.ToolDefinition) (*ai.ChatCompletionResponse, error) {
 	m.callCount++
 
@@ -500,5 +530,71 @@ func TestToolCallingAgent_EventCallback(t *testing.T) {
 	}
 	if events[1].Err != nil {
 		t.Errorf("expected no error in finished event, got %v", events[1].Err)
+	}
+}
+
+func TestToolCallingAgent_ProcessRequestWithContentVisionEnabled(t *testing.T) {
+	registry := tools.NewRegistry()
+	client := &recordingAIClient{
+		finalText:      "done",
+		supportsVision: true,
+	}
+	agent := NewToolCallingAgent(client, registry, &Personality{
+		Files: map[string]string{"IDENTITY.md": "Test Bot"},
+	})
+
+	userBlocks := []ai.ContentBlock{
+		{
+			Type: "image",
+			Source: &ai.ContentSource{
+				Type:      "base64",
+				MediaType: "image/jpeg",
+				Data:      "aGVsbG8=",
+			},
+		},
+		{Type: "text", Text: "describe this image"},
+	}
+
+	_, err := agent.ProcessRequestWithContent(context.Background(), "[Photo attached: ...]", userBlocks, "", nil)
+	if err != nil {
+		t.Fatalf("ProcessRequestWithContent failed: %v", err)
+	}
+
+	if len(client.lastMessages) == 0 {
+		t.Fatal("expected recorded messages")
+	}
+
+	user := client.lastMessages[len(client.lastMessages)-1]
+	if user.Role != ai.RoleUser {
+		t.Fatalf("expected last message role user, got %s", user.Role)
+	}
+	if len(user.ContentBlocks) != 2 {
+		t.Fatalf("expected multimodal content blocks to be preserved, got %d", len(user.ContentBlocks))
+	}
+}
+
+func TestToolCallingAgent_ProcessRequestWithContentVisionDisabledFallsBackToText(t *testing.T) {
+	registry := tools.NewRegistry()
+	client := &recordingAIClient{
+		finalText:      "done",
+		supportsVision: false,
+	}
+	agent := NewToolCallingAgent(client, registry, &Personality{
+		Files: map[string]string{"IDENTITY.md": "Test Bot"},
+	})
+
+	_, err := agent.ProcessRequestWithContent(context.Background(), "[Photo attached: fallback]", []ai.ContentBlock{
+		{Type: "text", Text: "caption"},
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("ProcessRequestWithContent failed: %v", err)
+	}
+
+	user := client.lastMessages[len(client.lastMessages)-1]
+	if user.Content != "[Photo attached: fallback]" {
+		t.Fatalf("expected fallback text content, got %q", user.Content)
+	}
+	if len(user.ContentBlocks) != 0 {
+		t.Fatalf("expected no multimodal blocks for non-vision client, got %d", len(user.ContentBlocks))
 	}
 }

--- a/internal/ai/anthropic_client.go
+++ b/internal/ai/anthropic_client.go
@@ -81,6 +81,11 @@ func NewAnthropicClient(config ProviderConfig) *AnthropicClient {
 	}
 }
 
+// SupportsVision reports whether the configured Anthropic model supports image inputs.
+func (c *AnthropicClient) SupportsVision() bool {
+	return anthropicModelSupportsVision(c.config.Model)
+}
+
 // Complete sends messages and returns the text response.
 func (c *AnthropicClient) Complete(ctx context.Context, messages []Message) (string, error) {
 	logger.Debugf("Anthropic Complete: model=%s messages=%d", c.config.Model, len(messages))
@@ -638,6 +643,16 @@ func translateMessages(messages []ChatMessage) (string, []AnthropicMessage) {
 			}
 
 		case RoleUser:
+			if len(msg.ContentBlocks) > 0 {
+				blocks := toAnthropicUserBlocks(msg.ContentBlocks)
+				if len(blocks) > 0 {
+					if msg.Content != "" && !hasTextBlock(blocks) {
+						blocks = append(blocks, ContentBlock{Type: "text", Text: msg.Content})
+					}
+					result = append(result, AnthropicMessage{Role: RoleUser, Content: blocks})
+					continue
+				}
+			}
 			result = append(result, AnthropicMessage{Role: RoleUser, Content: msg.Content})
 		}
 	}
@@ -745,6 +760,41 @@ func normalizeRawJSON(raw json.RawMessage) string {
 		return trimmed
 	}
 	return string(compact)
+}
+
+func toAnthropicUserBlocks(blocks []ContentBlock) []ContentBlock {
+	result := make([]ContentBlock, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			if strings.TrimSpace(b.Text) == "" {
+				continue
+			}
+			result = append(result, ContentBlock{Type: "text", Text: b.Text})
+		case "image":
+			if b.Source == nil || strings.TrimSpace(b.Source.Data) == "" {
+				continue
+			}
+			result = append(result, ContentBlock{
+				Type: "image",
+				Source: &ContentSource{
+					Type:      b.Source.Type,
+					MediaType: b.Source.MediaType,
+					Data:      b.Source.Data,
+				},
+			})
+		}
+	}
+	return result
+}
+
+func hasTextBlock(blocks []ContentBlock) bool {
+	for _, b := range blocks {
+		if b.Type == "text" && strings.TrimSpace(b.Text) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // isOAuthSetupToken checks if key is an OAuth setup-token from Claude Code.

--- a/internal/ai/anthropic_client_test.go
+++ b/internal/ai/anthropic_client_test.go
@@ -164,3 +164,49 @@ func TestAnthropicClientOAuthHeadersAndBetaQuery(t *testing.T) {
 		t.Fatalf("unexpected response: %q", resp)
 	}
 }
+
+func TestTranslateMessages_UserContentBlocks(t *testing.T) {
+	t.Parallel()
+
+	msgs := []ChatMessage{
+		{Role: RoleSystem, Content: "sys"},
+		{
+			Role:    RoleUser,
+			Content: "fallback text",
+			ContentBlocks: []ContentBlock{
+				{
+					Type: "image",
+					Source: &ContentSource{
+						Type:      "base64",
+						MediaType: "image/jpeg",
+						Data:      "aGVsbG8=",
+					},
+				},
+				{Type: "text", Text: "caption text"},
+			},
+		},
+	}
+
+	system, translated := translateMessages(msgs)
+	if system != "sys" {
+		t.Fatalf("unexpected system message: %q", system)
+	}
+	if len(translated) != 1 {
+		t.Fatalf("expected 1 translated message, got %d", len(translated))
+	}
+
+	userMsg := translated[0]
+	blocks, ok := userMsg.Content.([]ContentBlock)
+	if !ok {
+		t.Fatalf("expected []ContentBlock content, got %T", userMsg.Content)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(blocks))
+	}
+	if blocks[0].Type != "image" || blocks[0].Source == nil {
+		t.Fatalf("expected first block to be image with source, got %+v", blocks[0])
+	}
+	if blocks[1].Type != "text" || blocks[1].Text != "caption text" {
+		t.Fatalf("unexpected text block: %+v", blocks[1])
+	}
+}

--- a/internal/ai/anthropic_types.go
+++ b/internal/ai/anthropic_types.go
@@ -42,11 +42,19 @@ type AnthropicMessage struct {
 type ContentBlock struct {
 	Type      string          `json:"type"`                  // "text", "tool_use", "tool_result"
 	Text      string          `json:"text,omitempty"`        // for type="text"
+	Source    *ContentSource  `json:"source,omitempty"`      // for type="image"
 	ID        string          `json:"id,omitempty"`          // for type="tool_use"
 	Name      string          `json:"name,omitempty"`        // for type="tool_use"
 	Input     json.RawMessage `json:"input,omitempty"`       // for type="tool_use"
 	ToolUseID string          `json:"tool_use_id,omitempty"` // for type="tool_result"
 	Content   string          `json:"content,omitempty"`     // for type="tool_result"
+}
+
+// ContentSource represents an image source block for Anthropic multimodal input.
+type ContentSource struct {
+	Type      string `json:"type"`                 // "base64"
+	MediaType string `json:"media_type,omitempty"` // e.g. "image/jpeg"
+	Data      string `json:"data,omitempty"`       // base64-encoded bytes
 }
 
 // AnthropicResponse represents the Anthropic Messages API response.

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -60,6 +60,11 @@ type OpenAICompatibleClient struct {
 	httpClient *http.Client
 }
 
+// SupportsVision reports whether this client currently accepts multimodal user blocks.
+func (c *OpenAICompatibleClient) SupportsVision() bool {
+	return false
+}
+
 // NewClient creates a new AI client from provider configuration.
 // Returns Client interface — use type assertion for streaming support.
 func NewClient(config ProviderConfig) (Client, error) {

--- a/internal/ai/droid_client.go
+++ b/internal/ai/droid_client.go
@@ -35,6 +35,11 @@ type DroidClient struct {
 	droidCfg DroidConfig
 }
 
+// SupportsVision reports whether droid currently accepts multimodal user blocks.
+func (c *DroidClient) SupportsVision() bool {
+	return false
+}
+
 // NewDroidClient creates a new droid subprocess client.
 func NewDroidClient(config ProviderConfig, droidCfg DroidConfig) *DroidClient {
 	if droidCfg.BinaryPath == "" {

--- a/internal/ai/failover.go
+++ b/internal/ai/failover.go
@@ -25,6 +25,20 @@ type FailoverClient struct {
 	mu        sync.RWMutex
 }
 
+// SupportsVision reports true when every configured fallback client supports
+// multimodal input. This avoids routing image content to a non-vision fallback.
+func (fc *FailoverClient) SupportsVision() bool {
+	if len(fc.entries) == 0 {
+		return false
+	}
+	for _, entry := range fc.entries {
+		if !SupportsVision(entry.client) {
+			return false
+		}
+	}
+	return true
+}
+
 // NewClientWithFailover creates a FailoverClient from a primary ProviderConfig and fallback
 // model names. Fallback models share the same provider/API key/base URL as the primary.
 func NewClientWithFailover(primary ProviderConfig, fallbackModels []string) (*FailoverClient, error) {

--- a/internal/ai/types.go
+++ b/internal/ai/types.go
@@ -12,11 +12,12 @@ const (
 
 // ChatMessage represents a chat message with optional tool call support
 type ChatMessage struct {
-	Role       string     `json:"role"`
-	Content    string     `json:"content,omitempty"`
-	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
-	ToolCallID string     `json:"tool_call_id,omitempty"`
-	Name       string     `json:"name,omitempty"` // For tool responses
+	Role          string         `json:"role"`
+	Content       string         `json:"content,omitempty"`
+	ContentBlocks []ContentBlock `json:"-"` // Internal multimodal blocks (text/image)
+	ToolCalls     []ToolCall     `json:"tool_calls,omitempty"`
+	ToolCallID    string         `json:"tool_call_id,omitempty"`
+	Name          string         `json:"name,omitempty"` // For tool responses
 }
 
 // ToolDefinition defines a tool that the model can call

--- a/internal/ai/vision.go
+++ b/internal/ai/vision.go
@@ -1,0 +1,29 @@
+package ai
+
+import "strings"
+
+// visionCapable is implemented by clients that can accept image blocks
+// in user messages.
+type visionCapable interface {
+	SupportsVision() bool
+}
+
+// SupportsVision reports whether the client accepts multimodal user content.
+func SupportsVision(client Client) bool {
+	if client == nil {
+		return false
+	}
+	vc, ok := client.(visionCapable)
+	return ok && vc.SupportsVision()
+}
+
+func anthropicModelSupportsVision(model string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	if normalized == "" {
+		return false
+	}
+	if idx := strings.LastIndex(normalized, "/"); idx >= 0 && idx+1 < len(normalized) {
+		normalized = normalized[idx+1:]
+	}
+	return strings.HasPrefix(normalized, "claude-")
+}

--- a/internal/ai/vision_test.go
+++ b/internal/ai/vision_test.go
@@ -1,0 +1,60 @@
+package ai
+
+import (
+	"context"
+	"testing"
+)
+
+type visionStubClient struct {
+	vision bool
+}
+
+func (c *visionStubClient) Complete(_ context.Context, _ []Message) (string, error) {
+	return "", nil
+}
+
+func (c *visionStubClient) CompleteWithTools(_ context.Context, _ []ChatMessage, _ []ToolDefinition) (*ChatCompletionResponse, error) {
+	return &ChatCompletionResponse{}, nil
+}
+
+func (c *visionStubClient) SupportsVision() bool {
+	return c.vision
+}
+
+func TestSupportsVision(t *testing.T) {
+	t.Parallel()
+
+	if SupportsVision(nil) {
+		t.Fatal("expected nil client to not support vision")
+	}
+	if !SupportsVision(&visionStubClient{vision: true}) {
+		t.Fatal("expected explicit vision-capable client to support vision")
+	}
+	if SupportsVision(&visionStubClient{vision: false}) {
+		t.Fatal("expected explicit non-vision client to not support vision")
+	}
+}
+
+func TestFailoverClientSupportsVision(t *testing.T) {
+	t.Parallel()
+
+	allVision := &FailoverClient{
+		entries: []failoverEntry{
+			{model: "m1", client: &visionStubClient{vision: true}},
+			{model: "m2", client: &visionStubClient{vision: true}},
+		},
+	}
+	if !allVision.SupportsVision() {
+		t.Fatal("expected failover client with all vision entries to support vision")
+	}
+
+	mixed := &FailoverClient{
+		entries: []failoverEntry{
+			{model: "m1", client: &visionStubClient{vision: true}},
+			{model: "m2", client: &visionStubClient{vision: false}},
+		},
+	}
+	if mixed.SupportsVision() {
+		t.Fatal("expected failover client with non-vision fallback to disable vision")
+	}
+}

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/telebot.v4"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/ai"
 	"ok-gobot/internal/control"
 )
 
@@ -26,6 +27,17 @@ func sessionKeyForChat(chat *telebot.Chat) agent.SessionKey {
 // resulting events back to Telegram. The bot is a thin transport adapter here:
 // all agent creation, tool execution, and run orchestration happen inside the hub.
 func (b *Bot) processViaHub(ctx context.Context, c telebot.Context, sessionKey agent.SessionKey, content, session string) error {
+	return b.processViaHubWithContent(ctx, c, sessionKey, content, nil, session)
+}
+
+func (b *Bot) processViaHubWithContent(
+	ctx context.Context,
+	c telebot.Context,
+	sessionKey agent.SessionKey,
+	content string,
+	userContent []ai.ContentBlock,
+	session string,
+) error {
 	chatID := c.Chat().ID
 
 	// Set chat context so the LocalCommand ApprovalFunc can send prompts to the right chat.
@@ -121,6 +133,7 @@ func (b *Bot) processViaHub(ctx context.Context, c telebot.Context, sessionKey a
 		SessionKey:   sessionKey,
 		ChatID:       chatID,
 		Content:      content,
+		UserContent:  userContent,
 		Session:      session,
 		Context:      ctx,
 		OnToolEvent:  onToolEvent,

--- a/internal/bot/media_handler.go
+++ b/internal/bot/media_handler.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log"
@@ -10,6 +11,7 @@ import (
 
 	"gopkg.in/telebot.v4"
 
+	"ok-gobot/internal/ai"
 	"ok-gobot/internal/logger"
 )
 
@@ -202,13 +204,38 @@ func (b *Bot) handlePhotoMessage(ctx context.Context, c telebot.Context) error {
 		if err != nil {
 			log.Printf("Failed to get session: %v", err)
 		}
-		if err := b.processViaHub(ctx, c, sessionKey, combined, session); err != nil {
+		visionText := caption
+		if combined != content {
+			visionText = combined
+		}
+		visionContent := buildVisionImageContent(data, "image/jpeg", visionText)
+		if err := b.processViaHubWithContent(ctx, c, sessionKey, combined, visionContent, session); err != nil {
 			log.Printf("Failed to handle photo request: %v", err)
 			c.Send("❌ Sorry, I encountered an error processing your photo.") //nolint:errcheck
 		}
 	})
 
 	return nil
+}
+
+func buildVisionImageContent(data []byte, mediaType string, text string) []ai.ContentBlock {
+	if len(data) == 0 {
+		return nil
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(data)
+	blocks := []ai.ContentBlock{{
+		Type: "image",
+		Source: &ai.ContentSource{
+			Type:      "base64",
+			MediaType: mediaType,
+			Data:      encoded,
+		},
+	}}
+	if text != "" {
+		blocks = append(blocks, ai.ContentBlock{Type: "text", Text: text})
+	}
+	return blocks
 }
 
 // handleVoiceMessage processes incoming voice messages

--- a/internal/bot/media_handler_test.go
+++ b/internal/bot/media_handler_test.go
@@ -1,0 +1,42 @@
+package bot
+
+import "testing"
+
+func TestBuildVisionImageContent(t *testing.T) {
+	t.Parallel()
+
+	blocks := buildVisionImageContent([]byte("hello"), "image/jpeg", "caption")
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+
+	image := blocks[0]
+	if image.Type != "image" {
+		t.Fatalf("expected first block type image, got %q", image.Type)
+	}
+	if image.Source == nil {
+		t.Fatal("expected image source")
+	}
+	if image.Source.Type != "base64" {
+		t.Fatalf("expected source type base64, got %q", image.Source.Type)
+	}
+	if image.Source.MediaType != "image/jpeg" {
+		t.Fatalf("expected media type image/jpeg, got %q", image.Source.MediaType)
+	}
+	if image.Source.Data != "aGVsbG8=" {
+		t.Fatalf("unexpected base64 payload: %q", image.Source.Data)
+	}
+
+	text := blocks[1]
+	if text.Type != "text" || text.Text != "caption" {
+		t.Fatalf("unexpected text block: %+v", text)
+	}
+}
+
+func TestBuildVisionImageContentEmptyData(t *testing.T) {
+	t.Parallel()
+
+	if got := buildVisionImageContent(nil, "image/jpeg", "caption"); got != nil {
+		t.Fatalf("expected nil blocks for empty data, got %#v", got)
+	}
+}


### PR DESCRIPTION
Closes #145

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds multimodal (vision) support to the bot's AI pipeline, allowing Telegram photo messages to be forwarded as base64-encoded image blocks to Claude 3+ models instead of text-only descriptions. The architecture is well-structured: a new `visionCapable` interface lets each client opt-in, `ProcessRequestWithContent` cleanly extends the agent API without breaking existing callers, and the `FailoverClient.SupportsVision` correctly requires all fallback entries to support vision before enabling it.

Two critical issues were identified:

- **Overly broad vision model detection** (`internal/ai/vision.go`): `anthropicModelSupportsVision` returns `true` for any `claude-*` model name, including `claude-2.x` and `claude-instant`, which do not accept image input in the Anthropic API. A request with image blocks to those models will result in a `400 Bad Request` error.
- **Multi-photo debounce mismatch** (`internal/bot/media_handler.go`): When multiple photos arrive quickly and are debounced together, only the _last_ photo's raw bytes are captured in the closure that fires, while `combined` contains text from all photos. The resulting multimodal message sent to the AI has one image but a text description implying multiple — worse than the previous text-only fallback.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge without fixing the vision model detection bug, which will cause API errors for any user running a Claude 1/2 model. The multi-photo debounce mismatch actively misleads the vision model compared to the pre-PR text-only behavior.
- The core architecture is sound and the single-photo happy path works correctly, but the overly broad `anthropicModelSupportsVision` check is a definite runtime bug for legacy Claude models, and the multi-photo debounce logic sends misleading content to the model compared to the pre-PR behavior.
- `internal/ai/vision.go` (model detection heuristic) and `internal/bot/media_handler.go` (debounce closure captures only last photo's bytes)

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   The `data` variable (raw photo bytes) is captured at the time `handlePhotoMessage` is called — once per incoming photo. The debouncer fires only the _last_ registered callback, but with `combined` containing text from _all_ debounced photos (e.g., two `[Photo attached: ...]` prefixes).

   When two photos arrive quickly:
   1. Photo 1 → `data1`, callback closure created capturing `data1`
   2. Photo 2 → `data2`, callback closure created capturing `data2`
   3. Debouncer fires → photo 2's closure is invoked with `combined` containing descriptions of both photos

   Since `combined != content`, the code sets `visionText = combined` and builds `visionContent` from `data2` only. The model receives one image (photo 2) alongside a text block that describes _two_ photos — a factual mismatch that can confuse the model.

   Before this PR the fallback was text-only for all photos, which was at least consistent. Now, multi-photo debounce actively misleads the vision model. Consider either:
   - Using the existing `MediaGroupBuffer` infrastructure (which collects all `downloadedMedia` slices before flushing) to build a single multimodal request with all images, or
   - Logging a warning and only attaching vision content when `combined == content` (i.e., a single undebounced photo).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/bot/media_handler.go
   Line: 202-216

   Comment:
   The `data` variable (raw photo bytes) is captured at the time `handlePhotoMessage` is called — once per incoming photo. The debouncer fires only the _last_ registered callback, but with `combined` containing text from _all_ debounced photos (e.g., two `[Photo attached: ...]` prefixes).

   When two photos arrive quickly:
   1. Photo 1 → `data1`, callback closure created capturing `data1`
   2. Photo 2 → `data2`, callback closure created capturing `data2`
   3. Debouncer fires → photo 2's closure is invoked with `combined` containing descriptions of both photos

   Since `combined != content`, the code sets `visionText = combined` and builds `visionContent` from `data2` only. The model receives one image (photo 2) alongside a text block that describes _two_ photos — a factual mismatch that can confuse the model.

   Before this PR the fallback was text-only for all photos, which was at least consistent. Now, multi-photo debounce actively misleads the vision model. Consider either:
   - Using the existing `MediaGroupBuffer` infrastructure (which collects all `downloadedMedia` slices before flushing) to build a single multimodal request with all images, or
   - Logging a warning and only attaching vision content when `combined == content` (i.e., a single undebounced photo).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: c954e7c</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=65c03ede-8424-4d2e-b65d-7b9a6670ee59))
- Rule from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=beae9f31-4421-4dea-b358-985b3030d01f))
- Rule from `dashboard` - backend/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a504ee95-c8db-401f-9d25-091557a4fb94))
- Rule from `dashboard` - frontend/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0111cc3c-65b4-4bcb-893c-f747cb296ca9))
</details>


<!-- /greptile_comment -->