### PR TITLE
feat: feat(safety): operator can disable dangerous tools without restarting the process (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ All commands are auto-registered with BotFather for slash autocomplete.
 | `/verbose` | Toggle verbose mode |
 | `/queue [collect\|steer\|interrupt]` | Queue mode for concurrent messages |
 | `/tts [voice]` | Set TTS voice |
+| `/estop [on\|off\|status]` | Emergency-stop dangerous tool families (admin) |
 | `/activate` | Group: respond to all messages |
 | `/standby` | Group: respond only to mentions |
 | `/auth [add\|remove\|list\|pair]` | Manage authorization (admin) |
@@ -199,6 +200,7 @@ ok-gobot config models            # List available models
 ok-gobot auth anthropic login     # Anthropic OAuth login (Claude MAX)
 ok-gobot auth chatgpt login       # ChatGPT OAuth login (Plus/Team)
 ok-gobot status                   # Show status
+ok-gobot estop on|off|status      # Toggle emergency stop for dangerous tools
 ok-gobot doctor                   # Check config and dependencies
 ok-gobot daemon install|start|stop|status|logs|uninstall
 ok-gobot version

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -237,6 +237,7 @@ Beyond the core commands (`/start`, `/help`, `/status`, `/clear`, `/model`, `/ag
 | `/verbose` | Toggle verbose mode |
 | `/queue` | Set queue mode (collect/steer/interrupt) |
 | `/tts` | Set TTS voice |
+| `/estop` | Toggle dangerous tool families on/off/status (admin for on/off) |
 | `/restart` | Restart the bot process (admin only) |
 
 **Files:** `internal/bot/commands.go`, `internal/bot/status.go`

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -168,7 +168,7 @@ func (r *RunResolver) buildToolRegistry(chatID int64, profile *AgentProfile, isS
 
 	// Filter by agent's allowed tools.
 	if profile.HasToolRestrictions() {
-		filtered := tools.NewRegistry()
+		filtered := base.Child()
 		for _, tool := range base.List() {
 			if profile.IsToolAllowed(tool.Name()) {
 				filtered.Register(tool)
@@ -182,7 +182,7 @@ func (r *RunResolver) buildToolRegistry(chatID int64, profile *AgentProfile, isS
 	// Subagents get browser directly (no browser_task to prevent recursive spawning).
 	needsPerChat := (r.Scheduler != nil && chatID != 0) || (!isSubagent && r.SubagentSubmitter != nil && chatID != 0)
 	if needsPerChat {
-		chatRegistry := tools.NewRegistry()
+		chatRegistry := base.Child()
 		for _, tool := range base.List() {
 			switch tool.Name() {
 			case "cron", "browser_task":

--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -536,7 +536,12 @@ func (a *ToolCallingAgent) parseToolCall(response string) *ToolCall {
 func (a *ToolCallingAgent) executeToolWithTimeout(ctx context.Context, toolName, argsJSON string) (string, error) {
 	// browser_task manages its own timeout via SubmitAndWait — skip the generic timeout.
 	if a.ToolTimeout <= 0 || a.onToolTimeout == nil || toolName == "browser_task" {
-		return a.executeToolFromJSON(ctx, toolName, argsJSON)
+		out, err := a.executeToolFromJSON(ctx, toolName, argsJSON)
+		if err != nil {
+			logger.Debugf("ToolAgent: tool %s error: %v", toolName, err)
+			return fmt.Sprintf("Error executing tool: %v", err), nil
+		}
+		return out, nil
 	}
 
 	type toolResult struct {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -91,6 +91,7 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		BrowserProfile:  browserCfg.ProfilePath,
 		BrowserDebugURL: browserCfg.DebugURL,
 		MemoryManager:   memoryManager,
+		EmergencyStop:   store,
 	}
 	toolRegistry, _ := tools.LoadFromConfigWithOptions(personality.BasePath, toolsConfig)
 
@@ -233,6 +234,7 @@ func (b *Bot) registerCommands() {
 		{Text: "verbose", Description: "Toggle verbose mode"},
 		{Text: "queue", Description: "Adjust queue settings"},
 		{Text: "tts", Description: "Control text-to-speech"},
+		{Text: "estop", Description: "Emergency stop dangerous tools"},
 		{Text: "task", Description: "Spawn a sub-agent task"},
 		{Text: "activate", Description: "Activate bot in group"},
 		{Text: "standby", Description: "Set standby mode in group"},
@@ -295,6 +297,7 @@ func (b *Bot) Start(ctx context.Context) error {
 /agent - Manage agents (list/switch)
 /auth - Authorization management (admin only)
 /pair <code> - Pair with bot using pairing code
+/estop on|off|status - Toggle dangerous tool families (admin only)
 /reload - Reload configuration (admin only)`, name)
 		return c.Send(help)
 	}))

