### PR TITLE
feat: feat(runtime): jobs carry explicit budgets, output contracts, and memory policy (#177)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -331,7 +331,7 @@ Client -> Server:
 | `list_sessions` | -- | Request session list |
 | `new_session` | `name` | Create new session |
 | `switch_session` | `session_id` | Switch active session |
-| `spawn_subagent` | `task`, `model`, `thinking`, `tool_allowlist`, `workspace_root` | Spawn sub-agent |
+| `spawn_subagent` | `task`, `model`, `thinking`, `tool_allowlist`, `workspace_root`, `max_tool_calls`, `max_duration`, `output_format`, `output_schema`, `memory_policy` | Spawn sub-agent with an explicit delegated-run contract |
 | `bot_command` | `session_id`, `text` | Execute slash command |
 
 ## Server Messages
@@ -351,6 +351,12 @@ Client -> Server:
 | `event` | `child_done` | `child_session_key`, `content` | Sub-agent completed |
 | `event` | `child_failed` | `child_session_key`, `message` | Sub-agent failed |
 | `error` | -- | `message` | Error message |
+
+`spawn_subagent` delegated-run defaults:
+- `max_tool_calls`: `50`
+- `max_duration`: `10m`
+- `output_format`: `markdown`
+- `memory_policy`: `read_only`
 
 ## Example: Streaming Session
 

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -5,6 +5,7 @@ import (
 
 	"ok-gobot/internal/ai"
 	"ok-gobot/internal/config"
+	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/tools"
 )
 
@@ -55,13 +56,13 @@ type RunComponents struct {
 
 // Resolve creates the tool-calling agent and its dependencies for a chat session.
 // isSubagent prevents injecting browser_task (avoids recursive subagent spawning).
-func (r *RunResolver) Resolve(chatID int64, overrides *RunOverrides, isSubagent ...bool) (*RunComponents, error) {
+func (r *RunResolver) Resolve(chatID int64, overrides *RunOverrides, job *delegation.Job, isSubagent ...bool) (*RunComponents, error) {
 	profile := r.resolveProfile(chatID)
 	model := r.resolveModel(chatID, profile, overrides)
 	thinkLevel := r.resolveThinkLevel(chatID, overrides)
 	aiClient := r.buildAIClient(model, thinkLevel)
 	sub := len(isSubagent) > 0 && isSubagent[0]
-	toolReg := r.buildToolRegistry(chatID, profile, sub)
+	toolReg := r.buildToolRegistry(chatID, profile, sub, job)
 
 	aliases := r.AIConfig.ModelAliases
 	if aliases == nil {
@@ -162,7 +163,7 @@ func (r *RunResolver) buildAIClient(model, thinkLevel string) ai.Client {
 	return client
 }
 
-func (r *RunResolver) buildToolRegistry(chatID int64, profile *AgentProfile, isSubagent bool) *tools.Registry {
+func (r *RunResolver) buildToolRegistry(chatID int64, profile *AgentProfile, isSubagent bool, job *delegation.Job) *tools.Registry {
 	base := r.ToolRegistry
 
 	// Filter by agent's allowed tools.
@@ -201,7 +202,21 @@ func (r *RunResolver) buildToolRegistry(chatID int64, profile *AgentProfile, isS
 		if !isSubagent && r.SubagentSubmitter != nil && chatID != 0 {
 			chatRegistry.Register(tools.NewBrowserTaskTool(r.SubagentSubmitter, chatID))
 		}
-		return chatRegistry
+		base = chatRegistry
+	}
+
+	if job != nil && len(job.ToolAllowlist) > 0 {
+		filtered := tools.NewRegistry()
+		allowed := make(map[string]struct{}, len(job.ToolAllowlist))
+		for _, name := range job.ToolAllowlist {
+			allowed[name] = struct{}{}
+		}
+		for _, tool := range base.List() {
+			if _, ok := allowed[tool.Name()]; ok {
+				filtered.Register(tool)
+			}
+		}
+		base = filtered
 	}
 
 	return base

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -2,12 +2,14 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
 	"time"
 
 	"ok-gobot/internal/ai"
+	"ok-gobot/internal/delegation"
 )
 
 // SessionKey is the canonical identifier for a chat session.
@@ -57,6 +59,7 @@ type RunRequest struct {
 	OnDelta      func(string)    // optional callback for streamed text tokens
 	OnDeltaReset func()          // optional callback when tool calls follow text
 	Overrides    *RunOverrides   // optional explicit model/thinking overrides
+	Job          *delegation.Job // optional delegated-run contract
 	IsSubagent   bool            // true = don't inject browser_task into the run
 }
 
@@ -95,8 +98,33 @@ func NewRuntimeHub(resolver *RunResolver) *RuntimeHub {
 func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 	events := make(chan RunEvent, 1)
 
+	if req.Context == nil {
+		req.Context = context.Background()
+	}
+
+	var job *delegation.Job
+	if req.Job != nil {
+		normalized := req.Job.WithDefaults()
+		job = &normalized
+	}
+
+	overrides := req.Overrides
+	if job != nil && (job.Model != "" || job.Thinking != "") {
+		merged := RunOverrides{}
+		if overrides != nil {
+			merged = *overrides
+		}
+		if merged.Model == "" {
+			merged.Model = job.Model
+		}
+		if merged.ThinkLevel == "" {
+			merged.ThinkLevel = job.Thinking
+		}
+		overrides = &merged
+	}
+
 	// Resolve agent components.
-	components, err := h.resolver.Resolve(req.ChatID, req.Overrides, req.IsSubagent)
+	components, err := h.resolver.Resolve(req.ChatID, overrides, job, req.IsSubagent)
 	if err != nil {
 		events <- RunEvent{Type: RunEventError, Err: err}
 		close(events)
@@ -113,6 +141,9 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 	if req.OnDeltaReset != nil {
 		components.Agent.SetDeltaResetCallback(req.OnDeltaReset)
 	}
+	if job != nil {
+		components.Agent.SetMaxToolCalls(job.MaxToolCalls)
+	}
 
 	// Runtime no longer promotes timed-out tools into background subagent runs.
 	// Explicit orchestration tools like browser_task manage their own subagent
@@ -120,8 +151,20 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 	components.Agent.SetToolTimeoutCallback(0, nil)
 
 	profileName := components.Profile.Name
+	content := req.Content
+	if job != nil {
+		content = job.ContractPrompt(req.Content)
+	}
 
-	ctx, cancel := context.WithCancel(req.Context)
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	if job != nil && job.MaxDuration > 0 {
+		ctx, cancel = context.WithTimeout(req.Context, job.MaxDuration)
+	} else {
+		ctx, cancel = context.WithCancel(req.Context)
+	}
 	slot := &runSlot{cancel: cancel}
 
 	h.mu.Lock()
@@ -145,7 +188,7 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 		}()
 
 		log.Printf("[hub] starting run for session %s (agent: %s)", req.SessionKey, profileName)
-		result, err := components.Agent.ProcessRequestWithContent(ctx, req.Content, req.UserContent, req.Session, req.History)
+		result, err := components.Agent.ProcessRequestWithContent(ctx, content, req.UserContent, req.Session, req.History)
 		if err != nil {
 			if ctx.Err() != nil {
 				log.Printf("[hub] run for session %s was cancelled", req.SessionKey)
@@ -183,17 +226,20 @@ func (h *RuntimeHub) IsActive(key SessionKey) bool {
 
 // SubmitAndWait spawns a subagent run and blocks until it completes or times out.
 // Implements the SubagentSubmitter interface used by browser_task tool.
-func (h *RuntimeHub) SubmitAndWait(ctx context.Context, chatID int64, task string, timeout time.Duration) (string, error) {
-	subKey := SessionKey(fmt.Sprintf("subagent:%d:%d", chatID, time.Now().UnixNano()))
+func (h *RuntimeHub) SubmitAndWait(ctx context.Context, chatID int64, task string, job delegation.Job) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	job = job.WithDefaults()
 
-	runCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	subKey := SessionKey(fmt.Sprintf("subagent:%d:%d", chatID, time.Now().UnixNano()))
 
 	events := h.Submit(RunRequest{
 		SessionKey: subKey,
 		ChatID:     chatID,
 		Content:    task,
-		Context:    runCtx,
+		Context:    ctx,
+		Job:        &job,
 		IsSubagent: true,
 	})
 
@@ -206,12 +252,15 @@ func (h *RuntimeHub) SubmitAndWait(ctx context.Context, chatID int64, task strin
 			}
 			return "", fmt.Errorf("subagent returned nil result")
 		case RunEventError:
+			if errors.Is(ev.Err, context.DeadlineExceeded) {
+				return "", fmt.Errorf("subagent timed out after %s", job.MaxDuration)
+			}
 			return "", fmt.Errorf("subagent error: %w", ev.Err)
 		default:
 			return "", fmt.Errorf("unexpected event type: %s", ev.Type)
 		}
-	case <-runCtx.Done():
+	case <-ctx.Done():
 		h.Cancel(subKey)
-		return "", fmt.Errorf("subagent timed out after %s", timeout)
+		return "", ctx.Err()
 	}
 }

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -292,7 +292,7 @@ func TestRuntimeHub_Overrides(t *testing.T) {
 	components, err := resolver.Resolve(42, &RunOverrides{
 		Model:      "explicit-model",
 		ThinkLevel: "high",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
 	}

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -1,10 +1,34 @@
 package agent
 
+import (
+	"time"
+
+	"ok-gobot/internal/delegation"
+)
+
 // SubagentSpawnRequest defines parameters for spawning a child sub-agent.
 type SubagentSpawnRequest struct {
-	Description string // Task description passed to the sub-agent
-	Model       string // Optional model override (empty = use caller's default)
-	ThinkLevel  string // Optional thinking level: off, low, medium, high
+	Description  string        // Task description passed to the sub-agent
+	Model        string        // Optional model override (empty = use caller's default)
+	ThinkLevel   string        // Optional thinking level: off, low, medium, high
+	MaxToolCalls int           // Optional explicit tool-call budget
+	MaxDuration  time.Duration // Optional explicit max runtime
+	OutputFormat string        // Expected output format: markdown, text, json
+	OutputSchema string        // Optional output shape/schema hint
+	MemoryPolicy string        // Memory write policy: inherit, read_only, allow_writes
+}
+
+// Job returns the normalized delegated-run contract for this spawn request.
+func (r SubagentSpawnRequest) Job() delegation.Job {
+	return delegation.Job{
+		Model:        r.Model,
+		Thinking:     r.ThinkLevel,
+		MaxToolCalls: r.MaxToolCalls,
+		MaxDuration:  r.MaxDuration,
+		OutputFormat: r.OutputFormat,
+		OutputSchema: r.OutputSchema,
+		MemoryPolicy: r.MemoryPolicy,
+	}.WithDefaults()
 }
 
 // SubagentResult holds the outcome of a completed sub-agent run.

--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -42,6 +42,7 @@ type ToolCallingAgent struct {
 	modelAliases  map[string]string
 	ThinkLevel    string // "off", "low", "medium", "high" — controls extended thinking
 	PromptMode    string // "full", "minimal", "none" — controls system prompt verbosity
+	MaxToolCalls  int    // max number of tool executions allowed for this run (0 = default/unlimited)
 	onToolEvent   func(event ToolEvent)
 	onDelta       func(delta string) // fired for each streamed text token
 	onDeltaReset  func()             // fired when tool calls follow streaming text (content discarded)
@@ -94,6 +95,11 @@ func (a *ToolCallingAgent) SetThinkLevel(level string) {
 // SetPromptMode sets the prompt verbosity mode ("full", "minimal", "none")
 func (a *ToolCallingAgent) SetPromptMode(mode string) {
 	a.PromptMode = mode
+}
+
+// SetMaxToolCalls sets the per-run tool-call budget.
+func (a *ToolCallingAgent) SetMaxToolCalls(limit int) {
+	a.MaxToolCalls = limit
 }
 
 // SetModelAliases sets the model alias map for system prompt generation.
@@ -154,15 +160,18 @@ func (a *ToolCallingAgent) ProcessRequestWithContent(
 
 	// Maximum iterations to prevent infinite loops
 	maxIterations := 50
+	maxToolCalls := a.MaxToolCalls
 	var finalResponse string
 	var usedTools []string
 	var toolResults []string
 	var lastPromptTokens, totalCompletionTokens, lastTotalTokens int
 	completed := false
+	toolCallsUsed := 0
 
 	// Resolve streaming client once so we don't re-type-assert on every iteration.
 	streamClient, hasStreaming := a.aiClient.(ai.StreamingClient)
 
+iterationLoop:
 	for iteration := 0; iteration < maxIterations; iteration++ {
 		logger.Debugf("ToolAgent: iteration %d/%d", iteration+1, maxIterations)
 		// Use streaming when a delta callback is wired and the client supports it.
@@ -220,6 +229,10 @@ func (a *ToolCallingAgent) ProcessRequestWithContent(
 				if toolCall.Type != "function" {
 					continue
 				}
+				if maxToolCalls > 0 && toolCallsUsed >= maxToolCalls {
+					finalResponse = fmt.Sprintf("⚠️ Reached tool-call budget (%d). Task not finished.", maxToolCalls)
+					break iterationLoop
+				}
 
 				functionName := toolCall.Function.Name
 				arguments := toolCall.Function.Arguments
@@ -258,6 +271,7 @@ func (a *ToolCallingAgent) ProcessRequestWithContent(
 					Name:       functionName,
 				})
 
+				toolCallsUsed++
 				usedTools = append(usedTools, functionName)
 				toolResults = append(toolResults, result)
 			}

--- a/internal/agent/tool_agent_test.go
+++ b/internal/agent/tool_agent_test.go
@@ -56,6 +56,65 @@ func (c *recordingAIClient) SupportsVision() bool {
 	return c.supportsVision
 }
 
+type budgetAIClient struct {
+	callCount int
+}
+
+func (c *budgetAIClient) Complete(_ context.Context, _ []ai.Message) (string, error) {
+	return "", nil
+}
+
+func (c *budgetAIClient) CompleteWithTools(_ context.Context, _ []ai.ChatMessage, _ []ai.ToolDefinition) (*ai.ChatCompletionResponse, error) {
+	c.callCount++
+	if c.callCount > 1 {
+		return &ai.ChatCompletionResponse{
+			Choices: []struct {
+				Index        int            `json:"index"`
+				Message      ai.ChatMessage `json:"message"`
+				FinishReason string         `json:"finish_reason"`
+			}{
+				{
+					Message:      ai.ChatMessage{Role: ai.RoleAssistant, Content: "done"},
+					FinishReason: "stop",
+				},
+			},
+		}, nil
+	}
+
+	return &ai.ChatCompletionResponse{
+		Choices: []struct {
+			Index        int            `json:"index"`
+			Message      ai.ChatMessage `json:"message"`
+			FinishReason string         `json:"finish_reason"`
+		}{
+			{
+				Message: ai.ChatMessage{
+					Role: ai.RoleAssistant,
+					ToolCalls: []ai.ToolCall{
+						{
+							ID:   "call_1",
+							Type: "function",
+							Function: ai.FunctionCall{
+								Name:      "tool_one",
+								Arguments: `{"input":"first"}`,
+							},
+						},
+						{
+							ID:   "call_2",
+							Type: "function",
+							Function: ai.FunctionCall{
+								Name:      "tool_two",
+								Arguments: `{"input":"second"}`,
+							},
+						},
+					},
+				},
+				FinishReason: "tool_calls",
+			},
+		},
+	}, nil
+}
+
 func (m *mockAIClient) CompleteWithTools(ctx context.Context, messages []ai.ChatMessage, toolDefs []ai.ToolDefinition) (*ai.ChatCompletionResponse, error) {
 	m.callCount++
 
@@ -230,6 +289,34 @@ func TestToolCallingAgent_BrowserClickBySnapshotRef(t *testing.T) {
 	want := []string{"click", "snap-123", "r7"}
 	if !reflect.DeepEqual(browserTool.allArgs, want) {
 		t.Fatalf("browser args = %v, want %v", browserTool.allArgs, want)
+	}
+}
+
+func TestToolCallingAgent_MaxToolCallsStopsFurtherExecution(t *testing.T) {
+	registry := tools.NewRegistry()
+	first := &mockTool{name: "tool_one", desc: "first tool"}
+	second := &mockTool{name: "tool_two", desc: "second tool"}
+	registry.Register(first)
+	registry.Register(second)
+
+	agent := NewToolCallingAgent(&budgetAIClient{}, registry, &Personality{
+		Files: map[string]string{"IDENTITY.md": "Test Bot"},
+	})
+	agent.SetMaxToolCalls(1)
+
+	resp, err := agent.ProcessRequest(context.Background(), "use both tools", "")
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+
+	if !strings.Contains(resp.Message, "Reached tool-call budget (1)") {
+		t.Fatalf("expected tool budget warning, got %q", resp.Message)
+	}
+	if len(first.allArgs) == 0 {
+		t.Fatal("expected first tool to execute")
+	}
+	if len(second.allArgs) != 0 {
+		t.Fatalf("expected second tool to be skipped, got args %v", second.allArgs)
 	}
 }
 

--- a/internal/bot/chat_routing.go
+++ b/internal/bot/chat_routing.go
@@ -138,6 +138,10 @@ func (b *Bot) startTaskRun(chat *telebot.Chat, chatID int64, req agent.SubagentS
 	if model != "" {
 		model = b.resolveModelAlias(model)
 	}
+	job := req.Job()
+	if model != "" {
+		job.Model = model
+	}
 
 	go func() {
 		log.Printf("[task] spawning sub-agent for chat=%d model=%s thinking=%s desc=%.80s",
@@ -145,29 +149,25 @@ func (b *Bot) startTaskRun(chat *telebot.Chat, chatID int64, req agent.SubagentS
 
 		subKey := agent.SessionKey(fmt.Sprintf("subagent:%d:%d", chatID, time.Now().UnixNano()))
 
-		var overrides *agent.RunOverrides
-		if model != "" || req.ThinkLevel != "" {
-			overrides = &agent.RunOverrides{Model: model, ThinkLevel: req.ThinkLevel}
-		}
-
 		events := b.hub.Submit(agent.RunRequest{
 			SessionKey: subKey,
 			ChatID:     chatID,
 			Content:    req.Description,
 			Session:    "",
 			Context:    context.Background(),
-			Overrides:  overrides,
+			Job:        &job,
+			IsSubagent: true,
 		})
 
 		var notifText string
 		for ev := range events {
 			switch ev.Type {
 			case agent.RunEventDone:
-				summary := ev.Result.Message
-				if strings.TrimSpace(summary) == "" {
-					summary = "Task completed with no output."
+				result := ""
+				if ev.Result != nil {
+					result = ev.Result.Message
 				}
-				notifText = fmt.Sprintf("%s\n\n%s", style.doneHeading, summary)
+				notifText = fmt.Sprintf("%s\n\n%s", style.doneHeading, job.CompletionSummary(result))
 			case agent.RunEventError:
 				notifText = fmt.Sprintf("%s\n\n%s", style.failHeading, ev.Err.Error())
 			}

--- a/internal/bot/task_command.go
+++ b/internal/bot/task_command.go
@@ -3,15 +3,20 @@ package bot
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/telebot.v4"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/delegation"
 )
 
 // parseTaskArgs parses the /task command payload into a SubagentSpawnRequest.
-// Syntax: <description> [--model <model>] [--thinking <level>]
+// Syntax: <description> [--model <model>] [--thinking <level>] [--max-tools <n>]
+// [--max-duration <duration>] [--output <text|markdown|json>] [--schema <shape>]
+// [--memory <inherit|read_only|allow_writes>]
 func parseTaskArgs(payload string) (agent.SubagentSpawnRequest, error) {
 	var req agent.SubagentSpawnRequest
 
@@ -41,6 +46,52 @@ func parseTaskArgs(payload string) (agent.SubagentSpawnRequest, error) {
 				return req, fmt.Errorf("--thinking must be one of: off, low, medium, high")
 			}
 			req.ThinkLevel = level
+		case "--max-tools":
+			if i+1 >= len(words) {
+				return req, fmt.Errorf("--max-tools requires a value")
+			}
+			i++
+			n, err := strconv.Atoi(words[i])
+			if err != nil || n <= 0 {
+				return req, fmt.Errorf("--max-tools must be a positive integer")
+			}
+			req.MaxToolCalls = n
+		case "--max-duration":
+			if i+1 >= len(words) {
+				return req, fmt.Errorf("--max-duration requires a value")
+			}
+			i++
+			d, err := time.ParseDuration(words[i])
+			if err != nil || d <= 0 {
+				return req, fmt.Errorf("--max-duration must be a valid positive duration")
+			}
+			req.MaxDuration = d
+		case "--output":
+			if i+1 >= len(words) {
+				return req, fmt.Errorf("--output requires a value")
+			}
+			i++
+			format, ok := delegation.ParseOutputFormat(words[i])
+			if !ok {
+				return req, fmt.Errorf("--output must be one of: text, markdown, json")
+			}
+			req.OutputFormat = format
+		case "--schema":
+			if i+1 >= len(words) {
+				return req, fmt.Errorf("--schema requires a value")
+			}
+			i++
+			req.OutputSchema = words[i]
+		case "--memory":
+			if i+1 >= len(words) {
+				return req, fmt.Errorf("--memory requires a value")
+			}
+			i++
+			policy, ok := delegation.ParseMemoryPolicy(words[i])
+			if !ok {
+				return req, fmt.Errorf("--memory must be one of: inherit, read_only, allow_writes")
+			}
+			req.MemoryPolicy = policy
 		default:
 			descWords = append(descWords, words[i])
 		}
@@ -63,7 +114,7 @@ func (b *Bot) handleTaskCommand(c telebot.Context) error {
 
 	req, err := parseTaskArgs(payload)
 	if err != nil {
-		return c.Send(fmt.Sprintf("❌ Usage: /task <description> [--model <model>] [--thinking off|low|medium|high]\n\nError: %s", err))
+		return c.Send(fmt.Sprintf("❌ Usage: /task <description> [--model <model>] [--thinking off|low|medium|high] [--max-tools <n>] [--max-duration <duration>] [--output text|markdown|json] [--schema <shape>] [--memory inherit|read_only|allow_writes]\n\nError: %s", err))
 	}
 
 	// Resolve model alias if set.
@@ -71,6 +122,8 @@ func (b *Bot) handleTaskCommand(c telebot.Context) error {
 	if model != "" {
 		model = b.resolveModelAlias(model)
 	}
+	job := req.Job()
+	job.Model = model
 
 	// Acknowledge immediately so the user knows the task is queued.
 	thinkNote := ""
@@ -81,8 +134,8 @@ func (b *Bot) handleTaskCommand(c telebot.Context) error {
 	if displayModel == "" {
 		displayModel = "(session default)"
 	}
-	ackText := fmt.Sprintf("⚙️ Sub-agent started%s\nModel: `%s`\nTask: %s",
-		thinkNote, displayModel, req.Description)
+	ackText := fmt.Sprintf("⚙️ Sub-agent started%s\nModel: `%s`\nBudget: `%d tools / %s`\nOutput: `%s`\nMemory: `%s`\nTask: %s",
+		thinkNote, displayModel, job.MaxToolCalls, job.MaxDuration, job.OutputFormat, job.MemoryPolicy, req.Description)
 	if err := c.Send(ackText, &telebot.SendOptions{ParseMode: telebot.ModeMarkdown}); err != nil {
 		log.Printf("[task] failed to send ack: %v", err)
 	}

--- a/internal/bot/task_command_test.go
+++ b/internal/bot/task_command_test.go
@@ -6,12 +6,17 @@ import (
 
 func TestParseTaskArgs(t *testing.T) {
 	tests := []struct {
-		name        string
-		payload     string
-		wantDesc    string
-		wantModel   string
-		wantThink   string
-		wantErrMsg  string
+		name         string
+		payload      string
+		wantDesc     string
+		wantModel    string
+		wantThink    string
+		wantMaxTools int
+		wantMaxDur   string
+		wantOutput   string
+		wantSchema   string
+		wantMemory   string
+		wantErrMsg   string
 	}{
 		{
 			name:       "empty payload",
@@ -81,8 +86,8 @@ func TestParseTaskArgs(t *testing.T) {
 			wantThink: "low",
 		},
 		{
-			name:      "flags only, no description",
-			payload:   "--model sonnet --thinking high",
+			name:       "flags only, no description",
+			payload:    "--model sonnet --thinking high",
 			wantErrMsg: "no task description provided",
 		},
 		{
@@ -91,6 +96,36 @@ func TestParseTaskArgs(t *testing.T) {
 			wantDesc:  "analyse the code and suggest improvements",
 			wantModel: "claude-3-5-sonnet",
 			wantThink: "low",
+		},
+		{
+			name:         "explicit budgets and contract",
+			payload:      "summarise logs --max-tools 7 --max-duration 2m --output json --schema report_v1 --memory allow_writes",
+			wantDesc:     "summarise logs",
+			wantMaxTools: 7,
+			wantMaxDur:   "2m0s",
+			wantOutput:   "json",
+			wantSchema:   "report_v1",
+			wantMemory:   "allow_writes",
+		},
+		{
+			name:       "invalid max tools",
+			payload:    "some task --max-tools nope",
+			wantErrMsg: "--max-tools must be a positive integer",
+		},
+		{
+			name:       "invalid max duration",
+			payload:    "some task --max-duration later",
+			wantErrMsg: "--max-duration must be a valid positive duration",
+		},
+		{
+			name:       "invalid output format",
+			payload:    "some task --output xml",
+			wantErrMsg: "--output must be one of: text, markdown, json",
+		},
+		{
+			name:       "invalid memory policy",
+			payload:    "some task --memory yes",
+			wantErrMsg: "--memory must be one of: inherit, read_only, allow_writes",
 		},
 	}
 
@@ -120,6 +155,21 @@ func TestParseTaskArgs(t *testing.T) {
 			}
 			if req.ThinkLevel != tc.wantThink {
 				t.Errorf("ThinkLevel: got %q, want %q", req.ThinkLevel, tc.wantThink)
+			}
+			if req.MaxToolCalls != tc.wantMaxTools {
+				t.Errorf("MaxToolCalls: got %d, want %d", req.MaxToolCalls, tc.wantMaxTools)
+			}
+			if tc.wantMaxDur != "" && req.MaxDuration.String() != tc.wantMaxDur {
+				t.Errorf("MaxDuration: got %q, want %q", req.MaxDuration, tc.wantMaxDur)
+			}
+			if req.OutputFormat != tc.wantOutput {
+				t.Errorf("OutputFormat: got %q, want %q", req.OutputFormat, tc.wantOutput)
+			}
+			if req.OutputSchema != tc.wantSchema {
+				t.Errorf("OutputSchema: got %q, want %q", req.OutputSchema, tc.wantSchema)
+			}
+			if req.MemoryPolicy != tc.wantMemory {
+				t.Errorf("MemoryPolicy: got %q, want %q", req.MemoryPolicy, tc.wantMemory)
 			}
 		})
 	}

--- a/internal/bot/tui_runtime.go
+++ b/internal/bot/tui_runtime.go
@@ -35,6 +35,7 @@ func (b *Bot) SubmitTUIRun(ctx context.Context, req control.TUIRunRequest) <-cha
 		OnDelta:      req.OnDelta,
 		OnDeltaReset: req.OnDeltaReset,
 		Overrides:    overrides,
+		Job:          req.Job,
 	})
 }
 

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -163,9 +163,9 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 			SessionKey:  tuiSessionKeyForID(sessionID),
 			Content:     text,
 			UserContent: userContent,
-			Session:    snapshot.lastAssistant,
-			History:    snapshot.history,
-			Model:      snapshot.modelOverride,
+			Session:     snapshot.lastAssistant,
+			History:     snapshot.history,
+			Model:       snapshot.modelOverride,
 			OnDelta: func(delta string) {
 				if delta == "" {
 					return
@@ -302,14 +302,16 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 			return
 		}
 
+		job, err := buildDelegationJob(cmd)
+		if err != nil {
+			c.sendTUIError(err.Error())
+			return
+		}
 		parentKey := "agent:tui:" + sessionID
 		req := runtimepkg.SubagentSpawnRequest{
 			ParentSessionKey: parentKey,
 			Task:             task,
-			Model:            cmd.Model,
-			Thinking:         cmd.Thinking,
-			ToolAllowlist:    cmd.ToolAllowlist,
-			WorkspaceRoot:    cmd.WorkspaceRoot,
+			Job:              job,
 			DeliverBack:      true,
 		}
 
@@ -326,7 +328,8 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 			tuiReq := TUIRunRequest{
 				SessionKey: childKey,
 				Content:    task,
-				Model:      cmd.Model,
+				Model:      job.Model,
+				Job:        &job,
 			}
 			events := provider.SubmitTUIRun(ctx, tuiReq)
 			if events == nil {
@@ -334,15 +337,20 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 				return
 			}
 			var runErr error
+			var summary string
 			for ev := range events {
 				switch ev.Type {
 				case agent.RunEventDone:
-					// success
+					result := ""
+					if ev.Result != nil {
+						result = ev.Result.Message
+					}
+					summary = job.CompletionSummary(result)
 				case agent.RunEventError:
 					runErr = ev.Err
 				}
 			}
-			ack.Close(runErr)
+			ack.CloseWithSummary(summary, runErr)
 		})
 		if err != nil {
 			c.sendTUIError(fmt.Sprintf("spawn subagent: %v", err))
@@ -874,6 +882,7 @@ func (s *Server) bridgeRuntimeEvents(ctx context.Context, evCh <-chan runtimepkg
 				Kind:            kind,
 				SessionID:       sessionID,
 				ChildSessionKey: payload.ChildSessionKey,
+				Content:         payload.Summary,
 				Message:         msg,
 			})
 		}

--- a/internal/control/subagent_job.go
+++ b/internal/control/subagent_job.go
@@ -1,0 +1,48 @@
+package control
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"ok-gobot/internal/delegation"
+)
+
+func buildDelegationJob(cmd ClientMsg) (delegation.Job, error) {
+	job := delegation.Job{
+		Model:         strings.TrimSpace(cmd.Model),
+		Thinking:      strings.TrimSpace(cmd.Thinking),
+		ToolAllowlist: append([]string(nil), cmd.ToolAllowlist...),
+		WorkspaceRoot: strings.TrimSpace(cmd.WorkspaceRoot),
+		MaxToolCalls:  cmd.MaxToolCalls,
+		OutputFormat:  strings.TrimSpace(cmd.OutputFormat),
+		OutputSchema:  strings.TrimSpace(cmd.OutputSchema),
+		MemoryPolicy:  strings.TrimSpace(cmd.MemoryPolicy),
+	}
+
+	if raw := strings.TrimSpace(cmd.MaxDuration); raw != "" {
+		duration, err := time.ParseDuration(raw)
+		if err != nil {
+			return delegation.Job{}, fmt.Errorf("max_duration: %w", err)
+		}
+		job.MaxDuration = duration
+	}
+
+	if raw := strings.TrimSpace(cmd.OutputFormat); raw != "" {
+		if _, ok := delegation.ParseOutputFormat(raw); !ok {
+			return delegation.Job{}, fmt.Errorf("output_format must be one of: text, markdown, json")
+		}
+	}
+
+	if raw := strings.TrimSpace(cmd.MemoryPolicy); raw != "" {
+		if _, ok := delegation.ParseMemoryPolicy(raw); !ok {
+			return delegation.Job{}, fmt.Errorf("memory_policy must be one of: inherit, read_only, allow_writes")
+		}
+	}
+
+	if cmd.MaxToolCalls < 0 {
+		return delegation.Job{}, fmt.Errorf("max_tool_calls must be >= 0")
+	}
+
+	return job.WithDefaults(), nil
+}

--- a/internal/control/subagent_job_test.go
+++ b/internal/control/subagent_job_test.go
@@ -1,0 +1,45 @@
+package control
+
+import "testing"
+
+func TestBuildDelegationJob(t *testing.T) {
+	job, err := buildDelegationJob(ClientMsg{
+		Model:         "model-x",
+		Thinking:      "high",
+		ToolAllowlist: []string{"browser", "browser"},
+		WorkspaceRoot: "/tmp/work",
+		MaxToolCalls:  7,
+		MaxDuration:   "2m",
+		OutputFormat:  "json",
+		OutputSchema:  "report_v1",
+		MemoryPolicy:  "allow_writes",
+	})
+	if err != nil {
+		t.Fatalf("buildDelegationJob failed: %v", err)
+	}
+
+	if job.MaxToolCalls != 7 {
+		t.Fatalf("MaxToolCalls = %d, want 7", job.MaxToolCalls)
+	}
+	if got := job.MaxDuration.String(); got != "2m0s" {
+		t.Fatalf("MaxDuration = %q, want %q", got, "2m0s")
+	}
+	if job.OutputFormat != "json" {
+		t.Fatalf("OutputFormat = %q, want json", job.OutputFormat)
+	}
+	if job.MemoryPolicy != "allow_writes" {
+		t.Fatalf("MemoryPolicy = %q, want allow_writes", job.MemoryPolicy)
+	}
+	if len(job.ToolAllowlist) != 1 || job.ToolAllowlist[0] != "browser" {
+		t.Fatalf("ToolAllowlist = %v, want [browser]", job.ToolAllowlist)
+	}
+}
+
+func TestBuildDelegationJobRejectsInvalidEnums(t *testing.T) {
+	if _, err := buildDelegationJob(ClientMsg{OutputFormat: "xml"}); err == nil {
+		t.Fatal("expected invalid output format error")
+	}
+	if _, err := buildDelegationJob(ClientMsg{MemoryPolicy: "yes"}); err == nil {
+		t.Fatal("expected invalid memory policy error")
+	}
+}

--- a/internal/control/tui_runtime.go
+++ b/internal/control/tui_runtime.go
@@ -6,16 +6,18 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/ai"
+	"ok-gobot/internal/delegation"
 )
 
 // TUIRunRequest describes one isolated TUI run routed through the bot runtime hub.
 type TUIRunRequest struct {
 	SessionKey   string
 	Content      string
-	UserContent  []ai.ContentBlock   // optional multimodal blocks (e.g. image + text)
-	Session      string              // legacy: last assistant text (kept for compat)
-	History      []ai.ChatMessage    // full conversation history
+	UserContent  []ai.ContentBlock // optional multimodal blocks (e.g. image + text)
+	Session      string            // legacy: last assistant text (kept for compat)
+	History      []ai.ChatMessage  // full conversation history
 	Model        string
+	Job          *delegation.Job
 	OnToolEvent  func(agent.ToolEvent)
 	OnDelta      func(string)
 	OnDeltaReset func()

--- a/internal/control/tui_types.go
+++ b/internal/control/tui_types.go
@@ -78,6 +78,11 @@ type ClientMsg struct {
 	Thinking      string   `json:"thinking,omitempty"`
 	ToolAllowlist []string `json:"tool_allowlist,omitempty"`
 	WorkspaceRoot string   `json:"workspace_root,omitempty"`
+	MaxToolCalls  int      `json:"max_tool_calls,omitempty"`
+	MaxDuration   string   `json:"max_duration,omitempty"`
+	OutputFormat  string   `json:"output_format,omitempty"`
+	OutputSchema  string   `json:"output_schema,omitempty"`
+	MemoryPolicy  string   `json:"memory_policy,omitempty"`
 	DeliverBack   bool     `json:"deliver_back,omitempty"`
 }
 

--- a/internal/delegation/job.go
+++ b/internal/delegation/job.go
@@ -1,0 +1,227 @@
+package delegation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultMaxToolCalls = 50
+	DefaultMaxDuration  = 10 * time.Minute
+
+	OutputFormatText     = "text"
+	OutputFormatMarkdown = "markdown"
+	OutputFormatJSON     = "json"
+
+	MemoryPolicyInherit     = "inherit"
+	MemoryPolicyReadOnly    = "read_only"
+	MemoryPolicyAllowWrites = "allow_writes"
+)
+
+// Job describes the explicit contract for a delegated run.
+type Job struct {
+	Model         string
+	Thinking      string
+	ToolAllowlist []string
+	WorkspaceRoot string
+	MaxToolCalls  int
+	MaxDuration   time.Duration
+	OutputFormat  string
+	OutputSchema  string
+	MemoryPolicy  string
+}
+
+// WithDefaults returns a normalized copy with stable defaults.
+func (j Job) WithDefaults() Job {
+	if j.MaxToolCalls <= 0 {
+		j.MaxToolCalls = DefaultMaxToolCalls
+	}
+	if j.MaxDuration <= 0 {
+		j.MaxDuration = DefaultMaxDuration
+	}
+	j.OutputFormat = NormalizeOutputFormat(j.OutputFormat)
+	j.MemoryPolicy = NormalizeMemoryPolicy(j.MemoryPolicy)
+	j.Model = strings.TrimSpace(j.Model)
+	j.Thinking = strings.TrimSpace(j.Thinking)
+	j.OutputSchema = strings.TrimSpace(j.OutputSchema)
+	j.WorkspaceRoot = strings.TrimSpace(j.WorkspaceRoot)
+	j.ToolAllowlist = CompactToolAllowlist(j.ToolAllowlist)
+	return j
+}
+
+// ContractPrompt wraps a task with a machine-readable delegated-run contract.
+func (j Job) ContractPrompt(task string) string {
+	j = j.WithDefaults()
+	task = strings.TrimSpace(task)
+
+	lines := []string{
+		"You are executing a delegated run.",
+		"",
+		"TASK:",
+		task,
+		"",
+		"EXECUTION CONTRACT:",
+		fmt.Sprintf("- max_tool_calls: %d", j.MaxToolCalls),
+		fmt.Sprintf("- max_duration: %s", j.MaxDuration),
+		fmt.Sprintf("- model_override: %s", valueOrInherit(j.Model)),
+		fmt.Sprintf("- thinking_level: %s", valueOrInherit(j.Thinking)),
+		fmt.Sprintf("- output_format: %s", j.OutputFormat),
+		fmt.Sprintf("- memory_policy: %s", j.MemoryPolicy),
+	}
+	if j.OutputSchema != "" {
+		lines = append(lines, fmt.Sprintf("- output_schema: %s", j.OutputSchema))
+	}
+	if len(j.ToolAllowlist) > 0 {
+		lines = append(lines, fmt.Sprintf("- tool_allowlist: %s", strings.Join(j.ToolAllowlist, ", ")))
+	}
+	if j.WorkspaceRoot != "" {
+		lines = append(lines, fmt.Sprintf("- workspace_root: %s", j.WorkspaceRoot))
+	}
+
+	lines = append(lines, "", "REQUIREMENTS:")
+	switch j.OutputFormat {
+	case OutputFormatJSON:
+		lines = append(lines, "- Final response must be valid JSON.")
+	case OutputFormatText:
+		lines = append(lines, "- Final response must be concise plain text.")
+	default:
+		lines = append(lines, "- Final response must be concise Markdown.")
+	}
+	if j.OutputSchema != "" {
+		lines = append(lines, "- Final response must follow this exact output shape: "+j.OutputSchema)
+	}
+	if len(j.ToolAllowlist) > 0 {
+		lines = append(lines, "- Use only tools from the allowlist above.")
+	}
+	if j.MemoryPolicy == MemoryPolicyReadOnly {
+		lines = append(lines, "- Do not write to MEMORY.md, memory/*.md, or other long-term notes.")
+	}
+	if j.MemoryPolicy == MemoryPolicyAllowWrites {
+		lines = append(lines, "- Memory writes are allowed only when they are necessary for task completion.")
+	}
+	if j.WorkspaceRoot != "" {
+		lines = append(lines, "- Keep file work scoped to the declared workspace_root.")
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// CompletionSummary renders a readable operator-facing summary for a delegated run.
+func (j Job) CompletionSummary(result string) string {
+	j = j.WithDefaults()
+	result = strings.TrimSpace(result)
+	if result == "" {
+		result = "Task completed with no output."
+	}
+	result = trimForSummary(result, 1500)
+
+	lines := []string{
+		"Run contract:",
+		fmt.Sprintf("- Budget: %d tool calls / %s", j.MaxToolCalls, j.MaxDuration),
+		fmt.Sprintf("- Output: %s", outputSummary(j.OutputFormat, j.OutputSchema)),
+		fmt.Sprintf("- Memory: %s", j.MemoryPolicy),
+	}
+	if j.Model != "" || j.Thinking != "" {
+		lines = append(lines, fmt.Sprintf("- Model: %s", modelSummary(j.Model, j.Thinking)))
+	}
+	lines = append(lines, "", "Result:", result)
+	return strings.Join(lines, "\n")
+}
+
+func ParseOutputFormat(s string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case OutputFormatText:
+		return OutputFormatText, true
+	case OutputFormatMarkdown:
+		return OutputFormatMarkdown, true
+	case OutputFormatJSON:
+		return OutputFormatJSON, true
+	default:
+		return "", false
+	}
+}
+
+func NormalizeOutputFormat(s string) string {
+	if v, ok := ParseOutputFormat(s); ok {
+		return v
+	}
+	return OutputFormatMarkdown
+}
+
+func ParseMemoryPolicy(s string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case MemoryPolicyInherit:
+		return MemoryPolicyInherit, true
+	case MemoryPolicyReadOnly:
+		return MemoryPolicyReadOnly, true
+	case MemoryPolicyAllowWrites:
+		return MemoryPolicyAllowWrites, true
+	default:
+		return "", false
+	}
+}
+
+func NormalizeMemoryPolicy(s string) string {
+	if v, ok := ParseMemoryPolicy(s); ok {
+		return v
+	}
+	return MemoryPolicyReadOnly
+}
+
+// CompactToolAllowlist returns a trimmed, de-duplicated allowlist.
+func CompactToolAllowlist(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}
+
+func outputSummary(format, schema string) string {
+	if schema == "" {
+		return format
+	}
+	return format + " (" + schema + ")"
+}
+
+func modelSummary(model, thinking string) string {
+	if model == "" {
+		model = "inherit"
+	}
+	if thinking == "" {
+		thinking = "inherit"
+	}
+	return fmt.Sprintf("%s / thinking=%s", model, thinking)
+}
+
+func valueOrInherit(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "inherit"
+	}
+	return s
+}
+
+func trimForSummary(s string, limit int) string {
+	if limit <= 0 || len(s) <= limit {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= limit {
+		return s
+	}
+	return strings.TrimSpace(string(runes[:limit])) + "..."
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -71,6 +71,8 @@ type AckHandle interface {
 	Update(payload any)
 	// Close marks the request done. nil err means success.
 	Close(err error)
+	// CloseWithSummary marks the request done and forwards a human-readable summary.
+	CloseWithSummary(summary string, err error)
 }
 
 // RunFunc is the work to be executed for a session request.
@@ -349,6 +351,10 @@ func (h *handle) Update(payload any) {
 }
 
 func (h *handle) Close(err error) {
+	h.CloseWithSummary("", err)
+}
+
+func (h *handle) CloseWithSummary(summary string, err error) {
 	h.closeOnce.Do(func() {
 		evType := EventDone
 		if err != nil {
@@ -362,6 +368,6 @@ func (h *handle) Close(err error) {
 			Timestamp:  time.Now(),
 		})
 		// Route completion to parent session if registered.
-		h.hub.notifyParent(h.sessionKey, "", err)
+		h.hub.notifyParent(h.sessionKey, summary, err)
 	})
 }

--- a/internal/runtime/subagent.go
+++ b/internal/runtime/subagent.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/session"
 )
 
@@ -18,19 +19,8 @@ type SubagentSpawnRequest struct {
 	// Task is the task description sent to the sub-agent.
 	Task string
 
-	// Model is the model identifier to use for the sub-agent run.
-	// Empty string means the sub-agent inherits the default model.
-	Model string
-
-	// Thinking controls the reasoning level: "off", "low", "medium", "high".
-	Thinking string
-
-	// ToolAllowlist is the set of tool names the sub-agent is permitted to call.
-	// An empty slice means no restriction (all tools allowed).
-	ToolAllowlist []string
-
-	// WorkspaceRoot is the absolute path scoped to the sub-agent's workspace.
-	WorkspaceRoot string
+	// Job carries the explicit delegated-run contract for this sub-agent.
+	Job delegation.Job
 
 	// DeliverBack, when true, routes the sub-agent result back to the parent session.
 	DeliverBack bool

--- a/internal/runtime/subagent_test.go
+++ b/internal/runtime/subagent_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"ok-gobot/internal/delegation"
 )
 
 // TestExtractAgentID verifies that agent IDs are correctly parsed from session keys.
@@ -67,11 +69,13 @@ func TestSpawnSubagentSessionKeyFormat(t *testing.T) {
 	req := SubagentSpawnRequest{
 		ParentSessionKey: "agent:testAgent:telegram:dm:42",
 		Task:             "do something",
-		Model:            "claude-3-haiku",
-		Thinking:         "low",
-		ToolAllowlist:    []string{"search", "file"},
-		WorkspaceRoot:    "/tmp/workspace",
-		DeliverBack:      true,
+		Job: delegation.Job{
+			Model:         "claude-3-haiku",
+			Thinking:      "low",
+			ToolAllowlist: []string{"search", "file"},
+			WorkspaceRoot: "/tmp/workspace",
+		},
+		DeliverBack: true,
 	}
 
 	done := make(chan struct{})

--- a/internal/tools/browser_task.go
+++ b/internal/tools/browser_task.go
@@ -5,13 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"ok-gobot/internal/delegation"
 )
 
 // SubagentSubmitter allows tools to spawn subagent runs and wait for results.
 type SubagentSubmitter interface {
-	// SubmitAndWait spawns a subagent with the given task prompt and waits
-	// for completion up to the timeout. Returns the agent's text response.
-	SubmitAndWait(ctx context.Context, chatID int64, task string, timeout time.Duration) (string, error)
+	// SubmitAndWait spawns a subagent with an explicit delegated-run contract.
+	SubmitAndWait(ctx context.Context, chatID int64, task string, job delegation.Job) (string, error)
 }
 
 // BrowserTaskTool decomposes browser tasks into subagent runs.
@@ -67,7 +68,18 @@ RULES:
 - Be concise — extract the specific data requested, nothing more
 - Do NOT send messages to the user — just return your findings as your final response`, task)
 
-	result, err := t.submitter.SubmitAndWait(ctx, t.chatID, prompt, 3*time.Minute)
+	job := delegation.Job{
+		MaxToolCalls: 50,
+		MaxDuration:  3 * time.Minute,
+		OutputFormat: delegation.OutputFormatText,
+		OutputSchema: `Return extracted findings only. On failure use "BLOCKED: <reason>" or "NOT_FOUND: <reason>".`,
+		MemoryPolicy: delegation.MemoryPolicyReadOnly,
+		ToolAllowlist: []string{
+			"browser",
+		},
+	}.WithDefaults()
+
+	result, err := t.submitter.SubmitAndWait(ctx, t.chatID, prompt, job)
 	if err != nil {
 		return "", fmt.Errorf("browser task failed: %w", err)
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -34,7 +34,7 @@ const (
 type paneFocus int
 
 const (
-	focusChat     paneFocus = iota
+	focusChat paneFocus = iota
 	focusSessions
 )
 
@@ -61,8 +61,8 @@ type Model struct {
 	chatPaneWidth int
 
 	// state
-	screen    screen
-	paneFocus paneFocus
+	screen     screen
+	paneFocus  paneFocus
 	conn       *wsConn
 	serverAddr string
 
@@ -676,7 +676,11 @@ func (m *Model) handleEvent(msg controlserver.ServerMsg) tea.Cmd {
 		if label == "" {
 			label = "sub-agent"
 		}
-		m.addEntry(chatEntry{role: "system", content: fmt.Sprintf("Sub-agent completed: %s", label)})
+		content := fmt.Sprintf("Sub-agent completed: %s", label)
+		if strings.TrimSpace(msg.Content) != "" {
+			content += "\n\n" + msg.Content
+		}
+		m.addEntry(chatEntry{role: "system", content: content})
 		m.refreshViewport()
 
 	case controlserver.KindChildFailed:
@@ -1204,6 +1208,11 @@ func (m *Model) sendSpawnCmd(req SubagentSpawnRequest) {
 		Thinking:      req.ThinkingLevel,
 		ToolAllowlist: req.AllowedTools,
 		WorkspaceRoot: req.WorkspaceRoot,
+		MaxToolCalls:  req.MaxToolCalls,
+		MaxDuration:   req.MaxDuration,
+		OutputFormat:  req.OutputFormat,
+		OutputSchema:  req.OutputSchema,
+		MemoryPolicy:  req.MemoryPolicy,
 		DeliverBack:   true,
 	})
 }

--- a/internal/tui/spawn.go
+++ b/internal/tui/spawn.go
@@ -2,11 +2,14 @@
 package tui
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"ok-gobot/internal/delegation"
 )
 
 // SubagentSpawnRequest holds all fields required to spawn a sub-agent session.
@@ -16,6 +19,11 @@ type SubagentSpawnRequest struct {
 	ThinkingLevel string   // "off", "low", "medium", "high", "adaptive"
 	AllowedTools  []string // tool names the sub-agent is permitted to use
 	WorkspaceRoot string   // absolute path to the workspace root
+	MaxToolCalls  int      // explicit tool-call budget (0 = server default)
+	MaxDuration   string   // duration string, e.g. 3m
+	OutputFormat  string   // text, markdown, json
+	OutputSchema  string   // optional shape/schema hint
+	MemoryPolicy  string   // inherit, read_only, allow_writes
 }
 
 // spawnConfirmedMsg is sent when the user submits the spawn form.
@@ -33,6 +41,11 @@ const (
 	fieldThinking
 	fieldTools
 	fieldWorkspace
+	fieldMaxTools
+	fieldMaxDuration
+	fieldOutputFormat
+	fieldOutputSchema
+	fieldMemoryPolicy
 	fieldCount
 )
 
@@ -42,6 +55,11 @@ var fieldLabels = [fieldCount]string{
 	"Thinking level (off/low/medium/high/adaptive)",
 	"Allowed tools (comma-separated)",
 	"Workspace root",
+	"Max tool calls",
+	"Max duration (e.g. 3m)",
+	"Output format (text/markdown/json)",
+	"Output schema",
+	"Memory policy (inherit/read_only/allow_writes)",
 }
 
 var thinkingLevels = []string{"off", "low", "medium", "high", "adaptive"}
@@ -71,6 +89,16 @@ func NewSpawnDialog() SpawnDialog {
 	inputs[fieldTools].Placeholder = "local,file,grep (leave empty for all)"
 
 	inputs[fieldWorkspace].Placeholder = "/path/to/workspace"
+
+	inputs[fieldMaxTools].Placeholder = "50"
+
+	inputs[fieldMaxDuration].Placeholder = "10m"
+
+	inputs[fieldOutputFormat].Placeholder = "markdown"
+
+	inputs[fieldOutputSchema].Placeholder = "Short summary or JSON object shape"
+
+	inputs[fieldMemoryPolicy].Placeholder = "read_only"
 
 	return SpawnDialog{
 		inputs:  inputs,
@@ -129,10 +157,17 @@ func (d SpawnDialog) submit() tea.Cmd {
 		Model:         strings.TrimSpace(d.inputs[fieldModel].Value()),
 		ThinkingLevel: strings.TrimSpace(d.inputs[fieldThinking].Value()),
 		WorkspaceRoot: strings.TrimSpace(d.inputs[fieldWorkspace].Value()),
+		MaxDuration:   strings.TrimSpace(d.inputs[fieldMaxDuration].Value()),
+		OutputFormat:  strings.TrimSpace(d.inputs[fieldOutputFormat].Value()),
+		OutputSchema:  strings.TrimSpace(d.inputs[fieldOutputSchema].Value()),
+		MemoryPolicy:  strings.TrimSpace(d.inputs[fieldMemoryPolicy].Value()),
 	}
 
 	// Validate / normalise ThinkingLevel.
 	req.ThinkingLevel = normaliseThinkingLevel(req.ThinkingLevel)
+	req.OutputFormat = normaliseOutputFormat(req.OutputFormat)
+	req.MemoryPolicy = normaliseMemoryPolicy(req.MemoryPolicy)
+	req.MaxToolCalls = parsePositiveInt(d.inputs[fieldMaxTools].Value())
 
 	// Parse tool allowlist.
 	rawTools := strings.TrimSpace(d.inputs[fieldTools].Value())
@@ -194,4 +229,30 @@ func normaliseThinkingLevel(s string) string {
 		}
 	}
 	return "off"
+}
+
+func normaliseOutputFormat(s string) string {
+	if v, ok := delegation.ParseOutputFormat(s); ok {
+		return v
+	}
+	return delegation.OutputFormatMarkdown
+}
+
+func normaliseMemoryPolicy(s string) string {
+	if v, ok := delegation.ParseMemoryPolicy(s); ok {
+		return v
+	}
+	return delegation.MemoryPolicyReadOnly
+}
+
+func parsePositiveInt(s string) int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
 }


### PR DESCRIPTION
Closes #177

## What changed
- added a shared delegated-run contract (`internal/delegation.Job`) with explicit `max_tool_calls`, `max_duration`, `output_format`, `output_schema`, `memory_policy`, plus model/thinking overrides and tool allowlists
- threaded that contract through delegated execution paths: agent runtime subagents, `browser_task`, TUI/control `spawn_subagent`, Telegram `/task`, and the legacy bot subagent RPC
- enforced delegated-run limits in runtime by applying `max_duration` as a run context timeout and `max_tool_calls` inside `ToolCallingAgent`
- normalized child completion reporting so TUI/control child notifications now carry structured summaries instead of only a child session key
- updated TUI spawn inputs and API docs to expose the new delegated-run contract fields

## Targeted verification
- `go build ./...`
- `go test ./internal/agent ./internal/tools ./internal/control ./internal/runtime ./internal/tui`
- `go test ./internal/bot -run TestParseTaskArgs -count=1`

## Full suite
- `go test ./...` failed

## Known pre-existing or unrelated failures
- `internal/ai`: `TestAnthropicClientOAuthHeadersAndBetaQuery` fails with unexpected OAuth header behavior / EOF
- `internal/storage`: multiple `sqlite_v2` and `sqlite_schema` tests fail during migration with `canonical session backfill failed: table sessions_v2 has no column named state`
- `internal/bot`: DM auth tests fail with the same storage migration error, and `TestLiveStreamEditor_ScheduleEdit_TokenThreshold` times out

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a well-designed `delegation.Job` contract that threads explicit budgets (`max_tool_calls`, `max_duration`), output contracts (`output_format`, `output_schema`), and memory policy through every delegated-execution path: the agent runtime hub, `browser_task`, TUI/control `spawn_subagent`, Telegram `/task`, and the legacy bot subagent RPC. The architecture is clean — normalization lives in one place (`WithDefaults`), enforcement is split between the context-timeout layer and the `ToolCallingAgent` loop, and child-completion notifications now carry structured summaries via `ChildCompletionPayload.Summary`.

Key issues found:

- **`--schema` value truncated at whitespace** (`internal/bot/task_command.go:79`): the `/task` command parser captures only a single token for `--schema`, so any JSON schema containing spaces is silently truncated. Remaining tokens bleed into the task description.
- **Silent ack drop on special characters in task description** (`internal/bot/task_command.go:137`): `req.Description` is interpolated without escaping into a `ModeMarkdown` Telegram message, causing silent send failures if the description contains backticks, asterisks, or brackets.
- **`IsFallback` not set on budget-exceeded path** (`internal/agent/tool_agent.go:232`): every other synthetic fallback path sets `IsFallback: true`, but the tool-call-budget-exceeded branch does not, making the budget warning message look like a genuine model response to consumers that check this field.
- **`cmd.DeliverBack` silently ignored** (`internal/control/server_tui.go:311`): the `deliver_back` field in `ClientMsg` is never read; `DeliverBack` is hardcoded `true` in all spawns.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor fixes; no data-loss or security issues, but the `--schema` truncation and unescaped Markdown ack are user-facing bugs worth addressing before wide rollout.
- The core delegation contract, timeout enforcement, and tool-budget tracking are all correctly implemented. The four issues found are either UX/surface bugs (`--schema` truncation, Markdown escaping) or minor inconsistencies (`IsFallback` flag, dead `deliver_back` field) that don't affect runtime correctness or data integrity. The known test suite failures are all pre-existing and unrelated to this change.
- `internal/bot/task_command.go` (two user-facing bugs: schema truncation and Markdown escaping of task description)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/delegation/job.go | New central contract type for delegated runs. Well-structured with proper validation, UTF-8-aware truncation (via rune slice), and clear normalization helpers. |
| internal/agent/runtime.go | Hub now threads delegation.Job through Submit and applies MaxDuration as a child timeout. SubmitAndWait correctly distinguishes deadline errors, though the DeadlineExceeded message may reflect the job budget rather than the actual deadline that fired (noted in prior thread). |
| internal/agent/tool_agent.go | MaxToolCalls budget check is correctly placed pre-execution inside the inner loop; break iterationLoop is correct. Minor issue: IsFallback is not set to true when the budget-exceeded synthetic message is returned. |
| internal/bot/task_command.go | parseTaskArgs correctly routes all new delegation fields. Two issues: --schema only captures a single whitespace-delimited token (breaks JSON schemas with spaces), and req.Description is interpolated unescaped into a Telegram Markdown message which will cause parse errors if the description contains backtick/asterisk characters. |
| internal/control/server_tui.go | CmdSpawnSubagent handler correctly builds the job and wires the child run. Minor: cmd.DeliverBack is silently ignored and always overridden to true, making the client-facing field a no-op. |
| internal/control/tui_types.go | New fields for delegation contract added to ClientMsg. DeliverBack field is defined but ignored in the handler (always overridden to true). |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/bot/task_command.go
Line: 79-84

Comment:
**`--schema` silently truncates at whitespace**

`words[i]` captures only a single whitespace-delimited token. Any JSON/structural schema that contains spaces — e.g. `/task summarize --schema {"title": "string", "count": "int"}` — will have its value truncated at the first space, with the remaining tokens silently falling into `descWords` as part of the task description. Since `OutputSchema` is specifically described as an "output shape/schema hint", multi-word JSON schemas are a natural use-case.

Consider collecting tokens until the next flag or end-of-input (similar to how descriptions work), or document that the value must be a single token and quote accordingly in the help text.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/bot/task_command.go
Line: 137-140

Comment:
**Unescaped description in Markdown message may silently drop the ack**

`req.Description` is interpolated directly into `ackText` which is sent with `telebot.ModeMarkdown`. If the user's task description contains Markdown-special characters (backticks, asterisks, underscores, brackets), Telegram will return a parse error. The error is caught and logged — the user sees nothing — and the run still starts, so the only visible effect is a missing acknowledgment.

Consider wrapping `req.Description` in `telebot.Escape` / stripping it of Markdown entities, or switching the task line to a plain-text segment and applying Markdown only to the structured fields above it.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/agent/tool_agent.go
Line: 232-235

Comment:
**`IsFallback` not set when tool-call budget is exhausted**

When `maxToolCalls > 0 && toolCallsUsed >= maxToolCalls`, the function breaks out of `iterationLoop` with a synthetic warning string in `finalResponse`, then falls through to the normal return at line 311 with `IsFallback` left as its zero value (`false`). Every other synthetic/error path (iteration-limit exceeded, empty model output, tool-executed-but-model-failed) explicitly sets `IsFallback: true`. Consumers that gate on this field to decide whether to surface or log the result differently will incorrectly treat the budget-exceeded message as a genuine model response.

```suggestion
			if maxToolCalls > 0 && toolCallsUsed >= maxToolCalls {
				return &AgentResponse{
					Message:          fmt.Sprintf("⚠️ Reached tool-call budget (%d). Task not finished.", maxToolCalls),
					ToolUsed:         len(usedTools) > 0,
					ToolName:         strings.Join(usedTools, ", "),
					ToolResult:       strings.Join(toolResults, "\n\n"),
					PromptTokens:     lastPromptTokens,
					CompletionTokens: totalCompletionTokens,
					TotalTokens:      lastTotalTokens,
					IsFallback:       true,
				}, nil
			}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/control/server_tui.go
Line: 311-316

Comment:
**`cmd.DeliverBack` is silently ignored**

`ClientMsg` exposes a `deliver_back` JSON field and the `CmdSpawnSubagent` handler reads `cmd` to build the job, but `req.DeliverBack` is always hardcoded to `true` — the client-provided value is never consulted. This makes the `deliver_back` field a dead no-op in the protocol.

If always-deliver is intentional, the field should be removed from `ClientMsg` (and not surfaced in the API docs) to avoid misleading integrators. If opt-out is a desired capability, replace `DeliverBack: true` with `DeliverBack: cmd.DeliverBack`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 807f69b</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->