### PR TITLE
feat(runtime): roles route work by cost tier (#185)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -400,7 +400,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid runtime.session_queue_limit: %d (must be >= 0)", c.Runtime.SessionQueueLimit)
 	}
 	validCostTiers := map[string]bool{
-		"premium": true, "standard": true, "cheap": true, "background": true, "local": true,
+		"premium": true, "standard": true, "cheap": true, "local": true,
 	}
 	for name := range c.Runtime.CostTiers {
 		if !validCostTiers[name] {

--- a/internal/runtime/cost_tier.go
+++ b/internal/runtime/cost_tier.go
@@ -133,6 +133,9 @@ func (rp *RolePolicy) Resolve(tier CostTier) (CostTier, TierConfig, error) {
 
 // ResolveDefault returns the TierConfig for the role's default tier.
 func (rp *RolePolicy) ResolveDefault() (CostTier, TierConfig, error) {
+	if rp == nil {
+		return "", TierConfig{}, fmt.Errorf("role policy has no configured tiers")
+	}
 	tier := rp.DefaultTier
 	if tier == "" {
 		tier = CostTierStandard
@@ -207,7 +210,7 @@ func (ws *WorkerSelector) Resolve(roleName string, tier CostTier) (CostTier, Tie
 	if hasRole {
 		resolvedTier, roleTc, err := rp.Resolve(tier)
 		if err == nil {
-			globalTc := ws.globals[resolvedTier]
+			globalTc := ws.resolveGlobalBase(resolvedTier)
 			return resolvedTier, mergeTierConfig(globalTc, roleTc), nil
 		}
 	}
@@ -255,6 +258,26 @@ func (ws *WorkerSelector) RegisteredRoles() []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+// resolveGlobalBase returns the best-matching global TierConfig for the
+// given tier, walking the fallback chain. Used as a base layer when merging
+// role overrides. Returns a zero TierConfig if no global tier matches.
+func (ws *WorkerSelector) resolveGlobalBase(tier CostTier) TierConfig {
+	if tc, ok := ws.globals[tier]; ok {
+		return tc
+	}
+	for _, fb := range costTierFallbackOrder[tier] {
+		if tc, ok := ws.globals[fb]; ok {
+			return tc
+		}
+	}
+	for _, t := range allTiersOrdered {
+		if tc, ok := ws.globals[t]; ok {
+			return tc
+		}
+	}
+	return TierConfig{}
 }
 
 // resolveGlobal resolves a tier from the global tier set with fallback.

--- a/internal/runtime/cost_tier_test.go
+++ b/internal/runtime/cost_tier_test.go
@@ -145,6 +145,14 @@ func TestRolePolicyResolveDefaultFallsToStandard(t *testing.T) {
 	}
 }
 
+func TestRolePolicyResolveDefaultNilPolicy(t *testing.T) {
+	var rp *RolePolicy
+	_, _, err := rp.ResolveDefault()
+	if err == nil {
+		t.Error("expected error for nil policy, got nil")
+	}
+}
+
 // ── RolePolicy.HasTier / AvailableTiers ─────────────────────────────────────
 
 func TestRolePolicyHasTier(t *testing.T) {
@@ -491,6 +499,43 @@ func TestWorkerSelectorRegisteredRoles(t *testing.T) {
 	}
 	if !found["researcher"] || !found["monitor"] {
 		t.Errorf("RegisteredRoles() = %v, want [researcher, monitor]", names)
+	}
+}
+
+func TestWorkerSelectorResolveFallbackGlobalBase(t *testing.T) {
+	// Global only has standard; role defines cheap with overrides only.
+	// Requesting premium on the role should fall back to cheap (role tier)
+	// and merge on top of the nearest global tier (standard), not a zero config.
+	ws := NewWorkerSelector(
+		map[CostTier]TierConfig{
+			CostTierStandard: {Model: "sonnet", Provider: "anthropic", Thinking: "medium", MaxToolCalls: 50},
+		},
+		[]*RolePolicy{
+			{
+				Name: "worker",
+				Tiers: map[CostTier]TierConfig{
+					CostTierCheap: {MaxToolCalls: 10},
+				},
+			},
+		},
+	)
+
+	tier, tc, err := ws.Resolve("worker", CostTierPremium)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tier != CostTierCheap {
+		t.Errorf("tier = %q, want cheap (role fallback)", tier)
+	}
+	if tc.MaxToolCalls != 10 {
+		t.Errorf("MaxToolCalls = %d, want 10 (role override)", tc.MaxToolCalls)
+	}
+	// Model and Provider must come from the global fallback, not be empty.
+	if tc.Model != "sonnet" {
+		t.Errorf("Model = %q, want sonnet (from global fallback base)", tc.Model)
+	}
+	if tc.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want anthropic (from global fallback base)", tc.Provider)
 	}
 }
 


### PR DESCRIPTION
Implements #185

## Changes
- **CostTier type** (`premium`, `standard`, `cheap`, `local`) with `ParseCostTier` supporting aliases like `"background"` → `cheap`
- **TierConfig** struct: model, provider, base URL, thinking level, tool budget, and duration per tier
- **RolePolicy**: named role with a default tier and per-tier config map; `Resolve()` walks a deterministic fallback chain (e.g. `local` → `cheap` → `standard`) when the requested tier is missing
- **WorkerSelector**: two-layer resolver — global tier defaults + per-role overrides merged on top; `Resolve(role, tier)` and `ResolveForRole(role)` for callers; `HasLocalTier()` for local-worker discovery
- **MergeDelegation**: bridges `TierConfig` into `delegation.Job` overrides so existing subagent/job paths can adopt tier routing without refactoring
- **Config structs**: `CostTierEntry` and `RolePolicyEntry` added to `RuntimeConfig` with validation for tier names and role defaults; backward-compatible (new optional fields)

## Testing
- 32 new unit tests covering: `ParseCostTier`, `RolePolicy.Resolve` (direct hit, fallback, local fallback, nil/empty error paths), `ResolveDefault`, `HasTier`, `AvailableTiers`, `MergeDelegation` (override, empty, budget), `TierConfig.DelegationOverrides`, `WorkerSelector.Resolve` (role direct, global merge, role fallback, unknown role, empty tier, global-only fallback, nil inputs), `ResolveForRole`, `Role`, `HasLocalTier`, `RegisteredRoles`, `mergeTierConfig`
- Full `go test ./...`, `go vet ./...`, `go fmt ./...`, and `CGO_ENABLED=1 go build` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the cost-tier routing layer for the runtime: a `CostTier` type, `TierConfig`, `RolePolicy` (with deterministic fallback chains), and `WorkerSelector` (two-layer global + per-role merge). Config validation is extended with backward-compatible `cost_tiers` and `roles` fields in `RuntimeConfig`. The implementation is a clean foundation; wiring from `RuntimeConfig` into a live `WorkerSelector` is not part of this PR and is presumably coming in a follow-up.

- Both previously-flagged issues are resolved: `ResolveDefault` now has a nil-receiver guard (`TestRolePolicyResolveDefaultNilPolicy` locks it in), and `"background"` is correctly rejected as a `cost_tiers` map key in config validation.
- All 32 unit tests pass; nil-receiver, fallback-chain, and merge-semantics paths are all covered.
- `TierConfig.Provider` and `TierConfig.BaseURL` are parsed and stored but not forwarded through `DelegationOverrides()` or `MergeDelegation()` — `delegation.Job` has no matching fields today, so there is no runtime impact, but a comment clarifying their intended future use (client routing vs. delegation layer) would prevent confusion when the wiring PR arrives.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; no correctness bugs, both prior thread concerns are resolved, comprehensive test coverage.
- The logic is solid and well-tested. The only remaining item is a minor documentation gap around Provider/BaseURL intent — not a functional defect. Withholding one point because the config→WorkerSelector wiring path isn't yet visible, so the new config fields are currently validated but unused end-to-end.
- No files require special attention; `internal/runtime/cost_tier.go` has the minor Provider/BaseURL note but no blocking issues.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/runtime/cost_tier.go | New file implementing CostTier, TierConfig, RolePolicy, and WorkerSelector. Logic is clean and well-guarded (nil checks on all pointer-receiver methods). Minor: Provider/BaseURL stored in TierConfig but not propagated in DelegationOverrides or MergeDelegation. |
| internal/config/config.go | Adds CostTierEntry and RolePolicyEntry to RuntimeConfig with backward-compatible validation. "background" alias is correctly rejected as a cost_tiers map key (only canonical tier names allowed), resolving the previous review concern. |
| internal/runtime/cost_tier_test.go | 32 tests covering all major code paths including nil-receiver guards, fallback chains, merge semantics, and WorkerSelector resolution. TestRolePolicyResolveDefaultNilPolicy confirms the nil-check fix for ResolveDefault is locked in. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/runtime/cost_tier.go
Line: 151-158

Comment:
**`Provider` and `BaseURL` not propagated to `delegation.Job`**

`TierConfig` carries `Provider` and `BaseURL` fields, and `CostTierEntry` exposes them in config — but neither `DelegationOverrides()` nor `MergeDelegation` passes them through to `delegation.Job`. Since `delegation.Job` has no `Provider` or `BaseURL` fields today, this is not a runtime bug, but it means these config values are silently discarded on every job dispatch path that goes through `DelegationOverrides` or `MergeDelegation`.

If `Provider`/`BaseURL` are intended for a future client-routing layer rather than the delegation layer, a brief comment explaining that would prevent future contributors from treating it as an oversight and adding the fields to `delegation.Job` unnecessarily. If they *are* meant to influence job dispatch, the routing mechanism is missing from this PR.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix(runtime): addres..."](https://github.com/befeast/ok-gobot/commit/0123acf111c85d356611172ad39e5e36cc4daa22)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->