--- a/internal/bot/bot_approval.go
+++ b/internal/bot/bot_approval.go
@@ -31,7 +31,7 @@ func (b *Bot) wireLocalCommandApproval() {
 		return
 	}
 
-	localCmd, ok := localTool.(*tools.LocalCommand)
+	localCmd, ok := tools.AsLocalCommand(localTool)
 	if !ok {
 		log.Println("Warning: local tool is not a LocalCommand")
 		return

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -12,6 +12,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/ai"
+	"ok-gobot/internal/tools"
 )
 
 // registerExtraHandlers registers all additional command handlers
@@ -70,6 +71,10 @@ func (b *Bot) registerExtraHandlers() {
 
 	b.api.Handle("/restart", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleRestartCommand(c)
+	}))
+
+	b.api.Handle("/estop", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
+		return b.handleEstopCommand(c)
 	}))
 
 	b.api.Handle("/task", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
@@ -132,6 +137,7 @@ func (b *Bot) handleCommandsCommand(c telebot.Context) error {
 		{"verbose", "Toggle verbose mode (on/off)"},
 		{"queue", "Adjust queue settings"},
 		{"tts", "Control text-to-speech"},
+		{"estop", "Emergency stop for dangerous tools (admin)"},
 		{"task", "Spawn a sub-agent task"},
 		{"activate", "Activate bot in group"},
 		{"standby", "Set standby mode in group"},
@@ -435,4 +441,43 @@ func (b *Bot) handleRestartCommand(c telebot.Context) error {
 	}()
 
 	return nil
+}
+
+func (b *Bot) handleEstopCommand(c telebot.Context) error {
+	args := strings.Fields(strings.ToLower(strings.TrimSpace(c.Message().Payload)))
+	action := "status"
+	if len(args) > 0 {
+		action = args[0]
+	}
+
+	switch action {
+	case "status":
+		enabled, err := b.store.IsEmergencyStopEnabled()
+		if err != nil {
+			log.Printf("Failed to load estop state: %v", err)
+			return c.Send("❌ Failed to load estop state")
+		}
+		return c.Send(formatEstopStatus(enabled))
+	case "on", "off":
+		if !b.authManager.IsAdmin(c.Sender().ID) {
+			return c.Send("🔒 This command is only available to administrators.")
+		}
+
+		enabled := action == "on"
+		if err := b.store.SetEmergencyStopEnabled(enabled); err != nil {
+			log.Printf("Failed to update estop state: %v", err)
+			return c.Send("❌ Failed to update estop state")
+		}
+		return c.Send(formatEstopStatus(enabled))
+	default:
+		return c.Send("❌ Usage: /estop on | /estop off | /estop status")
+	}
+}
+
+func formatEstopStatus(enabled bool) string {
+	families := strings.Join(tools.DangerousToolFamilies(), ", ")
+	if enabled {
+		return fmt.Sprintf("🛑 estop is ON. Disabled tool families: %s", families)
+	}
+	return fmt.Sprintf("🟢 estop is OFF. Dangerous tool families enabled: %s", families)
 }

--- a/internal/bot/estop_test.go
+++ b/internal/bot/estop_test.go
@@ -1,0 +1,116 @@
+package bot
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/storage"
+)
+
+func TestHandleEstopCommand_AdminCanToggleAndReadStatus(t *testing.T) {
+	t.Parallel()
+
+	store, err := storage.New(filepath.Join(t.TempDir(), "bot.db"))
+	if err != nil {
+		t.Fatalf("storage.New() error = %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	bot := &Bot{
+		store: store,
+		authManager: NewAuthManager(store, config.AuthConfig{
+			Mode:    "allowlist",
+			AdminID: 42,
+		}),
+	}
+
+	ctx := &fakeContext{
+		msg: &telebot.Message{
+			Payload: "on",
+			Chat:    &telebot.Chat{ID: 100, Type: telebot.ChatPrivate},
+			Sender:  &telebot.User{ID: 42},
+		},
+	}
+	if err := bot.handleEstopCommand(ctx); err != nil {
+		t.Fatalf("handleEstopCommand(on) error = %v", err)
+	}
+
+	enabled, err := store.IsEmergencyStopEnabled()
+	if err != nil {
+		t.Fatalf("IsEmergencyStopEnabled() error = %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected estop to be enabled")
+	}
+	if got := ctx.sent[len(ctx.sent)-1]; !strings.Contains(got, "estop is ON") {
+		t.Fatalf("unexpected on response: %q", got)
+	}
+
+	ctx.msg.Payload = "status"
+	if err := bot.handleEstopCommand(ctx); err != nil {
+		t.Fatalf("handleEstopCommand(status) error = %v", err)
+	}
+	if got := ctx.sent[len(ctx.sent)-1]; !strings.Contains(got, "Disabled tool families") {
+		t.Fatalf("unexpected status response: %q", got)
+	}
+
+	ctx.msg.Payload = "off"
+	if err := bot.handleEstopCommand(ctx); err != nil {
+		t.Fatalf("handleEstopCommand(off) error = %v", err)
+	}
+
+	enabled, err = store.IsEmergencyStopEnabled()
+	if err != nil {
+		t.Fatalf("IsEmergencyStopEnabled() after off error = %v", err)
+	}
+	if enabled {
+		t.Fatal("expected estop to be disabled")
+	}
+	if got := ctx.sent[len(ctx.sent)-1]; !strings.Contains(got, "estop is OFF") {
+		t.Fatalf("unexpected off response: %q", got)
+	}
+}
+
+func TestHandleEstopCommand_RejectsUnauthorizedToggle(t *testing.T) {
+	t.Parallel()
+
+	store, err := storage.New(filepath.Join(t.TempDir(), "bot.db"))
+	if err != nil {
+		t.Fatalf("storage.New() error = %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	bot := &Bot{
+		store: store,
+		authManager: NewAuthManager(store, config.AuthConfig{
+			Mode:    "allowlist",
+			AdminID: 42,
+		}),
+	}
+
+	ctx := &fakeContext{
+		msg: &telebot.Message{
+			Payload: "on",
+			Chat:    &telebot.Chat{ID: 101, Type: telebot.ChatPrivate},
+			Sender:  &telebot.User{ID: 7},
+		},
+	}
+	if err := bot.handleEstopCommand(ctx); err != nil {
+		t.Fatalf("handleEstopCommand(on) error = %v", err)
+	}
+
+	enabled, err := store.IsEmergencyStopEnabled()
+	if err != nil {
+		t.Fatalf("IsEmergencyStopEnabled() error = %v", err)
+	}
+	if enabled {
+		t.Fatal("expected unauthorized toggle to leave estop disabled")
+	}
+	if got := ctx.sent[len(ctx.sent)-1]; !strings.Contains(got, "only available to administrators") {
+		t.Fatalf("unexpected unauthorized response: %q", got)
+	}
+}

--- a/internal/cli/estop.go
+++ b/internal/cli/estop.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/storage"
+	"ok-gobot/internal/tools"
+)
+
+func newEstopCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "estop [on|off|status]",
+		Short: "Toggle the runtime emergency stop for dangerous tool families",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			action := "status"
+			if len(args) > 0 {
+				action = strings.ToLower(strings.TrimSpace(args[0]))
+			}
+
+			store, err := storage.New(cfg.StoragePath)
+			if err != nil {
+				return fmt.Errorf("failed to open storage: %w", err)
+			}
+			defer store.Close() //nolint:errcheck
+
+			switch action {
+			case "status":
+				enabled, err := store.IsEmergencyStopEnabled()
+				if err != nil {
+					return fmt.Errorf("failed to read estop state: %w", err)
+				}
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), formatCLIEstopStatus(enabled))
+				return nil
+			case "on", "off":
+				enabled := action == "on"
+				if err := store.SetEmergencyStopEnabled(enabled); err != nil {
+					return fmt.Errorf("failed to update estop state: %w", err)
+				}
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), formatCLIEstopStatus(enabled))
+				return nil
+			default:
+				return fmt.Errorf("invalid action %q: use on, off, or status", action)
+			}
+		},
+	}
+}
+
+func formatCLIEstopStatus(enabled bool) string {
+	families := strings.Join(tools.DangerousToolFamilies(), ", ")
+	if enabled {
+		return fmt.Sprintf("estop is ON. Disabled tool families: %s", families)
+	}
+	return fmt.Sprintf("estop is OFF. Dangerous tool families enabled: %s", families)
+}

