### PR TITLE
feat(memory): context search expands only the relevant branch (#183)

### DIFF
--- a/internal/memory/manager.go
+++ b/internal/memory/manager.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // MetadataExtractor extracts structured metadata from raw memory content.
@@ -59,6 +60,62 @@ func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]M
 	}
 
 	return results, nil
+}
+
+// SearchExpanded searches for matching chunks, then expands each result to
+// include all chunks from the same branch (source_file + header_path).
+// This gives full section context without replaying the entire history.
+func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
+	if m.client == nil || m.store == nil {
+		return nil, fmt.Errorf("memory manager is not fully configured")
+	}
+
+	hits, err := m.Search(ctx, query, topK)
+	if err != nil {
+		return nil, err
+	}
+	if len(hits) == 0 {
+		return nil, nil
+	}
+
+	type branch struct{ file, header string }
+	var branches []branch
+	seen := make(map[branch]bool)
+	bestScores := make(map[branch]float32)
+
+	for _, h := range hits {
+		b := branch{h.SourceFile, h.HeaderPath}
+		if h.Similarity > bestScores[b] {
+			bestScores[b] = h.Similarity
+		}
+		if !seen[b] {
+			seen[b] = true
+			branches = append(branches, b)
+		}
+	}
+
+	expanded := make([]MemoryResult, 0, len(branches))
+	for _, b := range branches {
+		chunks, err := m.store.GetBranchChunks(ctx, b.file, b.header)
+		if err != nil || len(chunks) == 0 {
+			continue
+		}
+
+		texts := make([]string, len(chunks))
+		for i, c := range chunks {
+			texts[i] = c.Content
+		}
+
+		expanded = append(expanded, MemoryResult{
+			Source:     b.file,
+			SourceFile: b.file,
+			HeaderPath: b.header,
+			Content:    strings.Join(texts, "\n\n"),
+			Similarity: bestScores[b],
+		})
+	}
+
+	return expanded, nil
 }
 
 // Recall is kept as a compatibility alias for existing callers.

