### PR TITLE
feat: feat(runtime): droid exec runs through the new worker adapter contract (#169)

### DIFF
--- a/internal/ai/droid_client.go
+++ b/internal/ai/droid_client.go
@@ -1,26 +1,22 @@
 package ai
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"ok-gobot/internal/logger"
+	"ok-gobot/internal/worker"
 )
 
 // DroidConfig holds droid-specific configuration.
-type DroidConfig struct {
-	BinaryPath string `mapstructure:"binary_path"` // Path to droid binary (default: "droid")
-	AutoLevel  string `mapstructure:"auto_level"`  // Autonomy level: "", "low", "medium", "high"
-	WorkDir    string `mapstructure:"work_dir"`    // Working directory for droid execution
-}
+type DroidConfig = worker.DroidConfig
 
 // DroidClient implements Client and StreamingClient for factory.ai droid exec.
 //
-// Architecture: ok-gobot spawns `droid exec` as a subprocess per request.
+// Architecture: ok-gobot shapes message history into a task prompt, then sends
+// that task through the shared worker adapter contract. The default backend is
+// worker.DroidAdapter, which spawns `droid exec` as a subprocess per request.
 // Droid runs the model and handles tool execution internally, including MCP
 // tools registered with droid (e.g. ok-gobot's memory MCP server).
 //
