### PR TITLE
feat(memory): budget-aware context assembly for context tree (#182)

### DIFF
--- a/internal/agent/context_tree.go
+++ b/internal/agent/context_tree.go
@@ -220,3 +220,78 @@ const MinD1SpanMessages = 4
 
 // MinD1NodesForD2 is the minimum number of D1 nodes required to form a D2 node.
 const MinD1NodesForD2 = 3
+
+// BuildContextFromTree assembles a context window from the tree hierarchy,
+// respecting a token budget. It layers D2 summaries (oldest, most compressed),
+// then D1 summaries (mid-history), then recent D0 messages, fitting as much
+// context as possible within the budget.
+//
+// The nodes slice should be ordered by density DESC, then span_start ASC
+// (as returned by GetAllContextNodes). recentMessages are raw D0 messages
+// that follow the compacted region.
+func BuildContextFromTree(nodes []ContextNode, recentMessages []ai.Message, tokenBudget int) []ai.Message {
+	if tokenBudget <= 0 {
+		return recentMessages
+	}
+
+	// Reserve at least 30% of budget for recent messages so the bot
+	// always has immediate conversational context.
+	recentReserve := tokenBudget * 30 / 100
+	treeBudget := tokenBudget - recentReserve
+
+	var result []ai.Message
+	tokensUsed := 0
+
+	// Covered tracks span ranges already included via a higher-density node
+	// so we don't duplicate information by also including a lower-density
+	// node that covers the same span.
+	type span struct{ start, end int64 }
+	var covered []span
+
+	isCovered := func(s, e int64) bool {
+		for _, c := range covered {
+			if s >= c.start && e <= c.end {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Walk nodes highest density first (D2 → D1). The input should already
+	// be ordered this way from GetAllContextNodes.
+	for _, n := range nodes {
+		if n.Density == DensityD0 {
+			continue // D0 spans are handled via recentMessages
+		}
+		if isCovered(n.SpanStart, n.SpanEnd) {
+			continue
+		}
+		if tokensUsed+n.TokenCount > treeBudget {
+			continue // skip nodes that don't fit; keep trying smaller ones
+		}
+
+		label := "D1"
+		if n.Density == DensityD2 {
+			label = "D2"
+		}
+		result = append(result, ai.Message{
+			Role:    "assistant",
+			Content: fmt.Sprintf("[%s summary | msgs %d–%d]\n%s", label, n.SpanStart, n.SpanEnd, n.Summary),
+		})
+		tokensUsed += n.TokenCount
+		covered = append(covered, span{n.SpanStart, n.SpanEnd})
+	}
+
+	// Append recent D0 messages up to remaining budget.
+	tc := NewTokenCounter()
+	for _, msg := range recentMessages {
+		msgTokens := tc.CountTokens(msg.Content) + 4
+		if tokensUsed+msgTokens > tokenBudget {
+			break
+		}
+		result = append(result, msg)
+		tokensUsed += msgTokens
+	}
+
+	return result
+}

--- a/internal/agent/context_tree_test.go
+++ b/internal/agent/context_tree_test.go
@@ -178,6 +178,104 @@ func TestSpanMessagesToAI_SkipsSystem(t *testing.T) {
 	}
 }
 
+func TestBuildContextFromTree_MixedDensities(t *testing.T) {
+	nodes := []ContextNode{
+		// D2 first (highest density), as returned by GetAllContextNodes
+		{Density: DensityD2, Summary: "ancient history", SpanStart: 1, SpanEnd: 100, TokenCount: 40},
+		// D1 nodes (middle density)
+		{Density: DensityD1, Summary: "recent chunk A", SpanStart: 101, SpanEnd: 130, TokenCount: 25},
+		{Density: DensityD1, Summary: "recent chunk B", SpanStart: 131, SpanEnd: 160, TokenCount: 25},
+	}
+	recent := []ai.Message{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi there, how can I help?"},
+	}
+
+	result := BuildContextFromTree(nodes, recent, 10000)
+
+	// Should have D2 + 2×D1 + 2 recent = 5 messages
+	if len(result) < 5 {
+		t.Fatalf("expected at least 5 messages, got %d", len(result))
+	}
+
+	// First should be D2 summary
+	if !contains(result[0].Content, "D2 summary") {
+		t.Errorf("first message should be D2 summary, got: %s", result[0].Content)
+	}
+
+	// Last two should be recent messages
+	if result[len(result)-1].Content != "hi there, how can I help?" {
+		t.Errorf("last message = %q, want recent assistant message", result[len(result)-1].Content)
+	}
+}
+
+func TestBuildContextFromTree_BudgetSkipsLargeNodes(t *testing.T) {
+	nodes := []ContextNode{
+		{Density: DensityD2, Summary: "huge summary", SpanStart: 1, SpanEnd: 100, TokenCount: 5000},
+		{Density: DensityD1, Summary: "small summary", SpanStart: 101, SpanEnd: 110, TokenCount: 10},
+	}
+	recent := []ai.Message{
+		{Role: "user", Content: "hello"},
+	}
+
+	// Budget of 200: D2 (5000 tokens) should be skipped, D1 (10 tokens) fits
+	result := BuildContextFromTree(nodes, recent, 200)
+
+	// Should have D1 + recent = 2
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result))
+	}
+	if !contains(result[0].Content, "D1 summary") {
+		t.Errorf("expected D1 summary, got: %s", result[0].Content)
+	}
+}
+
+func TestBuildContextFromTree_ZeroBudget(t *testing.T) {
+	recent := []ai.Message{
+		{Role: "user", Content: "hello"},
+	}
+
+	result := BuildContextFromTree(nil, recent, 0)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 message for zero budget, got %d", len(result))
+	}
+}
+
+func TestBuildContextFromTree_SkipsCoveredSpans(t *testing.T) {
+	nodes := []ContextNode{
+		// D2 covers 1–60
+		{Density: DensityD2, Summary: "high level", SpanStart: 1, SpanEnd: 60, TokenCount: 30},
+		// D1 within the D2's span — should be skipped
+		{Density: DensityD1, Summary: "should skip", SpanStart: 1, SpanEnd: 30, TokenCount: 20},
+		// D1 outside D2's span — should be included
+		{Density: DensityD1, Summary: "outside span", SpanStart: 61, SpanEnd: 90, TokenCount: 20},
+	}
+
+	result := BuildContextFromTree(nodes, nil, 10000)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages (D2 + 1 D1), got %d", len(result))
+	}
+	if contains(result[1].Content, "should skip") {
+		t.Error("covered D1 node should have been skipped")
+	}
+	if !contains(result[1].Content, "outside span") {
+		t.Error("uncovered D1 node should be included")
+	}
+}
+
+func TestBuildContextFromTree_EmptyTree(t *testing.T) {
+	recent := []ai.Message{
+		{Role: "user", Content: "a"},
+		{Role: "assistant", Content: "b"},
+	}
+
+	result := BuildContextFromTree(nil, recent, 10000)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages (just recent), got %d", len(result))
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/internal/storage/context_nodes_test.go
+++ b/internal/storage/context_nodes_test.go
@@ -183,3 +183,113 @@ func TestGetContextNodes_EmptySession(t *testing.T) {
 		t.Fatalf("expected 0 nodes, got %d", len(nodes))
 	}
 }