--- a/internal/memory/search.go
+++ b/internal/memory/search.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -29,8 +30,9 @@ type MemorySnippet struct {
 
 // SearchOptions configures per-query filtering and result count.
 type SearchOptions struct {
-	Threshold float32
-	TopK      int
+	Threshold    float32
+	TopK         int
+	ExpandBranch bool // When true, expand results to include all chunks from matching branches.
 }
 
 // Searcher keeps memory chunk embeddings in RAM and performs cosine search in Go.
@@ -44,6 +46,7 @@ type Searcher struct {
 type indexedChunk struct {
 	File       string
 	HeaderPath string
+	Ordinal    int
 	Text       string
 	Embedding  []float32 // Pre-normalized for fast cosine dot products.
 }
@@ -51,6 +54,7 @@ type indexedChunk struct {
 type memoryChunkColumns struct {
 	File      string
 	Header    string
+	Ordinal   string
 	Text      string
 	Embedding string
 }
@@ -153,7 +157,71 @@ func (s *Searcher) Search(queryEmbedding []float32, opts SearchOptions) []Memory
 		bubbleUpByScore(best, len(best)-1)
 	}
 
+	if opts.ExpandBranch && len(best) > 0 {
+		best = s.expandBranches(best)
+	}
+
 	return best
+}
+
+// expandBranches groups matching snippets by (File, HeaderPath), collects all
+// chunks from each branch, and returns one combined snippet per branch.
+func (s *Searcher) expandBranches(hits []MemorySnippet) []MemorySnippet {
+	type branchKey struct {
+		file, headerPath string
+	}
+
+	// Collect unique branches preserving first-seen order, tracking best score.
+	var orderedKeys []branchKey
+	bestScores := make(map[branchKey]float32)
+	for _, h := range hits {
+		key := branchKey{h.File, h.HeaderPath}
+		prev, seen := bestScores[key]
+		if !seen {
+			orderedKeys = append(orderedKeys, key)
+		}
+		if !seen || h.Score > prev {
+			bestScores[key] = h.Score
+		}
+	}
+
+	// For each branch, collect all chunks from the in-RAM index.
+	type orderedText struct {
+		ordinal int
+		text    string
+	}
+
+	expanded := make([]MemorySnippet, 0, len(orderedKeys))
+	for _, key := range orderedKeys {
+		var parts []orderedText
+		for _, chunk := range s.chunks {
+			if chunk.File == key.file && chunk.HeaderPath == key.headerPath {
+				parts = append(parts, orderedText{ordinal: chunk.Ordinal, text: chunk.Text})
+			}
+		}
+
+		sort.Slice(parts, func(i, j int) bool {
+			return parts[i].ordinal < parts[j].ordinal
+		})
+
+		texts := make([]string, len(parts))
+		for i, p := range parts {
+			texts[i] = p.text
+		}
+
+		expanded = append(expanded, MemorySnippet{
+			File:       key.file,
+			HeaderPath: key.headerPath,
+			Text:       strings.Join(texts, "\n\n"),
+			Score:      bestScores[key],
+		})
+	}
+
+	sort.Slice(expanded, func(i, j int) bool {
+		return expanded[i].Score > expanded[j].Score
+	})
+
+	return expanded
 }
 
 func bubbleUpByScore(snippets []MemorySnippet, idx int) {
@@ -174,10 +242,16 @@ func loadChunksIntoRAM(ctx context.Context, db *sql.DB) ([]indexedChunk, int, er
 		headerExpr = quoteIdentifier(columns.Header)
 	}
 
+	ordinalExpr := "0"
+	if columns.Ordinal != "" {
+		ordinalExpr = quoteIdentifier(columns.Ordinal)
+	}
+
 	query := fmt.Sprintf(
-		"SELECT %s, %s, %s, %s FROM memory_chunks",
+		"SELECT %s, %s, %s, %s, %s FROM memory_chunks",
 		quoteIdentifier(columns.File),
 		headerExpr,
+		ordinalExpr,
 		quoteIdentifier(columns.Text),
 		quoteIdentifier(columns.Embedding),
 	)
@@ -197,11 +271,12 @@ func loadChunksIntoRAM(ctx context.Context, db *sql.DB) ([]indexedChunk, int, er
 		var (
 			file       sql.NullString
 			headerPath sql.NullString
+			ordinal    int
 			text       sql.NullString
 			rawVector  []byte
 		)
 
-		if err := rows.Scan(&file, &headerPath, &text, &rawVector); err != nil {
+		if err := rows.Scan(&file, &headerPath, &ordinal, &text, &rawVector); err != nil {
 			return nil, 0, fmt.Errorf("failed scanning memory chunk: %w", err)
 		}
 
@@ -225,6 +300,7 @@ func loadChunksIntoRAM(ctx context.Context, db *sql.DB) ([]indexedChunk, int, er
 		chunks = append(chunks, indexedChunk{
 			File:       file.String,
 			HeaderPath: headerPath.String,
+			Ordinal:    ordinal,
 			Text:       text.String,
 			Embedding:  normalized,
 		})
@@ -270,6 +346,7 @@ func resolveMemoryChunkColumns(ctx context.Context, db *sql.DB) (memoryChunkColu
 	columns := memoryChunkColumns{
 		File:      pickColumn(available, "file", "file_path", "filepath", "path"),
 		Header:    pickColumn(available, "header_path", "heading_path", "section_path", "header"),
+		Ordinal:   pickColumn(available, "chunk_ordinal", "ordinal", "chunk_order"),
 		Text:      pickColumn(available, "text", "chunk_text", "content"),
 		Embedding: pickColumn(available, "embedding", "vector", "embedding_blob"),
 	}

--- a/internal/memory/search_test.go
+++ b/internal/memory/search_test.go
@@ -230,6 +230,200 @@ func insertChunk(t *testing.T, db *sql.DB, file, headerPath, text string, embedd
 	}
 }
 
+func TestSearchExpandBranchCombinesSameBranch(t *testing.T) {
+	db := newMemoryChunksTestDBWithOrdinal(t)
+
+	// Three chunks from the same branch (file + header_path), only one matches query.
+	insertChunkWithOrdinal(t, db, "memory/2026-03-10.md", "Meeting Notes", 0, "Alice presented the architecture proposal", []float32{1, 0, 0})
+	insertChunkWithOrdinal(t, db, "memory/2026-03-10.md", "Meeting Notes", 1, "Bob raised concerns about latency", []float32{0.5, 0.5, 0})
+	insertChunkWithOrdinal(t, db, "memory/2026-03-10.md", "Meeting Notes", 2, "Decision: use edge caching", []float32{0.3, 0.3, 0.3})
+
+	// Unrelated chunk in different branch.
+	insertChunkWithOrdinal(t, db, "memory/2026-03-09.md", "Tasks", 0, "Deploy staging env", []float32{-1, 0, 0})
+
+	searcher, err := NewSearcher(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSearcher() error = %v", err)
+	}
+
+	// Search with expand: query matches chunk 0 strongly.
+	results := searcher.Search([]float32{1, 0, 0}, SearchOptions{
+		Threshold:    0.5,
+		TopK:         5,
+		ExpandBranch: true,
+	})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 expanded branch, got %d", len(results))
+	}
+
+	branch := results[0]
+	if branch.File != "memory/2026-03-10.md" {
+		t.Fatalf("expected file memory/2026-03-10.md, got %s", branch.File)
+	}
+	if branch.HeaderPath != "Meeting Notes" {
+		t.Fatalf("expected header_path 'Meeting Notes', got %s", branch.HeaderPath)
+	}
+
+	// All three chunks should be combined.
+	if !strings.Contains(branch.Text, "Alice presented") {
+		t.Fatalf("expanded branch missing chunk 0 text")
+	}
+	if !strings.Contains(branch.Text, "Bob raised") {
+		t.Fatalf("expanded branch missing chunk 1 text")
+	}
+	if !strings.Contains(branch.Text, "Decision: use edge caching") {
+		t.Fatalf("expanded branch missing chunk 2 text")
+	}
+}
+
+func TestSearchExpandBranchMultipleBranches(t *testing.T) {
+	db := newMemoryChunksTestDBWithOrdinal(t)
+
+	// Branch A: two chunks
+	insertChunkWithOrdinal(t, db, "memory/notes.md", "Project Alpha", 0, "Alpha kickoff meeting", []float32{0.9, 0.1, 0})
+	insertChunkWithOrdinal(t, db, "memory/notes.md", "Project Alpha", 1, "Alpha timeline set to Q2", []float32{0.85, 0.15, 0})
+
+	// Branch B: two chunks
+	insertChunkWithOrdinal(t, db, "memory/notes.md", "Project Beta", 0, "Beta requirements gathered", []float32{0.8, 0.2, 0})
+	insertChunkWithOrdinal(t, db, "memory/notes.md", "Project Beta", 1, "Beta design review", []float32{0.75, 0.25, 0})
+
+	// Unrelated
+	insertChunkWithOrdinal(t, db, "memory/old.md", "Archive", 0, "Deprecated notes", []float32{-1, 0, 0})
+
+	searcher, err := NewSearcher(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSearcher() error = %v", err)
+	}
+
+	results := searcher.Search([]float32{1, 0, 0}, SearchOptions{
+		Threshold:    0.7,
+		TopK:         5,
+		ExpandBranch: true,
+	})
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 expanded branches, got %d", len(results))
+	}
+
+	// Results should be sorted by score descending.
+	if results[0].Score < results[1].Score {
+		t.Fatalf("branches not sorted by score descending")
+	}
+
+	// First branch should be Project Alpha (higher scoring match).
+	if !strings.Contains(results[0].Text, "Alpha kickoff") || !strings.Contains(results[0].Text, "Alpha timeline") {
+		t.Fatalf("first branch should contain all Project Alpha chunks")
+	}
+}
+
+func TestSearchExpandBranchPreservesOrdinalOrder(t *testing.T) {
+	db := newMemoryChunksTestDBWithOrdinal(t)
+
+	// Insert chunks out of ordinal order.
+	insertChunkWithOrdinal(t, db, "memory/doc.md", "Steps", 2, "Step three", []float32{0.9, 0.1, 0})
+	insertChunkWithOrdinal(t, db, "memory/doc.md", "Steps", 0, "Step one", []float32{0.95, 0.05, 0})
+	insertChunkWithOrdinal(t, db, "memory/doc.md", "Steps", 1, "Step two", []float32{0.8, 0.2, 0})
+
+	searcher, err := NewSearcher(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSearcher() error = %v", err)
+	}
+
+	results := searcher.Search([]float32{1, 0, 0}, SearchOptions{
+		Threshold:    0.7,
+		TopK:         5,
+		ExpandBranch: true,
+	})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 branch, got %d", len(results))
+	}
+
+	// Text should be in ordinal order: one, two, three.
+	text := results[0].Text
+	idxOne := strings.Index(text, "Step one")
+	idxTwo := strings.Index(text, "Step two")
+	idxThree := strings.Index(text, "Step three")
+
+	if idxOne < 0 || idxTwo < 0 || idxThree < 0 {
+		t.Fatalf("expanded text missing steps, got: %s", text)
+	}
+	if idxOne >= idxTwo || idxTwo >= idxThree {
+		t.Fatalf("chunks not in ordinal order: one@%d, two@%d, three@%d", idxOne, idxTwo, idxThree)
+	}
+}
+
+func TestSearchExpandBranchFalseReturnsIndividualChunks(t *testing.T) {
+	db := newMemoryChunksTestDBWithOrdinal(t)
+
+	insertChunkWithOrdinal(t, db, "memory/f.md", "H", 0, "chunk A", []float32{1, 0, 0})
+	insertChunkWithOrdinal(t, db, "memory/f.md", "H", 1, "chunk B", []float32{0.9, 0.1, 0})
+
+	searcher, err := NewSearcher(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSearcher() error = %v", err)
+	}
+
+	// Without expand, both matching chunks should be separate results.
+	results := searcher.Search([]float32{1, 0, 0}, SearchOptions{
+		Threshold:    0.5,
+		TopK:         5,
+		ExpandBranch: false,
+	})
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 individual chunks, got %d", len(results))
+	}
+}
+
+func newMemoryChunksTestDBWithOrdinal(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE memory_chunks (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			file TEXT NOT NULL,
+			header_path TEXT DEFAULT '',
+			chunk_ordinal INTEGER DEFAULT 0,
+			text TEXT NOT NULL,
+			embedding BLOB NOT NULL
+		);
+	`)
+	if err != nil {
+		t.Fatalf("failed creating memory_chunks table: %v", err)
+	}
+
+	return db
+}
+
+func insertChunkWithOrdinal(t *testing.T, db *sql.DB, file, headerPath string, ordinal int, text string, embedding []float32) {
+	t.Helper()
+
+	encoded, err := encodeEmbedding(embedding)
+	if err != nil {
+		t.Fatalf("failed encoding embedding: %v", err)
+	}
+
+	_, err = db.Exec(
+		`INSERT INTO memory_chunks (file, header_path, chunk_ordinal, text, embedding) VALUES (?, ?, ?, ?, ?)`,
+		file,
+		headerPath,
+		ordinal,
+		text,
+		encoded,
+	)
+	if err != nil {
+		t.Fatalf("failed inserting chunk: %v", err)
+	}
+}
+
 func randomNormalizedVector(rng *rand.Rand, dimensions int) []float32 {
 	vector := make([]float32, dimensions)
 	for i := 0; i < dimensions; i++ {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -458,6 +458,48 @@ func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32
 	return results, nil
 }
 
+// GetBranchChunks loads all chunks for a specific (sourceFile, headerPath) branch,
+// ordered by chunk_ordinal. Used by branch expansion to reconstruct full sections.
+func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPath string) ([]MemoryResult, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, indexed_at
+		FROM memory_chunks
+		WHERE source_file = ? AND header_path = ?
+		ORDER BY chunk_ordinal ASC
+	`, sourceFile, headerPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query branch chunks: %w", err)
+	}
+	defer rows.Close()
+
+	var results []MemoryResult
+	for rows.Next() {
+		var (
+			id        int64
+			sf, hp    string
+			ordinal   int
+			content   string
+			hash      string
+			indexedAt time.Time
+		)
+		if err := rows.Scan(&id, &sf, &hp, &ordinal, &content, &hash, &indexedAt); err != nil {
+			continue
+		}
+		results = append(results, MemoryResult{
+			ID:           id,
+			Source:       sf,
+			SourceFile:   sf,
+			HeaderPath:   hp,
+			ChunkOrdinal: ordinal,
+			Content:      content,
+			ContentHash:  hash,
+			IndexedAt:    indexedAt,
+			UpdatedAt:    indexedAt,
+		})
+	}
+	return results, rows.Err()
+}
+
 // Search is kept as a compatibility alias for callers that still use the old name.
 func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
 	return s.SearchChunks(ctx, queryEmbedding, topK)

