### PR TITLE
fix: add connection timeout to TUI dialWS (currently hangs forever)

### DIFF
--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -6,12 +6,17 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"time"
 
 	"github.com/gobwas/ws"
 	"github.com/gobwas/ws/wsutil"
 
 	controlserver "ok-gobot/internal/control"
 )
+
+const dialWSTimeout = 5 * time.Second
+
+var wsDialContext = ws.DefaultDialer.Dial
 
 // wsConn wraps a raw WebSocket connection.
 type wsConn struct {
@@ -21,7 +26,10 @@ type wsConn struct {
 // dialWS establishes a WebSocket connection to the control server.
 func dialWS(addr string) (*wsConn, error) {
 	url := fmt.Sprintf("ws://%s/ws", addr)
-	conn, _, _, err := ws.DefaultDialer.Dial(context.Background(), url)
+	ctx, cancel := context.WithTimeout(context.Background(), dialWSTimeout)
+	defer cancel()
+
+	conn, _, _, err := wsDialContext(ctx, url)
 	if err != nil {
 		return nil, fmt.Errorf("dial control server %s: %w", url, err)
 	}

--- a/internal/tui/client_test.go
+++ b/internal/tui/client_test.go
@@ -1,0 +1,67 @@
+package tui
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+)
+
+func TestDialWSUsesConnectionTimeout(t *testing.T) {
+	originalDial := wsDialContext
+	t.Cleanup(func() {
+		wsDialContext = originalDial
+	})
+
+	wsDialContext = func(ctx context.Context, url string) (net.Conn, *bufio.Reader, ws.Handshake, error) {
+		if url != "ws://127.0.0.1:8787/ws" {
+			t.Fatalf("dialed unexpected url: %s", url)
+		}
+
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("expected dial context deadline")
+		}
+
+		remaining := time.Until(deadline)
+		if remaining < 4*time.Second || remaining > 6*time.Second {
+			t.Fatalf("expected deadline around %s, got %s", dialWSTimeout, remaining)
+		}
+
+		return nil, nil, ws.Handshake{}, errors.New("dial failed")
+	}
+
+	_, err := dialWS("127.0.0.1:8787")
+	if err == nil {
+		t.Fatal("expected dialWS to return an error")
+	}
+}
+
+func TestRunReturnsFriendlyConnectionError(t *testing.T) {
+	originalDial := wsDialContext
+	t.Cleanup(func() {
+		wsDialContext = originalDial
+	})
+
+	wsDialContext = func(context.Context, string) (net.Conn, *bufio.Reader, ws.Handshake, error) {
+		return nil, nil, ws.Handshake{}, errors.New("connection refused")
+	}
+
+	err := Run(Options{ServerAddr: "127.0.0.1:8787"})
+	if err == nil {
+		t.Fatal("expected Run to fail when dial fails")
+	}
+
+	want := "Could not connect to ok-gobot server at 127.0.0.1:8787 — is it running?"
+	if err.Error() != want {
+		t.Fatalf("unexpected error message:\nwant: %q\ngot:  %q", want, err.Error())
+	}
+	if strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("expected friendly error without raw transport details, got: %q", err.Error())
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -38,7 +38,7 @@ type Options struct {
 func Run(opts Options) error {
 	conn, err := dialWS(opts.ServerAddr)
 	if err != nil {
-		return fmt.Errorf("connect to control server at %s: %w", opts.ServerAddr, err)
+		return fmt.Errorf("Could not connect to ok-gobot server at %s — is it running?", opts.ServerAddr)
 	}
 
 	modelList := opts.ModelList


### PR DESCRIPTION
Closes #151

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a hang-forever bug in the TUI WebSocket dialer by introducing a 5-second connection timeout via `context.WithTimeout`, and adds a package-level `wsDialContext` variable to enable test injection. Two new tests cover the timeout behaviour and the friendly error message. The core fix is clean and correct; the main concern is in `tui.go` where the underlying dial error is silently dropped (no `%w` wrap, no logging), which obscures whether a failure was a timeout, a refused connection, or something else entirely.

- **`client.go`**: Correctly adds `dialWSTimeout = 5 * time.Second` and uses it via `context.WithTimeout`; `defer cancel()` is in place; test-injection variable is unexported and package-scoped appropriately.
- **`tui.go`**: The friendly error message is a nice UX improvement, but `err` is neither wrapped nor logged, so the new timeout error introduced by this PR is immediately discarded — making the two failure modes (timeout vs. refused) indistinguishable to the caller or a developer debugging.
- **`client_test.go`**: Good coverage of both the deadline injection and the friendly-message contract; `t.Cleanup` restoration pattern is correct.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the timeout fix is correct and the only issues are style-level concerns in the error handling.
- The core timeout mechanism is implemented correctly with proper context cancellation. The two style issues (discarded error, capitalised error string) don't affect runtime correctness or the fix itself, but the loss of the underlying error does reduce debuggability.
- internal/tui/tui.go — the underlying dial error is silently discarded without logging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tui/client.go | Adds a 5-second `dialWSTimeout` constant and a `wsDialContext` variable for test injection; `dialWS` now wraps the dial call with `context.WithTimeout` and defers cancel correctly. |
| internal/tui/tui.go | Error message in `Run` changed to a friendly string, but the underlying `err` is neither wrapped nor logged, silently discarding the timeout/connection details that the new timeout mechanism now generates. The error string also starts with a capital letter, violating Go conventions. |
| internal/tui/client_test.go | New test file covering both the timeout injection and the friendly error message; uses package-level variable replacement pattern correctly with `t.Cleanup` for restoration. |

</details>

<sub>Last reviewed commit: 1e5e355</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->