+
+func TestGetMessagesAfterID(t *testing.T) {
+	s := newV2TestStore(t)
+	key := "agent:bot:after-test"
+
+	// Seed session.
+	if err := s.UpsertSessionV2(&SessionV2{SessionKey: key, AgentID: "bot"}); err != nil {
+		t.Fatalf("UpsertSessionV2: %v", err)
+	}
+
+	// Insert 5 messages.
+	for i := 0; i < 5; i++ {
+		if err := s.SaveSessionMessageV2(key, "user", "msg", ""); err != nil {
+			t.Fatalf("SaveSessionMessageV2: %v", err)
+		}
+	}
+
+	// Get all messages to find IDs.
+	all, err := s.GetSessionMessagesV2(key, 100)
+	if err != nil {
+		t.Fatalf("GetSessionMessagesV2: %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("expected 5 messages, got %d", len(all))
+	}
+
+	// Get messages after the 3rd one.
+	afterID := all[2].ID
+	got, err := s.GetMessagesAfterID(key, afterID, 100)
+	if err != nil {
+		t.Fatalf("GetMessagesAfterID: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages after ID %d, got %d", afterID, len(got))
+	}
+	if got[0].ID != all[3].ID {
+		t.Errorf("first message ID = %d, want %d", got[0].ID, all[3].ID)
+	}
+}
+
+func TestGetMessagesAfterID_NoResults(t *testing.T) {
+	s := newV2TestStore(t)
+
+	got, err := s.GetMessagesAfterID("nonexistent", 999, 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 messages, got %d", len(got))
+	}
+}
+
+func TestGetUnparentedContextNodes(t *testing.T) {
+	s := newV2TestStore(t)
+	key := "agent:bot:unparented-test"
+
+	// Insert three D1 nodes: two orphans, one with parent.
+	for i := 0; i < 2; i++ {
+		_, err := s.SaveContextNode(ContextNode{
+			SessionKey: key,
+			Density:    1,
+			Summary:    "orphan D1",
+			SpanStart:  int64(i * 10),
+			SpanEnd:    int64(i*10 + 9),
+			ParentID:   0,
+			TokenCount: 20,
+		})
+		if err != nil {
+			t.Fatalf("save orphan D1: %v", err)
+		}
+	}
+
+	// This one has a parent.
+	parentedID, _ := s.SaveContextNode(ContextNode{
+		SessionKey: key,
+		Density:    1,
+		Summary:    "parented D1",
+		SpanStart:  20,
+		SpanEnd:    29,
+		ParentID:   999,
+		TokenCount: 20,
+	})
+
+	orphans, err := s.GetUnparentedContextNodes(key)
+	if err != nil {
+		t.Fatalf("GetUnparentedContextNodes: %v", err)
+	}
+	if len(orphans) != 2 {
+		t.Fatalf("expected 2 orphans, got %d", len(orphans))
+	}
+
+	// Make sure the parented one is not included.
+	for _, n := range orphans {
+		if n.ID == parentedID {
+			t.Error("parented node should not appear in unparented results")
+		}
+	}
+}
+
+func TestGetUnparentedContextNodes_EmptySession(t *testing.T) {
+	s := newV2TestStore(t)
+
+	orphans, err := s.GetUnparentedContextNodes("nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(orphans) != 0 {
+		t.Fatalf("expected 0 orphans, got %d", len(orphans))
+	}
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -2417,3 +2417,61 @@ func (s *Store) GetContextNodeChildren(parentID int64) ([]ContextNode, error) {
 	}
 	return nodes, rows.Err()
 }
+
+// GetMessagesAfterID returns session_messages_v2 rows with id > afterID
+// for the given session, ordered chronologically, up to limit.
+// This is useful for loading the D0 tail of messages that follow the
+// compacted region of the context tree.
+func (s *Store) GetMessagesAfterID(sessionKey string, afterID int64, limit int) ([]SessionMessageV2, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.db.Query(`
+		SELECT id, session_key, role, content, run_id, created_at
+		FROM session_messages_v2
+		WHERE session_key = ? AND id > ?
+		ORDER BY id ASC
+		LIMIT ?
+	`, sessionKey, afterID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var msgs []SessionMessageV2
+	for rows.Next() {
+		var m SessionMessageV2
+		if err := rows.Scan(&m.ID, &m.SessionKey, &m.Role, &m.Content, &m.RunID, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs, rows.Err()
+}
+
+// GetUnparentedContextNodes returns D1 context nodes that have no parent
+// (parent_id = 0) for a session, ordered by span_start ascending.
+// These are candidates for D2 roll-up.
+func (s *Store) GetUnparentedContextNodes(sessionKey string) ([]ContextNode, error) {
+	rows, err := s.db.Query(`
+		SELECT id, session_key, density, summary, span_start, span_end, parent_id, token_count, created_at
+		FROM context_nodes
+		WHERE session_key = ? AND density = 1 AND parent_id = 0
+		ORDER BY span_start ASC
+	`, sessionKey)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var nodes []ContextNode
+	for rows.Next() {
+		var n ContextNode
+		if err := rows.Scan(&n.ID, &n.SessionKey, &n.Density, &n.Summary,
+			&n.SpanStart, &n.SpanEnd, &n.ParentID, &n.TokenCount, &n.CreatedAt); err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, rows.Err()
+}


### PR DESCRIPTION
Implements #182

## Changes

Builds on the D0/D1/D2 context tree merged in #217 with three additions that enable practical use of the tree during context window construction:

- **`BuildContextFromTree`** (`internal/agent/context_tree.go`): Assembles a context window from the tree hierarchy respecting a token budget. Layers D2 summaries (oldest, most compressed) → D1 → D0 (recent messages), automatically skipping nodes whose spans are already covered by a higher-density summary. Reserves 30% of budget for recent messages so the bot always has immediate conversational context.

- **`GetMessagesAfterID`** (`internal/storage/sqlite.go`): Storage helper that returns transcript messages with `id > afterID`, enabling efficient loading of the D0 tail that follows the compacted region of the context tree.

- **`GetUnparentedContextNodes`** (`internal/storage/sqlite.go`): Storage helper that finds orphan D1 nodes (`parent_id = 0`) as candidates for D2 roll-up.

## Testing

- 5 new agent tests covering budget enforcement, span deduplication, zero-budget edge case, empty tree, and mixed-density assembly
- 4 new storage tests for `GetMessagesAfterID` and `GetUnparentedContextNodes` (including empty-result edge cases)
- All existing tests pass: `go test ./...`, `go vet ./...`, `go fmt ./...`
- Binary builds successfully with `CGO_ENABLED=1 go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `BuildContextFromTree` for budget-aware context window assembly, plus two storage helpers (`GetMessagesAfterID`, `GetUnparentedContextNodes`) that support loading the D0 tail and identifying D2 roll-up candidates. The storage layer and span-deduplication logic are solid, but there is one meaningful logic issue in the core function.

- **Recent-message ordering bug** (`context_tree.go:286–293`): The loop appends `recentMessages` from index 0 (oldest) to the end, stopping when the token budget is exhausted. Since `GetMessagesAfterID` returns rows `ORDER BY id ASC`, a tight budget will drop the _newest_ messages — exactly the ones the 30 % reserve is meant to protect. Messages should be selected newest-first and then reversed before appending.
- The `recentReserve` calculation correctly caps tree nodes at 70 % of the budget, but the actual enforcement for recent messages relies on the `tokenBudget` ceiling rather than a separate recent-budget ceiling, which is fine as long as the tree never overflows its own cap — and it doesn't, given the `treeBudget` check in the loop.
- Token overhead for the injected label (`[D2 summary | msgs X–Y]\n`) is not added to `n.TokenCount` when checking the tree budget; the stored count reflects only the summary text. In practice the label is small (~10 tokens) and is a minor inaccuracy, but worth noting for future calibration.
- Storage helpers and tests are clean and follow existing patterns.

<h3>Confidence Score: 3/5</h3>

- The PR introduces a logic bug where the most-recent messages can be silently dropped when the budget is tight, inverting the stated design goal of preserving immediate conversational context.
- The storage helpers are correct and the span-deduplication logic works as intended. However, the oldest-first traversal of recentMessages in BuildContextFromTree means the freshest turns are the first to be cut under budget pressure — directly contradicting the 30% reserve's purpose. This is a primary user-path concern (context quality degrades silently), warranting a fix before merge.
- internal/agent/context_tree.go — recent-message loop (lines 286–293)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/agent/context_tree.go | Adds BuildContextFromTree with budget enforcement and span deduplication; the recent-messages loop fills oldest-first rather than newest-first, so the most recent conversational context can be silently dropped when the 30%-reserved budget is tight. |
| internal/agent/context_tree_test.go | Good coverage of the five documented scenarios; no test exercises the budget-truncation ordering of recent messages (oldest vs. newest). |
| internal/storage/sqlite.go | Two straightforward storage helpers added; SQL, scanning, and limit/default logic look correct. |
| internal/storage/context_nodes_test.go | Four storage tests cover happy-path and empty-result edge cases for both new helpers; all look correct. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/agent/context_tree.go
Line: 286-293

Comment:
**Recent messages filled oldest-first, newest may be cut off**

`recentMessages` is provided in chronological order (oldest → newest, as `GetMessagesAfterID` returns `ORDER BY id ASC`). The loop iterates from the start and breaks as soon as the budget is exhausted. When the budget is tight this will include the oldest of the recent messages while silently dropping the newest ones — the opposite of what you want for "immediate conversational context".

The fix is to walk the slice in reverse to fill the most-recent messages first, then reverse the selected subset back into chronological order before appending:

```
// Collect recent messages newest-first until the budget is full,
// then reverse to restore chronological order.
var selected []ai.Message
for i := len(recentMessages) - 1; i >= 0; i-- {
    msg := recentMessages[i]
    msgTokens := tc.CountTokens(msg.Content) + 4
    if tokensUsed+msgTokens > tokenBudget {
        break
    }
    selected = append(selected, msg)
    tokensUsed += msgTokens
}
// Re-order oldest → newest before appending.
for i, j := 0, len(selected)-1; i < j; i, j = i+1, j-1 {
    selected[i], selected[j] = selected[j], selected[i]
}
result = append(result, selected...)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(memory): add budget-aware context a..."](https://github.com/befeast/ok-gobot/commit/cef589c7a91c22da0acd143be2f3041f651f4bdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25959351)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->