--- a/internal/memorymcp/server.go
+++ b/internal/memorymcp/server.go
@@ -85,6 +85,7 @@ func New(cfg Config, manager *memory.MemoryManager, dailyMemory *agent.Memory) *
 		mcp.WithDescription("Semantic memory search over indexed memory."),
 		mcp.WithString("query", mcp.Description("Search query"), mcp.Required()),
 		mcp.WithNumber("topK", mcp.Description("Maximum number of results to return"), mcp.DefaultNumber(5)),
+		mcp.WithBoolean("expand", mcp.Description("When true, expand each match to include the full branch (all chunks sharing the same source file and header path)")),
 	), s.handleMemorySearch)
 
 	mcpSrv.AddTool(mcp.NewTool(
@@ -153,11 +154,19 @@ func (s *Server) handleMemorySearch(ctx context.Context, request mcp.CallToolReq
 		topK = 5
 	}
 
+	expand := request.GetBool("expand", false)
+
 	if s.memoryManager == nil {
 		return mcp.NewToolResultError("memory_search backend is not configured (enable memory.enabled)"), nil
 	}
 
-	results, err := s.memoryManager.Recall(ctx, query, topK)
+	var results []memory.MemoryResult
+	var err error
+	if expand {
+		results, err = s.memoryManager.SearchExpanded(ctx, query, topK)
+	} else {
+		results, err = s.memoryManager.Recall(ctx, query, topK)
+	}
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("memory_search failed: %v", err)), nil
 	}

