### PR TITLE
feat(memory): old transcript history compacts into a source-linked context tree (#182)

### DIFF
--- a/internal/agent/context_tree.go
+++ b/internal/agent/context_tree.go
@@ -1,0 +1,222 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"ok-gobot/internal/ai"
+)
+
+// Density levels for context tree nodes.
+const (
+	DensityD0 = 0 // Raw transcript span (no summary stored — references messages directly)
+	DensityD1 = 1 // First-level summary of a D0 span
+	DensityD2 = 2 // High-level summary aggregating multiple D1 nodes
+)
+
+// ContextNode represents a summary node in the context tree.
+// Each node covers a span of transcript messages and optionally
+// references child nodes at a lower density level.
+type ContextNode struct {
+	ID         int64  // Database primary key (0 for unsaved nodes)
+	SessionKey string // Owning session
+	Density    int    // DensityD0, DensityD1, or DensityD2
+	Summary    string // AI-generated summary text (empty for D0)
+	SpanStart  int64  // First session_messages_v2.id in the span
+	SpanEnd    int64  // Last session_messages_v2.id in the span
+	ParentID   int64  // Parent node id (0 = root)
+	TokenCount int    // Estimated token count of the summary
+	CreatedAt  string // ISO timestamp
+}
+
+// ContextTree holds an ordered set of context nodes for a session,
+// providing a multi-resolution view of conversation history.
+type ContextTree struct {
+	SessionKey string
+	Nodes      []ContextNode
+}
+
+// FormatForPrompt renders the tree into a text block suitable for
+// injection into the system prompt or conversation history. It walks
+// from highest density (D2) down to D1, skipping D0 spans that are
+// already covered by a higher-density summary.
+func (ct *ContextTree) FormatForPrompt() string {
+	if len(ct.Nodes) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("[Compacted context tree]\n\n")
+
+	// Group by density, highest first.
+	for _, d := range []int{DensityD2, DensityD1} {
+		nodes := ct.nodesAtDensity(d)
+		if len(nodes) == 0 {
+			continue
+		}
+		label := "D1"
+		if d == DensityD2 {
+			label = "D2"
+		}
+		for _, n := range nodes {
+			sb.WriteString(fmt.Sprintf("[%s summary | msgs %d–%d]\n", label, n.SpanStart, n.SpanEnd))
+			sb.WriteString(n.Summary)
+			sb.WriteString("\n\n")
+		}
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// nodesAtDensity returns nodes filtered by density level, ordered by SpanStart.
+func (ct *ContextTree) nodesAtDensity(density int) []ContextNode {
+	var out []ContextNode
+	for _, n := range ct.Nodes {
+		if n.Density == density {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// TreeCompactor extends the base Compactor with context-tree aware compaction.
+type TreeCompactor struct {
+	*Compactor
+}
+
+// NewTreeCompactor creates a tree-aware compactor wrapping an AI client.
+func NewTreeCompactor(aiClient ai.Client, model string) *TreeCompactor {
+	return &TreeCompactor{
+		Compactor: NewCompactor(aiClient, model),
+	}
+}
+
+// CompactToD1 summarises a span of raw messages into a D1 context node.
+// The returned node has Density=1 and span boundaries set to the first
+// and last message IDs provided.
+func (tc *TreeCompactor) CompactToD1(ctx context.Context, sessionKey string, messages []SpanMessage) (*ContextNode, error) {
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("no messages to compact")
+	}
+
+	aiMsgs := spanMessagesToAI(messages)
+	result, err := tc.Compact(ctx, aiMsgs)
+	if err != nil {
+		return nil, fmt.Errorf("D1 compaction: %w", err)
+	}
+
+	return &ContextNode{
+		SessionKey: sessionKey,
+		Density:    DensityD1,
+		Summary:    result.Summary,
+		SpanStart:  messages[0].ID,
+		SpanEnd:    messages[len(messages)-1].ID,
+		TokenCount: result.SummaryTokens,
+	}, nil
+}
+
+// CompactToD2 summarises a set of D1 nodes into a single D2 context node.
+// The resulting node spans from the earliest D1 span start to the latest
+// D1 span end.
+func (tc *TreeCompactor) CompactToD2(ctx context.Context, sessionKey string, d1Nodes []ContextNode) (*ContextNode, error) {
+	if len(d1Nodes) == 0 {
+		return nil, fmt.Errorf("no D1 nodes to compact")
+	}
+
+	// Build a synthetic conversation from D1 summaries.
+	var msgs []ai.Message
+	for _, n := range d1Nodes {
+		msgs = append(msgs, ai.Message{
+			Role:    "assistant",
+			Content: fmt.Sprintf("[Summary of messages %d–%d]\n%s", n.SpanStart, n.SpanEnd, n.Summary),
+		})
+	}
+
+	result, err := tc.Compact(ctx, msgs)
+	if err != nil {
+		return nil, fmt.Errorf("D2 compaction: %w", err)
+	}
+
+	spanStart := d1Nodes[0].SpanStart
+	spanEnd := d1Nodes[len(d1Nodes)-1].SpanEnd
+	for _, n := range d1Nodes {
+		if n.SpanStart < spanStart {
+			spanStart = n.SpanStart
+		}
+		if n.SpanEnd > spanEnd {
+			spanEnd = n.SpanEnd
+		}
+	}
+
+	return &ContextNode{
+		SessionKey: sessionKey,
+		Density:    DensityD2,
+		Summary:    result.Summary,
+		SpanStart:  spanStart,
+		SpanEnd:    spanEnd,
+		TokenCount: result.SummaryTokens,
+	}, nil
+}
+
+// SpanMessage is a raw transcript message with its database ID, used as
+// input to tree compaction.
+type SpanMessage struct {
+	ID      int64
+	Role    string
+	Content string
+}
+
+// spanMessagesToAI converts SpanMessages to ai.Message for the compactor.
+func spanMessagesToAI(msgs []SpanMessage) []ai.Message {
+	out := make([]ai.Message, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Role == "system" {
+			continue
+		}
+		out = append(out, ai.Message{Role: m.Role, Content: m.Content})
+	}
+	return out
+}
+
+// TreeCompactionResult holds the outcome of a tree-aware compaction pass.
+type TreeCompactionResult struct {
+	NewNodes       []ContextNode // Nodes created during this compaction
+	ArchivedMsgIDs []int64       // Message IDs now covered by D1 nodes
+	OriginalTokens int
+	SummaryTokens  int
+	TokensSaved    int
+}
+
+// FormatNotification formats the tree compaction result for display.
+func (r *TreeCompactionResult) FormatNotification() string {
+	d1Count := 0
+	d2Count := 0
+	for _, n := range r.NewNodes {
+		switch n.Density {
+		case DensityD1:
+			d1Count++
+		case DensityD2:
+			d2Count++
+		}
+	}
+
+	parts := []string{fmt.Sprintf("🌳 Context tree compacted: %d → %d tokens (%d saved)",
+		r.OriginalTokens, r.SummaryTokens, r.TokensSaved)}
+
+	if d1Count > 0 {
+		parts = append(parts, fmt.Sprintf("D1 nodes created: %d", d1Count))
+	}
+	if d2Count > 0 {
+		parts = append(parts, fmt.Sprintf("D2 nodes created: %d", d2Count))
+	}
+	parts = append(parts, fmt.Sprintf("Archived messages: %d", len(r.ArchivedMsgIDs)))
+
+	return strings.Join(parts, "\n")
+}
+
+// MinD1SpanMessages is the minimum number of messages required to form a D1 node.
+const MinD1SpanMessages = 4
+
+// MinD1NodesForD2 is the minimum number of D1 nodes required to form a D2 node.
+const MinD1NodesForD2 = 3

--- a/internal/agent/context_tree_test.go
+++ b/internal/agent/context_tree_test.go
@@ -1,0 +1,192 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"ok-gobot/internal/ai"
+)
+
+// stubClient implements ai.Client, returning a fixed summary string.
+type stubClient struct{ summary string }
+
+func (s *stubClient) Complete(_ context.Context, _ []ai.Message) (string, error) {
+	return s.summary, nil
+}
+
+func (s *stubClient) CompleteWithTools(_ context.Context, _ []ai.ChatMessage, _ []ai.ToolDefinition) (*ai.ChatCompletionResponse, error) {
+	return &ai.ChatCompletionResponse{}, nil
+}
+
+func TestCompactToD1(t *testing.T) {
+	tc := NewTreeCompactor(&stubClient{summary: "D1 summary"}, "gpt-4o")
+
+	msgs := []SpanMessage{
+		{ID: 10, Role: "user", Content: "hello"},
+		{ID: 11, Role: "assistant", Content: "hi"},
+		{ID: 12, Role: "user", Content: "how are you"},
+		{ID: 13, Role: "assistant", Content: "fine thanks"},
+	}
+
+	node, err := tc.CompactToD1(context.Background(), "test-session", msgs)
+	if err != nil {
+		t.Fatalf("CompactToD1: %v", err)
+	}
+
+	if node.Density != DensityD1 {
+		t.Errorf("Density = %d, want %d", node.Density, DensityD1)
+	}
+	if node.Summary != "D1 summary" {
+		t.Errorf("Summary = %q, want %q", node.Summary, "D1 summary")
+	}
+	if node.SpanStart != 10 {
+		t.Errorf("SpanStart = %d, want 10", node.SpanStart)
+	}
+	if node.SpanEnd != 13 {
+		t.Errorf("SpanEnd = %d, want 13", node.SpanEnd)
+	}
+	if node.SessionKey != "test-session" {
+		t.Errorf("SessionKey = %q, want %q", node.SessionKey, "test-session")
+	}
+}
+
+func TestCompactToD1_EmptyMessages(t *testing.T) {
+	tc := NewTreeCompactor(&stubClient{summary: "whatever"}, "gpt-4o")
+
+	_, err := tc.CompactToD1(context.Background(), "test", nil)
+	if err == nil {
+		t.Fatal("expected error for empty messages")
+	}
+}
+
+func TestCompactToD2(t *testing.T) {
+	tc := NewTreeCompactor(&stubClient{summary: "D2 high-level summary"}, "gpt-4o")
+
+	d1Nodes := []ContextNode{
+		{ID: 1, Density: DensityD1, Summary: "first chunk summary", SpanStart: 1, SpanEnd: 10},
+		{ID: 2, Density: DensityD1, Summary: "second chunk summary", SpanStart: 11, SpanEnd: 20},
+		{ID: 3, Density: DensityD1, Summary: "third chunk summary", SpanStart: 21, SpanEnd: 30},
+	}
+
+	node, err := tc.CompactToD2(context.Background(), "test-session", d1Nodes)
+	if err != nil {
+		t.Fatalf("CompactToD2: %v", err)
+	}
+
+	if node.Density != DensityD2 {
+		t.Errorf("Density = %d, want %d", node.Density, DensityD2)
+	}
+	if node.Summary != "D2 high-level summary" {
+		t.Errorf("Summary = %q, want %q", node.Summary, "D2 high-level summary")
+	}
+	if node.SpanStart != 1 {
+		t.Errorf("SpanStart = %d, want 1", node.SpanStart)
+	}
+	if node.SpanEnd != 30 {
+		t.Errorf("SpanEnd = %d, want 30", node.SpanEnd)
+	}
+}
+
+func TestCompactToD2_EmptyNodes(t *testing.T) {
+	tc := NewTreeCompactor(&stubClient{summary: "whatever"}, "gpt-4o")
+
+	_, err := tc.CompactToD2(context.Background(), "test", nil)
+	if err == nil {
+		t.Fatal("expected error for empty D1 nodes")
+	}
+}
+
+func TestContextTreeFormatForPrompt(t *testing.T) {
+	tree := &ContextTree{
+		SessionKey: "test",
+		Nodes: []ContextNode{
+			{Density: DensityD2, Summary: "high level overview", SpanStart: 1, SpanEnd: 30},
+			{Density: DensityD1, Summary: "first conversation", SpanStart: 1, SpanEnd: 10},
+			{Density: DensityD1, Summary: "second conversation", SpanStart: 11, SpanEnd: 20},
+		},
+	}
+
+	output := tree.FormatForPrompt()
+	if output == "" {
+		t.Fatal("expected non-empty output")
+	}
+
+	// Should contain the tree header
+	if !contains(output, "[Compacted context tree]") {
+		t.Error("missing tree header")
+	}
+	// Should contain D2 label
+	if !contains(output, "[D2 summary") {
+		t.Error("missing D2 label")
+	}
+	// Should contain D1 labels
+	if !contains(output, "[D1 summary") {
+		t.Error("missing D1 label")
+	}
+	// Should contain the summaries
+	if !contains(output, "high level overview") {
+		t.Error("missing D2 summary content")
+	}
+}
+
+func TestContextTreeFormatForPrompt_Empty(t *testing.T) {
+	tree := &ContextTree{SessionKey: "test"}
+	if tree.FormatForPrompt() != "" {
+		t.Error("expected empty output for empty tree")
+	}
+}
+
+func TestTreeCompactionResultFormatNotification(t *testing.T) {
+	result := &TreeCompactionResult{
+		NewNodes: []ContextNode{
+			{Density: DensityD1},
+			{Density: DensityD2},
+		},
+		ArchivedMsgIDs: []int64{1, 2, 3, 4, 5},
+		OriginalTokens: 1000,
+		SummaryTokens:  200,
+		TokensSaved:    800,
+	}
+
+	output := result.FormatNotification()
+	if !contains(output, "1000") || !contains(output, "200") || !contains(output, "800") {
+		t.Errorf("notification missing token counts: %s", output)
+	}
+	if !contains(output, "D1 nodes created: 1") {
+		t.Error("missing D1 count")
+	}
+	if !contains(output, "D2 nodes created: 1") {
+		t.Error("missing D2 count")
+	}
+	if !contains(output, "Archived messages: 5") {
+		t.Error("missing archived count")
+	}
+}
+
+func TestSpanMessagesToAI_SkipsSystem(t *testing.T) {
+	msgs := []SpanMessage{
+		{ID: 1, Role: "system", Content: "you are a bot"},
+		{ID: 2, Role: "user", Content: "hello"},
+		{ID: 3, Role: "assistant", Content: "hi"},
+	}
+	aiMsgs := spanMessagesToAI(msgs)
+	if len(aiMsgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(aiMsgs))
+	}
+	if aiMsgs[0].Role != "user" {
+		t.Errorf("first message role = %q, want user", aiMsgs[0].Role)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/telebot.v4"
 
 	"ok-gobot/internal/agent"
-	"ok-gobot/internal/ai"
+	"ok-gobot/internal/storage"
 	"ok-gobot/internal/tools"
 )
 
@@ -270,47 +270,194 @@ func (b *Bot) handleContextCommand(c telebot.Context) error {
 	return c.Send(sb.String(), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 }
 
-// handleCompactCommand manually compacts session context by summarizing
-// the conversation history and replacing it with a compact summary.
+// handleCompactCommand manually compacts session context using the D0/D1/D2
+// context tree. Old transcript messages are summarised into D1 nodes that
+// reference the original message span; when enough D1 nodes accumulate they
+// are rolled up into a D2 node.
 func (b *Bot) handleCompactCommand(c telebot.Context) error {
 	sessionKey := sessionKeyForChat(c.Chat())
+	sk := string(sessionKey)
 
-	msgs, err := b.store.GetSessionMessagesV2(string(sessionKey), 500)
-	if err != nil || len(msgs) < 4 {
-		return c.Send("ℹ️ Not enough conversation to compact (need at least 4 messages).")
+	msgs, err := b.store.GetSessionMessagesV2(sk, 500)
+	if err != nil || len(msgs) < agent.MinD1SpanMessages {
+		return c.Send(fmt.Sprintf("ℹ️ Not enough conversation to compact (need at least %d messages).", agent.MinD1SpanMessages))
 	}
 
-	// Convert to ai.Message for compactor
-	aiMsgs := make([]ai.Message, 0, len(msgs))
-	for _, m := range msgs {
-		if m.Role == "system" {
-			continue
-		}
-		aiMsgs = append(aiMsgs, ai.Message{Role: m.Role, Content: m.Content})
-	}
+	_ = c.Send("🌳 Compacting conversation into context tree...")
 
-	_ = c.Send("🧹 Compacting conversation...")
-
-	compactor := agent.NewCompactor(b.ai, b.getEffectiveModel(c.Chat().ID))
-	result, err := compactor.Compact(context.Background(), aiMsgs)
+	tc := agent.NewTreeCompactor(b.ai, b.getEffectiveModel(c.Chat().ID))
+	treeResult, err := b.compactToTree(context.Background(), tc, sk, msgs)
 	if err != nil {
 		return c.Send(fmt.Sprintf("❌ Compaction failed: %v", err))
 	}
 
-	// Clear old messages and insert the summary as a single assistant message.
-	if err := b.store.ClearSessionMessagesV2(string(sessionKey)); err != nil {
-		return c.Send(fmt.Sprintf("❌ Failed to clear old messages: %v", err))
-	}
-
-	summary := "[Compacted conversation summary]\n\n" + result.Summary
-	if err := b.store.SaveSessionMessageV2(string(sessionKey), "assistant", summary, ""); err != nil {
-		return c.Send(fmt.Sprintf("❌ Failed to save summary: %v", err))
-	}
-
 	// Update compaction counter in legacy session store.
-	b.store.SaveSessionSummary(c.Chat().ID, result.Summary) //nolint:errcheck
+	if len(treeResult.NewNodes) > 0 {
+		b.store.SaveSessionSummary(c.Chat().ID, treeResult.NewNodes[0].Summary) //nolint:errcheck
+	}
 
-	return c.Send(result.FormatNotification())
+	return c.Send(treeResult.FormatNotification())
+}
+
+// compactToTree performs a full tree-compaction pass: creates D1 nodes from
+// raw messages, optionally rolls D1s into D2, then replaces the live
+// transcript with only the recent tail that was not compacted.
+func (b *Bot) compactToTree(ctx context.Context, tc *agent.TreeCompactor, sessionKey string, msgs []storage.SessionMessageV2) (*agent.TreeCompactionResult, error) {
+	result := &agent.TreeCompactionResult{}
+
+	// Keep the most recent MinD1SpanMessages messages as live context;
+	// compact everything before them.
+	cutoff := len(msgs) - agent.MinD1SpanMessages
+	if cutoff < agent.MinD1SpanMessages {
+		return nil, fmt.Errorf("not enough messages to compact")
+	}
+
+	toCompact := msgs[:cutoff]
+
+	// Build SpanMessages from the slice to compact.
+	spanMsgs := make([]agent.SpanMessage, 0, len(toCompact))
+	for _, m := range toCompact {
+		if m.Role == "system" {
+			continue
+		}
+		spanMsgs = append(spanMsgs, agent.SpanMessage{
+			ID:      m.ID,
+			Role:    m.Role,
+			Content: m.Content,
+		})
+	}
+	if len(spanMsgs) < agent.MinD1SpanMessages {
+		return nil, fmt.Errorf("not enough non-system messages to compact")
+	}
+
+	// Estimate original tokens.
+	counter := agent.NewTokenCounter()
+	for _, m := range spanMsgs {
+		result.OriginalTokens += counter.CountTokens(m.Content) + 4
+	}
+
+	// Create a D1 node for the compacted span.
+	d1Node, err := tc.CompactToD1(ctx, sessionKey, spanMsgs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Persist the D1 node.
+	d1ID, err := b.store.SaveContextNode(storage.ContextNode{
+		SessionKey: sessionKey,
+		Density:    d1Node.Density,
+		Summary:    d1Node.Summary,
+		SpanStart:  d1Node.SpanStart,
+		SpanEnd:    d1Node.SpanEnd,
+		TokenCount: d1Node.TokenCount,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("save D1 node: %w", err)
+	}
+	d1Node.ID = d1ID
+	result.NewNodes = append(result.NewNodes, *d1Node)
+	result.SummaryTokens += d1Node.TokenCount
+
+	// Record archived message IDs.
+	for _, m := range toCompact {
+		result.ArchivedMsgIDs = append(result.ArchivedMsgIDs, m.ID)
+	}
+
+	// Delete the compacted messages from the live transcript and replace
+	// with a single assistant message carrying the tree summary.
+	if err := b.store.ClearSessionMessagesV2(sessionKey); err != nil {
+		return nil, fmt.Errorf("clear old messages: %w", err)
+	}
+
+	// Re-insert the context tree summary + recent tail.
+	allNodes, err := b.store.GetAllContextNodes(sessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("load context nodes: %w", err)
+	}
+	tree := buildAgentTree(sessionKey, allNodes)
+	treeSummary := tree.FormatForPrompt()
+	if treeSummary != "" {
+		if err := b.store.SaveSessionMessageV2(sessionKey, "assistant", treeSummary, ""); err != nil {
+			return nil, fmt.Errorf("save tree summary: %w", err)
+		}
+	}
+
+	// Re-insert the recent tail messages that were not compacted.
+	tail := msgs[cutoff:]
+	for _, m := range tail {
+		if err := b.store.SaveSessionMessageV2(sessionKey, m.Role, m.Content, m.RunID); err != nil {
+			return nil, fmt.Errorf("re-insert tail message: %w", err)
+		}
+	}
+
+	// Check if we have enough D1 nodes to produce a D2 roll-up.
+	d1Nodes, err := b.store.GetContextNodes(sessionKey, agent.DensityD1)
+	if err != nil {
+		return nil, fmt.Errorf("load D1 nodes: %w", err)
+	}
+
+	// Only create a D2 if we have unparented D1 nodes meeting the threshold.
+	var unparentedD1 []agent.ContextNode
+	for _, n := range d1Nodes {
+		if n.ParentID == 0 {
+			unparentedD1 = append(unparentedD1, storageNodeToAgent(n))
+		}
+	}
+
+	if len(unparentedD1) >= agent.MinD1NodesForD2 {
+		d2Node, err := tc.CompactToD2(ctx, sessionKey, unparentedD1)
+		if err != nil {
+			return nil, fmt.Errorf("D2 compaction: %w", err)
+		}
+
+		d2ID, err := b.store.SaveContextNode(storage.ContextNode{
+			SessionKey: sessionKey,
+			Density:    d2Node.Density,
+			Summary:    d2Node.Summary,
+			SpanStart:  d2Node.SpanStart,
+			SpanEnd:    d2Node.SpanEnd,
+			TokenCount: d2Node.TokenCount,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("save D2 node: %w", err)
+		}
+		d2Node.ID = d2ID
+		result.NewNodes = append(result.NewNodes, *d2Node)
+
+		// Link the D1 nodes to the new D2 parent.
+		for _, n := range unparentedD1 {
+			if err := b.store.SetContextNodeParent(n.ID, d2ID); err != nil {
+				return nil, fmt.Errorf("set D1 parent: %w", err)
+			}
+		}
+	}
+
+	result.TokensSaved = result.OriginalTokens - result.SummaryTokens
+	return result, nil
+}
+
+// buildAgentTree converts storage context nodes into an agent.ContextTree.
+func buildAgentTree(sessionKey string, nodes []storage.ContextNode) *agent.ContextTree {
+	tree := &agent.ContextTree{SessionKey: sessionKey}
+	for _, n := range nodes {
+		tree.Nodes = append(tree.Nodes, storageNodeToAgent(n))
+	}
+	return tree
+}
+
+// storageNodeToAgent converts a storage.ContextNode to agent.ContextNode.
+func storageNodeToAgent(n storage.ContextNode) agent.ContextNode {
+	return agent.ContextNode{
+		ID:         n.ID,
+		SessionKey: n.SessionKey,
+		Density:    n.Density,
+		Summary:    n.Summary,
+		SpanStart:  n.SpanStart,
+		SpanEnd:    n.SpanEnd,
+		ParentID:   n.ParentID,
+		TokenCount: n.TokenCount,
+		CreatedAt:  n.CreatedAt,
+	}
 }
 
 // handleThinkCommand controls thinking level

--- a/internal/storage/context_nodes_test.go
+++ b/internal/storage/context_nodes_test.go
@@ -1,0 +1,185 @@
+package storage
+
+import (
+	"testing"
+)
+
+func TestContextNodesTableCreated(t *testing.T) {
+	s := newV2TestStore(t)
+	if !tableExists(t, s.DB(), "context_nodes") {
+		t.Fatal("context_nodes table not created by migration")
+	}
+}
+
+func TestSaveAndGetContextNodes(t *testing.T) {
+	s := newV2TestStore(t)
+
+	node := ContextNode{
+		SessionKey: "agent:bot:main",
+		Density:    1,
+		Summary:    "first summary",
+		SpanStart:  10,
+		SpanEnd:    20,
+		TokenCount: 50,
+	}
+
+	id, err := s.SaveContextNode(node)
+	if err != nil {
+		t.Fatalf("SaveContextNode: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("expected positive ID, got %d", id)
+	}
+
+	nodes, err := s.GetContextNodes("agent:bot:main", 1)
+	if err != nil {
+		t.Fatalf("GetContextNodes: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+	if nodes[0].ID != id {
+		t.Errorf("ID = %d, want %d", nodes[0].ID, id)
+	}
+	if nodes[0].Summary != "first summary" {
+		t.Errorf("Summary = %q, want %q", nodes[0].Summary, "first summary")
+	}
+	if nodes[0].SpanStart != 10 || nodes[0].SpanEnd != 20 {
+		t.Errorf("Span = [%d, %d], want [10, 20]", nodes[0].SpanStart, nodes[0].SpanEnd)
+	}
+	if nodes[0].TokenCount != 50 {
+		t.Errorf("TokenCount = %d, want 50", nodes[0].TokenCount)
+	}
+}
+
+func TestGetContextNodes_FiltersByDensity(t *testing.T) {
+	s := newV2TestStore(t)
+
+	for _, d := range []int{0, 1, 1, 2} {
+		_, err := s.SaveContextNode(ContextNode{
+			SessionKey: "sess",
+			Density:    d,
+			SpanStart:  1,
+			SpanEnd:    10,
+		})
+		if err != nil {
+			t.Fatalf("SaveContextNode density=%d: %v", d, err)
+		}
+	}
+
+	d1, err := s.GetContextNodes("sess", 1)
+	if err != nil {
+		t.Fatalf("GetContextNodes: %v", err)
+	}
+	if len(d1) != 2 {
+		t.Fatalf("expected 2 D1 nodes, got %d", len(d1))
+	}
+
+	d2, err := s.GetContextNodes("sess", 2)
+	if err != nil {
+		t.Fatalf("GetContextNodes: %v", err)
+	}
+	if len(d2) != 1 {
+		t.Fatalf("expected 1 D2 node, got %d", len(d2))
+	}
+}
+
+func TestGetAllContextNodes_OrderedByDensityDesc(t *testing.T) {
+	s := newV2TestStore(t)
+
+	for _, d := range []int{1, 2, 1} {
+		_, err := s.SaveContextNode(ContextNode{
+			SessionKey: "sess",
+			Density:    d,
+			SpanStart:  1,
+			SpanEnd:    10,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all, err := s.GetAllContextNodes("sess")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 nodes, got %d", len(all))
+	}
+	// First node should be density 2 (highest)
+	if all[0].Density != 2 {
+		t.Errorf("first node density = %d, want 2", all[0].Density)
+	}
+}
+
+func TestSetContextNodeParent(t *testing.T) {
+	s := newV2TestStore(t)
+
+	childID, _ := s.SaveContextNode(ContextNode{
+		SessionKey: "sess",
+		Density:    1,
+		SpanStart:  1,
+		SpanEnd:    10,
+	})
+	parentID, _ := s.SaveContextNode(ContextNode{
+		SessionKey: "sess",
+		Density:    2,
+		SpanStart:  1,
+		SpanEnd:    20,
+	})
+
+	if err := s.SetContextNodeParent(childID, parentID); err != nil {
+		t.Fatalf("SetContextNodeParent: %v", err)
+	}
+
+	children, err := s.GetContextNodeChildren(parentID)
+	if err != nil {
+		t.Fatalf("GetContextNodeChildren: %v", err)
+	}
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(children))
+	}
+	if children[0].ID != childID {
+		t.Errorf("child ID = %d, want %d", children[0].ID, childID)
+	}
+}
+
+func TestDeleteContextNodes(t *testing.T) {
+	s := newV2TestStore(t)
+
+	for i := 0; i < 3; i++ {
+		_, err := s.SaveContextNode(ContextNode{
+			SessionKey: "sess",
+			Density:    1,
+			SpanStart:  int64(i * 10),
+			SpanEnd:    int64(i*10 + 9),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := s.DeleteContextNodes("sess"); err != nil {
+		t.Fatalf("DeleteContextNodes: %v", err)
+	}
+
+	nodes, err := s.GetAllContextNodes("sess")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 0 {
+		t.Fatalf("expected 0 nodes after delete, got %d", len(nodes))
+	}
+}
+
+func TestGetContextNodes_EmptySession(t *testing.T) {
+	s := newV2TestStore(t)
+
+	nodes, err := s.GetContextNodes("nonexistent", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(nodes) != 0 {
+		t.Fatalf("expected 0 nodes, got %d", len(nodes))
+	}
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -350,6 +350,20 @@ func (s *Store) migrateCanonicalSchema() error {
 		`ALTER TABLE subagent_runs ADD COLUMN child_session_key TEXT NOT NULL DEFAULT '';`,
 		`CREATE INDEX IF NOT EXISTS idx_subagent_runs_run_id ON subagent_runs(run_id);`,
 		`CREATE INDEX IF NOT EXISTS idx_subagent_runs_child ON subagent_runs(child_session_key);`,
+		// context_nodes: D0/D1/D2 summary tree for compacted transcript history.
+		`CREATE TABLE IF NOT EXISTS context_nodes (
+			id          INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_key TEXT NOT NULL,
+			density     INTEGER NOT NULL DEFAULT 0,
+			summary     TEXT NOT NULL DEFAULT '',
+			span_start  INTEGER NOT NULL,
+			span_end    INTEGER NOT NULL,
+			parent_id   INTEGER NOT NULL DEFAULT 0,
+			token_count INTEGER NOT NULL DEFAULT 0,
+			created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);`,
+		`CREATE INDEX IF NOT EXISTS idx_context_nodes_session ON context_nodes(session_key, density);`,
+		`CREATE INDEX IF NOT EXISTS idx_context_nodes_parent ON context_nodes(parent_id);`,
 	}
 
 	for _, migration := range migrations {
@@ -2285,4 +2299,121 @@ func (s *Store) GetDailyStats(days int) ([]DailyStats, error) {
 		stats = append(stats, ds)
 	}
 	return stats, rows.Err()
+}
+
+// ─── context_nodes helpers ───────────────────────────────────────────────────
+
+// ContextNode holds one row from the context_nodes table.
+type ContextNode struct {
+	ID         int64
+	SessionKey string
+	Density    int
+	Summary    string
+	SpanStart  int64
+	SpanEnd    int64
+	ParentID   int64
+	TokenCount int
+	CreatedAt  string
+}
+
+// SaveContextNode inserts a new context node and returns its auto-generated ID.
+func (s *Store) SaveContextNode(node ContextNode) (int64, error) {
+	res, err := s.db.Exec(`
+		INSERT INTO context_nodes (session_key, density, summary, span_start, span_end, parent_id, token_count)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, node.SessionKey, node.Density, node.Summary, node.SpanStart, node.SpanEnd, node.ParentID, node.TokenCount)
+	if err != nil {
+		return 0, fmt.Errorf("insert context_node: %w", err)
+	}
+	return res.LastInsertId()
+}
+
+// GetContextNodes retrieves all context nodes for a session at a given density
+// level, ordered by span_start ascending.
+func (s *Store) GetContextNodes(sessionKey string, density int) ([]ContextNode, error) {
+	rows, err := s.db.Query(`
+		SELECT id, session_key, density, summary, span_start, span_end, parent_id, token_count, created_at
+		FROM context_nodes
+		WHERE session_key = ? AND density = ?
+		ORDER BY span_start ASC
+	`, sessionKey, density)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var nodes []ContextNode
+	for rows.Next() {
+		var n ContextNode
+		if err := rows.Scan(&n.ID, &n.SessionKey, &n.Density, &n.Summary,
+			&n.SpanStart, &n.SpanEnd, &n.ParentID, &n.TokenCount, &n.CreatedAt); err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, rows.Err()
+}
+
+// GetAllContextNodes retrieves all context nodes for a session across all
+// density levels, ordered by density descending then span_start ascending.
+func (s *Store) GetAllContextNodes(sessionKey string) ([]ContextNode, error) {
+	rows, err := s.db.Query(`
+		SELECT id, session_key, density, summary, span_start, span_end, parent_id, token_count, created_at
+		FROM context_nodes
+		WHERE session_key = ?
+		ORDER BY density DESC, span_start ASC
+	`, sessionKey)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var nodes []ContextNode
+	for rows.Next() {
+		var n ContextNode
+		if err := rows.Scan(&n.ID, &n.SessionKey, &n.Density, &n.Summary,
+			&n.SpanStart, &n.SpanEnd, &n.ParentID, &n.TokenCount, &n.CreatedAt); err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, rows.Err()
+}
+
+// SetContextNodeParent updates the parent_id of a context node.
+func (s *Store) SetContextNodeParent(nodeID, parentID int64) error {
+	_, err := s.db.Exec(`UPDATE context_nodes SET parent_id = ? WHERE id = ?`, parentID, nodeID)
+	return err
+}
+
+// DeleteContextNodes removes all context nodes for a session.
+func (s *Store) DeleteContextNodes(sessionKey string) error {
+	_, err := s.db.Exec(`DELETE FROM context_nodes WHERE session_key = ?`, sessionKey)
+	return err
+}
+
+// GetContextNodeChildren returns all context nodes whose parent_id matches the
+// given node ID.
+func (s *Store) GetContextNodeChildren(parentID int64) ([]ContextNode, error) {
+	rows, err := s.db.Query(`
+		SELECT id, session_key, density, summary, span_start, span_end, parent_id, token_count, created_at
+		FROM context_nodes
+		WHERE parent_id = ?
+		ORDER BY span_start ASC
+	`, parentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var nodes []ContextNode
+	for rows.Next() {
+		var n ContextNode
+		if err := rows.Scan(&n.ID, &n.SessionKey, &n.Density, &n.Summary,
+			&n.SpanStart, &n.SpanEnd, &n.ParentID, &n.TokenCount, &n.CreatedAt); err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, rows.Err()
 }


### PR DESCRIPTION
Implements #182

## Changes
Replace flat compaction with a D0/D1/D2 summary node tree that keeps references back to transcript spans.

**Before:** `/compact` deleted all messages and stored a single flat summary. Original transcript was lost permanently.

**After:** `/compact` creates **D1 summary nodes** that reference the original message span (first/last message ID). When ≥3 unparented D1 nodes accumulate, they are rolled up into a **D2 high-level summary**. Recent messages are preserved as live context tail.

### New files
- `internal/agent/context_tree.go` — `ContextNode` type with density levels (D0/D1/D2), `TreeCompactor` for tiered summarization, `ContextTree` for prompt formatting
- `internal/agent/context_tree_test.go` — Unit tests for D1/D2 compaction, tree formatting, edge cases
- `internal/storage/context_nodes_test.go` — Storage CRUD tests for the context_nodes table

### Modified files
- `internal/storage/sqlite.go` — Add `context_nodes` table (session_key, density, summary, span_start, span_end, parent_id, token_count) with indexes; add CRUD methods (SaveContextNode, GetContextNodes, GetAllContextNodes, SetContextNodeParent, DeleteContextNodes, GetContextNodeChildren)
- `internal/bot/commands.go` — Rewrite `/compact` handler to use `TreeCompactor` and `compactToTree()` instead of flat compaction; builds context tree from stored nodes and re-inserts tree summary + recent tail

### Context tree structure
```
D2 (high-level summary spanning msgs 1–300)
├── D1 (summary of msgs 1–100)
├── D1 (summary of msgs 101–200)
└── D1 (summary of msgs 201–300)
```

Each node stores `span_start` and `span_end` referencing `session_messages_v2.id`, enabling drill-back into original transcript.

## Testing
- `go test ./...` — all tests pass
- `go vet ./...` — clean
- `CGO_ENABLED=1 go build ./cmd/ok-gobot/` — builds successfully
- New unit tests cover: D1 compaction, D2 roll-up, empty input handling, tree formatting, notification formatting, system message filtering
- New storage tests cover: table creation, save/get by density, ordering, parent linking, deletion, empty session

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the flat `/compact` implementation with a D0/D1/D2 context-tree compaction system. The storage layer (`context_nodes` table, CRUD methods) and the unit tests are well-implemented. However, two ordering/logic issues in the core compaction flow need attention before merge:

- **D2 rollup happens after transcript is rebuilt** — when a D2 node is created, the live `session_messages_v2` transcript has already been written with the D1-only tree summary. The D2 won't appear in the bot's active context until the *next* `/compact` run, leaving the session with stale, incomplete context in the interim.
- **`FormatForPrompt` emits all D1 nodes even after D2 rollup** — D1 nodes whose `ParentID != 0` are already subsumed by their D2 parent, but they're rendered again as separate sections, doubling the injected context for those spans.
- Minor: the outer minimum-message guard (4) is lower than `compactToTree`'s true requirement (8), routing 4–7-message sessions to the error path instead of the friendly informational message.
- Minor: `SaveSessionSummary` stores the D1 node's summary even when a D2 was also produced; it should use the last (highest-density) node.

<h3>Confidence Score: 3/5</h3>

- Two logic bugs — stale transcript after D2 rollup and redundant D1 output in FormatForPrompt — should be resolved before merge to avoid leaving sessions with an incomplete context tree injected into the prompt.
- The storage layer and tests are clean. The two P1 issues are ordering/output bugs that directly affect the correctness of the primary user-facing feature: after any compaction that triggers a D2 rollup, the bot's live context is incomplete and the formatted tree is redundant. These aren't edge cases — they occur on every third `/compact` invocation once steady-state is reached.
- internal/bot/commands.go (D2 ordering bug, minimum-message mismatch) and internal/agent/context_tree.go (FormatForPrompt redundancy)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/agent/context_tree.go | New file introducing D0/D1/D2 node types and TreeCompactor; FormatForPrompt emits all D1 nodes including those already parented to a D2, causing redundant context injection after rollup. |
| internal/bot/commands.go | Rewrites /compact to use TreeCompactor; D2 rollup occurs after transcript has already been rebuilt (stale context bug), minimum-message guard is too low (4 vs 8 required), and legacy summary stores D1 instead of D2 when both exist. |
| internal/storage/sqlite.go | Adds context_nodes table with migration, indexes, and full CRUD methods; straightforward and correct. |
| internal/agent/context_tree_test.go | Good coverage of D1/D2 compaction, formatting, and edge cases; contains helper unnecessarily reimplements strings.Contains. |
| internal/storage/context_nodes_test.go | Comprehensive storage CRUD tests covering table creation, density filtering, ordering, parent linking, deletion, and empty session — all clean. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/bot/commands.go`, line 558-628 ([link](https://github.com/befeast/ok-gobot/blob/469ac0a9759edaa0003b27ee1468fda6916d9228/internal/bot/commands.go#L558-L628)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **D2 rollup occurs after transcript is already rewritten**

   The transcript rebuild (clear + insert tree summary + insert tail) happens on lines 558–584, but the D2 rollup happens on lines 587–626. When a D2 node is created, the transcript in `session_messages_v2` already contains only the D1-only tree summary — the D2 is persisted to the DB but never injected back into the live transcript.

   Concretely, on the compaction run that triggers a D2:
   1. `ClearSessionMessagesV2` is called (line 558)
   2. `GetAllContextNodes` returns only the D1 nodes at this point (line 565)
   3. A D1-only tree summary is written to `session_messages_v2` (line 572)
   4. Tail messages are written (lines 579–584)
   5. The D2 is created and saved to DB (lines 601–617)
   6. D1 nodes are linked to the D2 (lines 620–625)

   The bot now has a live context that doesn't include the D2 at all. It won't appear in the transcript until the *next* `/compact` invocation. During the intervening conversation, the compacted context is incomplete.

   Fix: perform the D2 roll-up check **before** rebuilding the transcript, or after creating the D2 node, re-run the clear+rebuild steps once more using the complete tree:

   ```go
   // Check and perform D2 roll-up BEFORE writing the transcript
   d1Nodes, err := b.store.GetContextNodes(sessionKey, agent.DensityD1)
   // ... create D2 if needed, link D1s ...

   // THEN rebuild transcript using the fully updated tree
   allNodes, err := b.store.GetAllContextNodes(sessionKey)
   // ... write tree summary + tail
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/bot/commands.go
   Line: 558-628

   Comment:
   **D2 rollup occurs after transcript is already rewritten**

   The transcript rebuild (clear + insert tree summary + insert tail) happens on lines 558–584, but the D2 rollup happens on lines 587–626. When a D2 node is created, the transcript in `session_messages_v2` already contains only the D1-only tree summary — the D2 is persisted to the DB but never injected back into the live transcript.

   Concretely, on the compaction run that triggers a D2:
   1. `ClearSessionMessagesV2` is called (line 558)
   2. `GetAllContextNodes` returns only the D1 nodes at this point (line 565)
   3. A D1-only tree summary is written to `session_messages_v2` (line 572)
   4. Tail messages are written (lines 579–584)
   5. The D2 is created and saved to DB (lines 601–617)
   6. D1 nodes are linked to the D2 (lines 620–625)

   The bot now has a live context that doesn't include the D2 at all. It won't appear in the transcript until the *next* `/compact` invocation. During the intervening conversation, the compacted context is incomplete.

   Fix: perform the D2 roll-up check **before** rebuilding the transcript, or after creating the D2 node, re-run the clear+rebuild steps once more using the complete tree:

   ```go
   // Check and perform D2 roll-up BEFORE writing the transcript
   d1Nodes, err := b.store.GetContextNodes(sessionKey, agent.DensityD1)
   // ... create D2 if needed, link D1s ...

   // THEN rebuild transcript using the fully updated tree
   allNodes, err := b.store.GetAllContextNodes(sessionKey)
   // ... write tree summary + tail
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/bot/commands.go`, line 474-476 ([link](https://github.com/befeast/ok-gobot/blob/469ac0a9759edaa0003b27ee1468fda6916d9228/internal/bot/commands.go#L474-L476)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Legacy summary uses D1 node even when D2 was just created**

   `treeResult.NewNodes` is appended in order: D1 first (line 542), D2 second (line 618). So `treeResult.NewNodes[0]` is always the D1 node, even when a D2 was also produced. The legacy `SaveSessionSummary` call should use the highest-density node — the last element — to store the most comprehensive summary:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/bot/commands.go
   Line: 474-476

   Comment:
   **Legacy summary uses D1 node even when D2 was just created**

   `treeResult.NewNodes` is appended in order: D1 first (line 542), D2 second (line 618). So `treeResult.NewNodes[0]` is always the D1 node, even when a D2 was also produced. The legacy `SaveSessionSummary` call should use the highest-density node — the last element — to store the most comprehensive summary:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `internal/agent/context_tree_test.go`, line 415-426 ([link](https://github.com/befeast/ok-gobot/blob/469ac0a9759edaa0003b27ee1468fda6916d9228/internal/agent/context_tree_test.go#L415-L426)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`contains` reimplements `strings.Contains`**

   Both `contains` and its helper `searchString` are a hand-rolled re-implementation of `strings.Contains` from the standard library. This adds noise and a collision risk with any future `strings` import. Use the stdlib function directly:

   

   (Add `"strings"` to the import block — it's already used transitively through the package so the import is fine.)

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/agent/context_tree_test.go
   Line: 415-426

   Comment:
   **`contains` reimplements `strings.Contains`**

   Both `contains` and its helper `searchString` are a hand-rolled re-implementation of `strings.Contains` from the standard library. This adds noise and a collision risk with any future `strings` import. Use the stdlib function directly:

   

   (Add `"strings"` to the import block — it's already used transitively through the package so the import is fine.)

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/bot/commands.go
Line: 558-628

Comment:
**D2 rollup occurs after transcript is already rewritten**

The transcript rebuild (clear + insert tree summary + insert tail) happens on lines 558–584, but the D2 rollup happens on lines 587–626. When a D2 node is created, the transcript in `session_messages_v2` already contains only the D1-only tree summary — the D2 is persisted to the DB but never injected back into the live transcript.

Concretely, on the compaction run that triggers a D2:
1. `ClearSessionMessagesV2` is called (line 558)
2. `GetAllContextNodes` returns only the D1 nodes at this point (line 565)
3. A D1-only tree summary is written to `session_messages_v2` (line 572)
4. Tail messages are written (lines 579–584)
5. The D2 is created and saved to DB (lines 601–617)
6. D1 nodes are linked to the D2 (lines 620–625)

The bot now has a live context that doesn't include the D2 at all. It won't appear in the transcript until the *next* `/compact` invocation. During the intervening conversation, the compacted context is incomplete.

Fix: perform the D2 roll-up check **before** rebuilding the transcript, or after creating the D2 node, re-run the clear+rebuild steps once more using the complete tree:

```go
// Check and perform D2 roll-up BEFORE writing the transcript
d1Nodes, err := b.store.GetContextNodes(sessionKey, agent.DensityD1)
// ... create D2 if needed, link D1s ...

// THEN rebuild transcript using the fully updated tree
allNodes, err := b.store.GetAllContextNodes(sessionKey)
// ... write tree summary + tail
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/agent/context_tree.go
Line: 59-76

Comment:
**`FormatForPrompt` emits D1 nodes already rolled up into a D2**

The comment above `FormatForPrompt` says it skips spans "already covered by a higher-density summary", but the implementation iterates all D1 nodes unconditionally via `nodesAtDensity(DensityD1)`, regardless of their `ParentID`.

After a D2 rollup, every D1 child has `ParentID != 0`. The formatted output will contain both the D2 summary **and** all the D1 summaries it subsumes — double-counting the same history in the injected context and consuming extra tokens every compaction cycle.

```go
// Current: all D1 nodes shown even when parented to D2
nodes := ct.nodesAtDensity(d)

// Suggested fix: skip D1 nodes already covered by a D2 parent
func (ct *ContextTree) unparentedNodesAtDensity(density int) []ContextNode {
    var out []ContextNode
    for _, n := range ct.Nodes {
        if n.Density == density && n.ParentID == 0 {
            out = append(out, n)
        }
    }
    return out
}
```

Use `unparentedNodesAtDensity(DensityD1)` in the loop so that once D1 nodes are subsumed by a D2, they no longer appear in the formatted output.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/bot/commands.go
Line: 457-460

Comment:
**Minimum-message gate doesn't match `compactToTree`'s actual requirement**

`handleCompactCommand` sends the friendly "not enough conversation" message when `len(msgs) < MinD1SpanMessages` (4). But `compactToTree` requires at least `2 × MinD1SpanMessages` (8 messages total) — four to compact and four to keep as the live tail:

```go
cutoff := len(msgs) - agent.MinD1SpanMessages  // need 4 in tail
if cutoff < agent.MinD1SpanMessages {          // need ≥4 to compact
    return nil, fmt.Errorf("not enough messages to compact")
}
```

A session with 4–7 messages passes the outer gate but then receives `"❌ Compaction failed: not enough messages to compact"` — the error path rather than the informational message. 

```suggestion
	msgs, err := b.store.GetSessionMessagesV2(sk, 500)
	if err != nil || len(msgs) < agent.MinD1SpanMessages*2 {
		return c.Send(fmt.Sprintf("ℹ️ Not enough conversation to compact (need at least %d messages).", agent.MinD1SpanMessages*2))
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/bot/commands.go
Line: 474-476

Comment:
**Legacy summary uses D1 node even when D2 was just created**

`treeResult.NewNodes` is appended in order: D1 first (line 542), D2 second (line 618). So `treeResult.NewNodes[0]` is always the D1 node, even when a D2 was also produced. The legacy `SaveSessionSummary` call should use the highest-density node — the last element — to store the most comprehensive summary:

```suggestion
	if len(treeResult.NewNodes) > 0 {
		b.store.SaveSessionSummary(c.Chat().ID, treeResult.NewNodes[len(treeResult.NewNodes)-1].Summary) //nolint:errcheck
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/agent/context_tree_test.go
Line: 415-426

Comment:
**`contains` reimplements `strings.Contains`**

Both `contains` and its helper `searchString` are a hand-rolled re-implementation of `strings.Contains` from the standard library. This adds noise and a collision risk with any future `strings` import. Use the stdlib function directly:

```suggestion
func contains(s, substr string) bool {
	return strings.Contains(s, substr)
}
```

(Add `"strings"` to the import block — it's already used transitively through the package so the import is fine.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(memory): replac..."](https://github.com/befeast/ok-gobot/commit/469ac0a9759edaa0003b27ee1468fda6916d9228)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->