@@ -33,6 +29,7 @@ type DroidConfig struct {
 type DroidClient struct {
 	config   ProviderConfig
 	droidCfg DroidConfig
+	adapter  worker.Adapter
 }
 
 // SupportsVision reports whether droid currently accepts multimodal user blocks.
@@ -42,49 +39,29 @@ func (c *DroidClient) SupportsVision() bool {
 
 // NewDroidClient creates a new droid subprocess client.
 func NewDroidClient(config ProviderConfig, droidCfg DroidConfig) *DroidClient {
+	return newDroidClientWithAdapter(config, droidCfg, nil)
+}
+
+func newDroidClientWithAdapter(config ProviderConfig, droidCfg DroidConfig, adapter worker.Adapter) *DroidClient {
 	if droidCfg.BinaryPath == "" {
 		droidCfg.BinaryPath = "droid"
+	}
+	if adapter == nil {
+		adapter = worker.NewDroidAdapter(droidCfg)
 	}
 	return &DroidClient{
 		config:   config,
 		droidCfg: droidCfg,
+		adapter:  adapter,
 	}
 }
 
-// droidStreamEvent represents a single event from droid's stream-json output.
-type droidStreamEvent struct {
-	Type    string `json:"type"`
-	Content string `json:"content,omitempty"`
-	Text    string `json:"text,omitempty"`
-	// completion fields
-	Result    string `json:"result,omitempty"`
-	SessionID string `json:"session_id,omitempty"`
-	IsError   bool   `json:"is_error,omitempty"`
-	// tool event fields (informational — droid handles tools internally)
-	ToolName string          `json:"tool_name,omitempty"`
-	Input    json.RawMessage `json:"input,omitempty"`
-}
-
-// buildArgs constructs the droid exec command arguments.
-func (c *DroidClient) buildArgs(prompt string, outputFmt string) []string {
-	args := []string{"exec"}
-
-	if c.config.Model != "" {
-		args = append(args, "-m", c.config.Model)
+func (c *DroidClient) buildRequest(prompt string) worker.Request {
+	return worker.Request{
+		Task:    prompt,
+		Model:   c.config.Model,
+		WorkDir: c.droidCfg.WorkDir,
 	}
-
-	args = append(args, "-o", outputFmt)
-
-	if c.droidCfg.AutoLevel != "" {
-		args = append(args, "--auto", c.droidCfg.AutoLevel)
-	}
-
-	if c.droidCfg.WorkDir != "" {
-		args = append(args, "--cwd", c.droidCfg.WorkDir)
-	}
-
-	args = append(args, prompt)
-	return args
 }
 
 // formatDroidPrompt converts a legacy message history into a single prompt string.
@@ -140,33 +117,13 @@ func (c *DroidClient) Complete(ctx context.Context, messages []Message) (string,
 	prompt := formatDroidPrompt(messages)
 	logger.Debugf("Droid Complete: model=%s prompt_len=%d", c.config.Model, len(prompt))
 
-	args := c.buildArgs(prompt, "json")
-	cmd := exec.CommandContext(ctx, c.droidCfg.BinaryPath, args...)
-
-	output, err := cmd.Output()
+	result, err := c.adapter.Run(ctx, c.buildRequest(prompt))
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return "", fmt.Errorf("droid exec failed (exit %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
-		}
-		return "", fmt.Errorf("droid exec failed: %w", err)
+		return "", err
 	}
 
-	var result struct {
-		Result    string `json:"result"`
-		IsError   bool   `json:"is_error"`
-		SessionID string `json:"session_id"`
-	}
-	if err := json.Unmarshal(output, &result); err != nil {
-		// If JSON parse fails, return raw output as text.
-		return strings.TrimSpace(string(output)), nil
-	}
-
-	if result.IsError {
-		return "", fmt.Errorf("droid error: %s", result.Result)
-	}
-
-	logger.Debugf("Droid Complete response: len=%d session=%s", len(result.Result), result.SessionID)
-	return result.Result, nil
+	logger.Debugf("Droid Complete response: len=%d session=%s", len(result.Content), result.SessionID)
+	return result.Content, nil
 }
 
 // CompleteWithTools sends messages with tool definitions and returns the full response.
@@ -176,29 +133,9 @@ func (c *DroidClient) CompleteWithTools(ctx context.Context, messages []ChatMess
 	logger.Debugf("Droid CompleteWithTools: model=%s prompt_len=%d tools=%d (ignored, droid uses MCP)",
 		c.config.Model, len(prompt), len(tools))
 
-	args := c.buildArgs(prompt, "json")
-	cmd := exec.CommandContext(ctx, c.droidCfg.BinaryPath, args...)
-
-	output, err := cmd.Output()
+	result, err := c.adapter.Run(ctx, c.buildRequest(prompt))
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("droid exec failed (exit %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
-		}
-		return nil, fmt.Errorf("droid exec failed: %w", err)
-	}
-
-	var result struct {
-		Result    string `json:"result"`
-		IsError   bool   `json:"is_error"`
-		SessionID string `json:"session_id"`
-		NumTurns  int    `json:"num_turns"`
-	}
-	if err := json.Unmarshal(output, &result); err != nil {
-		result.Result = strings.TrimSpace(string(output))
-	}
-
-	if result.IsError {
-		return nil, fmt.Errorf("droid error: %s", result.Result)
+		return nil, err
 	}
 
 	return &ChatCompletionResponse{
@@ -213,7 +150,7 @@ func (c *DroidClient) CompleteWithTools(ctx context.Context, messages []ChatMess
 				Index: 0,
 				Message: ChatMessage{
 					Role:    RoleAssistant,
-					Content: result.Result,
+					Content: result.Content,
 				},
 				FinishReason: "stop",
 			},
@@ -237,97 +174,16 @@ func (c *DroidClient) CompleteStreamWithTools(ctx context.Context, messages []Ch
 
 		prompt := formatDroidChatPrompt(messages)
 		logger.Debugf("Droid stream: model=%s prompt_len=%d", c.config.Model, len(prompt))
-
-		args := c.buildArgs(prompt, "stream-json")
-		cmd := exec.CommandContext(ctx, c.droidCfg.BinaryPath, args...)
-
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			ch <- StreamChunk{Error: fmt.Errorf("failed to create stdout pipe: %w", err)}
-			return
-		}
-
-		if err := cmd.Start(); err != nil {
-			ch <- StreamChunk{Error: fmt.Errorf("failed to start droid: %w", err)}
-			return
-		}
-
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
-
-		for scanner.Scan() {
-			select {
-			case <-ctx.Done():
-				_ = cmd.Process.Kill()
-				ch <- StreamChunk{Error: ctx.Err(), Done: true}
-				return
-			default:
+		for evt := range c.adapter.Stream(ctx, c.buildRequest(prompt)) {
+			chunk := StreamChunk{
+				Content: evt.Content,
+				Done:    evt.Done,
+				Error:   evt.Error,
 			}
-
-			line := strings.TrimSpace(scanner.Text())
-			if line == "" {
-				continue
+			if evt.Done && evt.Error == nil {
+				chunk.FinishReason = "stop"
 			}
-
-			var evt droidStreamEvent
-			if err := json.Unmarshal([]byte(line), &evt); err != nil {
-				continue
-			}
-
-			switch evt.Type {
-			case "message":
-				text := evt.Content
-				if text == "" {
-					text = evt.Text
-				}
-				if text != "" {
-					ch <- StreamChunk{Content: text}
-				}
-
-			case "completion":
-				text := evt.Result
-				if text == "" {
-					text = evt.Content
-				}
-				if text != "" {
-					ch <- StreamChunk{Content: text}
-				}
-				ch <- StreamChunk{Done: true, FinishReason: "stop"}
-				_ = cmd.Wait()
-				return
-
-			case "error":
-				errMsg := evt.Content
-				if errMsg == "" {
-					errMsg = evt.Result
-				}
-				if errMsg == "" {
-					errMsg = "unknown droid error"
-				}
-				ch <- StreamChunk{Error: fmt.Errorf("droid: %s", errMsg), Done: true}
-				_ = cmd.Wait()
-				return
-
-			case "tool_call", "tool_result":
-				// Informational — droid handles tools internally.
-				logger.Debugf("Droid stream tool event: type=%s tool=%s", evt.Type, evt.ToolName)
-			}
-		}
-
-		if err := scanner.Err(); err != nil {
-			ch <- StreamChunk{Error: fmt.Errorf("stream read error: %w", err), Done: true}
-		}
-
-		if err := cmd.Wait(); err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				ch <- StreamChunk{
-					Error: fmt.Errorf("droid exited with code %d: %s",
-						exitErr.ExitCode(), string(exitErr.Stderr)),
-					Done: true,
-				}
-			}
-		} else {
-			ch <- StreamChunk{Done: true, FinishReason: "stop"}
+			ch <- chunk
 		}
 	}()
 

--- a/internal/ai/droid_client_test.go
+++ b/internal/ai/droid_client_test.go
@@ -6,7 +6,34 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"ok-gobot/internal/worker"
 )
+
+type stubWorkerAdapter struct {
+	runResult    *worker.Result
+	runErr       error
+	runReq       worker.Request
+	streamReq    worker.Request
+	streamEvents []worker.Event
+}
+
+func (s *stubWorkerAdapter) Run(_ context.Context, req worker.Request) (*worker.Result, error) {
+	s.runReq = req
+	return s.runResult, s.runErr
+}
+
+func (s *stubWorkerAdapter) Stream(_ context.Context, req worker.Request) <-chan worker.Event {
+	s.streamReq = req
+	ch := make(chan worker.Event, len(s.streamEvents))
+	go func() {
+		defer close(ch)
+		for _, evt := range s.streamEvents {
+			ch <- evt
+		}
+	}()
+	return ch
+}
 
 func TestNewDroidClient_Defaults(t *testing.T) {
 	client := NewDroidClient(ProviderConfig{Name: "droid"}, DroidConfig{})
@@ -19,66 +46,6 @@ func TestNewDroidClient_CustomBinary(t *testing.T) {
 	client := NewDroidClient(ProviderConfig{Name: "droid"}, DroidConfig{BinaryPath: "/usr/local/bin/droid"})
 	if client.droidCfg.BinaryPath != "/usr/local/bin/droid" {
 		t.Errorf("expected custom binary_path, got %q", client.droidCfg.BinaryPath)
-	}
-}
-
-func TestDroidClient_BuildArgs(t *testing.T) {
-	tests := []struct {
-		name      string
-		config    ProviderConfig
-		droidCfg  DroidConfig
-		prompt    string
-		outputFmt string
-		wantArgs  []string
-	}{
-		{
-			name:      "minimal",
-			config:    ProviderConfig{Model: "glm-5"},
-			droidCfg:  DroidConfig{BinaryPath: "droid"},
-			prompt:    "hello",
-			outputFmt: "json",
-			wantArgs:  []string{"exec", "-m", "glm-5", "-o", "json", "hello"},
-		},
-		{
-			name:      "with auto level",
-			config:    ProviderConfig{Model: "kimi-k2.5"},
-			droidCfg:  DroidConfig{BinaryPath: "droid", AutoLevel: "low"},
-			prompt:    "test prompt",
-			outputFmt: "stream-json",
-			wantArgs:  []string{"exec", "-m", "kimi-k2.5", "-o", "stream-json", "--auto", "low", "test prompt"},
-		},
-		{
-			name:      "with work dir",
-			config:    ProviderConfig{Model: "glm-5"},
-			droidCfg:  DroidConfig{BinaryPath: "droid", WorkDir: "/tmp/work"},
-			prompt:    "prompt",
-			outputFmt: "json",
-			wantArgs:  []string{"exec", "-m", "glm-5", "-o", "json", "--cwd", "/tmp/work", "prompt"},
-		},
-		{
-			name:      "no model",
-			config:    ProviderConfig{},
-			droidCfg:  DroidConfig{BinaryPath: "droid"},
-			prompt:    "prompt",
-			outputFmt: "json",
-			wantArgs:  []string{"exec", "-o", "json", "prompt"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client := NewDroidClient(tt.config, tt.droidCfg)
-			got := client.buildArgs(tt.prompt, tt.outputFmt)
-
-			if len(got) != len(tt.wantArgs) {
-				t.Fatalf("arg count: got %d, want %d\n  got:  %v\n  want: %v", len(got), len(tt.wantArgs), got, tt.wantArgs)
-			}
-			for i, g := range got {
-				if g != tt.wantArgs[i] {
-					t.Errorf("arg[%d]: got %q, want %q", i, g, tt.wantArgs[i])
-				}
-			}
-		})
 	}
 }
 
@@ -153,6 +120,78 @@ func TestNewClient_DroidDefaultModel(t *testing.T) {
 	}
 	if dc.config.Model != "glm-5" {
 		t.Errorf("expected default model 'glm-5', got %q", dc.config.Model)
+	}
+}
+
+func TestDroidClient_Complete_UsesWorkerAdapter(t *testing.T) {
+	adapter := &stubWorkerAdapter{
+		runResult: &worker.Result{
+			Content:   "adapter result",
+			SessionID: "sess-adapter",
+		},
+	}
+	client := newDroidClientWithAdapter(
+		ProviderConfig{Name: "droid", Model: "glm-5"},
+		DroidConfig{WorkDir: "/tmp/droid-work"},
+		adapter,
+	)
+
+	result, err := client.Complete(context.Background(), []Message{
+		{Role: "system", Content: "System prompt"},
+		{Role: "user", Content: "Hello"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "adapter result" {
+		t.Fatalf("result = %q, want %q", result, "adapter result")
+	}
+	if adapter.runReq.Model != "glm-5" {
+		t.Fatalf("model = %q, want %q", adapter.runReq.Model, "glm-5")
+	}
+	if adapter.runReq.WorkDir != "/tmp/droid-work" {
+		t.Fatalf("workdir = %q, want %q", adapter.runReq.WorkDir, "/tmp/droid-work")
+	}
+	if !contains(adapter.runReq.Task, "[System]") || !contains(adapter.runReq.Task, "Hello") {
+		t.Fatalf("worker task did not include formatted prompt: %q", adapter.runReq.Task)
+	}
+}
+
+func TestDroidClient_CompleteStreamWithTools_UsesWorkerAdapter(t *testing.T) {
+	adapter := &stubWorkerAdapter{
+		streamEvents: []worker.Event{
+			{Content: "Hello "},
+			{Content: "world"},
+			{Done: true},
+		},
+	}
+	client := newDroidClientWithAdapter(
+		ProviderConfig{Name: "droid", Model: "glm-5"},
+		DroidConfig{},
+		adapter,
+	)
+
+	ch := client.CompleteStreamWithTools(context.Background(), []ChatMessage{
+		{Role: RoleSystem, Content: "System prompt"},
+		{Role: RoleUser, Content: "Question"},
+	}, nil)
+
+	var chunks []StreamChunk
+	for chunk := range ch {
+		chunks = append(chunks, chunk)
+	}
+
+	if len(chunks) != 3 {
+		t.Fatalf("chunk count = %d, want 3", len(chunks))
+	}
+	if chunks[0].Content != "Hello " || chunks[1].Content != "world" {
+		t.Fatalf("unexpected content chunks: %+v", chunks)
+	}
+	if !chunks[2].Done || chunks[2].FinishReason != "stop" {
+		t.Fatalf("final chunk = %+v, want done stop", chunks[2])
+	}
+	if !contains(adapter.streamReq.Task, "Question") {
+		t.Fatalf("worker stream task did not include user prompt: %q", adapter.streamReq.Task)
 	}
 }
 

--- a/internal/worker/adapter.go
+++ b/internal/worker/adapter.go
@@ -1,0 +1,31 @@
+package worker
+
+import "context"
+
+// Request describes one bounded worker task.
+// Callers shape the task text; adapters normalize execution and result handling.
+type Request struct {
+	Task    string
+	Model   string
+	WorkDir string
+}
+
+// Result is the normalized final output from a worker backend.
+type Result struct {
+	Content   string
+	SessionID string
+}
+
+// Event is a streamed update from a worker backend.
+type Event struct {
+	Content string
+	Done    bool
+	Error   error
+}
+
+// Adapter executes a task through a worker backend.
+// Implementations must respect context cancellation and timeouts.
+type Adapter interface {
+	Run(ctx context.Context, req Request) (*Result, error)
+	Stream(ctx context.Context, req Request) <-chan Event
+}

--- a/internal/worker/droid.go
+++ b/internal/worker/droid.go
@@ -1,0 +1,208 @@
+package worker
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"ok-gobot/internal/logger"
+)
+
+// DroidConfig holds droid-specific configuration.
+type DroidConfig struct {
+	BinaryPath string `mapstructure:"binary_path"` // Path to droid binary (default: "droid")
+	AutoLevel  string `mapstructure:"auto_level"`  // Autonomy level: "", "low", "medium", "high"
+	WorkDir    string `mapstructure:"work_dir"`    // Working directory for droid execution
+}
+
+// DroidAdapter executes worker tasks through `droid exec`.
+type DroidAdapter struct {
+	config DroidConfig
+}
+
+var _ Adapter = (*DroidAdapter)(nil)
+
+// NewDroidAdapter creates a Droid-backed worker adapter.
+func NewDroidAdapter(cfg DroidConfig) *DroidAdapter {
+	if cfg.BinaryPath == "" {
+		cfg.BinaryPath = "droid"
+	}
+	return &DroidAdapter{config: cfg}
+}
+
+type droidStreamEvent struct {
+	Type    string `json:"type"`
+	Content string `json:"content,omitempty"`
+	Text    string `json:"text,omitempty"`
+
+	Result    string `json:"result,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	IsError   bool   `json:"is_error,omitempty"`
+
+	ToolName string          `json:"tool_name,omitempty"`
+	Input    json.RawMessage `json:"input,omitempty"`
+}
+
+type droidResult struct {
+	Result    string `json:"result"`
+	IsError   bool   `json:"is_error"`
+	SessionID string `json:"session_id"`
+}
+
+func (a *DroidAdapter) buildArgs(req Request, outputFmt string) []string {
+	args := []string{"exec"}
+
+	if req.Model != "" {
+		args = append(args, "-m", req.Model)
+	}
+
+	args = append(args, "-o", outputFmt)
+
+	if a.config.AutoLevel != "" {
+		args = append(args, "--auto", a.config.AutoLevel)
+	}
+
+	workDir := strings.TrimSpace(req.WorkDir)
+	if workDir == "" {
+		workDir = strings.TrimSpace(a.config.WorkDir)
+	}
+	if workDir != "" {
+		args = append(args, "--cwd", workDir)
+	}
+
+	args = append(args, req.Task)
+	return args
+}
+
+// Run executes a droid task and returns its final output.
+func (a *DroidAdapter) Run(ctx context.Context, req Request) (*Result, error) {
+	args := a.buildArgs(req, "json")
+	cmd := exec.CommandContext(ctx, a.config.BinaryPath, args...)
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("droid exec failed (exit %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("droid exec failed: %w", err)
+	}
+
+	var result droidResult
+	if err := json.Unmarshal(output, &result); err != nil {
+		return &Result{Content: strings.TrimSpace(string(output))}, nil
+	}
+
+	if result.IsError {
+		return nil, fmt.Errorf("droid error: %s", result.Result)
+	}
+
+	return &Result{
+		Content:   result.Result,
+		SessionID: result.SessionID,
+	}, nil
+}
+
+// Stream executes a droid task in stream-json mode.
+func (a *DroidAdapter) Stream(ctx context.Context, req Request) <-chan Event {
+	ch := make(chan Event, 100)
+
+	go func() {
+		defer close(ch)
+
+		args := a.buildArgs(req, "stream-json")
+		cmd := exec.CommandContext(ctx, a.config.BinaryPath, args...)
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			ch <- Event{Error: fmt.Errorf("failed to create stdout pipe: %w", err)}
+			return
+		}
+
+		if err := cmd.Start(); err != nil {
+			ch <- Event{Error: fmt.Errorf("failed to start droid: %w", err)}
+			return
+		}
+
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				_ = cmd.Process.Kill()
+				ch <- Event{Error: ctx.Err(), Done: true}
+				return
+			default:
+			}
+
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+
+			var evt droidStreamEvent
+			if err := json.Unmarshal([]byte(line), &evt); err != nil {
+				continue
+			}
+
+			switch evt.Type {
+			case "message":
+				text := evt.Content
+				if text == "" {
+					text = evt.Text
+				}
+				if text != "" {
+					ch <- Event{Content: text}
+				}
+
+			case "completion":
+				text := evt.Result
+				if text == "" {
+					text = evt.Content
+				}
+				if text != "" {
+					ch <- Event{Content: text}
+				}
+				ch <- Event{Done: true}
+				_ = cmd.Wait()
+				return
+
+			case "error":
+				errMsg := evt.Content
+				if errMsg == "" {
+					errMsg = evt.Result
+				}
+				if errMsg == "" {
+					errMsg = "unknown droid error"
+				}
+				ch <- Event{Error: fmt.Errorf("droid: %s", errMsg), Done: true}
+				_ = cmd.Wait()
+				return
+
+			case "tool_call", "tool_result":
+				logger.Debugf("Droid stream tool event: type=%s tool=%s", evt.Type, evt.ToolName)
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			ch <- Event{Error: fmt.Errorf("stream read error: %w", err), Done: true}
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				ch <- Event{
+					Error: fmt.Errorf("droid exited with code %d: %s",
+						exitErr.ExitCode(), string(exitErr.Stderr)),
+					Done: true,
+				}
+			}
+		} else {
+			ch <- Event{Done: true}
+		}
+	}()
+
+	return ch
+}

--- a/internal/worker/droid_test.go
+++ b/internal/worker/droid_test.go
@@ -1,0 +1,225 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNewDroidAdapter_Defaults(t *testing.T) {
+	adapter := NewDroidAdapter(DroidConfig{})
+	if adapter.config.BinaryPath != "droid" {
+		t.Fatalf("binary_path = %q, want %q", adapter.config.BinaryPath, "droid")
+	}
+}
+
+func TestDroidAdapterBuildArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    DroidConfig
+		req       Request
+		outputFmt string
+		wantArgs  []string
+	}{
+		{
+			name:      "minimal",
+			config:    DroidConfig{BinaryPath: "droid"},
+			req:       Request{Task: "hello", Model: "glm-5"},
+			outputFmt: "json",
+			wantArgs:  []string{"exec", "-m", "glm-5", "-o", "json", "hello"},
+		},
+		{
+			name:      "with auto level",
+			config:    DroidConfig{BinaryPath: "droid", AutoLevel: "low"},
+			req:       Request{Task: "test prompt", Model: "kimi-k2.5"},
+			outputFmt: "stream-json",
+			wantArgs:  []string{"exec", "-m", "kimi-k2.5", "-o", "stream-json", "--auto", "low", "test prompt"},
+		},
+		{
+			name:      "adapter work dir fallback",
+			config:    DroidConfig{BinaryPath: "droid", WorkDir: "/tmp/work"},
+			req:       Request{Task: "prompt", Model: "glm-5"},
+			outputFmt: "json",
+			wantArgs:  []string{"exec", "-m", "glm-5", "-o", "json", "--cwd", "/tmp/work", "prompt"},
+		},
+		{
+			name:      "request work dir overrides adapter",
+			config:    DroidConfig{BinaryPath: "droid", WorkDir: "/tmp/work"},
+			req:       Request{Task: "prompt", Model: "glm-5", WorkDir: "/tmp/override"},
+			outputFmt: "json",
+			wantArgs:  []string{"exec", "-m", "glm-5", "-o", "json", "--cwd", "/tmp/override", "prompt"},
+		},
+		{
+			name:      "no model",
+			config:    DroidConfig{BinaryPath: "droid"},
+			req:       Request{Task: "prompt"},
+			outputFmt: "json",
+			wantArgs:  []string{"exec", "-o", "json", "prompt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewDroidAdapter(tt.config)
+			got := adapter.buildArgs(tt.req, tt.outputFmt)
+
+			if len(got) != len(tt.wantArgs) {
+				t.Fatalf("arg count: got %d, want %d\n  got:  %v\n  want: %v", len(got), len(tt.wantArgs), got, tt.wantArgs)
+			}
+			for i, g := range got {
+				if g != tt.wantArgs[i] {
+					t.Fatalf("arg[%d] = %q, want %q", i, g, tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDroidAdapterRunBinaryNotFound(t *testing.T) {
+	adapter := NewDroidAdapter(DroidConfig{BinaryPath: "/nonexistent/droid-binary-12345"})
+
+	_, err := adapter.Run(context.Background(), Request{
+		Task:  "test",
+		Model: "glm-5",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	if !strings.Contains(err.Error(), "droid exec failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDroidAdapterRunMockScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "droid")
+	mockScript := `#!/bin/sh
+echo '{"type":"completion","result":"Hello from mock droid","is_error":false,"session_id":"sess-123"}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewDroidAdapter(DroidConfig{BinaryPath: mockBinary})
+	result, err := adapter.Run(context.Background(), Request{
+		Task:  "test",
+		Model: "glm-5",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Content != "Hello from mock droid" {
+		t.Fatalf("content = %q, want %q", result.Content, "Hello from mock droid")
+	}
+	if result.SessionID != "sess-123" {
+		t.Fatalf("session_id = %q, want %q", result.SessionID, "sess-123")
+	}
+}
+
+func TestDroidAdapterStreamMockScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "droid")
+	mockScript := `#!/bin/sh
+echo '{"type":"message","content":"Hello "}'
+echo '{"type":"message","content":"world!"}'
+echo '{"type":"completion","result":"","session_id":"sess-789"}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewDroidAdapter(DroidConfig{BinaryPath: mockBinary})
+	ch := adapter.Stream(context.Background(), Request{
+		Task:  "test",
+		Model: "glm-5",
+	})
+
+	var events []Event
+	for evt := range ch {
+		events = append(events, evt)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("event count = %d, want 3", len(events))
+	}
+	if events[0].Content != "Hello " || events[1].Content != "world!" {
+		t.Fatalf("unexpected content events: %+v", events)
+	}
+	if !events[2].Done || events[2].Error != nil {
+		t.Fatalf("final event = %+v, want done without error", events[2])
+	}
+}
+
+func TestDroidAdapterStreamErrorEvent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "droid")
+	mockScript := `#!/bin/sh
+echo '{"type":"message","content":"partial "}'
+echo '{"type":"error","content":"rate limit exceeded"}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewDroidAdapter(DroidConfig{BinaryPath: mockBinary})
+	ch := adapter.Stream(context.Background(), Request{
+		Task:  "test",
+		Model: "glm-5",
+	})
+
+	var gotError bool
+	for evt := range ch {
+		if evt.Error != nil {
+			gotError = true
+			if !strings.Contains(evt.Error.Error(), "rate limit exceeded") {
+				t.Fatalf("unexpected error: %v", evt.Error)
+			}
+		}
+	}
+	if !gotError {
+		t.Fatal("expected error event in stream")
+	}
+}
+
+func TestDroidAdapterContextCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "droid")
+	mockScript := `#!/bin/sh
+sleep 30
+echo '{"type":"completion","result":"should not reach"}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewDroidAdapter(DroidConfig{BinaryPath: mockBinary})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := adapter.Run(ctx, Request{
+		Task:  "test",
+		Model: "glm-5",
+	})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}


### PR DESCRIPTION
Closes #169

## What changed
- added a shared `internal/worker.Adapter` contract with normalized `Request`, `Result`, and streamed `Event` types
- implemented `internal/worker.DroidAdapter` to own `droid exec` subprocess invocation, JSON parsing, streaming, cancellation, and cwd/model handling
- switched `internal/ai.DroidClient` to format prompts and delegate execution through the shared worker adapter instead of spawning the subprocess directly
- added direct worker adapter tests plus DroidClient tests that verify the adapter contract is exercised

## Verification
- `go build ./...`
- `go test ./internal/worker -run 'TestDroidAdapter'`
- `go test ./internal/ai -run 'Test(NewDroidClient|DroidClient_|FormatDroid|AvailableModels_IncludesDroid|NewClientWithDroid|NewClient_DroidDefaultModel)'`

## Full suite
- `go test ./...` failed

## Known pre-existing or unrelated failures
- `internal/ai`: `TestAnthropicClientOAuthHeadersAndBetaQuery`
- `internal/storage`: multiple migration tests fail with `canonical session backfill failed: table sessions_v2 has no column named state`
- `internal/bot`: `dm_auth` tests fail because the same storage migration error bubbles up during test setup

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a shared `worker.Adapter` interface that normalizes task execution behind `Request`/`Result`/`Event` types, then extracts all subprocess management from `ai.DroidClient` into `worker.DroidAdapter`. `DroidClient` now formats prompts and delegates through the adapter, keeping the AI layer focused on prompt shaping. A type alias (`ai.DroidConfig = worker.DroidConfig`) preserves backward compatibility for existing consumers in `config` and `app`.

- New `internal/worker` package with `Adapter` interface, `DroidAdapter` implementation, and comprehensive tests
- `DroidClient` simplified from ~200 lines of subprocess/parsing logic to thin delegation through `worker.Adapter`
- Test strategy uses both a `stubWorkerAdapter` for fast contract verification and retained mock-script integration tests
- Minor inconsistency: `Stream()` early error events (pipe/start failure) omit `Done: true`, diverging from the convention used by all other error paths and stream producers in the codebase

<h3>Confidence Score: 4/5</h3>

- This PR is a well-structured refactor that is safe to merge; the one inconsistency found is low-risk due to existing consumer error-checking patterns.
- The refactoring is clean and behavior-preserving. The extracted adapter faithfully reproduces the original subprocess logic, with the added benefit of request-level WorkDir override. One minor inconsistency (missing Done: true on early stream errors) is flagged but won't cause runtime issues with current consumers. Tests are thorough at both unit and integration levels.
- `internal/worker/droid.go` — early error paths in `Stream()` should set `Done: true` for consistency with the rest of the codebase.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/adapter.go | New file defining the shared `Adapter` interface, `Request`, `Result`, and `Event` types. Clean, minimal contract with no issues. |
| internal/worker/droid.go | New `DroidAdapter` implementation extracted from `droid_client.go`. Mostly a clean move, but `Stream()` early error paths (pipe/start failures) omit `Done: true`, inconsistent with all other error events. |
| internal/ai/droid_client.go | Simplified to delegate execution through `worker.Adapter`. Type alias for `DroidConfig` preserves API compatibility. `newDroidClientWithAdapter` enables clean test injection. |
| internal/ai/droid_client_test.go | Good test coverage: stub adapter verifies contract delegation for `Complete` and `CompleteStreamWithTools`, existing mock-script tests retained for integration coverage. |
| internal/worker/droid_test.go | Thorough tests for the new adapter: arg building, binary-not-found, mock script Run/Stream, error events, and context cancellation. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/worker/droid.go
Line: 119-126

Comment:
**Early error events missing `Done: true`**

These two error events (stdout pipe failure on line 120 and process start failure on line 125) are emitted without `Done: true`, unlike every other error path in `Stream()` (lines 136, 181, 191, 196-200) which all set `Done: true`. The `Adapter` contract comment says "Implementations must respect context cancellation and timeouts" but doesn't specify `Done` semantics — however the implicit convention across this file and all other `StreamChunk` producers in the codebase (`anthropic_client.go`, `chatgpt_client.go`, `client.go`) is that terminal error events always set `Done: true`.

Current consumers (`bot.go:523`, `agent_handler.go:51`, `tool_agent.go:326`) check `Error` before `Done` so this won't crash today, but any future consumer relying on `Done` as the "stream is finished" signal would miss these terminal events.

```suggestion
		stdout, err := cmd.StdoutPipe()
		if err != nil {
			ch <- Event{Error: fmt.Errorf("failed to create stdout pipe: %w", err), Done: true}
			return
		}

		if err := cmd.Start(); err != nil {
			ch <- Event{Error: fmt.Errorf("failed to start droid: %w", err), Done: true}
			return
		}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 8903a9b</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->