--- a/internal/tools/memory_search_tool.go
+++ b/internal/tools/memory_search_tool.go
@@ -29,7 +29,7 @@ func (m *MemorySearchTool) Description() string {
 
 func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string, error) {
 	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
-		return "", fmt.Errorf("usage: memory_search <query> [limit]")
+		return "", fmt.Errorf("usage: memory_search <query> [limit] [expand]")
 	}
 	if m.manager == nil {
 		return "", fmt.Errorf("memory manager is not configured")
@@ -44,7 +44,18 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 		}
 	}
 
-	results, err := m.manager.Search(ctx, query, limit)
+	expand := false
+	if len(args) > 2 {
+		expand = strings.EqualFold(strings.TrimSpace(args[2]), "true")
+	}
+
+	var results []memory.MemoryResult
+	var err error
+	if expand {
+		results, err = m.manager.SearchExpanded(ctx, query, limit)
+	} else {
+		results, err = m.manager.Search(ctx, query, limit)
+	}
 	if err != nil {
 		return "", fmt.Errorf("failed to search memory index: %w", err)
 	}
@@ -53,8 +64,13 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 		return "No memory chunks found matching your query.", nil
 	}
 
+	label := "chunks"
+	if expand {
+		label = "branches"
+	}
+
 	var out strings.Builder
