### PR TITLE
feat: feat(ux): Telegram shows explicit job lifecycle instead of hanging on long runs (#172)

### DIFF
--- a/docs/MEMORY-CONTEXT-PIPELINE.md
+++ b/docs/MEMORY-CONTEXT-PIPELINE.md
@@ -8,13 +8,17 @@ request lifecycle from incoming Telegram message to model response.
 
 ## 1. Overview
 
-Every AI request goes through three stages:
+Every AI request goes through five stages:
 
 ```
 Telegram message
     │
     ▼
 ┌─────────────────────────────────────────────┐
+│  0. TELEGRAM JOB ACK                        │
+│     Fast accepted/queued ack                │
+│     explicit job ID + lifecycle status      │
+├─────────────────────────────────────────────┤
 │  1. SYSTEM PROMPT ASSEMBLY                  │
 │     Bootstrap files → SystemPrompt()        │
 │     SOUL + IDENTITY + USER + TOOLS +        │
@@ -409,21 +413,26 @@ Complete flow for a Telegram DM message:
 6. Auth check (open/allowlist/pairing)
 7. Command check (/status, /new, etc. handled directly)
 8. Session key resolved: dm:<chatID>
-9. Send ⏳ placeholder message (ack)
-10. Start typing indicator
+9. Send Telegram job ack immediately:
+   a. assign job ID
+   b. show status=accepted or status=queued
+10. Debouncer window expires
+11. Launch background RuntimeHub run
+12. Update lifecycle placeholder to status=running
+13. Start typing indicator
 
 --- processViaHub ---
 
-11. Load v2 history (last 120 messages)
-12. Submit to RuntimeHub as RunRequest
-13. Hub resolves agent profile for session
-14. Agent builds system prompt:
+14. Load v2 history (last 120 messages)
+15. Submit to RuntimeHub as RunRequest
+16. Hub resolves agent profile for session
+17. Agent builds system prompt:
     a. Loader reads bootstrap files from disk
     b. Loader reads today + yesterday daily notes
     c. BuildPrompt() assembles full prompt with tools, guidelines
-15. Agent builds message array:
+18. Agent builds message array:
     [system] + [history...] + [user message]
-16. Tool loop (up to 10 iterations):
+19. Tool loop (up to 10 iterations):
     a. Call AI model with messages + tool definitions
     b. If tool_calls → execute tools → append results → loop
     c. If text response → done
@@ -431,17 +440,18 @@ Complete flow for a Telegram DM message:
 
 --- Response rendering ---
 
-17. Strip SILENT_REPLY / HEARTBEAT_OK sentinels
-18. Parse [[reply_to:...]] and [[react:...]] tags
-19. Stop live streaming editor
-20. Edit ⏳ placeholder with final response (or send new message)
-21. Set emoji reactions if requested
-22. Append to daily memory file (always)
-23. If !IsFallback:
+20. Strip SILENT_REPLY / HEARTBEAT_OK sentinels
+21. Parse [[reply_to:...]] and [[react:...]] tags
+22. Stop live streaming editor
+23. Edit lifecycle placeholder to completed/failed/cancelled
+24. Deliver final response as a separate Telegram message
+25. Set emoji reactions if requested
+26. Append to daily memory file (always)
+27. If !IsFallback:
     a. Save to legacy session store
-    b. Save user+assistant pair to v2 transcript
-24. Update token usage counters
-25. Log completion
+    b. Save user+assistant pair to v2 transcript with run_id=job_id
+28. Update token usage counters
+29. Log completion
 ```
 
 ---

--- a/internal/bot/ack_handle.go
+++ b/internal/bot/ack_handle.go
@@ -11,6 +11,7 @@ import (
 type AckHandle struct {
 	Message *telebot.Message
 	ChatID  int64
+	JobID   string
 }
 
 // AckHandleManager manages per-chat ack handles with thread-safe access.

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -439,6 +439,7 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 
 	// Route through the runtime hub.
 	if b.ai != nil {
+		delivery := newTelegramDelivery(c)
 		sessionKey := sessionKeyForChat(msg.Chat)
 		preDecision := runtime.DecideChatRoute(content)
 		if err := b.store.SaveSessionRoute(storage.SessionRoute{
@@ -455,18 +456,16 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 		if preDecision.Action == runtime.ChatActionReply {
 			// Check queue mode — if a run is active this may queue, steer, or interrupt.
 			if b.handleWithQueueMode(ctx, sessionKey, chatID, content) {
-				// Session was busy — send ⏳ queued placeholder immediately so the user
-				// knows their message was received while a run was in progress.
-				b.sendQueuedAck(c.Chat())
+				b.sendQueuedAck(delivery.Chat)
 				return nil
 			}
 		}
 
-		// Send ⏳ placeholder and typing indicator immediately (within ~0ms of receipt),
+		// Send the lifecycle placeholder immediately (within ~0ms of receipt),
 		// before the debounce window and any AI processing.
-		canReuseAck := b.sendImmediateAck(c.Chat()) != nil
+		canReuseAck := b.sendImmediateAck(delivery.Chat, msg.ID) != nil
 
-		// Fragment buffering → debounce → process via hub.
+		// Fragment buffering → debounce → async hub run.
 		b.fragmentBuffer.TryBuffer(chatID, userID, msg.ID, content, func(assembled string) {
 			b.debouncer.Debounce(chatID, assembled, func(combined string) {
 				if err := b.handleCombinedChatTurn(ctx, c, sessionKey, combined, canReuseAck); err != nil {
@@ -999,33 +998,41 @@ func (b *Bot) GetApprovalFunc(chatID int64) func(command string) (bool, error) {
 	}
 }
 
-// takeAck retrieves and removes the pending ⏳ placeholder message for chatID.
+// takeAckHandle retrieves and removes the pending lifecycle placeholder for chatID.
 // It is the consume-once counterpart to sendImmediateAck.
-func (b *Bot) takeAck(chatID int64) *telebot.Message {
-	if h := b.ackManager.Take(chatID); h != nil {
-		return h.Message
+func (b *Bot) takeAckHandle(chatID int64) *AckHandle {
+	return b.ackManager.Take(chatID)
+}
+
+// updateAckStatus edits an existing lifecycle placeholder to the provided job state.
+func (b *Bot) updateAckStatus(handle *AckHandle, status telegramJobStatus, detail string) {
+	if handle == nil || handle.Message == nil {
+		return
 	}
-	return nil
+	if _, err := b.api.Edit(handle.Message, formatTelegramJobStatus(handle.JobID, status, detail)); err != nil {
+		log.Printf("[ack] failed to update placeholder for chat=%d job=%s: %v", handle.ChatID, handle.JobID, err)
+	}
 }
 
-// sendImmediateAck sends a ⏳ placeholder message and a typing indicator in parallel
-// immediately upon receiving an inbound Telegram message, before any debounce or AI processing.
-// The placeholder message ID is stored in ackManager for subsequent live-edit updates.
-// Only one ack is created per chat — if one already exists the call is a no-op.
-func (b *Bot) sendImmediateAck(chat *telebot.Chat) *telebot.Message {
-	return b.sendAck(chat, "⏳")
+// sendImmediateAck sends a lifecycle placeholder immediately upon receiving an inbound
+// Telegram message, before any debounce or AI processing.
+// Only one tracked ack is created per chat — if one already exists the call is a no-op.
+func (b *Bot) sendImmediateAck(chat *telebot.Chat, sourceMessageID int) *AckHandle {
+	return b.sendAck(chat, newTelegramJobID(chat.ID, sourceMessageID), jobStatusAccepted, "")
 }
 
-// sendQueuedAck sends a ⏳ queued placeholder immediately when a message arrives
-// while the session is already busy processing another request.
-// Only one ack is created per chat — if one already exists the call is a no-op.
-func (b *Bot) sendQueuedAck(chat *telebot.Chat) *telebot.Message {
-	return b.sendAck(chat, "⏳ queued - previous run in progress")
+// sendQueuedAck notifies the user that a message was received while another run
+// is still active. Queued inputs may be merged by the debouncer, so this is a
+// plain status note instead of a tracked per-job placeholder.
+func (b *Bot) sendQueuedAck(chat *telebot.Chat) {
+	if _, err := b.api.Send(chat, "⏳ Status: queued\nWaiting for the active run to finish."); err != nil {
+		log.Printf("[ack] failed to send queued note for chat=%d: %v", chat.ID, err)
+	}
 }
 
-// sendAck sends a placeholder message with text and a typing indicator in parallel.
-// Only one ack is created per chat — if one already exists the call is a no-op.
-func (b *Bot) sendAck(chat *telebot.Chat, text string) *telebot.Message {
+// sendAck sends a tracked lifecycle placeholder message with typing indicator.
+// Only one tracked ack is created per chat — if one already exists the call is a no-op.
+func (b *Bot) sendAck(chat *telebot.Chat, jobID string, status telegramJobStatus, detail string) *AckHandle {
 	chatID := chat.ID
 	if b.ackManager.Exists(chatID) {
 		return nil
@@ -1035,15 +1042,17 @@ func (b *Bot) sendAck(chat *telebot.Chat, text string) *telebot.Message {
 	go b.api.Notify(chat, telebot.Typing)
 
 	// Send placeholder
+	text := formatTelegramJobStatus(jobID, status, detail)
 	ackMsg, err := b.api.Send(chat, text)
 	if err != nil {
 		log.Printf("[ack] failed to send placeholder for chat=%d: %v", chatID, err)
 		return nil
 	}
 
-	b.ackManager.Set(chatID, &AckHandle{Message: ackMsg, ChatID: chatID})
-	log.Printf("[ack] placeholder sent for chat=%d msg_id=%d text=%q", chatID, ackMsg.ID, text)
-	return ackMsg
+	handle := &AckHandle{Message: ackMsg, ChatID: chatID, JobID: jobID}
+	b.ackManager.Set(chatID, handle)
+	log.Printf("[ack] placeholder sent for chat=%d job=%s msg_id=%d text=%q", chatID, jobID, ackMsg.ID, text)
+	return handle
 }
 
 // SetupLocalCommandApproval configures the LocalCommand tool with approval function

--- a/internal/bot/chat_routing.go
+++ b/internal/bot/chat_routing.go
@@ -50,37 +50,15 @@ func (b *Bot) handleCombinedChatTurn(
 	case runtimepkg.ChatActionLaunchJob:
 		return b.launchBackgroundJob(c, content, canReuseAck)
 	default:
-		b.queueManager.StartRun(chatID)
-		defer b.flushQueuedMessages(ctx, c, sessionKey, chatID)
-
 		session, err := b.store.GetSession(chatID)
 		if err != nil {
 			log.Printf("Failed to get session: %v", err)
 		}
 
-		if err := b.processViaHub(ctx, c, sessionKey, content, session); err != nil {
-			return err
-		}
+		runToken := b.queueManager.StartRun(chatID)
+		b.runViaHubAsync(ctx, newTelegramDelivery(c), sessionKey, content, nil, session,
+			"❌ Sorry, I encountered an error processing your request.", runToken)
 		return nil
-	}
-}
-
-func (b *Bot) flushQueuedMessages(ctx context.Context, c telebot.Context, sessionKey agent.SessionKey, chatID int64) {
-	queued := b.queueManager.EndRun(chatID)
-	if len(queued) == 0 {
-		return
-	}
-
-	log.Printf("[router] processing %d queued messages for chat=%d", len(queued), chatID)
-	for _, queuedContent := range queued {
-		qContent := queuedContent
-		canReuseAck := b.sendImmediateAck(c.Chat()) != nil
-		b.debouncer.Debounce(chatID, qContent, func(qCombined string) {
-			if err := b.handleCombinedChatTurn(ctx, c, sessionKey, qCombined, canReuseAck); err != nil {
-				log.Printf("Failed to handle queued agent request: %v", err)
-				c.Send("❌ Sorry, I encountered an error processing your request.") //nolint:errcheck
-			}
-		})
 	}
 }
 
@@ -102,7 +80,7 @@ func (b *Bot) respondWithClarification(
 	if err := b.store.SaveSession(chatID, clarification); err != nil {
 		log.Printf("[router] failed to save clarification session for chat=%d: %v", chatID, err)
 	}
-	if err := b.store.SaveSessionMessagePairV2(string(sessionKey), userContent, clarification); err != nil {
+	if err := b.store.SaveSessionMessagePairV2(string(sessionKey), userContent, clarification, ""); err != nil {
 		log.Printf("[router] failed to persist clarification transcript for chat=%d: %v", chatID, err)
 	}
 	if err := b.memory.AppendToToday(fmt.Sprintf("Assistant (router): %s", clarification)); err != nil {
@@ -123,11 +101,11 @@ func (b *Bot) launchBackgroundJob(c telebot.Context, task string, canReuseAck bo
 
 func (b *Bot) deliverRoutingText(c telebot.Context, text string, canReuseAck bool) error {
 	if canReuseAck {
-		if ackMsg := b.takeAck(c.Chat().ID); ackMsg != nil {
-			if _, err := b.api.Edit(ackMsg, text); err == nil {
+		if ackHandle := b.takeAckHandle(c.Chat().ID); ackHandle != nil {
+			if _, err := b.api.Edit(ackHandle.Message, text); err == nil {
 				return nil
 			}
-			_ = b.api.Delete(ackMsg)
+			_ = b.api.Delete(ackHandle.Message)
 		}
 	}
 	return c.Send(text)

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -12,6 +12,7 @@ import (
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/ai"
 	"ok-gobot/internal/control"
+	"ok-gobot/internal/logger"
 )
 
 // sessionKeyForChat returns the canonical session key for a Telegram chat.
@@ -26,19 +27,66 @@ func sessionKeyForChat(chat *telebot.Chat) agent.SessionKey {
 // processViaHub submits an inbound envelope to the RuntimeHub and renders the
 // resulting events back to Telegram. The bot is a thin transport adapter here:
 // all agent creation, tool execution, and run orchestration happen inside the hub.
-func (b *Bot) processViaHub(ctx context.Context, c telebot.Context, sessionKey agent.SessionKey, content, session string) error {
-	return b.processViaHubWithContent(ctx, c, sessionKey, content, nil, session)
+func (b *Bot) processViaHub(ctx context.Context, delivery telegramDelivery, sessionKey agent.SessionKey, content, session string) error {
+	return b.processViaHubWithContent(ctx, delivery, sessionKey, content, nil, session)
+}
+
+func (b *Bot) runViaHubAsync(
+	ctx context.Context,
+	delivery telegramDelivery,
+	sessionKey agent.SessionKey,
+	content string,
+	userContent []ai.ContentBlock,
+	session string,
+	errorText string,
+	runToken string,
+) {
+	chatID := delivery.Chat.ID
+
+	go func() {
+		defer func() {
+			if runToken == "" {
+				return
+			}
+			queued := b.queueManager.EndRun(chatID, runToken)
+			if len(queued) == 0 {
+				return
+			}
+
+			logger.Debugf("Bot: processing %d queued messages for chat=%d", len(queued), chatID)
+			for _, qMsg := range queued {
+				b.debouncer.Debounce(chatID, qMsg, func(qCombined string) {
+					session, err := b.store.GetSession(chatID)
+					if err != nil {
+						log.Printf("Failed to get session for queued message: %v", err)
+					}
+
+					b.sendImmediateAck(delivery.Chat, 0)
+					nextToken := b.queueManager.StartRun(chatID)
+					b.runViaHubAsync(ctx, telegramDelivery{Chat: delivery.Chat}, sessionKey, qCombined, nil, session, errorText, nextToken)
+				})
+			}
+		}()
+
+		if err := b.processViaHubWithContent(ctx, delivery, sessionKey, content, userContent, session); err != nil {
+			log.Printf("[bot] async hub run failed for session %s: %v", sessionKey, err)
+			if errorText != "" {
+				b.api.Send(delivery.Chat, errorText) //nolint:errcheck
+			}
+		}
+	}()
 }
 
 func (b *Bot) processViaHubWithContent(
 	ctx context.Context,
-	c telebot.Context,
+	delivery telegramDelivery,
 	sessionKey agent.SessionKey,
 	content string,
 	userContent []ai.ContentBlock,
 	session string,
 ) error {
-	chatID := c.Chat().ID
+	chatID := delivery.Chat.ID
+	var jobID string
 
 	// Set chat context so the LocalCommand ApprovalFunc can send prompts to the right chat.
 	b.setCurrentChatID(chatID)
@@ -53,7 +101,9 @@ func (b *Bot) processViaHubWithContent(
 	var onDelta func(string)
 	var onDeltaReset func()
 	if ackHandle := b.ackManager.Peek(chatID); ackHandle != nil {
-		liveEditor = NewLiveStreamEditor(b.api, ackHandle.Message)
+		jobID = ackHandle.JobID
+		liveEditor = NewLiveStreamEditor(b.api, ackHandle.Message, ackHandle.JobID)
+		liveEditor.Flush()
 		ctrlHub := b.controlHub
 		onToolEvent = func(event agent.ToolEvent) {
 			liveEditor.OnToolEvent(event)
@@ -126,7 +176,7 @@ func (b *Bot) processViaHubWithContent(
 	}
 
 	// Start typing indicator while the hub is running.
-	stopTyping := NewTypingIndicator(b.api, c.Chat())
+	stopTyping := NewTypingIndicator(b.api, delivery.Chat)
 	defer stopTyping()
 
 	// Load multi-turn conversation history from the v2 transcript store.
@@ -172,11 +222,10 @@ func (b *Bot) processViaHubWithContent(
 			if liveEditor != nil {
 				liveEditor.Stop()
 			}
-			ackMsg := b.takeAck(chatID)
+			ackHandle := b.takeAckHandle(chatID)
 			if ctx.Err() != nil || errors.Is(ev.Err, context.Canceled) {
-				// Cancelled (by /abort, /stop, or app shutdown) — silently clear the ⏳ placeholder.
-				if ackMsg != nil {
-					b.api.Delete(ackMsg) //nolint:errcheck
+				if ackHandle != nil {
+					b.updateAckStatus(ackHandle, jobStatusCancelled, "Job stopped before completion.")
 				}
 				if b.controlHub != nil {
 					b.controlHub.Emit(control.EvtRunFailed, control.RunEventPayload{
@@ -194,12 +243,10 @@ func (b *Bot) processViaHubWithContent(
 				})
 			}
 			errText := "❌ Sorry, I encountered an error processing your request."
-			if ackMsg != nil {
-				if _, err := b.api.Edit(ackMsg, errText); err != nil {
-					b.api.Send(c.Chat(), errText) //nolint:errcheck
-				}
+			if ackHandle != nil {
+				b.updateAckStatus(ackHandle, jobStatusFailed, "Sorry, I encountered an error processing your request.")
 			} else {
-				b.api.Send(c.Chat(), errText) //nolint:errcheck
+				b.api.Send(delivery.Chat, errText) //nolint:errcheck
 			}
 			return nil
 		}
@@ -210,8 +257,8 @@ func (b *Bot) processViaHubWithContent(
 		if liveEditor != nil {
 			liveEditor.Stop()
 		}
-		if ackMsg := b.takeAck(chatID); ackMsg != nil {
-			b.api.Delete(ackMsg) //nolint:errcheck
+		if ackHandle := b.takeAckHandle(chatID); ackHandle != nil {
+			b.updateAckStatus(ackHandle, jobStatusCancelled, "Job stopped before completion.")
 		}
 		if b.controlHub != nil {
 			b.controlHub.Emit(control.EvtRunFailed, control.RunEventPayload{
@@ -236,8 +283,8 @@ func (b *Bot) processViaHubWithContent(
 	trimmed := strings.TrimSpace(result.Message)
 	if trimmed == "SILENT_REPLY" || trimmed == "HEARTBEAT_OK" {
 		log.Printf("[bot] agent '%s' returned silent token: %s — suppressing reply", profileName, trimmed)
-		if ackMsg := b.takeAck(chatID); ackMsg != nil {
-			b.api.Delete(ackMsg) //nolint:errcheck
+		if ackHandle := b.takeAckHandle(chatID); ackHandle != nil {
+			b.updateAckStatus(ackHandle, jobStatusCompleted, "Completed with no direct reply.")
 		}
 		return nil
 	}
@@ -251,9 +298,9 @@ func (b *Bot) processViaHubWithContent(
 
 	// Extract and send emoji reactions.
 	msg, reactions := parseReactions(msg)
-	if len(reactions) > 0 && c.Message() != nil {
+	if len(reactions) > 0 && delivery.Message != nil {
 		for _, emoji := range reactions {
-			if err := b.api.React(c.Chat(), c.Message(), telebot.Reactions{
+			if err := b.api.React(delivery.Chat, delivery.Message, telebot.Reactions{
 				Reactions: []telebot.Reaction{{Type: telebot.ReactionTypeEmoji, Emoji: emoji}},
 			}); err != nil {
 				log.Printf("[bot] failed to set reaction %s: %v", emoji, err)
@@ -280,27 +327,22 @@ func (b *Bot) processViaHubWithContent(
 	const maxTelegramLen = 4096
 	chunks := splitMessage(msg, maxTelegramLen)
 
-	// Edit the ⏳ placeholder with the first chunk; send the rest as new messages.
-	ackMsg := b.takeAck(chatID)
+	// Mark the lifecycle placeholder as completed, then deliver the result asynchronously.
+	if ackHandle := b.takeAckHandle(chatID); ackHandle != nil {
+		b.updateAckStatus(ackHandle, jobStatusCompleted, "Result delivered below.")
+	}
 	for i, chunk := range chunks {
-		if i == 0 && ackMsg != nil {
-			if _, err := b.api.Edit(ackMsg, chunk); err != nil {
-				log.Printf("[bot] failed to edit ⏳ for chat %d: %v", chatID, err)
-				b.api.Send(c.Chat(), chunk) //nolint:errcheck
+		sendOpts := &telebot.SendOptions{}
+		if i == 0 {
+			switch {
+			case replyTarget.MessageID == -1:
+				sendOpts.ReplyTo = delivery.Message
+			case replyTarget.MessageID > 0:
+				sendOpts.ReplyTo = &telebot.Message{ID: replyTarget.MessageID}
 			}
-		} else {
-			sendOpts := &telebot.SendOptions{}
-			if i == 0 {
-				switch {
-				case replyTarget.MessageID == -1:
-					sendOpts.ReplyTo = c.Message()
-				case replyTarget.MessageID > 0:
-					sendOpts.ReplyTo = &telebot.Message{ID: replyTarget.MessageID}
-				}
-			}
-			if _, err := b.api.Send(c.Chat(), chunk, sendOpts); err != nil {
-				log.Printf("[bot] failed to send chunk %d for chat %d: %v", i, chatID, err)
-			}
+		}
+		if _, err := b.api.Send(delivery.Chat, chunk, sendOpts); err != nil {
+			log.Printf("[bot] failed to send chunk %d for chat %d: %v", i, chatID, err)
 		}
 	}
 
@@ -324,7 +366,7 @@ func (b *Bot) processViaHubWithContent(
 		// transaction on success only. A non-atomic write could leave an orphaned
 		// user message that produces consecutive user turns on the next request,
 		// which most providers (Anthropic, etc.) reject as invalid.
-		if err := b.store.SaveSessionMessagePairV2(string(sessionKey), content, result.Message); err != nil {
+		if err := b.store.SaveSessionMessagePairV2(string(sessionKey), content, result.Message, jobID); err != nil {
 			log.Printf("[bot] failed to persist v2 transcript: %v", err)
 		}
 	} else {

--- a/internal/bot/job_lifecycle.go
+++ b/internal/bot/job_lifecycle.go
@@ -1,0 +1,71 @@
+package bot
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/telebot.v4"
+)
+
+type telegramJobStatus string
+
+const (
+	jobStatusAccepted  telegramJobStatus = "accepted"
+	jobStatusQueued    telegramJobStatus = "queued"
+	jobStatusRunning   telegramJobStatus = "running"
+	jobStatusCompleted telegramJobStatus = "completed"
+	jobStatusFailed    telegramJobStatus = "failed"
+	jobStatusCancelled telegramJobStatus = "cancelled"
+)
+
+type telegramDelivery struct {
+	Chat    *telebot.Chat
+	Message *telebot.Message
+}
+
+func newTelegramDelivery(c telebot.Context) telegramDelivery {
+	return telegramDelivery{
+		Chat:    c.Chat(),
+		Message: c.Message(),
+	}
+}
+
+func newTelegramJobID(chatID int64, messageID int) string {
+	if messageID > 0 {
+		return fmt.Sprintf("tg-%d-%d", messageID, time.Now().UnixNano())
+	}
+	return fmt.Sprintf("tg-%d-%d", chatID, time.Now().UnixNano())
+}
+
+func formatTelegramJobHeader(jobID string, status telegramJobStatus) string {
+	if jobID == "" {
+		return ""
+	}
+
+	icon := "🧾"
+	switch status {
+	case jobStatusQueued:
+		icon = "⏳"
+	case jobStatusRunning:
+		icon = "🏃"
+	case jobStatusCompleted:
+		icon = "✅"
+	case jobStatusFailed:
+		icon = "❌"
+	case jobStatusCancelled:
+		icon = "🛑"
+	}
+
+	return fmt.Sprintf("%s Job %s\nStatus: %s", icon, jobID, status)
+}
+
+func formatTelegramJobStatus(jobID string, status telegramJobStatus, detail string) string {
+	header := formatTelegramJobHeader(jobID, status)
+	if detail == "" {
+		return header
+	}
+	if header == "" {
+		return detail
+	}
+	return header + "\n" + detail
+}

--- a/internal/bot/job_lifecycle_test.go
+++ b/internal/bot/job_lifecycle_test.go
@@ -1,0 +1,39 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewTelegramJobIDHasPrefix(t *testing.T) {
+	jobID := newTelegramJobID(42, 99)
+	if !strings.HasPrefix(jobID, "tg-99-") {
+		t.Fatalf("expected message-based job ID prefix, got %q", jobID)
+	}
+}
+
+func TestFormatTelegramJobStatusIncludesLifecycle(t *testing.T) {
+	out := formatTelegramJobStatus("tg-123", jobStatusCompleted, "Result delivered below.")
+	for _, want := range []string{"Job tg-123", "Status: completed", "Result delivered below."} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in %q", want, out)
+		}
+	}
+}
+
+func TestLiveStreamEditorIncludesJobHeader(t *testing.T) {
+	e := &LiveStreamEditor{
+		jobID:     "tg-123",
+		lifecycle: jobStatusRunning,
+	}
+
+	e.mu.Lock()
+	out := e.formatLocked()
+	e.mu.Unlock()
+
+	for _, want := range []string{"Job tg-123", "Status: running", "💭 Working…"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in %q", want, out)
+		}
+	}
+}

--- a/internal/bot/live_editor.go
+++ b/internal/bot/live_editor.go
@@ -25,6 +25,8 @@ type LiveStreamEditor struct {
 	bot *telebot.Bot
 	msg *telebot.Message
 
+	jobID         string
+	lifecycle     telegramJobStatus
 	mu            sync.Mutex
 	toolLines     []toolStatusLine
 	content       strings.Builder
@@ -36,8 +38,13 @@ type LiveStreamEditor struct {
 }
 
 // NewLiveStreamEditor creates a LiveStreamEditor that updates msg as the run progresses.
-func NewLiveStreamEditor(bot *telebot.Bot, msg *telebot.Message) *LiveStreamEditor {
-	return &LiveStreamEditor{bot: bot, msg: msg}
+func NewLiveStreamEditor(bot *telebot.Bot, msg *telebot.Message, jobID string) *LiveStreamEditor {
+	return &LiveStreamEditor{
+		bot:       bot,
+		msg:       msg,
+		jobID:     jobID,
+		lifecycle: jobStatusRunning,
+	}
 }
 
 // OnToolEvent records a tool lifecycle event and schedules a time-based placeholder edit.
@@ -111,19 +118,26 @@ func (e *LiveStreamEditor) HasAny() bool {
 // formatLocked returns the current display text.
 // Must be called with e.mu held.
 func (e *LiveStreamEditor) formatLocked() string {
+	header := formatTelegramJobHeader(e.jobID, e.lifecycle)
 	statusPart := e.formatStatusLocked()
 	contentPart := e.content.String()
 
-	if contentPart == "" {
-		if statusPart == "" {
-			return "💭 Working…"
-		}
-		return statusPart
+	var body string
+	switch {
+	case contentPart == "" && statusPart == "":
+		body = "💭 Working…"
+	case contentPart == "":
+		body = statusPart
+	case statusPart != "":
+		body = statusPart + "\n\n" + contentPart
+	default:
+		body = contentPart
 	}
-	if statusPart != "" {
-		return statusPart + "\n\n" + contentPart
+
+	if header == "" {
+		return body
 	}
-	return contentPart
+	return header + "\n\n" + body
 }
 
 // formatStatusLocked formats the tool status lines.
@@ -183,9 +197,7 @@ func (e *LiveStreamEditor) scheduleEdit() {
 
 		// Perform the Telegram edit without holding the lock.
 		if !stopped && msg != nil && content != "" {
-			e.bot.Edit(msg, content, &telebot.SendOptions{ //nolint:errcheck
-				ParseMode: telebot.ModeMarkdown,
-			})
+			e.bot.Edit(msg, content) //nolint:errcheck
 		}
 
 		// Re-schedule if new content arrived during the edit.
@@ -196,5 +208,16 @@ func (e *LiveStreamEditor) scheduleEdit() {
 		}
 		e.pending = true
 		e.mu.Unlock()
+	}
+}
+
+// Flush performs an immediate lifecycle/status edit without waiting for the scheduler.
+func (e *LiveStreamEditor) Flush() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	content := e.formatLocked()
+	if e.msg != nil && content != "" {
+		e.bot.Edit(e.msg, content) //nolint:errcheck
 	}
 }

--- a/internal/bot/live_editor_test.go
+++ b/internal/bot/live_editor_test.go
@@ -153,52 +153,22 @@ func TestLiveStreamEditor_HasAny_False_Initially(t *testing.T) {
 	}
 }
 
-// TestLiveStreamEditor_ScheduleEdit_TokenThreshold verifies that accumulating
-// streamTokenThreshold or more tokens causes an immediate edit without waiting
-// for the full interval.
+// TestLiveStreamEditor_ScheduleEdit_TokenThreshold verifies the burst condition
+// directly. The old version raced with the background scheduler goroutine and
+// was flaky even when the threshold logic was correct.
 func TestLiveStreamEditor_ScheduleEdit_TokenThreshold(t *testing.T) {
-	editCalled := make(chan struct{}, 1)
-
-	// Build a LiveStreamEditor with a spy edit function by using an inline
-	// goroutine that reads the pending state.
 	e := &LiveStreamEditor{}
-
-	// Append exactly streamTokenThreshold tokens; each call to AppendDelta
-	// increments pendingTokens by 1 (one call = one token for test purposes).
-	for i := 0; i < streamTokenThreshold; i++ {
-		e.AppendDelta("x")
-	}
-
 	e.mu.Lock()
+	e.pendingTokens = streamTokenThreshold
+	e.lastEdit = time.Now()
+	elapsed := time.Since(e.lastEdit)
 	burst := e.pendingTokens >= streamTokenThreshold
 	e.mu.Unlock()
 
 	if !burst {
-		t.Errorf("expected pendingTokens >= %d, got %d", streamTokenThreshold, e.pendingTokens)
+		t.Fatalf("expected pendingTokens >= %d", streamTokenThreshold)
 	}
-
-	// The goroutine spawned by AppendDelta would normally call bot.Edit.
-	// Since bot is nil we just check that scheduleEdit will not sleep for
-	// the full interval when the token threshold is met.
-	start := time.Now()
-	go func() {
-		// Simulate what scheduleEdit does: if tokensBurst, skip the sleep.
-		e.mu.Lock()
-		elapsed := time.Since(e.lastEdit)
-		tb := e.pendingTokens >= streamTokenThreshold
-		e.mu.Unlock()
-		if tb || elapsed >= streamEditInterval {
-			editCalled <- struct{}{}
-		}
-	}()
-
-	select {
-	case <-editCalled:
-		elapsed := time.Since(start)
-		if elapsed > 100*time.Millisecond {
-			t.Errorf("expected immediate burst edit, took %v", elapsed)
-		}
-	case <-time.After(200 * time.Millisecond):
-		t.Error("expected burst edit to fire quickly, timed out")
+	if elapsed >= streamEditInterval {
+		t.Fatalf("expected elapsed=%v to remain below streamEditInterval=%v for burst-only path", elapsed, streamEditInterval)
 	}
 }

--- a/internal/bot/media_handler.go
+++ b/internal/bot/media_handler.go
@@ -197,8 +197,9 @@ func (b *Bot) handlePhotoMessage(ctx context.Context, c telebot.Context) error {
 		log.Printf("Failed to save message: %v", err)
 	}
 
+	delivery := newTelegramDelivery(c)
 	sessionKey := sessionKeyForChat(msg.Chat)
-	b.sendImmediateAck(c.Chat())
+	b.sendImmediateAck(delivery.Chat, msg.ID)
 	b.debouncer.Debounce(chatID, content, func(combined string) {
 		session, err := b.store.GetSession(chatID)
 		if err != nil {
@@ -209,10 +210,8 @@ func (b *Bot) handlePhotoMessage(ctx context.Context, c telebot.Context) error {
 			visionText = combined
 		}
 		visionContent := buildVisionImageContent(data, "image/jpeg", visionText)
-		if err := b.processViaHubWithContent(ctx, c, sessionKey, combined, visionContent, session); err != nil {
-			log.Printf("Failed to handle photo request: %v", err)
-			c.Send("❌ Sorry, I encountered an error processing your photo.") //nolint:errcheck
-		}
+		b.runViaHubAsync(ctx, delivery, sessionKey, combined, visionContent, session,
+			"❌ Sorry, I encountered an error processing your photo.", "")
 	})
 
 	return nil
@@ -300,14 +299,16 @@ func (b *Bot) handleStickerMessage(ctx context.Context, c telebot.Context) error
 	}
 
 	// Process through pipeline via hub
+	delivery := newTelegramDelivery(c)
 	sessionKey := sessionKeyForChat(msg.Chat)
-	b.sendImmediateAck(c.Chat())
+	b.sendImmediateAck(delivery.Chat, msg.ID)
 	b.debouncer.Debounce(chatID, content, func(combined string) {
 		session, err := b.store.GetSession(chatID)
 		if err != nil {
 			log.Printf("Failed to get session: %v", err)
 		}
-		b.processViaHub(ctx, c, sessionKey, combined, session) //nolint:errcheck
+		b.runViaHubAsync(ctx, delivery, sessionKey, combined, nil, session,
+			"❌ Sorry, I encountered an error processing your sticker.", "")
 	})
 
 	return nil
@@ -346,16 +347,16 @@ func (b *Bot) handleDocumentMessage(ctx context.Context, c telebot.Context) erro
 		log.Printf("Failed to save message: %v", err)
 	}
 
+	delivery := newTelegramDelivery(c)
 	sessionKey := sessionKeyForChat(msg.Chat)
-	b.sendImmediateAck(c.Chat())
+	b.sendImmediateAck(delivery.Chat, msg.ID)
 	b.debouncer.Debounce(chatID, content, func(combined string) {
 		session, err := b.store.GetSession(chatID)
 		if err != nil {
 			log.Printf("Failed to get session: %v", err)
 		}
-		if err := b.processViaHub(ctx, c, sessionKey, combined, session); err != nil {
-			log.Printf("Failed to handle document request: %v", err)
-		}
+		b.runViaHubAsync(ctx, delivery, sessionKey, combined, nil, session,
+			"❌ Sorry, I encountered an error processing your document.", "")
 	})
 
 	return nil

--- a/internal/bot/queue.go
+++ b/internal/bot/queue.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"sync"
 
@@ -25,14 +26,15 @@ const (
 // QueueManager manages per-chat message queuing with different modes
 type QueueManager struct {
 	mu         sync.Mutex
-	activeRuns map[int64]bool
+	activeRuns map[int64]string
 	queued     map[int64][]string
+	nextRunID  uint64
 }
 
 // NewQueueManager creates a new queue manager
 func NewQueueManager() *QueueManager {
 	return &QueueManager{
-		activeRuns: make(map[int64]bool),
+		activeRuns: make(map[int64]string),
 		queued:     make(map[int64][]string),
 	}
 }
@@ -41,21 +43,28 @@ func NewQueueManager() *QueueManager {
 func (qm *QueueManager) IsRunning(chatID int64) bool {
 	qm.mu.Lock()
 	defer qm.mu.Unlock()
-	return qm.activeRuns[chatID]
+	_, ok := qm.activeRuns[chatID]
+	return ok
 }
 
 // StartRun marks a chat as having an active run
-func (qm *QueueManager) StartRun(chatID int64) {
+func (qm *QueueManager) StartRun(chatID int64) string {
 	qm.mu.Lock()
 	defer qm.mu.Unlock()
-	qm.activeRuns[chatID] = true
+	qm.nextRunID++
+	token := fmt.Sprintf("run-%d", qm.nextRunID)
+	qm.activeRuns[chatID] = token
+	return token
 }
 
 // EndRun marks a chat's run as complete and returns any queued messages
-func (qm *QueueManager) EndRun(chatID int64) []string {
+func (qm *QueueManager) EndRun(chatID int64, token string) []string {
 	qm.mu.Lock()
 	defer qm.mu.Unlock()
-	qm.activeRuns[chatID] = false
+	if current, ok := qm.activeRuns[chatID]; !ok || current != token {
+		return nil
+	}
+	delete(qm.activeRuns, chatID)
 	queued := qm.queued[chatID]
 	delete(qm.queued, chatID)
 	return queued
@@ -101,6 +110,9 @@ func (b *Bot) handleWithQueueMode(ctx context.Context, sessionKey agent.SessionK
 	case QueueInterrupt:
 		// Interrupt: cancel the active run via the hub, then let the new message proceed.
 		b.hub.Cancel(sessionKey)
+		if ack := b.takeAckHandle(chatID); ack != nil {
+			b.updateAckStatus(ack, jobStatusCancelled, "Interrupted by a newer message.")
+		}
 		log.Printf("[bot] interrupted active run for session %s", sessionKey)
 		return false // Let the message proceed normally after interrupt
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -1383,7 +1383,7 @@ func (s *Store) SaveSessionMessageV2(sessionKey, role, content, runID string) er
 // SaveSessionMessagePairV2 atomically persists a user+assistant message pair
 // to the v2 transcript within a single transaction. This prevents orphaned
 // user messages if the assistant write fails.
-func (s *Store) SaveSessionMessagePairV2(sessionKey, userContent, assistantContent string) error {
+func (s *Store) SaveSessionMessagePairV2(sessionKey, userContent, assistantContent, runID string) error {
 	tx, err := s.db.Begin()
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
@@ -1396,8 +1396,8 @@ func (s *Store) SaveSessionMessagePairV2(sessionKey, userContent, assistantConte
 	} {
 		if _, err := tx.Exec(`
 			INSERT INTO session_messages_v2 (session_key, role, content, run_id)
-			VALUES (?, ?, ?, '')
-		`, sessionKey, msg.role, msg.content); err != nil {
+			VALUES (?, ?, ?, ?)
+		`, sessionKey, msg.role, msg.content, runID); err != nil {
 			return fmt.Errorf("insert %s message: %w", msg.role, err)
 		}
 	}

--- a/internal/storage/sqlite_v2_test.go
+++ b/internal/storage/sqlite_v2_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"database/sql"
 	"path/filepath"
 	"testing"
 )
@@ -128,6 +129,63 @@ func TestSaveAndGetSessionMessagesV2(t *testing.T) {
 	}
 	if sess.MessageCount != 3 {
 		t.Errorf("MessageCount = %d, want 3", sess.MessageCount)
+	}
+}
+
+func TestSaveSessionMessagePairV2StoresRunID(t *testing.T) {
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "pair.db"))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	stmts := []string{
+		`CREATE TABLE sessions_v2 (
+			session_key TEXT PRIMARY KEY,
+			message_count INTEGER NOT NULL DEFAULT 0,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);`,
+		`CREATE TABLE session_messages_v2 (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_key TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT NOT NULL,
+			run_id TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);`,
+		`INSERT INTO sessions_v2 (session_key, message_count) VALUES ('agent:bot:pair', 0);`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed schema: %v\nSQL: %s", err, stmt)
+		}
+	}
+
+	s := &Store{db: db}
+	key := "agent:bot:pair"
+	if err := s.SaveSessionMessagePairV2(key, "hello", "world", "job-1"); err != nil {
+		t.Fatalf("SaveSessionMessagePairV2: %v", err)
+	}
+
+	got, err := s.GetSessionMessagesV2(key, 10)
+	if err != nil {
+		t.Fatalf("GetSessionMessagesV2: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(got))
+	}
+	for i, msg := range got {
+		if msg.RunID != "job-1" {
+			t.Fatalf("message %d run_id = %q, want job-1", i, msg.RunID)
+		}
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT message_count FROM sessions_v2 WHERE session_key = ?`, key).Scan(&count); err != nil {
+		t.Fatalf("query message_count: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("message_count = %d, want 2", count)
 	}
 }
 


### PR DESCRIPTION
Closes #172

What changed
- Telegram text/photo/sticker/document flows now acknowledge immediately and execute hub work in the background instead of blocking the update handler.
- Telegram lifecycle placeholders now show explicit job IDs and statuses (`accepted`, `queued`, `running`, `completed`, `failed`, `cancelled`). Long-running results are delivered as separate async messages.
- Transcript persistence now stores `run_id=job_id` for Telegram reply pairs, and the request lifecycle doc was updated to reflect the new async behavior.

Targeted verification
- `go build ./...`
- `go test ./internal/bot ./internal/storage` (fails due pre-existing baseline issues listed below)
- `go test ./internal/bot -run 'Test(NewTelegramJobIDHasPrefix|TestFormatTelegramJobStatusIncludesLifecycle|TestLiveStreamEditorIncludesJobHeader|TestLiveStreamEditor_)'`\n- `go test ./internal/storage -run TestSaveSessionMessagePairV2StoresRunID`\n\nFull suite\n- `go test ./...` failed\n\nKnown pre-existing or unrelated failures that remain\n- `internal/storage`: multiple tests fail during `storage.New()` migration bootstrap with `failed to migrate database: canonical session backfill failed: table sessions_v2 has no column named state`.\n- `internal/bot`: `dm_auth_test.go` fails for the same storage migration bootstrap issue before the touched lifecycle code runs.\n- `internal/ai`: `TestAnthropicClientOAuthHeadersAndBetaQuery` fails with an unexpected `Authorization` header assertion followed by `EOF`.\n

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR decouples Telegram message receipt from AI processing by making hub runs asynchronous. Instead of blocking the update handler, inbound messages now receive an immediate lifecycle placeholder (with a unique job ID and status like `accepted`/`running`/`completed`/`failed`/`cancelled`), and AI processing runs in a background goroutine. Results are delivered as separate messages. The `QueueManager` is upgraded with token-based run tracking to prevent stale goroutines from flushing queued messages, and transcript persistence now stores `run_id` for traceability.

- **Async hub runs via `runViaHubAsync`**: The core text handler now fires `processViaHubWithContent` in a goroutine, with deferred queue flush and error delivery. Token-based `EndRun` validation prevents race conditions from superseded runs.
- **Lifecycle placeholders**: New `job_lifecycle.go` defines job statuses, ID generation (`tg-{msgID}-{nanos}`), and formatting. The `LiveStreamEditor` now prepends a job header to all placeholder updates.
- **`telegramDelivery` value capture**: Replaces direct `telebot.Context` usage in async paths, extracting `Chat`/`Message` pointers synchronously before passing to the goroutine.
- **`Flush()` holds mutex during network I/O** (`live_editor.go`): Unlike `scheduleEdit()` which releases the lock before calling `bot.Edit`, `Flush()` holds `e.mu` during the Telegram API call — this can block streaming updates under load.
- **Media handlers skip queue management**: Photo, sticker, and document flows pass empty `runToken` to `runViaHubAsync`, so they don't register as active runs in the `QueueManager`. This means concurrent media + text runs can overlap without queueing, and any queued messages during media runs won't be flushed.

<h3>Confidence Score: 3/5</h3>

- The async refactor is well-designed with token-based safety, but the mutex-during-IO pattern in Flush() and missing queue management for media handlers could cause issues under load.
- Score of 3 reflects solid architectural direction with token-based run tracking and proper context capture, but two concrete issues: (1) Flush() holds the mutex during a blocking Telegram API call, diverging from the established scheduleEdit() pattern, which could cause contention; (2) media handlers bypass QueueManager entirely, allowing concurrent runs per chat and orphaned queued messages.
- Pay close attention to `internal/bot/live_editor.go` (Flush mutex issue) and `internal/bot/media_handler.go` (missing queue management for photo/sticker/document flows).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/bot/hub_handler.go | Core async refactor: introduces `runViaHubAsync` goroutine with token-based queue flush, replaces `telebot.Context` with `telegramDelivery` value type. Lifecycle/status updates and error handling are well-structured. |
| internal/bot/job_lifecycle.go | New file defining job statuses, delivery struct, job ID generation, and formatting helpers. Clean and well-organized. Note: `jobStatusAccepted` intentionally falls through to default icon. |
| internal/bot/live_editor.go | Adds job lifecycle header to live editor output, new `Flush()` method, and removes Markdown parse mode. `Flush()` holds mutex during Telegram API call — inconsistent with `scheduleEdit()` pattern. |
| internal/bot/media_handler.go | Photo/sticker/document handlers migrated to async via `runViaHubAsync`, but pass empty `runToken`, bypassing queue management and preventing queued message flush. |
| internal/bot/chat_routing.go | Removes synchronous `flushQueuedMessages`, delegates to async `runViaHubAsync` with queue token. Correctly calls `StartRun` before async launch. Removed `defer` queue flush is now handled inside goroutine. |
| internal/bot/bot.go | Updates ack methods to use `AckHandle` with job IDs, introduces `updateAckStatus` for lifecycle edits. `sendQueuedAck` simplified to fire-and-forget message. Changes are consistent with the async model. |
| internal/bot/queue.go | Token-based run tracking prevents stale goroutine cleanup races. `EndRun` validates token before releasing queued messages. Clean, thread-safe implementation. |
| internal/storage/sqlite.go | Adds `runID` parameter to `SaveSessionMessagePairV2` and passes it through to both user and assistant inserts. Clean, backwards-compatible change. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/bot/live_editor.go
Line: 215-223

Comment:
**`Flush()` holds mutex during Telegram API call**

`Flush()` calls `e.bot.Edit(...)` while holding `e.mu`. The existing `scheduleEdit()` method (line 196) deliberately releases the lock before making the network call to avoid blocking other goroutines that call `AppendDelta()` or `OnToolEvent()`. Under load, a slow Telegram API response in `Flush()` will block all streaming updates from being recorded, potentially causing visible lag or even goroutine pileup.

Consider releasing the lock before the edit, mirroring what `scheduleEdit` does:

```suggestion
func (e *LiveStreamEditor) Flush() {
	e.mu.Lock()
	content := e.formatLocked()
	msg := e.msg
	e.mu.Unlock()

	if msg != nil && content != "" {
		e.bot.Edit(msg, content) //nolint:errcheck
	}
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/bot/media_handler.go
Line: 213-214

Comment:
**Media handlers bypass queue management**

Photo, sticker (line 310-311), and document (line 358-359) handlers all pass `runToken: ""` to `runViaHubAsync`, which means `QueueManager.StartRun()` is never called for these media flows. Consequently:

1. A media message won't register as an "active run" in the `QueueManager`, so subsequent text messages won't be queued — they'll start a concurrent run for the same chat.
2. Any messages queued during a media run will never be flushed, because `EndRun` early-returns when `runToken == ""`.

The text handler in `chat_routing.go:58` correctly calls `StartRun` before `runViaHubAsync`. Was this omission intentional (e.g., media runs are expected to be short-lived and don't warrant queueing), or should media handlers also participate in queue management?

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 741885a</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->