### PR TITLE
feat: process: legacy hub/subagent runtime is frozen and marked for removal (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ ok-gobot/
 │   ├── memorymcp/        # Memory MCP server
 │   ├── migrate/          # Database migrations
 │   ├── redact/           # Log redaction
-│   ├── runtime/          # Runtime hub, session scheduling
+│   ├── runtime/          # Chat/jobs mailbox runtime, session scheduling
 │   ├── sanitize/         # Input sanitization
 │   ├── session/          # Context monitoring
 │   ├── storage/          # SQLite persistence
@@ -259,7 +259,7 @@ ok-gobot/
 - [Roadmap](docs/ROADMAP.md) -- Implementation backlog derived from the competitor analysis
 - [Installation Guide](docs/INSTALL.md) -- Setup, configuration, providers, deployment
 - [API Reference](docs/API.md) -- HTTP REST API and WebSocket control protocol
-- [Architecture](docs/ARCHITECTURE.md) -- Runtime-hub architecture and canonical config reference
+- [Architecture](docs/ARCHITECTURE.md) -- Chat/jobs architecture contract, legacy-runtime freeze, and canonical config reference
 - [Features](docs/FEATURES.md) -- Detailed feature descriptions
 - [Tools Reference](docs/TOOLS.md) -- All tools with usage examples
 - [Memory](docs/MEMORY.md) -- Semantic memory system

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -110,9 +110,9 @@ control:
 #   Auth:  Authorization: Bearer <token>  (or ?token=<token>)
 
 # Runtime configuration
+# runtime.mode from older configs is ignored; the chat/jobs contract is fixed.
 runtime:
-  mode: "hub"  # hub (default) or legacy — selects execution path; legacy will be removed in a future release
-  session_queue_limit: 100  # Per-session queue capacity
+  session_queue_limit: 100  # Per-session queue capacity for the chat/jobs mailbox runtime
 
 # Session key routing configuration
 session:

--- a/config.schema.json
+++ b/config.schema.json
@@ -280,20 +280,11 @@
     "runtime": {
       "additionalProperties": false,
       "default": {},
-      "description": "Runtime behavior and rollout flags.",
+      "description": "Mailbox runtime settings for the active chat/jobs path.",
       "properties": {
-        "mode": {
-          "default": "hub",
-          "description": "Execution path: hub runtime (default) or legacy path.",
-          "enum": [
-            "hub",
-            "legacy"
-          ],
-          "type": "string"
-        },
         "session_queue_limit": {
           "default": 100,
-          "description": "Per-session queue capacity for runtime mailbox execution.",
+          "description": "Per-session queue capacity for chat/jobs mailbox execution.",
           "type": "integer"
         }
       },

--- a/docs/API.md
+++ b/docs/API.md
@@ -331,7 +331,7 @@ Client -> Server:
 | `list_sessions` | -- | Request session list |
 | `new_session` | `name` | Create new session |
 | `switch_session` | `session_id` | Switch active session |
-| `spawn_subagent` | `task`, `model`, `thinking`, `tool_allowlist`, `workspace_root`, `max_tool_calls`, `max_duration`, `output_format`, `output_schema`, `memory_policy` | Spawn sub-agent with an explicit delegated-run contract |
+| `spawn_subagent` | `task`, `model`, `thinking`, `tool_allowlist`, `workspace_root`, `max_tool_calls`, `max_duration`, `output_format`, `output_schema`, `memory_policy` | Spawn sub-agent with an explicit delegated-run contract (legacy/frozen compatibility surface) |
 | `bot_command` | `session_id`, `text` | Execute slash command |
 
 ## Server Messages

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,16 +1,22 @@
-# ok-gobot Architecture v2
+# ok-gobot Architecture Contract
 
 ## 1. Scope
 
-This document defines the runtime architecture for the hub-based execution model.
+This document defines the active architecture contract for the chat/jobs runtime path.
 For configuration, this document is the source of truth.
 
-## 2. Runtime Hub
+The legacy hub/subagent runtime (`internal/agent/runtime.go`, the Telegram
+`hub_handler` flow, and legacy control-server sub-agent surfaces) is frozen for
+compatibility only. New feature work must target the chat/jobs path backed by
+`internal/runtime`, not the legacy runtime.
 
-- One runtime hub owns execution scheduling.
+## 2. Active Runtime Contract
+
+- Chat ingress and scheduled jobs are the product execution surfaces.
+- `internal/runtime` owns mailbox scheduling, queueing, cancellation, and child completion routing.
 - Different session keys execute in parallel.
 - Each session key executes one run at a time.
-- Transport layers submit requests; they do not execute model logic directly.
+- Transport layers submit work; they do not execute model logic directly.
 
 ## 3. Session Model
 
@@ -22,26 +28,33 @@ Canonical session keys:
 - `agent:<agentId>:telegram:group:<chatId>:thread:<topicId>`
 - `agent:<agentId>:subagent:<runSlug>`
 
-## 4. Transport Adapters
+## 4. Adapters and Workers
 
-- Telegram and TUI are adapters over runtime events.
+- Telegram, control/TUI, and jobs are adapters over chat/jobs requests and runtime events.
 - Adapters handle input/output rendering and acknowledgments.
-- Execution, queueing, and cancellation stay in runtime.
+- Execution, queueing, cancellation, and child completion routing stay in `internal/runtime`.
 
 ## 5. Control Plane
 
 The control server provides loopback API/WS access for status, session operations,
-abort, model/agent switching, and sub-agent actions.
+abort, and chat/job control. Legacy sub-agent RPC surfaces remain available only
+as frozen compatibility shims.
 
-## 6. Persistence
+## 6. Legacy Freeze Policy
+
+- `internal/agent.RuntimeHub` is legacy compatibility code.
+- `browser_task`, `/task`, and legacy control-server sub-agent helpers may still depend on it today.
+- Keep changes there limited to bug fixes or removal prep; do not add new product surface area.
+
+## 7. Persistence
 
 SQLite remains the persistence layer for sessions, messages, routes, and runtime metadata.
 
-## 7. Memory
+## 8. Memory
 
 Memory remains markdown-first (`MEMORY.md` + `memory/*.md`) with semantic indexing for retrieval.
 
-## 8. Configuration Reference (Canonical)
+## 9. Configuration Reference (Canonical)
 
 `config.schema.json` is generated from the canonical JSON block below. This section is the
 single source of truth for configuration keys, types, defaults, and descriptions.
@@ -232,21 +245,12 @@ single source of truth for configuration keys, types, defaults, and descriptions
     "runtime": {
       "type": "object",
       "default": {},
-      "description": "Runtime behavior and rollout flags.",
+      "description": "Mailbox runtime settings for the active chat/jobs path.",
       "properties": {
-        "mode": {
-          "type": "string",
-          "default": "hub",
-          "enum": [
-            "hub",
-            "legacy"
-          ],
-          "description": "Execution path: hub runtime (default) or legacy path."
-        },
         "session_queue_limit": {
           "type": "integer",
           "default": 100,
-          "description": "Per-session queue capacity for runtime mailbox execution."
+          "description": "Per-session queue capacity for chat/jobs mailbox execution."
         }
       }
     },
@@ -403,17 +407,20 @@ single source of truth for configuration keys, types, defaults, and descriptions
 ```
 <!-- CONFIG_CANONICAL:END -->
 
-### 8.1 PRD Extensions
+### 9.1 PRD Extensions
 
 PRD adds rollout-specific configuration extensions to the canonical reference:
 
-- `runtime.mode`
 - `session.dm_scope`
 - `runtime.session_queue_limit`
 
 These keys remain part of the canonical schema above and must stay synchronized with PRD language.
 
-### 8.2 Compatibility Notes
+### 9.2 Compatibility Notes
+
+Legacy `runtime.mode` values (`hub`, `legacy`) are still accepted on load as
+ignored compatibility aliases for older config files, but they are not canonical
+keys and are intentionally excluded from the schema.
 
 Legacy `openai.api_key` and `openai.model` are still accepted as migration aliases,
 but they are not canonical keys and are intentionally excluded from the schema.

--- a/docs/MEMORY-CONTEXT-PIPELINE.md
+++ b/docs/MEMORY-CONTEXT-PIPELINE.md
@@ -4,6 +4,11 @@ How ok-gobot assembles context for every AI request, manages conversation histor
 and persists long-term memory. This is the authoritative reference for the full
 request lifecycle from incoming Telegram message to model response.
 
+The active architecture contract now lives in `docs/ARCHITECTURE.md`. The
+`processViaHub` / `agent.RuntimeHub` path documented here is a frozen
+compatibility flow for the current Telegram request pipeline while the chat/jobs
+runtime takes over.
+
 ---
 
 ## 1. Overview

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -1,3 +1,7 @@
+// Legacy hub/subagent runtime compatibility layer.
+// New architecture work must target internal/runtime and the chat/jobs
+// contract in docs/ARCHITECTURE.md. Keep changes here limited to
+// compatibility fixes and removal prep.
 package agent
 
 import (

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -21,8 +21,8 @@ import (
 )
 
 // Bot wraps the Telegram bot with business logic.
-// It is a thin transport adapter: auth, normalization, and delivery rendering.
-// All agent creation, tool execution, and run orchestration are owned by the RuntimeHub.
+// Telegram currently still uses the legacy agent.RuntimeHub compatibility path.
+// New architecture work should target the chat/jobs mailbox runtime in internal/runtime.
 type Bot struct {
 	ctx              context.Context // bot lifetime context, set during Start
 	api              *telebot.Bot
@@ -38,7 +38,7 @@ type Bot struct {
 	authManager      *AuthManager
 	groupManager     *GroupManager
 	approvalManager  *ApprovalManager
-	hub              *agent.RuntimeHub
+	hub              *agent.RuntimeHub // legacy hub/subagent compatibility runtime for Telegram/TUI bridging
 	subagentHub      *runtime.Hub      // event bus for sub-agent completion routing
 	subagentNotifier *SubagentNotifier // routes child completions to parent Telegram chats
 	adminID          int64

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -24,9 +24,9 @@ func sessionKeyForChat(chat *telebot.Chat) agent.SessionKey {
 	return agent.NewGroupSessionKey(chat.ID)
 }
 
-// processViaHub submits an inbound envelope to the RuntimeHub and renders the
-// resulting events back to Telegram. The bot is a thin transport adapter here:
-// all agent creation, tool execution, and run orchestration happen inside the hub.
+// processViaHub submits an inbound envelope to the legacy RuntimeHub compatibility
+// path and renders the resulting events back to Telegram. New feature work should
+// land on the chat/jobs runtime contract instead of expanding this flow.
 func (b *Bot) processViaHub(ctx context.Context, delivery telegramDelivery, sessionKey agent.SessionKey, content, session string) error {
 	return b.processViaHubWithContent(ctx, delivery, sessionKey, content, nil, session)
 }

--- a/internal/bot/task_command.go
+++ b/internal/bot/task_command.go
@@ -106,8 +106,8 @@ func parseTaskArgs(payload string) (agent.SubagentSpawnRequest, error) {
 }
 
 // handleTaskCommand handles the /task command.
-// It spawns a sub-agent as an isolated child session via the RuntimeHub and
-// notifies the parent chat with a summary or failure message when it finishes.
+// It still depends on the legacy RuntimeHub compatibility path; keep new
+// feature work off this surface while the chat/jobs runtime takes over.
 func (b *Bot) handleTaskCommand(c telebot.Context) error {
 	chatID := c.Chat().ID
 	payload := strings.TrimSpace(c.Message().Payload)

--- a/internal/bot/tui_runtime.go
+++ b/internal/bot/tui_runtime.go
@@ -10,9 +10,10 @@ import (
 	"ok-gobot/internal/control"
 )
 
-// SubmitTUIRun submits an isolated TUI run through the bot's RuntimeHub.
-// TUI runs intentionally use ChatID=0 so they stay independent from Telegram
-// chat sessions while still reusing the same resolver, tools, and personality.
+// SubmitTUIRun submits an isolated TUI run through the bot's legacy RuntimeHub
+// compatibility path. TUI runs intentionally use ChatID=0 so they stay
+// independent from Telegram chat sessions while still reusing the same
+// resolver, tools, and personality.
 func (b *Bot) SubmitTUIRun(ctx context.Context, req control.TUIRunRequest) <-chan agent.RunEvent {
 	if ctx == nil {
 		ctx = context.Background()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,14 +35,14 @@ type ControlConfig struct {
 	AllowLoopbackWithoutToken bool   `mapstructure:"allow_loopback_without_token"`
 }
 
-// RuntimeConfig holds runtime execution configuration.
+// RuntimeConfig holds runtime mailbox configuration.
 type RuntimeConfig struct {
-	// Mode selects the execution path: "hub" (default) or "legacy".
-	// "hub" routes all requests through the RuntimeHub for per-session concurrency.
-	// "legacy" is kept temporarily for rollback; it will be removed in a future release.
+	// Mode is a legacy compatibility knob retained so older configs still decode.
+	// It is ignored: the active architecture contract is the chat/jobs mailbox runtime.
+	// Supported legacy values remain "", "hub", and "legacy" while removal is pending.
 	Mode string `mapstructure:"mode"`
-	// SessionQueueLimit is the per-session queue capacity for runtime mailbox execution.
-	// 0 falls back to runtime defaults where applicable.
+	// SessionQueueLimit is the per-session queue capacity for chat/jobs mailbox execution.
+	// 0 falls back to runtime defaults where applicable for the active runtime path.
 	SessionQueueLimit int `mapstructure:"session_queue_limit"`
 }
 
@@ -76,7 +76,7 @@ type Config struct {
 	TTS          TTSConfig         `mapstructure:"tts"`
 	Memory       MemoryConfig      `mapstructure:"memory"`
 	Agents       []AgentConfig     `mapstructure:"agents"`
-	Models       []string          `mapstructure:"models"`        // list of models for TUI/web picker
+	Models       []string          `mapstructure:"models"` // list of models for TUI/web picker
 	ModelAliases map[string]string `mapstructure:"model_aliases"`
 	Contacts     map[string]int64  `mapstructure:"contacts"` // alias -> chatID for message tool allowlist
 	StoragePath  string            `mapstructure:"storage_path"`
@@ -209,7 +209,6 @@ func Load() (*Config, error) {
 	v.SetDefault("control.port", 8787)
 	v.SetDefault("control.token", "")
 	v.SetDefault("control.allow_loopback_without_token", true)
-	v.SetDefault("runtime.mode", "hub")
 	v.SetDefault("runtime.session_queue_limit", 100)
 	v.SetDefault("session.dm_scope", "main")
 
@@ -308,7 +307,6 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("control.port", 8787)
 	v.SetDefault("control.token", "")
 	v.SetDefault("control.allow_loopback_without_token", true)
-	v.SetDefault("runtime.mode", "hub")
 	v.SetDefault("runtime.session_queue_limit", 100)
 	v.SetDefault("session.dm_scope", "main")
 
@@ -371,10 +369,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid auth.mode: %s (must be 'open', 'allowlist', or 'pairing')", c.Auth.Mode)
 	}
 
-	// Validate runtime mode
-	validRuntimeModes := map[string]bool{"hub": true, "legacy": true}
-	if c.Runtime.Mode != "" && !validRuntimeModes[c.Runtime.Mode] {
-		return fmt.Errorf("invalid runtime.mode: %s (must be 'hub' or 'legacy')", c.Runtime.Mode)
+	// Validate legacy runtime.mode compatibility.
+	validRuntimeModes := map[string]bool{"": true, "hub": true, "legacy": true}
+	if !validRuntimeModes[c.Runtime.Mode] {
+		return fmt.Errorf("invalid runtime.mode: %q (legacy compatibility only; allowed: '', 'hub', 'legacy')", c.Runtime.Mode)
 	}
 	if c.Runtime.SessionQueueLimit < 0 {
 		return fmt.Errorf("invalid runtime.session_queue_limit: %d (must be >= 0)", c.Runtime.SessionQueueLimit)
@@ -447,7 +445,6 @@ func (c *Config) Save() error {
 	v.Set("storage_path", c.StoragePath)
 	v.Set("soul_path", c.SoulPath)
 	v.Set("log_level", c.LogLevel)
-	v.Set("runtime.mode", c.Runtime.Mode)
 	v.Set("runtime.session_queue_limit", c.Runtime.SessionQueueLimit)
 	v.Set("session.dm_scope", c.Session.DMScope)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestLoadFromDefaultRuntimeMode(t *testing.T) {
+func TestLoadFromDefaultRuntimeConfig(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "config-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -31,8 +31,8 @@ storage_path: "/tmp/test.db"
 		t.Fatalf("LoadFrom failed: %v", err)
 	}
 
-	if cfg.Runtime.Mode != "hub" {
-		t.Errorf("expected runtime.mode=%q, got %q", "hub", cfg.Runtime.Mode)
+	if cfg.Runtime.Mode != "" {
+		t.Errorf("expected runtime.mode to remain empty by default, got %q", cfg.Runtime.Mode)
 	}
 	if cfg.Runtime.SessionQueueLimit != 100 {
 		t.Errorf("expected runtime.session_queue_limit=%d, got %d", 100, cfg.Runtime.SessionQueueLimit)
@@ -48,7 +48,7 @@ storage_path: "/tmp/test.db"
 	}
 }
 
-func TestLoadFromExplicitRuntimeMode(t *testing.T) {
+func TestLoadFromLegacyRuntimeModeCompatibility(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "config-test-explicit-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -95,6 +95,9 @@ memory:
 	}
 	if cfg.Memory.MetadataModel != "claude-haiku-3.5" {
 		t.Errorf("expected memory.metadata_model override, got %q", cfg.Memory.MetadataModel)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected legacy runtime.mode compatibility to validate, got %v", err)
 	}
 }
 

--- a/internal/configschema/schema_test.go
+++ b/internal/configschema/schema_test.go
@@ -29,7 +29,7 @@ func TestGenerateMatchesCheckedInSchema(t *testing.T) {
 	}
 }
 
-func TestCanonicalIncludesPRDExtensions(t *testing.T) {
+func TestCanonicalIncludesActiveRuntimeExtensions(t *testing.T) {
 	root := repoRoot(t)
 	architecturePath := filepath.Join(root, "docs", "ARCHITECTURE.md")
 
@@ -39,7 +39,6 @@ func TestCanonicalIncludesPRDExtensions(t *testing.T) {
 	}
 
 	required := []string{
-		"runtime.mode",
 		"runtime.session_queue_limit",
 		"session.dm_scope",
 	}
@@ -47,6 +46,10 @@ func TestCanonicalIncludesPRDExtensions(t *testing.T) {
 		if _, ok := lookup(node, key); !ok {
 			t.Fatalf("canonical key missing: %s", key)
 		}
+	}
+
+	if _, ok := lookup(node, "runtime.mode"); ok {
+		t.Fatal("runtime.mode should remain a legacy compatibility alias, not a canonical key")
 	}
 }
 

--- a/internal/tools/browser_task.go
+++ b/internal/tools/browser_task.go
@@ -10,15 +10,15 @@ import (
 )
 
 // SubagentSubmitter allows tools to spawn subagent runs and wait for results.
+// This is a legacy compatibility seam while the chat/jobs runtime takes over.
 type SubagentSubmitter interface {
 	// SubmitAndWait spawns a subagent with an explicit delegated-run contract.
 	SubmitAndWait(ctx context.Context, chatID int64, task string, job delegation.Job) (string, error)
 }
 
 // BrowserTaskTool decomposes browser tasks into subagent runs.
-// Instead of the main agent burning all its iterations on browser
-// navigation, each site/step gets its own isolated subagent run
-// with a full iteration budget.
+// It is part of the frozen legacy hub/subagent runtime surface and should only
+// receive compatibility fixes until the chat/jobs replacement lands.
 type BrowserTaskTool struct {
 	submitter SubagentSubmitter
 	chatID    int64


### PR DESCRIPTION
Closes #167

## What changed
- rewrote `docs/ARCHITECTURE.md` so the active contract is the chat/jobs path backed by `internal/runtime`, with the hub/subagent runtime explicitly frozen for compatibility only
- removed `runtime.mode` from the canonical schema and example config while keeping it as an ignored legacy compatibility knob in `internal/config`
- marked legacy hub/subagent surfaces (`internal/agent/runtime.go`, Telegram hub handler flow, `/task`, `browser_task`) as frozen/compatibility-only in code comments and docs
- updated related docs (`README.md`, `docs/API.md`, `docs/MEMORY-CONTEXT-PIPELINE.md`) and regenerated `config.schema.json`

## Targeted verification
- `go build ./...`
- `go test ./internal/config ./internal/configschema ./internal/agent ./internal/bot ./internal/control ./internal/tools`

Targeted results:
- passed: `internal/config`, `internal/configschema`, `internal/agent`, `internal/control`, `internal/tools`
- failed with an unrelated baseline issue in `internal/bot`:
  - `TestHandleMessage_DeniesUnauthorizedDirectMessageWithoutSideEffects`
  - `TestGuardUnauthorizedDM_BlocksWrappedHandlerBeforeStateMutation`
  - `TestGuardUnauthorizedDM_AllowsExplicitlyUnauthenticatedPairingCommand`
  - all fail during `storage.New()` migration with `table sessions_v2 has no column named state`

## Full suite
- `go test ./...` failed

Known pre-existing or unrelated failures that remain:
- `internal/ai`: `TestAnthropicClientOAuthHeadersAndBetaQuery`
- `internal/bot`: unauthorized DM tests fail during `storage.New()` migration with `table sessions_v2 has no column named state`
- `internal/storage`: multiple v2 schema/migration tests fail with `table sessions_v2 has no column named state`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Freezes the legacy hub/subagent runtime (`internal/agent/runtime.go`, Telegram hub handler, `/task`, `browser_task`) as compatibility-only code and establishes the chat/jobs mailbox runtime (`internal/runtime`) as the active architecture contract. Removes `runtime.mode` from the canonical schema and example config while retaining it as an ignored legacy compatibility field in the Go struct so older config files still load without errors.

- `docs/ARCHITECTURE.md` rewritten as the active architecture contract with a new Legacy Freeze Policy section (§6) that explicitly gates new feature work to the chat/jobs path
- `runtime.mode` removed from canonical schema, `config.schema.json`, and `config.example.yaml`; the Go struct field and validator keep it as a silent compat knob
- Legacy surfaces (`processViaHub`, `SubmitTUIRun`, `handleTaskCommand`, `BrowserTaskTool`, `SubagentSubmitter`) annotated with freeze comments in code
- Tests updated: default config now expects empty `Mode`, new negative assertion ensures `runtime.mode` stays out of canonical schema, legacy compat test validates old configs still pass `Validate()`
- `docs/MEMORY-CONTEXT-PIPELINE.md` and `docs/API.md` updated with freeze annotations

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is primarily documentation, comments, and config schema changes with no runtime behavior modifications.
- All code changes are limited to comments, doc updates, config default removal, and test adjustments. The `runtime.mode` field is retained in the Go struct for backward compatibility, validation still accepts legacy values, and the JSON schema is only used for editor support (not runtime validation). No execution paths are altered. The test suite covers both the default-empty and legacy-compat scenarios.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Removes `runtime.mode` default and Save() persistence; keeps Mode field in struct for legacy compat; validation updated to accept empty string. Clean and correct. |
| internal/config/config_test.go | Tests renamed to reflect new semantics; default test now expects empty Mode; legacy compat test validates that old `mode: "legacy"` configs still load and pass Validate(). |
| internal/configschema/schema_test.go | Removes `runtime.mode` from required canonical keys; adds negative assertion ensuring runtime.mode stays out of canonical schema. Well-structured guard test. |
| config.schema.json | Removes `runtime.mode` enum property; updates description to reflect chat/jobs path. Generated file consistent with ARCHITECTURE.md canonical block. |
| docs/ARCHITECTURE.md | Rewritten as the active architecture contract; adds Legacy Freeze Policy section (§6); removes runtime.mode from canonical config; adds compatibility notes for legacy mode values. |
| internal/agent/runtime.go | Adds package-level legacy freeze comment directing new work to internal/runtime. Comment-only change, no behavior impact. |
| internal/bot/bot.go | Updates Bot struct and hub field comments to mark RuntimeHub as legacy compatibility path. Comment-only change. |
| internal/bot/hub_handler.go | Updates processViaHub doc comment to mark it as legacy compatibility flow. Comment-only change. |
| internal/bot/task_command.go | Updates handleTaskCommand doc comment to mark /task as legacy RuntimeHub surface. Comment-only change. |
| internal/bot/tui_runtime.go | Updates SubmitTUIRun doc comment to mark it as legacy RuntimeHub compatibility path. Comment-only change. |
| internal/tools/browser_task.go | Adds legacy freeze comments to SubagentSubmitter interface and BrowserTaskTool struct. Comment-only change. |
| docs/MEMORY-CONTEXT-PIPELINE.md | Adds preamble clarifying that the processViaHub path documented here is a frozen compatibility flow, with the active contract in ARCHITECTURE.md. |
| config.example.yaml | Removes `mode: "hub"` from runtime section; adds comment that runtime.mode from older configs is ignored. Consistent with schema removal. |
| README.md | Updates directory tree and docs index descriptions to reference chat/jobs architecture instead of hub. Documentation-only. |
| docs/API.md | Marks spawn_subagent WebSocket command as legacy/frozen compatibility surface. Documentation-only. |

</details>

<sub>Last reviewed commit: 7fdac25</sub>

<!-- /greptile_comment -->