-	out.WriteString(fmt.Sprintf("Found %d relevant memory chunks:\n\n", len(results)))
+	out.WriteString(fmt.Sprintf("Found %d relevant memory %s:\n\n", len(results), label))
 	for i, result := range results {
 		headerPath := result.HeaderPath
 		if headerPath == "" {
@@ -62,7 +78,9 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 		}
 		out.WriteString(fmt.Sprintf("%d. Source: %s\n", i+1, result.Source))
 		out.WriteString(fmt.Sprintf("   Header Path: %s\n", headerPath))
-		out.WriteString(fmt.Sprintf("   Lines: %d-%d\n", result.StartLine, result.EndLine))
+		if !expand {
+			out.WriteString(fmt.Sprintf("   Lines: %d-%d\n", result.StartLine, result.EndLine))
+		}
 		out.WriteString(fmt.Sprintf("   Similarity: %.2f\n", result.Similarity))
 		out.WriteString(fmt.Sprintf("   %s\n\n", result.Content))
 	}
@@ -81,6 +99,10 @@ func (m *MemorySearchTool) GetSchema() map[string]interface{} {
 			"limit": map[string]interface{}{
 				"type":        "integer",
 				"description": "Maximum number of chunks to return (default 5)",
+			},
+			"expand": map[string]interface{}{
+				"type":        "boolean",
+				"description": "When true, expand each match to include the full branch (all chunks sharing the same source file and header path)",
 			},
 		},
 		"required": []string{"query"},


