### PR TITLE
feat: feat(runtime): chat routing chooses reply, clarification, or job launch (#171)

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -180,6 +180,14 @@ Commands: `/queue collect|steer|interrupt [debounce_ms]`
 
 **Files:** `internal/bot/queue.go`
 
+### Rules-First Chat Routing
+Incoming chat turns are classified before execution:
+- **reply** — lightweight turns stay on the inline AI reply path
+- **clarification** — underspecified work requests get a short follow-up question first
+- **background job** — obvious heavy work is launched as an explicit isolated task instead of blocking the main chat session
+
+**Files:** `internal/runtime/chat_router.go`, `internal/bot/chat_routing.go`
+
 ### Usage Footer
 Optional token usage display appended to AI responses. Modes: `off` (default), `tokens`, `full`.
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -84,13 +84,13 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 	// root so that file/path tools resolve relative paths against the configured soul
 	// directory instead of the process working directory.
 	toolsConfig := &tools.ToolsConfig{
-		OpenAIAPIKey:   aiCfg.APIKey,
-		TTSProvider:    ttsCfg.Provider,
-		TTSVoice:       ttsCfg.DefaultVoice,
+		OpenAIAPIKey:    aiCfg.APIKey,
+		TTSProvider:     ttsCfg.Provider,
+		TTSVoice:        ttsCfg.DefaultVoice,
 		ChromePath:      browserCfg.ChromePath,
 		BrowserProfile:  browserCfg.ProfilePath,
 		BrowserDebugURL: browserCfg.DebugURL,
-		MemoryManager:  memoryManager,
+		MemoryManager:   memoryManager,
 	}
 	toolRegistry, _ := tools.LoadFromConfigWithOptions(personality.BasePath, toolsConfig)
 
@@ -440,6 +440,7 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 	// Route through the runtime hub.
 	if b.ai != nil {
 		sessionKey := sessionKeyForChat(msg.Chat)
+		preDecision := runtime.DecideChatRoute(content)
 		if err := b.store.SaveSessionRoute(storage.SessionRoute{
 			SessionKey:       string(sessionKey),
 			Channel:          "telegram",
@@ -451,43 +452,24 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 			log.Printf("[bot] failed to persist session route for %s: %v", sessionKey, err)
 		}
 
-		// Check queue mode — if a run is active this may queue, steer, or interrupt.
-		if b.handleWithQueueMode(ctx, sessionKey, chatID, content) {
-			// Session was busy — send ⏳ queued placeholder immediately so the user
-			// knows their message was received while a run was in progress.
-			b.sendQueuedAck(c.Chat())
-			return nil
+		if preDecision.Action == runtime.ChatActionReply {
+			// Check queue mode — if a run is active this may queue, steer, or interrupt.
+			if b.handleWithQueueMode(ctx, sessionKey, chatID, content) {
+				// Session was busy — send ⏳ queued placeholder immediately so the user
+				// knows their message was received while a run was in progress.
+				b.sendQueuedAck(c.Chat())
+				return nil
+			}
 		}
 
 		// Send ⏳ placeholder and typing indicator immediately (within ~0ms of receipt),
 		// before the debounce window and any AI processing.
-		b.sendImmediateAck(c.Chat())
+		canReuseAck := b.sendImmediateAck(c.Chat()) != nil
 
 		// Fragment buffering → debounce → process via hub.
 		b.fragmentBuffer.TryBuffer(chatID, userID, msg.ID, content, func(assembled string) {
 			b.debouncer.Debounce(chatID, assembled, func(combined string) {
-				b.queueManager.StartRun(chatID)
-				defer func() {
-					// Process any messages that were queued while the run was active.
-					queued := b.queueManager.EndRun(chatID)
-					if len(queued) > 0 {
-						logger.Debugf("Bot: processing %d queued messages for chat=%d", len(queued), chatID)
-						for _, qMsg := range queued {
-							b.debouncer.Debounce(chatID, qMsg, func(qCombined string) {
-								session, _ := b.store.GetSession(chatID)
-								b.sendImmediateAck(c.Chat())
-								b.processViaHub(ctx, c, sessionKey, qCombined, session) //nolint:errcheck
-							})
-						}
-					}
-				}()
-
-				session, err := b.store.GetSession(chatID)
-				if err != nil {
-					log.Printf("Failed to get session: %v", err)
-				}
-
-				if err := b.processViaHub(ctx, c, sessionKey, combined, session); err != nil {
+				if err := b.handleCombinedChatTurn(ctx, c, sessionKey, combined, canReuseAck); err != nil {
 					log.Printf("Failed to handle agent request: %v", err)
 					c.Send("❌ Sorry, I encountered an error processing your request.") //nolint:errcheck
 				}
@@ -1030,23 +1012,23 @@ func (b *Bot) takeAck(chatID int64) *telebot.Message {
 // immediately upon receiving an inbound Telegram message, before any debounce or AI processing.
 // The placeholder message ID is stored in ackManager for subsequent live-edit updates.
 // Only one ack is created per chat — if one already exists the call is a no-op.
-func (b *Bot) sendImmediateAck(chat *telebot.Chat) {
-	b.sendAck(chat, "⏳")
+func (b *Bot) sendImmediateAck(chat *telebot.Chat) *telebot.Message {
+	return b.sendAck(chat, "⏳")
 }
 
 // sendQueuedAck sends a ⏳ queued placeholder immediately when a message arrives
 // while the session is already busy processing another request.
 // Only one ack is created per chat — if one already exists the call is a no-op.
-func (b *Bot) sendQueuedAck(chat *telebot.Chat) {
-	b.sendAck(chat, "⏳ queued — previous run in progress")
+func (b *Bot) sendQueuedAck(chat *telebot.Chat) *telebot.Message {
+	return b.sendAck(chat, "⏳ queued - previous run in progress")
 }
 
 // sendAck sends a placeholder message with text and a typing indicator in parallel.
 // Only one ack is created per chat — if one already exists the call is a no-op.
-func (b *Bot) sendAck(chat *telebot.Chat, text string) {
+func (b *Bot) sendAck(chat *telebot.Chat, text string) *telebot.Message {
 	chatID := chat.ID
 	if b.ackManager.Exists(chatID) {
-		return
+		return nil
 	}
 
 	// Typing indicator in parallel — satisfies "sendChatAction immediately" requirement
@@ -1056,11 +1038,12 @@ func (b *Bot) sendAck(chat *telebot.Chat, text string) {
 	ackMsg, err := b.api.Send(chat, text)
 	if err != nil {
 		log.Printf("[ack] failed to send placeholder for chat=%d: %v", chatID, err)
-		return
+		return nil
 	}
 
 	b.ackManager.Set(chatID, &AckHandle{Message: ackMsg, ChatID: chatID})
 	log.Printf("[ack] placeholder sent for chat=%d msg_id=%d text=%q", chatID, ackMsg.ID, text)
+	return ackMsg
 }
 
 // SetupLocalCommandApproval configures the LocalCommand tool with approval function

--- a/internal/bot/chat_routing.go
+++ b/internal/bot/chat_routing.go
@@ -1,0 +1,198 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/agent"
+	runtimepkg "ok-gobot/internal/runtime"
+)
+
+type taskNotificationStyle struct {
+	doneHeading string
+	failHeading string
+}
+
+var (
+	taskCommandNotifications = taskNotificationStyle{
+		doneHeading: "✅ *Task completed*",
+		failHeading: "❌ *Task failed*",
+	}
+	backgroundJobNotifications = taskNotificationStyle{
+		doneHeading: "✅ *Background job completed*",
+		failHeading: "❌ *Background job failed*",
+	}
+)
+
+func (b *Bot) handleCombinedChatTurn(
+	ctx context.Context,
+	c telebot.Context,
+	sessionKey agent.SessionKey,
+	content string,
+	canReuseAck bool,
+) error {
+	decision := runtimepkg.DecideChatRoute(content)
+	chatID := c.Chat().ID
+	loggerReason := decision.Reason
+	if loggerReason == "" {
+		loggerReason = "unspecified"
+	}
+	log.Printf("[router] chat=%d action=%s reason=%s", chatID, decision.Action, loggerReason)
+
+	switch decision.Action {
+	case runtimepkg.ChatActionClarify:
+		return b.respondWithClarification(c, sessionKey, content, decision.Clarification, canReuseAck)
+	case runtimepkg.ChatActionLaunchJob:
+		return b.launchBackgroundJob(c, content, canReuseAck)
+	default:
+		b.queueManager.StartRun(chatID)
+		defer b.flushQueuedMessages(ctx, c, sessionKey, chatID)
+
+		session, err := b.store.GetSession(chatID)
+		if err != nil {
+			log.Printf("Failed to get session: %v", err)
+		}
+
+		if err := b.processViaHub(ctx, c, sessionKey, content, session); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func (b *Bot) flushQueuedMessages(ctx context.Context, c telebot.Context, sessionKey agent.SessionKey, chatID int64) {
+	queued := b.queueManager.EndRun(chatID)
+	if len(queued) == 0 {
+		return
+	}
+
+	log.Printf("[router] processing %d queued messages for chat=%d", len(queued), chatID)
+	for _, queuedContent := range queued {
+		qContent := queuedContent
+		canReuseAck := b.sendImmediateAck(c.Chat()) != nil
+		b.debouncer.Debounce(chatID, qContent, func(qCombined string) {
+			if err := b.handleCombinedChatTurn(ctx, c, sessionKey, qCombined, canReuseAck); err != nil {
+				log.Printf("Failed to handle queued agent request: %v", err)
+				c.Send("❌ Sorry, I encountered an error processing your request.") //nolint:errcheck
+			}
+		})
+	}
+}
+
+func (b *Bot) respondWithClarification(
+	c telebot.Context,
+	sessionKey agent.SessionKey,
+	userContent string,
+	clarification string,
+	canReuseAck bool,
+) error {
+	if clarification == "" {
+		clarification = "What should I work on exactly?"
+	}
+	if err := b.deliverRoutingText(c, clarification, canReuseAck); err != nil {
+		return err
+	}
+
+	chatID := c.Chat().ID
+	if err := b.store.SaveSession(chatID, clarification); err != nil {
+		log.Printf("[router] failed to save clarification session for chat=%d: %v", chatID, err)
+	}
+	if err := b.store.SaveSessionMessagePairV2(string(sessionKey), userContent, clarification); err != nil {
+		log.Printf("[router] failed to persist clarification transcript for chat=%d: %v", chatID, err)
+	}
+	if err := b.memory.AppendToToday(fmt.Sprintf("Assistant (router): %s", clarification)); err != nil {
+		log.Printf("[router] failed to append clarification to memory for chat=%d: %v", chatID, err)
+	}
+	return nil
+}
+
+func (b *Bot) launchBackgroundJob(c telebot.Context, task string, canReuseAck bool) error {
+	ackText := fmt.Sprintf("⚙️ Background job started\nTask: %s", abbreviateForAck(task, 160))
+	if err := b.deliverRoutingText(c, ackText, canReuseAck); err != nil {
+		return err
+	}
+
+	b.startTaskRun(c.Chat(), c.Chat().ID, agent.SubagentSpawnRequest{Description: task}, backgroundJobNotifications)
+	return nil
+}
+
+func (b *Bot) deliverRoutingText(c telebot.Context, text string, canReuseAck bool) error {
+	if canReuseAck {
+		if ackMsg := b.takeAck(c.Chat().ID); ackMsg != nil {
+			if _, err := b.api.Edit(ackMsg, text); err == nil {
+				return nil
+			}
+			_ = b.api.Delete(ackMsg)
+		}
+	}
+	return c.Send(text)
+}
+
+func (b *Bot) startTaskRun(chat *telebot.Chat, chatID int64, req agent.SubagentSpawnRequest, style taskNotificationStyle) {
+	model := req.Model
+	if model != "" {
+		model = b.resolveModelAlias(model)
+	}
+
+	go func() {
+		log.Printf("[task] spawning sub-agent for chat=%d model=%s thinking=%s desc=%.80s",
+			chatID, model, req.ThinkLevel, req.Description)
+
+		subKey := agent.SessionKey(fmt.Sprintf("subagent:%d:%d", chatID, time.Now().UnixNano()))
+
+		var overrides *agent.RunOverrides
+		if model != "" || req.ThinkLevel != "" {
+			overrides = &agent.RunOverrides{Model: model, ThinkLevel: req.ThinkLevel}
+		}
+
+		events := b.hub.Submit(agent.RunRequest{
+			SessionKey: subKey,
+			ChatID:     chatID,
+			Content:    req.Description,
+			Session:    "",
+			Context:    context.Background(),
+			Overrides:  overrides,
+		})
+
+		var notifText string
+		for ev := range events {
+			switch ev.Type {
+			case agent.RunEventDone:
+				summary := ev.Result.Message
+				if strings.TrimSpace(summary) == "" {
+					summary = "Task completed with no output."
+				}
+				notifText = fmt.Sprintf("%s\n\n%s", style.doneHeading, summary)
+			case agent.RunEventError:
+				notifText = fmt.Sprintf("%s\n\n%s", style.failHeading, ev.Err.Error())
+			}
+		}
+
+		if notifText != "" {
+			if _, err := b.api.Send(chat, notifText, &telebot.SendOptions{ParseMode: telebot.ModeMarkdown}); err != nil {
+				log.Printf("[task] failed to send completion notification to chat=%d: %v", chatID, err)
+			}
+		}
+	}()
+}
+
+func abbreviateForAck(input string, maxRunes int) string {
+	compact := strings.Join(strings.Fields(strings.TrimSpace(input)), " ")
+	if compact == "" {
+		return ""
+	}
+
+	runes := []rune(compact)
+	if len(runes) <= maxRunes {
+		return compact
+	}
+	if maxRunes <= 3 {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-3]) + "..."
+}

--- a/internal/bot/chat_routing_test.go
+++ b/internal/bot/chat_routing_test.go
@@ -1,0 +1,39 @@
+package bot
+
+import "testing"
+
+func TestAbbreviateForAck(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		limit int
+		want  string
+	}{
+		{
+			name:  "keeps short text intact",
+			input: "investigate repo tests",
+			limit: 40,
+			want:  "investigate repo tests",
+		},
+		{
+			name:  "compacts whitespace before truncation",
+			input: "investigate   repo\n\nlogs now",
+			limit: 32,
+			want:  "investigate repo logs now",
+		},
+		{
+			name:  "truncates with ascii ellipsis",
+			input: "investigate the failing tests in the repository and prepare a fix",
+			limit: 24,
+			want:  "investigate the faili...",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := abbreviateForAck(tc.input, tc.limit); got != tc.want {
+				t.Fatalf("abbreviateForAck() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/bot/task_command.go
+++ b/internal/bot/task_command.go
@@ -1,11 +1,9 @@
 package bot
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"gopkg.in/telebot.v4"
 
@@ -92,51 +90,8 @@ func (b *Bot) handleTaskCommand(c telebot.Context) error {
 	// Capture chat reference for the notification goroutine.
 	chat := c.Chat()
 
-	go func() {
-		log.Printf("[task] spawning sub-agent for chat=%d model=%s thinking=%s desc=%.80s",
-			chatID, model, req.ThinkLevel, req.Description)
-
-		// Build a unique session key for the sub-agent run.
-		subKey := agent.SessionKey(fmt.Sprintf("subagent:%d:%d", chatID, time.Now().UnixNano()))
-
-		// Build overrides from the /task flags.
-		var overrides *agent.RunOverrides
-		if model != "" || req.ThinkLevel != "" {
-			overrides = &agent.RunOverrides{Model: model, ThinkLevel: req.ThinkLevel}
-		}
-
-		// Submit through the RuntimeHub — it owns agent creation and execution.
-		events := b.hub.Submit(agent.RunRequest{
-			SessionKey: subKey,
-			ChatID:     chatID,
-			Content:    req.Description,
-			Session:    "",
-			Context:    context.Background(),
-			Overrides:  overrides,
-		})
-
-		// Wait for result and send notification.
-		var notifText string
-		for ev := range events {
-			switch ev.Type {
-			case agent.RunEventDone:
-				summary := ev.Result.Message
-				if strings.TrimSpace(summary) == "" {
-					summary = "Task completed with no output."
-				}
-				notifText = fmt.Sprintf("✅ *Task completed*\n\n%s", summary)
-
-			case agent.RunEventError:
-				notifText = fmt.Sprintf("❌ *Task failed*\n\n%s", ev.Err.Error())
-			}
-		}
-
-		if notifText != "" {
-			if _, err := b.api.Send(chat, notifText, &telebot.SendOptions{ParseMode: telebot.ModeMarkdown}); err != nil {
-				log.Printf("[task] failed to send completion notification to chat=%d: %v", chatID, err)
-			}
-		}
-	}()
+	req.Model = model
+	b.startTaskRun(chat, chatID, req, taskCommandNotifications)
 
 	return nil
 }

--- a/internal/runtime/chat_router.go
+++ b/internal/runtime/chat_router.go
@@ -1,0 +1,199 @@
+package runtime
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ChatAction is the rules-first action chosen for an inbound chat turn.
+type ChatAction string
+
+const (
+	// ChatActionReply keeps the message on the fast inline reply path.
+	ChatActionReply ChatAction = "reply"
+	// ChatActionClarify asks the user for a missing detail before doing work.
+	ChatActionClarify ChatAction = "clarification"
+	// ChatActionLaunchJob moves the work onto an isolated background job path.
+	ChatActionLaunchJob ChatAction = "launch_job"
+)
+
+// ChatRouteDecision is the output of the rules-first chat router.
+type ChatRouteDecision struct {
+	Action        ChatAction
+	Reason        string
+	Clarification string
+}
+
+var (
+	ambiguousTaskPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`^(please )?(task|job|background job|background task)[.!?]*$`),
+		regexp.MustCompile(`^(please )?(help|start|continue|go ahead)[.!?]*$`),
+		regexp.MustCompile(`^(please )?(do|handle|work on|check|review|look into|investigate|analy[sz]e|debug|fix|run|build|implement|finish|summari[sz]e|compare)( (it|this|that|these|those))?[.!?]*$`),
+		regexp.MustCompile(`^(please )?(can|could) you (do|handle|work on|check|review|look into|investigate|analy[sz]e|debug|fix|run|build|implement|finish|summari[sz]e|compare)( (it|this|that|these|those))?[?!.]*$`),
+	}
+	heavyLeadPhrases = []string{
+		"investigate ",
+		"look into ",
+		"debug ",
+		"fix ",
+		"implement ",
+		"refactor ",
+		"review ",
+		"browse ",
+		"scrape ",
+		"run ",
+		"test ",
+		"build ",
+		"open a pr",
+		"create a pr",
+		"prepare a pr",
+	}
+	heavyContextTerms = []string{
+		"repo",
+		"repository",
+		"codebase",
+		"code",
+		"file",
+		"files",
+		"branch",
+		"commit",
+		"pr",
+		"pull request",
+		"issue",
+		"bug",
+		"failing test",
+		"tests",
+		"log",
+		"logs",
+		"stack trace",
+		"website",
+		"site",
+		"browser",
+		"page",
+		"pages",
+		"doc",
+		"docs",
+		"documentation",
+		"server",
+		"service",
+		"services",
+		"api",
+		"apis",
+	}
+	forcedJobPrefixes = []string{"job:", "task:", "background:"}
+)
+
+const defaultClarification = "What should I work on exactly? Include the repo, file, site, or desired outcome."
+
+// DecideChatRoute applies deterministic rules to keep lightweight turns on the
+// reply path while moving obvious work requests onto an explicit job path.
+func DecideChatRoute(input string) ChatRouteDecision {
+	raw := strings.TrimSpace(input)
+	if raw == "" {
+		return ChatRouteDecision{
+			Action:        ChatActionClarify,
+			Reason:        "empty_request",
+			Clarification: defaultClarification,
+		}
+	}
+
+	normalized := normalizeChatInput(raw)
+	if prefix, desc, ok := splitForcedJobPrefix(raw, normalized); ok {
+		descNorm := normalizeChatInput(desc)
+		if descNorm == "" || isAmbiguousTaskRequest(descNorm) {
+			return ChatRouteDecision{
+				Action:        ChatActionClarify,
+				Reason:        "forced_job_missing_scope",
+				Clarification: defaultClarification,
+			}
+		}
+		return ChatRouteDecision{
+			Action: ChatActionLaunchJob,
+			Reason: "forced_job_prefix:" + prefix,
+		}
+	}
+
+	if isAmbiguousTaskRequest(normalized) {
+		return ChatRouteDecision{
+			Action:        ChatActionClarify,
+			Reason:        "ambiguous_task_request",
+			Clarification: defaultClarification,
+		}
+	}
+
+	if isHeavyJobRequest(raw, normalized) {
+		return ChatRouteDecision{
+			Action: ChatActionLaunchJob,
+			Reason: "heavy_work_request",
+		}
+	}
+
+	return ChatRouteDecision{
+		Action: ChatActionReply,
+		Reason: "default_reply",
+	}
+}
+
+func normalizeChatInput(input string) string {
+	return strings.ToLower(strings.Join(strings.Fields(input), " "))
+}
+
+func splitForcedJobPrefix(raw, normalized string) (prefix, desc string, ok bool) {
+	for _, candidate := range forcedJobPrefixes {
+		if !strings.HasPrefix(normalized, candidate) {
+			continue
+		}
+		idx := strings.Index(raw, ":")
+		if idx == -1 {
+			return candidate, "", true
+		}
+		return candidate, strings.TrimSpace(raw[idx+1:]), true
+	}
+	return "", "", false
+}
+
+func isAmbiguousTaskRequest(normalized string) bool {
+	for _, pattern := range ambiguousTaskPatterns {
+		if pattern.MatchString(normalized) {
+			return true
+		}
+	}
+	return false
+}
+
+func isHeavyJobRequest(raw, normalized string) bool {
+	lead := countContains(normalized, heavyLeadPhrases)
+	context := countContains(normalized, heavyContextTerms)
+
+	score := 0
+	if lead > 0 {
+		score += 2
+	}
+	if context > 0 {
+		score++
+	}
+	if context > 1 {
+		score++
+	}
+	if strings.Contains(raw, "\n") {
+		score++
+	}
+	if strings.Contains(raw, "```") {
+		score += 2
+	}
+	if len(raw) >= 180 {
+		score++
+	}
+
+	return score >= 3
+}
+
+func countContains(input string, needles []string) int {
+	hits := 0
+	for _, needle := range needles {
+		if strings.Contains(input, needle) {
+			hits++
+		}
+	}
+	return hits
+}

--- a/internal/runtime/chat_router_test.go
+++ b/internal/runtime/chat_router_test.go
@@ -1,0 +1,70 @@
+package runtime
+
+import "testing"
+
+func TestDecideChatRoute(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantAction  ChatAction
+		wantReason  string
+		wantClarify bool
+	}{
+		{
+			name:       "simple question stays on reply path",
+			input:      "What does queue mode do?",
+			wantAction: ChatActionReply,
+			wantReason: "default_reply",
+		},
+		{
+			name:       "forced job prefix launches job",
+			input:      "job: investigate failing tests in internal/runtime and open a PR",
+			wantAction: ChatActionLaunchJob,
+			wantReason: "forced_job_prefix:job:",
+		},
+		{
+			name:        "forced job prefix without scope asks clarification",
+			input:       "task: fix it",
+			wantAction:  ChatActionClarify,
+			wantReason:  "forced_job_missing_scope",
+			wantClarify: true,
+		},
+		{
+			name:        "underspecified action asks clarification",
+			input:       "can you investigate this?",
+			wantAction:  ChatActionClarify,
+			wantReason:  "ambiguous_task_request",
+			wantClarify: true,
+		},
+		{
+			name:       "obvious repo work launches job",
+			input:      "Investigate the failing tests in the repo, check the logs, and open a PR with the fix.",
+			wantAction: ChatActionLaunchJob,
+			wantReason: "heavy_work_request",
+		},
+		{
+			name:       "multi-line implementation request launches job",
+			input:      "Implement this in the codebase:\n- inspect the repo\n- fix the bug\n- run tests",
+			wantAction: ChatActionLaunchJob,
+			wantReason: "heavy_work_request",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DecideChatRoute(tc.input)
+			if got.Action != tc.wantAction {
+				t.Fatalf("Action = %q, want %q", got.Action, tc.wantAction)
+			}
+			if got.Reason != tc.wantReason {
+				t.Fatalf("Reason = %q, want %q", got.Reason, tc.wantReason)
+			}
+			if tc.wantClarify && got.Clarification == "" {
+				t.Fatal("expected clarification text, got empty string")
+			}
+			if !tc.wantClarify && got.Clarification != "" {
+				t.Fatalf("expected empty clarification, got %q", got.Clarification)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #171

## What changed
- added a rules-first chat router in `internal/runtime` that classifies inbound turns as `reply`, `clarification`, or `launch_job`
- kept lightweight turns on the existing inline `processViaHub` path, but made underspecified action requests return a short clarification instead of entering the runtime blindly
- auto-launched obvious heavy work as isolated background jobs via the existing sub-agent runtime so the main chat session is not blocked by repo/browser/task-style requests
- reused the same sub-agent execution helper for `/task` and router-launched background jobs to keep completion notifications consistent
- documented the new routing behavior in `docs/FEATURES.md`

## Targeted verification
- `go build ./...` ✅
- `go test ./internal/runtime -run 'TestDecideChatRoute'` ✅
- `go test ./internal/bot -run 'TestParseTaskArgs|TestAbbreviateForAck'` ✅
- `go test ./internal/runtime ./internal/bot` ❌
  - `internal/runtime` passed
  - `internal/bot` failed on unrelated baseline tests:
    - `TestHandleMessage_DeniesUnauthorizedDirectMessageWithoutSideEffects`
    - `TestGuardUnauthorizedDM_BlocksWrappedHandlerBeforeStateMutation`
    - `TestGuardUnauthorizedDM_AllowsExplicitlyUnauthenticatedPairingCommand`
    - failure: `failed to migrate database: canonical session backfill failed: table sessions_v2 has no column named state`
    - `TestLiveStreamEditor_ScheduleEdit_TokenThreshold` timed out waiting for a burst edit

## Full suite
- `go test ./...` ❌
- unrelated/pre-existing failures observed:
  - `internal/ai`: `TestAnthropicClientOAuthHeadersAndBetaQuery`
  - `internal/bot`: the same storage migration + `TestLiveStreamEditor_ScheduleEdit_TokenThreshold` failures above
  - `internal/storage`: multiple `sqlite_v2` / `sqlite_schema` tests fail with `canonical session backfill failed: table sessions_v2 has no column named state`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a deterministic rules-first chat router that classifies inbound messages as `reply`, `clarification`, or `launch_job` before they enter the AI pipeline. Lightweight turns stay on the existing inline path, underspecified requests get a clarifying follow-up, and heavy work requests are auto-launched as isolated background jobs. The `/task` command's inline goroutine was cleanly refactored into a shared `startTaskRun` helper reused by both the command and the router.

- The chat router's `heavyContextTerms` list uses substring matching (`strings.Contains`) on short terms like `"pr"`, `"log"`, `"doc"`, and `"code"`, which will match inside unrelated words (e.g., "improve", "dialog", "encode") and cause false-positive job launches
- `DecideChatRoute` is called twice per message — once on raw text (pre-debounce) and again on debounced/combined text — which can produce inconsistent routing decisions between the queue-mode gate and the final dispatch
- Clarification and background-job routes bypass queue mode entirely, meaning a clarification reply can race with an in-flight AI response during an active run

<h3>Confidence Score: 3/5</h3>

- Functional but has routing edge cases that could cause unexpected behavior under message batching and concurrent runs.
- The core routing logic and refactoring are sound, but three issues lower confidence: (1) substring matching on short context terms will produce false-positive background job launches for normal conversational messages, (2) the dual DecideChatRoute call creates a window where pre-debounce and post-debounce routing decisions can disagree, and (3) non-reply routes bypass queue mode which could cause race conditions with active runs.
- Pay close attention to `internal/runtime/chat_router.go` (false-positive matching) and `internal/bot/bot.go` (dual routing call).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/runtime/chat_router.go | New rules-first chat router with deterministic scoring. Substring matching for short context terms ("pr", "log", "doc", "code") will cause false-positive heavy-job classifications. |
| internal/bot/bot.go | Integrates chat router into message handling. DecideChatRoute is called twice — once on raw text (pre-debounce) and again on combined text (post-debounce) — which can produce inconsistent routing decisions. |
| internal/bot/chat_routing.go | New file consolidating routing dispatch and task execution. Clarification and launch_job routes bypass queue mode, which could cause race conditions with in-flight AI responses. |
| internal/bot/task_command.go | Clean refactor — moved inline goroutine to shared startTaskRun helper. No issues. |
| internal/runtime/chat_router_test.go | Good test coverage for core routing paths. Could benefit from edge-case tests (e.g., substring false positives, empty forced prefixes). |
| internal/bot/chat_routing_test.go | Tests for abbreviateForAck helper. Clean and correct. |
| docs/FEATURES.md | Documentation addition for the new routing feature. Accurate and well-placed. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/runtime/chat_router.go
Line: 51-82

Comment:
**Substring matching causes false positives for short context terms**

`countContains` uses `strings.Contains` on the normalized (lowercased) input, so short terms like `"pr"`, `"log"`, `"doc"`, `"bug"`, `"code"`, and `"site"` will match inside longer unrelated words. For example:

- `"pr"` matches "**pr**actice", "**pr**int", "**pr**ogress", "**pr**ocess", "im**pr**ove", "**pr**icing", "**pr**ompt"
- `"log"` matches "dia**log**", "cata**log**", "b**log**"
- `"doc"` matches "**doc**ker", "**doc**tor"
- `"code"` matches "en**code**", "de**code**", "bar**code**", "uni**code**", "pass**code**"
- `"bug"` matches "ham**bug**er", "de**bug**" (already counted via `heavyLeadPhrases`)

A user message like "improve the process for printing reports" would match `"pr"` three times and score `context >= 2`, and if it also starts with a heavy lead phrase, it reaches score >= 4 — launching a background job for what is a normal conversational request. Consider using word-boundary matching (e.g., `\bpr\b`) or requiring the terms to appear as whole words.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/bot/bot.go
Line: 443

Comment:
**Routing decision made on raw text, re-evaluated on debounced text**

`DecideChatRoute` is called here on the raw single-message `content`, and the result gates whether queue mode is checked (line 455). But then `handleCombinedChatTurn` (line 472) calls `DecideChatRoute` again on the debounced/combined `combined` string, which may include additional messages merged by `FragmentBuffer` and `Debouncer`.

This means the pre-decision and the final decision can disagree. For example: if the first fragment is a short "reply"-classified message, queue mode is checked and returns false (no run active). Then more fragments arrive, and the combined text becomes a heavy-work request — `handleCombinedChatTurn` launches a background job. Conversely, if the pre-decision is `launch_job` (queue check skipped), but the final decision on the combined text is `reply`, the queue check was incorrectly skipped and a concurrent run won't be detected.

Consider passing the pre-decision into `handleCombinedChatTurn` to avoid the redundant call, or moving the pre-decision to after debouncing.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/bot/chat_routing.go
Line: 47-51

Comment:
**Clarification and launch_job routes bypass queue mode entirely**

When a message is routed as `ChatActionClarify` or `ChatActionLaunchJob`, the queue manager's `StartRun`/`EndRun` lifecycle is never invoked, and `handleWithQueueMode` was already skipped at the call site (only checked for `ChatActionReply`).

This means if the bot is processing an active run and a user sends a message that the router classifies as a heavy work request, a background job is launched *concurrently* with the active run — no queuing, no coordination. For `launch_job` this may be intentional (background jobs are isolated), but for `clarification` this means the bot could send a clarification reply that races with the in-flight AI response, leading to confusing out-of-order messages in the chat.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: f62ba32</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->