--- a/internal/cli/estop_test.go
+++ b/internal/cli/estop_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/storage"
+)
+
+func TestEstopCommand_TogglesAndReportsStatus(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "cli.db")
+	cfg := &config.Config{StoragePath: dbPath}
+	cmd := newEstopCommand(cfg)
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"on"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(on) error = %v", err)
+	}
+	if !strings.Contains(out.String(), "estop is ON") {
+		t.Fatalf("unexpected on output: %q", out.String())
+	}
+
+	store, err := storage.New(dbPath)
+	if err != nil {
+		t.Fatalf("storage.New() error = %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	enabled, err := store.IsEmergencyStopEnabled()
+	if err != nil {
+		t.Fatalf("IsEmergencyStopEnabled() error = %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected estop to be enabled after CLI on")
+	}
+
+	out.Reset()
+	cmd.SetArgs([]string{"status"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(status) error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Disabled tool families") {
+		t.Fatalf("unexpected status output: %q", out.String())
+	}
+
+	out.Reset()
+	cmd.SetArgs([]string{"off"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(off) error = %v", err)
+	}
+	if !strings.Contains(out.String(), "estop is OFF") {
+		t.Fatalf("unexpected off output: %q", out.String())
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -35,6 +35,7 @@ Supports Telegram bot integration with personality and memory.`,
 	root.AddCommand(newDaemonCommand(cfg))
 	root.AddCommand(newTUICommand(cfg))
 	root.AddCommand(newAuthCommand(cfg))
+	root.AddCommand(newEstopCommand(cfg))
 	root.AddCommand(newOnboardCommand())
 	root.AddCommand(newMigrateCommand(cfg))
 	root.AddCommand(newWebCommand(cfg))

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -21,6 +21,7 @@ const (
 	defaultQueueMode      = "collect"
 	defaultQueueDebounce  = 1500
 	defaultRouteTransport = "telegram"
+	emergencyStopStateKey = "estop_enabled"
 )
 
 // New creates a new storage instance
@@ -131,6 +132,12 @@ func (s *Store) migrate() error {
 			paired_by TEXT
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_authorized_users_user_id ON authorized_users(user_id);`,
+		// Global app state table for operator/runtime flags.
+		`CREATE TABLE IF NOT EXISTS app_state (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL DEFAULT '',
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);`,
 		// Sub-agent runs table
 		`CREATE TABLE IF NOT EXISTS subagent_runs (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1133,6 +1140,45 @@ func (s *Store) ResetSession(chatID int64) error {
 		}
 	}
 	return nil
+}
+
+// IsEmergencyStopEnabled reports whether dangerous tool families are disabled.
+// Missing state defaults to false so the bot starts in the trusted default mode.
+func (s *Store) IsEmergencyStopEnabled() (bool, error) {
+	var raw string
+	err := s.db.QueryRow(`SELECT value FROM app_state WHERE key = ?`, emergencyStopStateKey).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "0", "false", "off":
+		return false, nil
+	case "1", "true", "on":
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid estop state %q", raw)
+	}
+}
+
+// SetEmergencyStopEnabled persists the global estop flag.
+func (s *Store) SetEmergencyStopEnabled(enabled bool) error {
+	value := "0"
+	if enabled {
+		value = "1"
+	}
+
+	_, err := s.db.Exec(`
+		INSERT INTO app_state (key, value, updated_at)
+		VALUES (?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(key) DO UPDATE SET
+			value = excluded.value,
+			updated_at = CURRENT_TIMESTAMP
+	`, emergencyStopStateKey, value)
+	return err
 }
 
 // GetSessionOption retrieves a string option from session

--- a/internal/storage/sqlite_schema_test.go
+++ b/internal/storage/sqlite_schema_test.go
@@ -12,10 +12,61 @@ func TestCanonicalSchemaTablesCreated(t *testing.T) {
 	store := newTestStore(t)
 	defer store.Close() //nolint:errcheck
 
-	for _, table := range []string{"sessions_v2", "session_routes", "session_messages_v2", "run_queue_state", "subagent_runs", "jobs", "job_events", "job_artifacts"} {
+	for _, table := range []string{"sessions_v2", "session_routes", "session_messages_v2", "run_queue_state", "subagent_runs", "jobs", "job_events", "job_artifacts", "app_state"} {
 		if !tableExists(t, store.DB(), table) {
 			t.Fatalf("expected table %q to exist", table)
 		}
+	}
+}
+
+func TestEmergencyStopStatePersistsAcrossReopen(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "estop.db")
+
+	store, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	enabled, err := store.IsEmergencyStopEnabled()
+	if err != nil {
+		t.Fatalf("IsEmergencyStopEnabled() failed: %v", err)
+	}
+	if enabled {
+		t.Fatal("expected estop to default to off")
+	}
+
+	if err := store.SetEmergencyStopEnabled(true); err != nil {
+		t.Fatalf("SetEmergencyStopEnabled(true) failed: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+
+	reopened, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() reopen failed: %v", err)
+	}
+	defer reopened.Close() //nolint:errcheck
+
+	enabled, err = reopened.IsEmergencyStopEnabled()
+	if err != nil {
+		t.Fatalf("IsEmergencyStopEnabled() after reopen failed: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected estop state to persist after reopen")
+	}
+
+	if err := reopened.SetEmergencyStopEnabled(false); err != nil {
+		t.Fatalf("SetEmergencyStopEnabled(false) failed: %v", err)
+	}
+	enabled, err = reopened.IsEmergencyStopEnabled()
+	if err != nil {
+		t.Fatalf("IsEmergencyStopEnabled() after disable failed: %v", err)
+	}
+	if enabled {
+		t.Fatal("expected estop to be off after disable")
 	}
 }
 

--- a/internal/tools/estop_test.go
+++ b/internal/tools/estop_test.go
@@ -1,0 +1,115 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type stubEmergencyStopProvider struct {
+	enabled bool
+}
+
+func (s stubEmergencyStopProvider) IsEmergencyStopEnabled() (bool, error) {
+	return s.enabled, nil
+}
+
+type stubTool struct {
+	name   string
+	called int
+}
+
+func (s *stubTool) Name() string {
+	return s.name
+}
+
+func (s *stubTool) Description() string {
+	return "stub"
+}
+
+func (s *stubTool) Execute(context.Context, ...string) (string, error) {
+	s.called++
+	return "ok", nil
+}
+
+type stubJSONTool struct {
+	*stubTool
+	jsonCalled int
+}
+
+func (s *stubJSONTool) ExecuteJSON(context.Context, map[string]string) (string, error) {
+	s.jsonCalled++
+	return "ok", nil
+}
+
+func TestRegistryBlocksDangerousToolsWhenEmergencyStopEnabled(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistryWithEmergencyStop(stubEmergencyStopProvider{enabled: true})
+	tool := &stubTool{name: "message"}
+	reg.Register(tool)
+
+	_, err := reg.Execute(context.Background(), "message", "alice", "hello")
+	if err == nil {
+		t.Fatal("expected estop to block message tool")
+	}
+	if !strings.Contains(err.Error(), `estop is ON`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tool.called != 0 {
+		t.Fatalf("expected wrapped tool not to execute, called=%d", tool.called)
+	}
+}
+
+func TestChildRegistryPreservesEmergencyStopForJSONTools(t *testing.T) {
+	t.Parallel()
+
+	parent := NewRegistryWithEmergencyStop(stubEmergencyStopProvider{enabled: true})
+	child := parent.Child()
+	tool := &stubJSONTool{stubTool: &stubTool{name: "browser_task"}}
+	child.Register(tool)
+
+	got, ok := child.Get("browser_task")
+	if !ok {
+		t.Fatal("expected browser_task to be registered")
+	}
+
+	jsonExec, ok := got.(interface {
+		ExecuteJSON(context.Context, map[string]string) (string, error)
+	})
+	if !ok {
+		t.Fatal("expected wrapped browser_task to preserve ExecuteJSON")
+	}
+
+	_, err := jsonExec.ExecuteJSON(context.Background(), map[string]string{"task": "visit example.com"})
+	if err == nil {
+		t.Fatal("expected estop to block browser_task")
+	}
+	if !strings.Contains(err.Error(), `"browser"`) {
+		t.Fatalf("expected browser family in error, got %v", err)
+	}
+	if tool.jsonCalled != 0 {
+		t.Fatalf("expected wrapped JSON tool not to execute, called=%d", tool.jsonCalled)
+	}
+}
+
+func TestAsLocalCommandUnwrapsEmergencyStopGuard(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistryWithEmergencyStop(stubEmergencyStopProvider{enabled: false})
+	local := &LocalCommand{}
+	reg.Register(local)
+
+	got, ok := reg.Get("local")
+	if !ok {
+		t.Fatal("expected local tool to be registered")
+	}
+
+	unwrapped, ok := AsLocalCommand(got)
+	if !ok {
+		t.Fatal("expected AsLocalCommand to unwrap guarded local tool")
+	}
+	if unwrapped != local {
+		t.Fatal("expected AsLocalCommand to return the original local command")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -28,6 +28,39 @@ type ToolSchema interface {
 	GetSchema() map[string]interface{}
 }
 
+// EmergencyStopProvider reports whether dangerous tool families are disabled.
+type EmergencyStopProvider interface {
+	IsEmergencyStopEnabled() (bool, error)
+}
+
+type jsonExecutor interface {
+	ExecuteJSON(ctx context.Context, params map[string]string) (string, error)
+}
+
+var dangerousToolFamilyNames = []string{"local", "ssh", "browser", "cron", "message"}
+
+var dangerousToolFamiliesByTool = map[string]string{
+	"local":        "local",
+	"ssh":          "ssh",
+	"browser":      "browser",
+	"browser_task": "browser",
+	"cron":         "cron",
+	"message":      "message",
+}
+
+// DangerousToolFamilies returns the operator-controlled tool families covered by estop.
+func DangerousToolFamilies() []string {
+	out := make([]string, len(dangerousToolFamilyNames))
+	copy(out, dangerousToolFamilyNames)
+	return out
+}
+
+// DangerousToolFamily returns the dangerous family for a tool name, if any.
+func DangerousToolFamily(toolName string) (string, bool) {
+	family, ok := dangerousToolFamiliesByTool[toolName]
+	return family, ok
+}
+
 // SSHTool executes commands on remote hosts via SSH
 type SSHTool struct {
 	Host     string
@@ -236,18 +269,32 @@ func (f *FileTool) Execute(ctx context.Context, args ...string) (string, error) 
 
 // Registry holds all available tools
 type Registry struct {
-	tools map[string]Tool
+	tools             map[string]Tool
+	stopStateProvider EmergencyStopProvider
 }
 
 // NewRegistry creates a new tool registry
 func NewRegistry() *Registry {
+	return NewRegistryWithEmergencyStop(nil)
+}
+
+// NewRegistryWithEmergencyStop creates a registry that auto-guards dangerous tools.
+func NewRegistryWithEmergencyStop(provider EmergencyStopProvider) *Registry {
 	return &Registry{
-		tools: make(map[string]Tool),
+		tools:             make(map[string]Tool),
+		stopStateProvider: provider,
 	}
 }
 
 // Register adds a tool to the registry
 func (r *Registry) Register(tool Tool) {
+	if r.stopStateProvider != nil {
+		if _, ok := tool.(estopGuarded); !ok {
+			if family, dangerous := DangerousToolFamily(tool.Name()); dangerous {
+				tool = wrapToolWithEmergencyStop(tool, family, r.stopStateProvider)
+			}
+		}
+	}
 	r.tools[tool.Name()] = tool
 }
 
@@ -266,6 +313,141 @@ func (r *Registry) List() []Tool {
 	return list
 }
 
+// Child creates an empty registry that preserves the same runtime guard policy.
+func (r *Registry) Child() *Registry {
+	if r == nil {
+		return NewRegistry()
+	}
+	return NewRegistryWithEmergencyStop(r.stopStateProvider)
+}
+
+// AsLocalCommand unwraps registry decorators until a LocalCommand is found.
+func AsLocalCommand(tool Tool) (*LocalCommand, bool) {
+	unwrapped := tool
+	for {
+		wrapped, ok := unwrapped.(interface{ Unwrap() Tool })
+		if !ok {
+			break
+		}
+		unwrapped = wrapped.Unwrap()
+	}
+
+	localCmd, ok := unwrapped.(*LocalCommand)
+	return localCmd, ok
+}
+
+type estopGuarded interface {
+	isEstopGuarded()
+}
+
+type emergencyStopGuard struct {
+	tool     Tool
+	family   string
+	provider EmergencyStopProvider
+}
+
+func (g *emergencyStopGuard) isEstopGuarded() {}
+
+func (g *emergencyStopGuard) Name() string {
+	return g.tool.Name()
+}
+
+func (g *emergencyStopGuard) Description() string {
+	return g.tool.Description()
+}
+
+func (g *emergencyStopGuard) Unwrap() Tool {
+	return g.tool
+}
+
+func (g *emergencyStopGuard) Execute(ctx context.Context, args ...string) (string, error) {
+	if err := g.check(); err != nil {
+		return "", err
+	}
+	return g.tool.Execute(ctx, args...)
+}
+
+func (g *emergencyStopGuard) check() error {
+	enabled, err := g.provider.IsEmergencyStopEnabled()
+	if err != nil {
+		return fmt.Errorf("failed to read estop state: %w", err)
+	}
+	if enabled {
+		return fmt.Errorf("estop is ON: tool family %q is disabled (tool: %s)", g.family, g.tool.Name())
+	}
+	return nil
+}
+
+type emergencyStopGuardWithSchema struct {
+	*emergencyStopGuard
+	schema ToolSchema
+}
+
+func (g *emergencyStopGuardWithSchema) GetSchema() map[string]interface{} {
+	return g.schema.GetSchema()
+}
+
+type emergencyStopGuardWithJSON struct {
+	*emergencyStopGuard
+	json jsonExecutor
+}
+
+func (g *emergencyStopGuardWithJSON) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
+	if err := g.check(); err != nil {
+		return "", err
+	}
+	return g.json.ExecuteJSON(ctx, params)
+}
+
+type emergencyStopGuardWithSchemaAndJSON struct {
+	*emergencyStopGuard
+	schema ToolSchema
+	json   jsonExecutor
+}
+
+func (g *emergencyStopGuardWithSchemaAndJSON) GetSchema() map[string]interface{} {
+	return g.schema.GetSchema()
+}
+
+func (g *emergencyStopGuardWithSchemaAndJSON) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
+	if err := g.check(); err != nil {
+		return "", err
+	}
+	return g.json.ExecuteJSON(ctx, params)
+}
+
+func wrapToolWithEmergencyStop(tool Tool, family string, provider EmergencyStopProvider) Tool {
+	base := &emergencyStopGuard{
+		tool:     tool,
+		family:   family,
+		provider: provider,
+	}
+
+	schema, hasSchema := tool.(ToolSchema)
+	jsonExec, hasJSON := tool.(jsonExecutor)
+
+	switch {
+	case hasSchema && hasJSON:
+		return &emergencyStopGuardWithSchemaAndJSON{
+			emergencyStopGuard: base,
+			schema:             schema,
+			json:               jsonExec,
+		}
+	case hasSchema:
+		return &emergencyStopGuardWithSchema{
+			emergencyStopGuard: base,
+			schema:             schema,
+		}
+	case hasJSON:
+		return &emergencyStopGuardWithJSON{
+			emergencyStopGuard: base,
+			json:               jsonExec,
+		}
+	default:
+		return base
+	}
+}
+
 // ToolsConfig holds configuration for optional tools
 type ToolsConfig struct {
 	OpenAIAPIKey    string
@@ -281,8 +463,9 @@ type ToolsConfig struct {
 	CronScheduler   CronScheduler
 	MessageSender   MessageSender
 	Contacts        map[string]int64 // alias -> chatID for message tool allowlist
-	CurrentChatID      int64
-	MemoryManager      *memory.MemoryManager
+	CurrentChatID   int64
+	MemoryManager   *memory.MemoryManager
+	EmergencyStop   EmergencyStopProvider
 }
 
 // LoadFromConfig loads tools from TOOLS.md
@@ -292,7 +475,11 @@ func LoadFromConfig(basePath string) (*Registry, error) {
 
 // LoadFromConfigWithOptions loads tools with additional configuration
 func LoadFromConfigWithOptions(basePath string, cfg *ToolsConfig) (*Registry, error) {
-	registry := NewRegistry()
+	var provider EmergencyStopProvider
+	if cfg != nil {
+		provider = cfg.EmergencyStop
+	}
+	registry := NewRegistryWithEmergencyStop(provider)
 
 	// Always register local command
 	registry.Register(&LocalCommand{})


### PR DESCRIPTION
Closes #157

## What changed
- added a persisted SQLite-backed estop flag with `ok-gobot estop on|off|status`
- guarded dangerous tool families at runtime (`local`, `ssh`, `browser`/`browser_task`, `cron`, `message`) so blocked tools fail fast with a clear error
- added Telegram `/estop on|off|status` handling plus command registration/help/docs updates
- added regression tests for storage persistence, tool guards, CLI, and Telegram handling
- repaired the canonical `sessions_v2` migration on fresh databases by adding missing columns required by the existing backfill path

## Targeted verification
- `go build ./...`
- `go test ./internal/storage ./internal/tools ./internal/bot ./internal/cli ./internal/agent`

## Full suite
- `go test ./...` fails

## Known unrelated failures
- `ok-gobot/internal/ai`: `TestAnthropicClientOAuthHeadersAndBetaQuery`
- `internal/ai/anthropic_client_test.go:141` unexpected Authorization header
- `internal/ai/anthropic_client_test.go:161` `Complete failed: request failed: Post "http://127.0.0.1:64753/v1/messages?beta=true": EOF`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a runtime emergency stop (estop) feature that lets operators disable dangerous tool families (`local`, `ssh`, `browser`, `cron`, `message`) without restarting the process. The flag is persisted in a new `app_state` SQLite table and checked at tool execution time via a decorator pattern. Surfaces through both Telegram (`/estop on|off|status`) and CLI (`ok-gobot estop on|off|status`).

- **Estop bypass in delegated jobs**: `resolver.go` line 209 still uses `tools.NewRegistry()` instead of `base.Child()`, so jobs with a tool allowlist create a registry without the estop provider — dangerous tools in those jobs won't be blocked.
- **Error swallowing in `tool_agent.go`**: The change to `executeToolWithTimeout` converts all tool errors (including context cancellation) into successful string results. This may prevent `/stop` from cancelling active runs and changes error propagation semantics for all tools, not just estop-guarded ones.
- Well-structured decorator pattern in `tools.go` with double-wrap prevention and interface preservation (`ToolSchema`, `ExecuteJSON`).
- Good test coverage across storage, tool guards, CLI, and Telegram handler layers.

<h3>Confidence Score: 2/5</h3>

- Two issues should be resolved before merging: the estop bypass for delegated jobs undermines the safety feature, and the error-swallowing change has unintended side effects on run cancellation.
- The core estop decorator design is solid, but the missed NewRegistry() call in the job-filtering path creates a bypass for the very safety mechanism being added. The error-swallowing change in tool_agent.go affects all tool execution paths and may break context cancellation semantics. Both are fixable but warrant attention before merge.
- Pay close attention to `internal/agent/resolver.go` (estop bypass for jobs) and `internal/agent/tool_agent.go` (error swallowing changes cancellation behavior).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tools/tools.go | Core estop implementation: adds EmergencyStopProvider interface, decorator pattern for guarding dangerous tools, and Child() for propagating guards to child registries. Well-designed with double-wrap prevention via estopGuarded marker interface. |
| internal/agent/resolver.go | Two of three NewRegistry() calls updated to base.Child(), but the job-filtering path at line 209 still uses tools.NewRegistry(), bypassing estop for delegated jobs with tool allowlists. |
| internal/agent/tool_agent.go | Error-swallowing change in executeToolWithTimeout converts all tool errors (including context cancellation) into successful string results, which may prevent run cancellation from working correctly. |
| internal/storage/sqlite.go | Adds app_state table and IsEmergencyStopEnabled/SetEmergencyStopEnabled methods. Clean implementation using UPSERT and robust value parsing. |
| internal/bot/commands.go | Adds /estop command handler with admin-only toggle and public status. Correctly checks IsAdmin for on/off mutations. |
| internal/bot/bot_approval.go | Updates type assertion to use tools.AsLocalCommand() to unwrap the estop decorator, ensuring approval flow works with wrapped tools. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/agent/resolver.go`, line 209 ([link](https://github.com/befeast/ok-gobot/blob/c22f42fe985aa34392e48ce39b28a5a1da219570/internal/agent/resolver.go#L209)) 

   **Estop bypass for delegated jobs**

   The profile-filtering path (line 171) and per-chat path (line 185) were both updated from `tools.NewRegistry()` to `base.Child()`, which preserves the emergency stop provider. However, this job-filtering path still uses `tools.NewRegistry()`, creating a registry with a `nil` `stopStateProvider`. Tools registered into this registry will not be wrapped with the estop guard, so delegated jobs with a tool allowlist silently bypass the emergency stop.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/agent/resolver.go
   Line: 209

   Comment:
   **Estop bypass for delegated jobs**

   The profile-filtering path (line 171) and per-chat path (line 185) were both updated from `tools.NewRegistry()` to `base.Child()`, which preserves the emergency stop provider. However, this job-filtering path still uses `tools.NewRegistry()`, creating a registry with a `nil` `stopStateProvider`. Tools registered into this registry will not be wrapped with the estop guard, so delegated jobs with a tool allowlist silently bypass the emergency stop.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/agent/resolver.go
Line: 209

Comment:
**Estop bypass for delegated jobs**

The profile-filtering path (line 171) and per-chat path (line 185) were both updated from `tools.NewRegistry()` to `base.Child()`, which preserves the emergency stop provider. However, this job-filtering path still uses `tools.NewRegistry()`, creating a registry with a `nil` `stopStateProvider`. Tools registered into this registry will not be wrapped with the estop guard, so delegated jobs with a tool allowlist silently bypass the emergency stop.

```suggestion
		filtered := base.Child()
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/agent/tool_agent.go
Line: 539-544

Comment:
**Error swallowing changes behavior for all tools**

Previously this branch returned `(output, err)` directly, allowing callers to distinguish successful results from errors (e.g. context cancellation propagated up). The new code converts *every* error into a successful string result (`"Error executing tool: ..."`, `nil`), which means:

1. Context cancellations (user hitting `/stop`) are no longer propagated — the agent loop may continue processing instead of stopping.
2. All tool errors are silently presented to the LLM as "results", potentially causing it to hallucinate recovery instead of failing the run.

If the intent is to surface estop errors to the model, consider checking for the estop-specific error type rather than blanket-catching all errors:

```go
out, err := a.executeToolFromJSON(ctx, toolName, argsJSON)
if err != nil {
    if ctx.Err() != nil {
        return "", ctx.Err() // propagate cancellation
    }
    logger.Debugf("ToolAgent: tool %s error: %v", toolName, err)
    return fmt.Sprintf("Error executing tool: %v", err), nil
}
return out, nil
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: c22f42f</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->