### PR TITLE
fix: hide bootstrap tool calls from TUI chat view

### DIFF
--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -2,9 +2,12 @@ package control
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,6 +21,8 @@ const (
 	defaultTUISessionName = "Main"
 	tuiSessionKeyPrefix   = "agent:default:tui:"
 )
+
+var bootstrapDailyMemoryRe = regexp.MustCompile(`(?:^|/)memory/\d{4}-\d{2}-\d{2}\.md$`)
 
 func isTUICommand(cmdType string) bool {
 	switch cmdType {
@@ -125,6 +130,7 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 		// Append user message to history before the run
 		s.appendTUIHistory(sessionID, ai.ChatMessage{Role: ai.RoleUser, Content: text})
 
+		suppressedToolFinishes := make(map[string]int)
 		req := TUIRunRequest{
 			SessionKey: tuiSessionKeyForID(sessionID),
 			Content:    text,
@@ -143,6 +149,9 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 				})
 			},
 			OnToolEvent: func(event agent.ToolEvent) {
+				if shouldSuppressBootstrapToolEvent(event, suppressedToolFinishes) {
+					return
+				}
 				switch event.Type {
 				case agent.ToolEventStarted:
 					s.hub.BroadcastTUI(ServerMsg{
@@ -671,6 +680,90 @@ func selectSessionID(sessions []TUISessionInfo, requestedID, fallbackID string) 
 
 func tuiSessionKeyForID(sessionID string) string {
 	return tuiSessionKeyPrefix + sessionID
+}
+
+func shouldSuppressBootstrapToolEvent(event agent.ToolEvent, suppressed map[string]int) bool {
+	switch event.Type {
+	case agent.ToolEventStarted:
+		if isBootstrapToolStartEvent(event) {
+			suppressed[event.ToolName]++
+			return true
+		}
+	case agent.ToolEventFinished:
+		if pending := suppressed[event.ToolName]; pending > 0 {
+			if pending == 1 {
+				delete(suppressed, event.ToolName)
+			} else {
+				suppressed[event.ToolName] = pending - 1
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func isBootstrapToolStartEvent(event agent.ToolEvent) bool {
+	if event.Type != agent.ToolEventStarted {
+		return false
+	}
+	raw := strings.TrimSpace(event.Input)
+	if raw == "" {
+		return false
+	}
+
+	var args map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &args); err != nil {
+		return false
+	}
+
+	if command, ok := stringArg(args["command"]); ok && strings.EqualFold(command, "read") {
+		if path, ok := stringArg(args["path"]); ok && isBootstrapToolPath(path) {
+			return true
+		}
+	}
+
+	if source, ok := stringArg(args["source"]); ok && isBootstrapToolPath(source) {
+		return true
+	}
+
+	return false
+}
+
+func isBootstrapToolPath(path string) bool {
+	p := strings.TrimSpace(path)
+	if p == "" {
+		return false
+	}
+
+	// Normalise to slash-separated, cleaned paths.
+	p = strings.ReplaceAll(p, "\\", "/")
+	p = filepath.ToSlash(filepath.Clean(p))
+	p = strings.TrimPrefix(p, "./")
+	low := strings.ToLower(p)
+
+	if bootstrapDailyMemoryRe.MatchString(low) {
+		return true
+	}
+
+	for _, name := range []string{"soul.md", "user.md", "agents.md", "memory.md"} {
+		if low == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func stringArg(value interface{}) (string, bool) {
+	s, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", false
+	}
+	return s, true
 }
 
 func (s *Server) bridgeRuntimeEvents(ctx context.Context, evCh <-chan runtimepkg.RuntimeEvent) {

--- a/internal/control/server_tui_filter_test.go
+++ b/internal/control/server_tui_filter_test.go
@@ -1,0 +1,83 @@
+package control
+
+import (
+	"testing"
+
+	"ok-gobot/internal/agent"
+)
+
+func TestIsBootstrapToolPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "soul", path: "SOUL.md", want: true},
+		{name: "user with dot slash", path: "./USER.md", want: true},
+		{name: "agents", path: "AGENTS.md", want: true},
+		{name: "memory root", path: "MEMORY.md", want: true},
+		{name: "daily memory", path: "memory/2026-03-05.md", want: true},
+		{name: "daily memory windows", path: `memory\\2026-03-05.md`, want: true},
+		{name: "daily memory absolute", path: "/tmp/memory/2026-03-05.md", want: true},
+		{name: "blank", path: "", want: false},
+		{name: "nested soul file", path: "docs/SOUL.md", want: false},
+		{name: "invalid daily memory name", path: "memory/today.md", want: false},
+		{name: "invalid daily memory date", path: "memory/2026-3-5.md", want: false},
+		{name: "nested memory root file", path: "notes/MEMORY.md", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBootstrapToolPath(tt.path); got != tt.want {
+				t.Fatalf("isBootstrapToolPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldSuppressBootstrapToolEvent(t *testing.T) {
+	suppressed := make(map[string]int)
+
+	bootstrapStart := agent.ToolEvent{
+		ToolName: "file",
+		Type:     agent.ToolEventStarted,
+		Input:    `{"command":"read","path":"SOUL.md"}`,
+	}
+	if !shouldSuppressBootstrapToolEvent(bootstrapStart, suppressed) {
+		t.Fatal("expected bootstrap start event to be suppressed")
+	}
+	if suppressed["file"] != 1 {
+		t.Fatalf("expected pending suppressed count=1, got %d", suppressed["file"])
+	}
+
+	bootstrapFinish := agent.ToolEvent{ToolName: "file", Type: agent.ToolEventFinished}
+	if !shouldSuppressBootstrapToolEvent(bootstrapFinish, suppressed) {
+		t.Fatal("expected bootstrap finish event to be suppressed")
+	}
+	if _, ok := suppressed["file"]; ok {
+		t.Fatal("expected suppressed counter to be cleared after matching finish")
+	}
+
+	normalStart := agent.ToolEvent{
+		ToolName: "search",
+		Type:     agent.ToolEventStarted,
+		Input:    `{"query":"weather"}`,
+	}
+	if shouldSuppressBootstrapToolEvent(normalStart, suppressed) {
+		t.Fatal("did not expect non-bootstrap start event to be suppressed")
+	}
+
+	normalFinish := agent.ToolEvent{ToolName: "search", Type: agent.ToolEventFinished}
+	if shouldSuppressBootstrapToolEvent(normalFinish, suppressed) {
+		t.Fatal("did not expect non-bootstrap finish event to be suppressed")
+	}
+
+	malformed := agent.ToolEvent{
+		ToolName: "file",
+		Type:     agent.ToolEventStarted,
+		Input:    "{bad json",
+	}
+	if shouldSuppressBootstrapToolEvent(malformed, suppressed) {
+		t.Fatal("did not expect malformed tool input to be suppressed")
+	}
+}

--- a/internal/control/server_tui_test.go
+++ b/internal/control/server_tui_test.go
@@ -325,6 +325,119 @@ func TestControlServerHandlesTUISend(t *testing.T) {
 	}
 }
 
+func TestControlServerTUISendSuppressesBootstrapToolEvents(t *testing.T) {
+	state := &mockTUIState{}
+	state.tuiSubmitFn = func(req control.TUIRunRequest) <-chan agent.RunEvent {
+		ch := make(chan agent.RunEvent, 1)
+		go func() {
+			if req.OnToolEvent != nil {
+				req.OnToolEvent(agent.ToolEvent{
+					ToolName: "file",
+					Type:     agent.ToolEventStarted,
+					Input:    `{"command":"read","path":"SOUL.md"}`,
+				})
+				req.OnToolEvent(agent.ToolEvent{
+					ToolName: "file",
+					Type:     agent.ToolEventFinished,
+					Output:   "soul content",
+				})
+				req.OnToolEvent(agent.ToolEvent{
+					ToolName: "memory_get",
+					Type:     agent.ToolEventStarted,
+					Input:    `{"source":"memory/2026-03-05.md"}`,
+				})
+				req.OnToolEvent(agent.ToolEvent{
+					ToolName: "memory_get",
+					Type:     agent.ToolEventFinished,
+					Output:   "daily memory",
+				})
+				req.OnToolEvent(agent.ToolEvent{
+					ToolName: "search",
+					Type:     agent.ToolEventStarted,
+					Input:    `{"query":"weather"}`,
+				})
+				req.OnToolEvent(agent.ToolEvent{
+					ToolName: "search",
+					Type:     agent.ToolEventFinished,
+					Output:   "ok",
+				})
+			}
+			if req.OnDelta != nil {
+				req.OnDelta("token")
+			}
+			ch <- agent.RunEvent{
+				Type: agent.RunEventDone,
+				Result: &agent.AgentResponse{
+					Message: "assistant reply",
+				},
+			}
+			close(ch)
+		}()
+		return ch
+	}
+
+	_, addr, cancel := startServerWithHandle(t, state)
+	defer cancel()
+
+	conn := wsConnect(t, addr)
+
+	sendTUIRequest(t, conn, control.ClientMsg{Type: control.CmdListSessions})
+	_ = readTUIMessage(t, conn) // connected
+	_ = readTUIMessage(t, conn) // sessions
+
+	sendTUIRequest(t, conn, control.ClientMsg{
+		Type:      control.CmdSend,
+		SessionID: "main",
+		Text:      "test bootstrap filtering",
+	})
+
+	var (
+		sawBootstrapTool bool
+		sawSearchStart   bool
+		sawSearchEnd     bool
+		sawRunEnd        bool
+		deadline         = time.Now().Add(2 * time.Second)
+	)
+
+	for time.Now().Before(deadline) {
+		msg := readTUIMessage(t, conn)
+		if msg.Type != control.MsgTypeEvent {
+			continue
+		}
+		switch msg.Kind {
+		case control.KindToolStart:
+			if msg.ToolName == "file" || msg.ToolName == "memory_get" {
+				sawBootstrapTool = true
+			}
+			if msg.ToolName == "search" {
+				sawSearchStart = true
+			}
+		case control.KindToolEnd:
+			if msg.ToolName == "file" || msg.ToolName == "memory_get" {
+				sawBootstrapTool = true
+			}
+			if msg.ToolName == "search" {
+				sawSearchEnd = true
+			}
+		case control.KindRunEnd:
+			sawRunEnd = true
+		}
+		if sawRunEnd {
+			break
+		}
+	}
+
+	if !sawRunEnd {
+		t.Fatal("expected run_end event")
+	}
+	if sawBootstrapTool {
+		t.Fatal("received bootstrap tool event that should be suppressed")
+	}
+	if !sawSearchStart || !sawSearchEnd {
+		t.Fatalf("expected non-bootstrap tool start/end events, got start=%v end=%v", sawSearchStart, sawSearchEnd)
+	}
+}
+
 func TestControlServerAbortRoutesToTUIRuntimeProvider(t *testing.T) {
 	state := &mockTUIState{}
 	_, addr, cancel := startServerWithHandle(t, state)


### PR DESCRIPTION
Closes #148

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a filtering layer to the TUI chat view that hides tool-call events generated during the agent's bootstrap phase (reading `SOUL.md`, `USER.md`, `AGENTS.md`, `MEMORY.md`, and daily memory files). The implementation is clean and well-tested — new unit tests cover path normalization edge cases (Windows separators, absolute paths, case-insensitivity) and the end-to-end integration test confirms bootstrap events are suppressed while normal tool events continue to reach the client.

Key changes:
- New `shouldSuppressBootstrapToolEvent` function tracks in-flight suppressed starts in a per-run `map[string]int`, keyed by tool name, and suppresses the matching finish event when it arrives.
- `isBootstrapToolStartEvent` / `isBootstrapToolPath` parse tool input JSON and classify a tool call as bootstrap based on file name or a date-stamped memory-path regex.
- Minor: `strings.TrimPrefix(p, "./")` on line 741 is dead code — `filepath.Clean` already removes the `./` prefix before this line executes.
- The `pending > 1` branch in `shouldSuppressBootstrapToolEvent` has no test coverage.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — no logic bugs found; only minor style and test-coverage gaps.
- The core suppression logic is correct for the sequential execution model of the tool agent, the path-matching regex is well-formed, and both unit and integration tests cover the primary use cases. Score is 4 rather than 5 because of the untested `pending > 1` branch and the minor dead-code issue on line 741.
- No files require special attention

<sub>Last reviewed commit: c652e3a</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->