### PR DESCRIPTION
Implements #183

## Changes
- **Branch expansion for memory search**: After finding top-K matching chunks via cosine similarity, results can now be grouped by `(source_file, header_path)` and expanded to include all chunks from the matching section. This gives full section context without replaying the entire history.
- **`Searcher.Search()` (`search.go`)**: Added `ExpandBranch` option to `SearchOptions`. When enabled, the in-RAM searcher groups hits by branch, collects all sibling chunks, sorts by ordinal, and returns one combined snippet per branch.
- **`MemoryStore.GetBranchChunks()` (`store.go`)**: New method to load all chunks for a specific `(source_file, header_path)` branch from the DB, ordered by `chunk_ordinal`.
- **`MemoryManager.SearchExpanded()` (`manager.go`)**: Higher-level method that performs a regular search, then expands each hit's branch via `GetBranchChunks`.
- **`memory_search` tool and MCP server**: Added `expand` parameter (boolean). When true, returns expanded branch results instead of individual chunks.
- **Ordinal tracking**: `indexedChunk` now loads `chunk_ordinal` (when available) to preserve correct ordering within expanded branches.

## Testing
- 4 new unit tests covering branch expansion:
  - `TestSearchExpandBranchCombinesSameBranch` — verifies all chunks from a matching branch are combined
  - `TestSearchExpandBranchMultipleBranches` — verifies multiple branches are returned sorted by score
  - `TestSearchExpandBranchPreservesOrdinalOrder` — verifies chunks are combined in ordinal order even when inserted out of order
  - `TestSearchExpandBranchFalseReturnsIndividualChunks` — verifies default behavior is unchanged
