### PR TITLE
fix: TUI slow startup (7-8s) + OSC 11 escape in input field

### DIFF
--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -3,16 +3,18 @@ package tui
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	// Colors — adaptive: dark terminal / light terminal
-	colorPrimary = lipgloss.AdaptiveColor{Dark: "39", Light: "24"}   // blue
-	colorAccent  = lipgloss.AdaptiveColor{Dark: "41", Light: "28"}   // green
-	colorWarning = lipgloss.AdaptiveColor{Dark: "220", Light: "130"} // yellow/brown
-	colorError   = lipgloss.AdaptiveColor{Dark: "196", Light: "160"} // red
-	colorMuted   = lipgloss.AdaptiveColor{Dark: "240", Light: "245"} // grey
-	colorUser    = lipgloss.AdaptiveColor{Dark: "75", Light: "19"}   // blue
-	colorBot     = lipgloss.AdaptiveColor{Dark: "87", Light: "22"}   // cyan / dark green
-	colorTool    = lipgloss.AdaptiveColor{Dark: "214", Light: "130"} // orange
-	colorSubtle  = lipgloss.AdaptiveColor{Dark: "238", Light: "250"} // subtle
+	// Colors - fixed dark-palette values.
+	// Using fixed colors avoids lipgloss/termenv background probing (OSC 11),
+	// which can delay startup and leak escape responses into input on some terminals.
+	colorPrimary = lipgloss.Color("39")  // blue
+	colorAccent  = lipgloss.Color("41")  // green
+	colorWarning = lipgloss.Color("220") // yellow
+	colorError   = lipgloss.Color("196") // red
+	colorMuted   = lipgloss.Color("240") // grey
+	colorUser    = lipgloss.Color("75")  // blue
+	colorBot     = lipgloss.Color("87")  // cyan
+	colorTool    = lipgloss.Color("214") // orange
+	colorSubtle  = lipgloss.Color("238") // subtle
 
 	// Status bar at the bottom
 	statusBarStyle = lipgloss.NewStyle().
@@ -149,7 +151,7 @@ var (
 				Padding(1, 2)
 
 	sessionItemStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.AdaptiveColor{Dark: "252", Light: "235"})
+				Foreground(lipgloss.Color("252"))
 
 	sessionItemActiveStyle = lipgloss.NewStyle().
 				Foreground(colorAccent).
@@ -254,7 +256,7 @@ var (
 				Padding(1, 2)
 
 	modelItemStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.AdaptiveColor{Dark: "252", Light: "235"})
+			Foreground(lipgloss.Color("252"))
 
 	modelItemActiveStyle = lipgloss.NewStyle().
 				Foreground(colorAccent).

--- a/internal/tui/styles_test.go
+++ b/internal/tui/styles_test.go
@@ -1,0 +1,26 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestStylesDoNotUseAdaptiveColor(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to resolve test file path")
+	}
+
+	stylesPath := filepath.Join(filepath.Dir(thisFile), "styles.go")
+	content, err := os.ReadFile(stylesPath)
+	if err != nil {
+		t.Fatalf("read styles.go: %v", err)
+	}
+
+	if strings.Contains(string(content), "AdaptiveColor") {
+		t.Fatalf("styles.go must not use lipgloss.AdaptiveColor to avoid OSC 11 background probing")
+	}
+}


### PR DESCRIPTION
Closes #147

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a 7–8 second TUI startup delay and OSC 11 escape codes leaking into the input field by replacing all `lipgloss.AdaptiveColor` instances in `styles.go` with fixed dark-palette `lipgloss.Color` values, preventing `termenv` from issuing a background-color terminal probe at startup. A new regression test is added to guard against reintroducing `AdaptiveColor`.

**Key changes:**
- All nine named color variables and two inline `AdaptiveColor` usages (for `sessionItemStyle` and `modelItemStyle`) are replaced with fixed ANSI-256 colour codes from the original dark-palette branch.
- `styles_test.go` is added as a source-level regression guard using `runtime.Caller(0)` + `os.ReadFile` to assert no `AdaptiveColor` appears in `styles.go`.

**Trade-off:**
Light-terminal support is permanently removed as a side-effect. Users with light terminal backgrounds will now see low-contrast or invisible text (e.g. grey-on-white for muted elements). The code comment acknowledges the "fixed dark-palette values" and explains the reason (avoiding OSC 11 probing).

<h3>Confidence Score: 4/5</h3>

- Safe to merge. The core fix is correct and solves the OSC 11 startup probe issue. The intentional light-theme regression is documented in code comments.
- The PR correctly addresses the performance issue by eliminating `AdaptiveColor` background probing. The code changes are minimal and well-targeted. The main concern is a brittleness in the new regression test: the string match will trigger on `"AdaptiveColor"` in comments, not just actual code usages. This is minor and doesn't affect runtime correctness.
- internal/tui/styles_test.go — the string match should be tightened to `"lipgloss.AdaptiveColor"` to avoid false positives from comments.

<sub>Last reviewed commit: af047cd</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->