### PR TITLE
feat(runtime): roles route work by cost tier (#185)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 
@@ -399,14 +400,22 @@ func (c *Config) Validate() error {
 	if c.Runtime.SessionQueueLimit < 0 {
 		return fmt.Errorf("invalid runtime.session_queue_limit: %d (must be >= 0)", c.Runtime.SessionQueueLimit)
 	}
+	// Validate cost tier names and durations.
 	validCostTiers := map[string]bool{
 		"premium": true, "standard": true, "cheap": true, "local": true,
 	}
-	for name := range c.Runtime.CostTiers {
+	for name, entry := range c.Runtime.CostTiers {
 		if !validCostTiers[name] {
 			return fmt.Errorf("invalid runtime.cost_tiers key: %q (allowed: premium, standard, cheap, local)", name)
 		}
+		if entry.MaxDuration != "" {
+			if _, err := time.ParseDuration(entry.MaxDuration); err != nil {
+				return fmt.Errorf("invalid runtime.cost_tiers.%s.max_duration: %w", name, err)
+			}
+		}
 	}
+
+	// Validate role policies.
 	for _, role := range c.Runtime.Roles {
 		if role.Name == "" {
 			return fmt.Errorf("runtime.roles: each role must have a name")
@@ -414,9 +423,14 @@ func (c *Config) Validate() error {
 		if role.DefaultTier != "" && !validCostTiers[role.DefaultTier] {
 			return fmt.Errorf("runtime.roles[%s].default_tier: invalid tier %q", role.Name, role.DefaultTier)
 		}
-		for tierName := range role.Tiers {
+		for tierName, entry := range role.Tiers {
 			if !validCostTiers[tierName] {
 				return fmt.Errorf("runtime.roles[%s].tiers: invalid tier %q", role.Name, tierName)
+			}
+			if entry.MaxDuration != "" {
+				if _, err := time.ParseDuration(entry.MaxDuration); err != nil {
+					return fmt.Errorf("runtime.roles[%s].tiers.%s.max_duration: %w", role.Name, tierName, err)
+				}
 			}
 		}
 	}

--- a/internal/runtime/cost_tier.go
+++ b/internal/runtime/cost_tier.go
@@ -22,6 +22,20 @@ const (
 	CostTierLocal CostTier = "local"
 )
 
+// validCostTiers is the canonical set of recognized tier names.
+var validCostTiers = map[CostTier]struct{}{
+	CostTierPremium:  {},
+	CostTierStandard: {},
+	CostTierCheap:    {},
+	CostTierLocal:    {},
+}
+
+// ValidCostTier reports whether t is a recognized cost tier.
+func ValidCostTier(t CostTier) bool {
+	_, ok := validCostTiers[t]
+	return ok
+}
+
 // costTierFallbackOrder defines which tiers to try when the requested tier
 // is not configured. Resolution walks this list in order and stops at the
 // first configured tier.
@@ -64,6 +78,12 @@ type TierConfig struct {
 	Thinking     string
 	MaxToolCalls int
 	MaxDuration  time.Duration
+}
+
+// IsZero reports whether every field is at its zero value.
+func (tc TierConfig) IsZero() bool {
+	return tc.Model == "" && tc.Provider == "" && tc.BaseURL == "" &&
+		tc.Thinking == "" && tc.MaxToolCalls == 0 && tc.MaxDuration == 0
 }
 
 // DelegationOverrides produces a delegation.Job with the tier's non-zero
@@ -187,7 +207,7 @@ func NewWorkerSelector(globals map[CostTier]TierConfig, roles []*RolePolicy) *Wo
 		ws.globals = make(map[CostTier]TierConfig)
 	}
 	for _, r := range roles {
-		if r != nil {
+		if r != nil && r.Name != "" {
 			ws.roles[r.Name] = r
 		}
 	}
@@ -202,8 +222,15 @@ func NewWorkerSelector(globals map[CostTier]TierConfig, roles []*RolePolicy) *Wo
 //  2. If no role matches, resolve directly from global tiers with fallback.
 //  3. Error if no usable tier is found anywhere.
 func (ws *WorkerSelector) Resolve(roleName string, tier CostTier) (CostTier, TierConfig, error) {
+	if ws == nil {
+		return "", TierConfig{}, fmt.Errorf("worker selector is nil")
+	}
+
 	if tier == "" {
 		tier = CostTierStandard
+		if rp, ok := ws.roles[roleName]; ok && rp.DefaultTier != "" {
+			tier = rp.DefaultTier
+		}
 	}
 
 	rp, hasRole := ws.roles[roleName]
@@ -221,6 +248,9 @@ func (ws *WorkerSelector) Resolve(roleName string, tier CostTier) (CostTier, Tie
 // ResolveForRole resolves the default tier for a named role.
 // If the role is not registered, it falls back to the global standard tier.
 func (ws *WorkerSelector) ResolveForRole(roleName string) (CostTier, TierConfig, error) {
+	if ws == nil {
+		return "", TierConfig{}, fmt.Errorf("worker selector is nil")
+	}
 	rp, ok := ws.roles[roleName]
 	if !ok {
 		return ws.resolveGlobal(CostTierStandard)
@@ -234,12 +264,18 @@ func (ws *WorkerSelector) ResolveForRole(roleName string) (CostTier, TierConfig,
 
 // Role returns the RolePolicy for name, or nil if not registered.
 func (ws *WorkerSelector) Role(name string) *RolePolicy {
+	if ws == nil {
+		return nil
+	}
 	return ws.roles[name]
 }
 
 // HasLocalTier reports whether any registered role or the global tier set
 // includes a local cost tier.
 func (ws *WorkerSelector) HasLocalTier() bool {
+	if ws == nil {
+		return false
+	}
 	if _, ok := ws.globals[CostTierLocal]; ok {
 		return true
 	}
@@ -251,8 +287,20 @@ func (ws *WorkerSelector) HasLocalTier() bool {
 	return false
 }
 
+// HasTier reports whether the selector has a global config for tier.
+func (ws *WorkerSelector) HasTier(tier CostTier) bool {
+	if ws == nil {
+		return false
+	}
+	tc, ok := ws.globals[tier]
+	return ok && !tc.IsZero()
+}
+
 // RegisteredRoles returns the names of all registered role policies.
 func (ws *WorkerSelector) RegisteredRoles() []string {
+	if ws == nil {
+		return nil
+	}
 	names := make([]string, 0, len(ws.roles))
 	for name := range ws.roles {
 		names = append(names, name)

--- a/internal/runtime/cost_tier_test.go
+++ b/internal/runtime/cost_tier_test.go
@@ -35,6 +35,38 @@ func TestParseCostTier(t *testing.T) {
 	}
 }
 
+// ── ValidCostTier ───────────────────────────────────────────────────────────
+
+func TestValidCostTier(t *testing.T) {
+	tests := []struct {
+		tier CostTier
+		want bool
+	}{
+		{CostTierPremium, true},
+		{CostTierStandard, true},
+		{CostTierCheap, true},
+		{CostTierLocal, true},
+		{"unknown", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := ValidCostTier(tt.tier); got != tt.want {
+			t.Errorf("ValidCostTier(%q) = %v, want %v", tt.tier, got, tt.want)
+		}
+	}
+}
+
+// ── TierConfig.IsZero ───────────────────────────────────────────────────────
+
+func TestTierConfigIsZero(t *testing.T) {
+	if !(TierConfig{}).IsZero() {
+		t.Error("zero TierConfig.IsZero() should be true")
+	}
+	if (TierConfig{Model: "x"}).IsZero() {
+		t.Error("non-zero TierConfig.IsZero() should be false")
+	}
+}
+
 // ── RolePolicy.Resolve ──────────────────────────────────────────────────────
 
 func TestRolePolicyResolveDirectHit(t *testing.T) {
@@ -409,7 +441,7 @@ func TestWorkerSelectorResolveUnknownRole(t *testing.T) {
 func TestWorkerSelectorResolveEmptyTier(t *testing.T) {
 	ws := newTestSelector()
 
-	// Empty tier string defaults to standard.
+	// Empty tier string defaults to standard (researcher's default).
 	tier, tc, err := ws.Resolve("researcher", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -419,6 +451,29 @@ func TestWorkerSelectorResolveEmptyTier(t *testing.T) {
 	}
 	if tc.Model != "sonnet-research" {
 		t.Errorf("Model = %q, want sonnet-research", tc.Model)
+	}
+}
+
+func TestWorkerSelectorResolveDefaultTierFromRole(t *testing.T) {
+	globals := map[CostTier]TierConfig{
+		CostTierStandard: {Model: "sonnet"},
+		CostTierCheap:    {Model: "haiku"},
+	}
+	roles := []*RolePolicy{
+		{Name: "background", DefaultTier: CostTierCheap},
+	}
+	ws := NewWorkerSelector(globals, roles)
+
+	// Empty tier → use role default (cheap).
+	tier, tc, err := ws.Resolve("background", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tier != CostTierCheap {
+		t.Errorf("tier = %q, want cheap (role default)", tier)
+	}
+	if tc.Model != "haiku" {
+		t.Errorf("Model = %q, want haiku", tc.Model)
 	}
 }
 
@@ -486,6 +541,20 @@ func TestWorkerSelectorHasLocalTier(t *testing.T) {
 	}
 }
 
+func TestWorkerSelectorHasTier(t *testing.T) {
+	globals := map[CostTier]TierConfig{
+		CostTierStandard: {Model: "sonnet"},
+	}
+	ws := NewWorkerSelector(globals, nil)
+
+	if !ws.HasTier(CostTierStandard) {
+		t.Error("expected HasTier(standard) = true")
+	}
+	if ws.HasTier(CostTierLocal) {
+		t.Error("expected HasTier(local) = false")
+	}
+}
+
 func TestWorkerSelectorRegisteredRoles(t *testing.T) {
 	ws := newTestSelector()
 	names := ws.RegisteredRoles()
@@ -547,6 +616,23 @@ func TestWorkerSelectorNilInputs(t *testing.T) {
 	}
 }
 
+func TestWorkerSelectorNilSafe(t *testing.T) {
+	var ws *WorkerSelector
+	_, _, err := ws.Resolve("", CostTierStandard)
+	if err == nil {
+		t.Error("expected error for nil selector, got nil")
+	}
+	if ws.Role("x") != nil {
+		t.Error("nil selector.Role should return nil")
+	}
+	if ws.HasTier(CostTierStandard) {
+		t.Error("nil selector.HasTier should return false")
+	}
+	if ws.HasLocalTier() {
+		t.Error("nil selector.HasLocalTier should return false")
+	}
+}
+
 func TestWorkerSelectorGlobalOnlyFallback(t *testing.T) {
 	ws := NewWorkerSelector(
 		map[CostTier]TierConfig{
@@ -565,6 +651,18 @@ func TestWorkerSelectorGlobalOnlyFallback(t *testing.T) {
 	}
 	if tc.Model != "haiku" {
 		t.Errorf("Model = %q, want haiku", tc.Model)
+	}
+}
+
+func TestWorkerSelectorIgnoresNilRoles(t *testing.T) {
+	roles := []*RolePolicy{nil, {Name: ""}, {Name: "valid"}}
+	ws := NewWorkerSelector(nil, roles)
+
+	if ws.Role("valid") == nil {
+		t.Error("expected non-nil role for 'valid'")
+	}
+	if ws.Role("") != nil {
+		t.Error("empty-name role should not be registered")
 	}
 }
 


### PR DESCRIPTION
Implements #185

## Changes
- Add `ValidCostTier()` helper and `TierConfig.IsZero()` for tier validation
- Add `WorkerSelector.HasTier()` and nil-safety across all WorkerSelector/RolePolicy methods
- Enhance `WorkerSelector.Resolve()` to use role's `DefaultTier` when no tier is explicitly requested
- Add duration validation for `max_duration` fields in config validation
- Merge upstream cost tier foundation with comprehensive additional test coverage:
  - `ValidCostTier`, `IsZero`, nil-safety, delegation merge, global-only fallback,
    last-resort scan, role default tier routing, ignore nil/empty roles

Key design: `WorkerSelector.Resolve(role, tier)` resolves through:
1. Role-specific override merged onto global tier config
2. Global config for requested tier
3. Tier fallback chain (premium→standard→cheap, local→cheap→standard)
4. Last-resort canonical scan

Config example:
```yaml
runtime:
  cost_tiers:
    premium:
      model: "claude-opus-4-5-20251101"
      thinking: "high"
    standard:
      model: "claude-sonnet-4-5-20250929"
    cheap:
      model: "claude-haiku-3-5-20241022"
      max_tool_calls: 20
    local:
      model: "llama3"
      base_url: "http://localhost:11434/v1"
  roles:
    - name: "researcher"
      default_tier: "standard"
      tiers:
        premium:
          thinking: "high"
          max_tool_calls: 100
    - name: "background"
      default_tier: "cheap"
```

## Testing
- 30+ unit tests covering all resolution paths, fallback chains, nil safety, delegation merge, config validation
- `go test ./...` all pass
- `go vet ./...` clean
- `CGO_ENABLED=1 go build ./cmd/ok-gobot/` succeeds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements role-based cost tier routing (#185), wiring up `WorkerSelector.Resolve` to consult a role's `DefaultTier` when no explicit tier is requested, and adds the surrounding infrastructure (`ValidCostTier`, `TierConfig.IsZero`, `WorkerSelector.HasTier`, nil-safety guards) along with `max_duration` format validation in config. The changes integrate cleanly with the existing fallback-chain resolution logic and are backed by thorough test coverage.

Key changes:
- `WorkerSelector.Resolve` now uses the role's `DefaultTier` as the effective tier when the caller passes an empty string, before falling through to the global fallback chain
- `ValidCostTier` and `TierConfig.IsZero` add canonical validation helpers reusable across the runtime package
- Nil-safety guards added to all public `WorkerSelector` and `RolePolicy` methods
- `config.Validate()` now calls `time.ParseDuration` on `max_duration` strings so invalid durations are caught at startup
- One inconsistency: `HasLocalTier` checks for a key's presence in globals without `IsZero()`, while the new `HasTier` requires `!IsZero()` — these can return opposite answers for the same zero-value `CostTierLocal` entry

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the HasLocalTier/HasTier inconsistency — one-line fix.
- The core routing logic is correct and well-tested across 30+ cases. The only concrete issue is a minor inconsistency between HasLocalTier (no IsZero check on globals) and the new HasTier (IsZero required), which could cause callers to receive contradictory results for the same local tier entry. All other additions are clean and the config validation improvement is a clear win.
- internal/runtime/cost_tier.go — the HasLocalTier globals check at line 279

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/runtime/cost_tier.go | Adds ValidCostTier, TierConfig.IsZero, WorkerSelector.HasTier, nil-safety guards, and role DefaultTier routing in Resolve. One inconsistency: HasLocalTier checks global key existence without IsZero, while the new HasTier requires !IsZero for the same globals map. |
| internal/config/config.go | Adds time.ParseDuration validation for max_duration fields in both global cost tier entries and per-role tier entries. Straightforward and correct. |
| internal/runtime/cost_tier_test.go | Adds 30+ tests covering ValidCostTier, IsZero, HasTier, nil-safe methods, role DefaultTier routing, and edge cases. Coverage is thorough. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/runtime/cost_tier.go
Line: 279-280

Comment:
**`HasLocalTier` and `HasTier` behave inconsistently for zero-value configs**

`HasLocalTier` returns `true` for any `CostTierLocal` key in globals, including a zero-value `TierConfig`. Meanwhile, the newly added `HasTier` uses `!tc.IsZero()` and would return `false` for the same entry. Callers of `HasLocalTier()` and `HasTier(CostTierLocal)` can therefore receive opposite answers for an identically stored local tier, which is misleading.

Applying the same `IsZero` guard to `HasLocalTier` makes the behaviour consistent:

```suggestion
	if tc, ok := ws.globals[CostTierLocal]; ok && !tc.IsZero() {
		return true
	}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(runtime): roles route work by cost ..."](https://github.com/befeast/ok-gobot/commit/3321bf2251c3ebd037636ebec9ac4a6603871fef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25959177)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->