- All existing tests pass (`go test ./...`)
- `go vet ./...` clean
- `CGO_ENABLED=1 go build ./cmd/ok-gobot/` succeeds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements branch-aware context expansion for memory search (#183). After finding top-K matching chunks via cosine similarity, results can now be grouped by `(source_file, header_path)` and expanded to include all sibling chunks from that section. The feature is exposed via an `expand` boolean in both the `memory_search` CLI tool and the MCP server, with dual implementations: an in-RAM path (`Searcher.expandBranches`) for direct searcher usage and a DB-backed path (`MemoryManager.SearchExpanded` + `MemoryStore.GetBranchChunks`) for the higher-level manager. The code is well-structured and includes four new unit tests covering same-branch combination, multiple-branch scoring, ordinal ordering, and backward-compatibility.

- **`GetBranchChunks` silently swallows scan errors** — a `continue` on `rows.Scan` failure can return partial branch content to the caller with `nil` error, which could silently serve truncated context; this is the one concrete fix needed before merge.
- The two expansion paths (in-RAM vs. DB) are behaviorally consistent: both preserve ordinal order and sort results by best score descending.
- The `Ordinal` field defaults to `0` when the column is absent, ensuring backwards-compatibility with pre-V2 databases.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the silent scan-error swallow in GetBranchChunks that can return incomplete branch data with no error.
- The feature is well-designed and thoroughly tested. The dual in-RAM / DB expansion paths are consistent. The one concrete bug — silently discarding scan errors in GetBranchChunks — is a targeted, easy fix and is the only thing blocking a 5.
- internal/memory/store.go — GetBranchChunks scan error handling on line 485.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/memory/store.go | Adds GetBranchChunks to load all chunks for a (sourceFile, headerPath) branch ordered by chunk_ordinal. Scan errors are silently swallowed with continue, which can return incomplete branch data without propagating an error. |
| internal/memory/manager.go | Adds SearchExpanded which retrieves topK hits, deduplicates by branch, fetches all chunks per branch from the DB, and joins them. Ordering of expanded results inherits from the score-sorted hits list, so no explicit sort is needed. |
| internal/memory/search.go | Adds ExpandBranch option and expandBranches helper that groups top-K hits by (File, HeaderPath), collects all sibling chunks from the in-RAM index sorted by Ordinal, and returns one merged snippet per branch sorted by best score. Ordinal column discovery falls back to 0 gracefully. |
| internal/memory/search_test.go | Four new unit tests cover the expand-branch path: same-branch combination, multiple branches sorted by score, ordinal ordering, and no-expand baseline. Tests use a dedicated helper with chunk_ordinal schema. |
| internal/memorymcp/server.go | Adds expand boolean parameter to the memory_search MCP tool; routes to SearchExpanded or Recall accordingly. Clean, minimal change. |
| internal/tools/memory_search_tool.go | Adds optional expand CLI argument (args[2]), routes to SearchExpanded when true, and adjusts output label and lines display. Backwards-compatible. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/memory/store.go
Line: 485-487

Comment:
**Silent scan error swallows incomplete branch data**

When `rows.Scan` fails (e.g. `indexed_at` is `NULL` in legacy-migrated rows, which can't be scanned into a non-pointer `time.Time`), the row is silently skipped via `continue`. The function then returns a partial result set — missing one or more chunks — with `rows.Err()` returning `nil`. The caller (`SearchExpanded`) has no way to detect that the branch content is incomplete, so it stitches together and serves a truncated context to the user without any indication of the data loss.

The fix is to either propagate the scan error or scan nullable fields with pointer types:

```go
if err := rows.Scan(&id, &sf, &hp, &ordinal, &content, &hash, &indexedAt); err != nil {
    return nil, fmt.Errorf("failed scanning branch chunk row: %w", err)
}
```

Alternatively, use `*time.Time` for `indexedAt` to handle `NULL` gracefully:
```go
var indexedAt *time.Time
if err := rows.Scan(&id, &sf, &hp, &ordinal, &content, &hash, &indexedAt); err != nil {
    return nil, fmt.Errorf("failed scanning branch chunk row: %w", err)
}
t := time.Time{}
if indexedAt != nil {
    t = *indexedAt
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(memory): context search expands onl..."](https://github.com/befeast/ok-gobot/commit/edd19f951b226d0dfbc8cc478bf57b7ec3a5f6ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25959215)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->