### PR TITLE
feat: recommend next role from observed work patterns (#181)

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -91,6 +91,7 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		BrowserProfile:  browserCfg.ProfilePath,
 		BrowserDebugURL: browserCfg.DebugURL,
 		MemoryManager:   memoryManager,
+		PatternStore:    store,
 		EmergencyStop:   store,
 	}
 	toolRegistry, _ := tools.LoadFromConfigWithOptions(personality.BasePath, toolsConfig)

--- a/internal/recommend/recommend.go
+++ b/internal/recommend/recommend.go
@@ -1,0 +1,327 @@
+// Package recommend analyzes chat and job patterns to propose new agent roles.
+package recommend
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"ok-gobot/internal/storage"
+)
+
+// PatternStore is the subset of storage.Store the recommender needs.
+type PatternStore interface {
+	GetChatActivityStats(limit int) ([]storage.ChatActivityRow, error)
+	GetRecentUserMessages(limit int) ([]storage.UserMessageRow, error)
+	CronJobSummary() ([]storage.CronJob, error)
+	JobKindCounts(limit int) (map[string]int, error)
+}
+
+// RoleRecommendation is a concrete proposal for a new agent role.
+type RoleRecommendation struct {
+	Name          string // e.g. "monitor"
+	Description   string // what this role does
+	Schedule      string // suggested cron expression (5-field)
+	OutputExample string // sample output the role would produce
+	Rationale     string // why we recommend it, based on observed data
+}
+
+// topicDef maps keyword groups to a role archetype.
+type topicDef struct {
+	keywords      []string
+	role          string
+	description   string
+	schedule      string
+	outputExample string
+}
+
+// builtinTopics defines the role archetypes we can detect.
+var builtinTopics = []topicDef{
+	{
+		keywords:    []string{"check", "status", "monitor", "running", "health", "alive", "up", "ping", "uptime"},
+		role:        "monitor",
+		description: "Periodically check service health and alert on anomalies.",
+		schedule:    "*/15 * * * *",
+		outputExample: `All systems operational.
+  - api: 200 OK (43ms)
+  - db:  connected (2 replicas)
+  - queue: 0 backlog`,
+	},
+	{
+		keywords:    []string{"summary", "report", "digest", "stats", "analytics", "overview", "numbers"},
+		role:        "reporter",
+		description: "Generate periodic summaries of activity, metrics, or progress.",
+		schedule:    "0 9 * * *",
+		outputExample: `Daily digest (2026-03-21):
+  - 42 messages processed
+  - 3 jobs completed, 1 failed
+  - Top topic: deployment`,
+	},
+	{
+		keywords:    []string{"remind", "reminder", "follow up", "don't forget", "later", "schedule", "alert me"},
+		role:        "reminder",
+		description: "Send scheduled reminders and follow-up nudges.",
+		schedule:    "0 9 * * 1-5",
+		outputExample: `Reminder: standup in 15 minutes.
+Open items from yesterday:
+  - Review PR #42
+  - Reply to infra thread`,
+	},
+	{
+		keywords:    []string{"search", "find", "look up", "research", "google", "browse", "fetch"},
+		role:        "researcher",
+		description: "Perform scheduled web research and compile findings.",
+		schedule:    "0 8 * * 1",
+		outputExample: `Weekly research brief:
+  1. Go 1.24 released — notable: range-over-func stabilised
+  2. SQLite 3.48 — new JSON improvements
+  3. Telegram Bot API 8.1 — reaction support`,
+	},
+	{
+		keywords:    []string{"deploy", "build", "test", "ci", "cd", "release", "update", "upgrade", "migration"},
+		role:        "ops",
+		description: "Run maintenance tasks: builds, deploys, dependency updates.",
+		schedule:    "0 3 * * 0",
+		outputExample: `Weekly maintenance completed:
+  - Dependencies updated (2 minor bumps)
+  - go test ./... — all 147 tests pass
+  - Docker image rebuilt and pushed`,
+	},
+	{
+		keywords:    []string{"clean", "tidy", "archive", "prune", "delete old", "rotate", "backup"},
+		role:        "janitor",
+		description: "Housekeeping: prune old data, rotate logs, run backups.",
+		schedule:    "0 2 * * 0",
+		outputExample: `Housekeeping report:
+  - Pruned 230 old session messages (>30d)
+  - Log rotation: 3 files archived
+  - Disk usage: 42% (was 58%)`,
+	},
+}
+
+// Recommender analyzes stored patterns and generates role proposals.
+type Recommender struct {
+	store PatternStore
+}
+
+// New creates a Recommender backed by the given store.
+func New(store PatternStore) *Recommender {
+	return &Recommender{store: store}
+}
+
+// Analyze gathers data and returns zero or more role recommendations.
+func (r *Recommender) Analyze() ([]RoleRecommendation, error) {
+	messages, err := r.store.GetRecentUserMessages(500)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read recent messages: %w", err)
+	}
+
+	cronJobs, err := r.store.CronJobSummary()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cron jobs: %w", err)
+	}
+
+	jobKinds, err := r.store.JobKindCounts(50)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read job kinds: %w", err)
+	}
+
+	activity, err := r.store.GetChatActivityStats(50)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read activity stats: %w", err)
+	}
+
+	// Count keyword hits across user messages.
+	topicHits := r.countTopicHits(messages)
+
+	// Build set of existing cron task keywords to avoid redundant recommendations.
+	existingCronKeywords := r.existingCronKeywords(cronJobs)
+
+	var recs []RoleRecommendation
+
+	// Score each topic and recommend if hits exceed the threshold.
+	threshold := r.hitThreshold(len(messages))
+	for _, td := range builtinTopics {
+		hits := topicHits[td.role]
+		if hits < threshold {
+			continue
+		}
+
+		// Skip if there's already a cron job that covers this role.
+		if r.cronAlreadyCovers(td, existingCronKeywords) {
+			continue
+		}
+
+		rationale := fmt.Sprintf(
+			"Detected %d messages matching %q patterns across %d recent user messages.",
+			hits, td.role, len(messages),
+		)
+
+		recs = append(recs, RoleRecommendation{
+			Name:          td.role,
+			Description:   td.description,
+			Schedule:      td.schedule,
+			OutputExample: td.outputExample,
+			Rationale:     rationale,
+		})
+	}
+
+	// If there are many durable jobs of a specific kind, suggest a dedicated role.
+	recs = append(recs, r.recommendFromJobKinds(jobKinds)...)
+
+	// If there are many active sessions, suggest a coordinator role.
+	recs = append(recs, r.recommendFromActivity(activity)...)
+
+	// Sort by name for stable output.
+	sort.Slice(recs, func(i, j int) bool {
+		return recs[i].Name < recs[j].Name
+	})
+
+	return recs, nil
+}
+
+// hitThreshold returns the minimum number of keyword matches required.
+// With very few messages we require at least 2 hits; with more data, 3+.
+func (r *Recommender) hitThreshold(totalMessages int) int {
+	if totalMessages < 20 {
+		return 2
+	}
+	return 3
+}
+
+// countTopicHits scores each topic archetype against the message corpus.
+func (r *Recommender) countTopicHits(messages []storage.UserMessageRow) map[string]int {
+	hits := make(map[string]int)
+	for _, msg := range messages {
+		lower := strings.ToLower(msg.Content)
+		for _, td := range builtinTopics {
+			for _, kw := range td.keywords {
+				if strings.Contains(lower, kw) {
+					hits[td.role]++
+					break // count each message at most once per topic
+				}
+			}
+		}
+	}
+	return hits
+}
+
+// existingCronKeywords extracts lowercase keywords from existing cron task descriptions.
+func (r *Recommender) existingCronKeywords(jobs []storage.CronJob) map[string]bool {
+	kw := make(map[string]bool)
+	for _, job := range jobs {
+		for _, word := range strings.Fields(strings.ToLower(job.Task)) {
+			kw[word] = true
+		}
+	}
+	return kw
+}
+
+// cronAlreadyCovers checks if existing cron keywords overlap significantly
+// with a topic's keyword set.
+func (r *Recommender) cronAlreadyCovers(td topicDef, cronKW map[string]bool) bool {
+	matches := 0
+	for _, kw := range td.keywords {
+		if cronKW[kw] {
+			matches++
+		}
+	}
+	// If 2+ keywords from this topic already appear in cron tasks, skip.
+	return matches >= 2
+}
+
+// recommendFromJobKinds looks for frequently-used job kinds that don't have
+// a matching cron job and suggests scheduling them.
+func (r *Recommender) recommendFromJobKinds(kinds map[string]int) []RoleRecommendation {
+	var recs []RoleRecommendation
+	for kind, count := range kinds {
+		if count < 3 {
+			continue
+		}
+		recs = append(recs, RoleRecommendation{
+			Name:        fmt.Sprintf("%s-scheduler", kind),
+			Description: fmt.Sprintf("Automate recurring %q jobs that are currently triggered manually.", kind),
+			Schedule:    "0 8 * * 1-5",
+			OutputExample: fmt.Sprintf(`Scheduled %s job completed.
+  - Status: succeeded
+  - Duration: 2m 15s`, kind),
+			Rationale: fmt.Sprintf(
+				"Found %d manually-triggered %q jobs. A scheduled role could automate these.",
+				count, kind,
+			),
+		})
+	}
+	return recs
+}
+
+// recommendFromActivity checks if there are many active chats that could
+// benefit from a coordinator or triage role.
+func (r *Recommender) recommendFromActivity(activity []storage.ChatActivityRow) []RoleRecommendation {
+	if len(activity) < 5 {
+		return nil
+	}
+
+	// Count unique agents in use.
+	agents := make(map[string]int)
+	totalMessages := 0
+	for _, a := range activity {
+		agents[a.AgentID] += a.MessageCount
+		totalMessages += a.MessageCount
+	}
+
+	if len(agents) < 2 || totalMessages < 50 {
+		return nil
+	}
+
+	return []RoleRecommendation{
+		{
+			Name:        "triage",
+			Description: "Route incoming messages to the best-suited agent based on content and history.",
+			Schedule:    "0 8 * * *",
+			OutputExample: fmt.Sprintf(`Triage summary:
+  - %d active sessions across %d agents
+  - Busiest agent: %s
+  - Suggestion: redistribute load from busiest agent`, len(activity), len(agents), busiestAgent(agents)),
+			Rationale: fmt.Sprintf(
+				"Observed %d active sessions using %d distinct agents with %d total messages. A triage role could improve routing.",
+				len(activity), len(agents), totalMessages,
+			),
+		},
+	}
+}
+
+// busiestAgent returns the agent with the highest message count.
+func busiestAgent(agents map[string]int) string {
+	best := ""
+	bestCount := 0
+	for name, count := range agents {
+		if count > bestCount {
+			best = name
+			bestCount = count
+		}
+	}
+	return best
+}
+
+// Format renders recommendations as human-readable text.
+func Format(recs []RoleRecommendation) string {
+	if len(recs) == 0 {
+		return "No role recommendations at this time. Keep chatting and scheduling jobs — patterns will emerge."
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Found %d role recommendation(s) based on observed patterns:\n", len(recs)))
+
+	for i, rec := range recs {
+		sb.WriteString(fmt.Sprintf("\n--- %d. %s ---\n", i+1, rec.Name))
+		sb.WriteString(fmt.Sprintf("Description: %s\n", rec.Description))
+		sb.WriteString(fmt.Sprintf("Suggested schedule: %s\n", rec.Schedule))
+		sb.WriteString(fmt.Sprintf("Rationale: %s\n", rec.Rationale))
+		sb.WriteString("Sample output:\n")
+		for _, line := range strings.Split(rec.OutputExample, "\n") {
+			sb.WriteString(fmt.Sprintf("  | %s\n", line))
+		}
+	}
+
+	return sb.String()
+}

--- a/internal/recommend/recommend_test.go
+++ b/internal/recommend/recommend_test.go
@@ -1,0 +1,234 @@
+package recommend
+
+import (
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/storage"
+)
+
+// mockStore implements PatternStore for testing.
+type mockStore struct {
+	activity []storage.ChatActivityRow
+	messages []storage.UserMessageRow
+	cronJobs []storage.CronJob
+	jobKinds map[string]int
+}
+
+func (m *mockStore) GetChatActivityStats(limit int) ([]storage.ChatActivityRow, error) {
+	return m.activity, nil
+}
+
+func (m *mockStore) GetRecentUserMessages(limit int) ([]storage.UserMessageRow, error) {
+	return m.messages, nil
+}
+
+func (m *mockStore) CronJobSummary() ([]storage.CronJob, error) {
+	return m.cronJobs, nil
+}
+
+func (m *mockStore) JobKindCounts(limit int) (map[string]int, error) {
+	return m.jobKinds, nil
+}
+
+func TestAnalyze_NoData(t *testing.T) {
+	store := &mockStore{jobKinds: map[string]int{}}
+	r := New(store)
+
+	recs, err := r.Analyze()
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Errorf("expected 0 recommendations, got %d", len(recs))
+	}
+}
+
+func TestAnalyze_DetectsMonitorPattern(t *testing.T) {
+	store := &mockStore{
+		messages: []storage.UserMessageRow{
+			{Content: "check if the API is running"},
+			{Content: "is the service alive?"},
+			{Content: "can you check the status of the deploy?"},
+			{Content: "monitor the health endpoint"},
+		},
+		jobKinds: map[string]int{},
+	}
+
+	r := New(store)
+	recs, err := r.Analyze()
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	found := false
+	for _, rec := range recs {
+		if rec.Name == "monitor" {
+			found = true
+			if rec.Schedule == "" {
+				t.Error("monitor recommendation has empty schedule")
+			}
+			if rec.OutputExample == "" {
+				t.Error("monitor recommendation has empty output example")
+			}
+			if !strings.Contains(rec.Rationale, "monitor") {
+				t.Errorf("rationale should mention monitor, got: %s", rec.Rationale)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected monitor role recommendation")
+	}
+}
+
+func TestAnalyze_DetectsReporterPattern(t *testing.T) {
+	store := &mockStore{
+		messages: []storage.UserMessageRow{
+			{Content: "give me a summary of yesterday"},
+			{Content: "what are the stats for this week?"},
+			{Content: "daily report please"},
+		},
+		jobKinds: map[string]int{},
+	}
+
+	r := New(store)
+	recs, err := r.Analyze()
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	found := false
+	for _, rec := range recs {
+		if rec.Name == "reporter" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected reporter role recommendation")
+	}
+}
+
+func TestAnalyze_SkipsWhenCronAlreadyCovers(t *testing.T) {
+	store := &mockStore{
+		messages: []storage.UserMessageRow{
+			{Content: "check the status"},
+			{Content: "is the service running"},
+			{Content: "monitor health please"},
+		},
+		cronJobs: []storage.CronJob{
+			{Task: "check health status of all services", Enabled: true},
+		},
+		jobKinds: map[string]int{},
+	}
+
+	r := New(store)
+	recs, err := r.Analyze()
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	for _, rec := range recs {
+		if rec.Name == "monitor" {
+			t.Error("should not recommend monitor when cron already covers it")
+		}
+	}
+}
+
+func TestAnalyze_RecommendsFromJobKinds(t *testing.T) {
+	store := &mockStore{
+		jobKinds: map[string]int{
+			"backup": 5,
+		},
+	}
+
+	r := New(store)
+	recs, err := r.Analyze()
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	found := false
+	for _, rec := range recs {
+		if rec.Name == "backup-scheduler" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected backup-scheduler recommendation from job kinds")
+	}
+}
+
+func TestAnalyze_RecommendsTriageFromMultiAgentActivity(t *testing.T) {
+	var activity []storage.ChatActivityRow
+	for i := 0; i < 6; i++ {
+		agentID := "bot"
+		if i%2 == 0 {
+			agentID = "assistant"
+		}
+		activity = append(activity, storage.ChatActivityRow{
+			ChatID:       int64(100 + i),
+			AgentID:      agentID,
+			MessageCount: 20,
+		})
+	}
+
+	store := &mockStore{
+		activity: activity,
+		jobKinds: map[string]int{},
+	}
+
+	r := New(store)
+	recs, err := r.Analyze()
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	found := false
+	for _, rec := range recs {
+		if rec.Name == "triage" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected triage recommendation from multi-agent activity")
+	}
+}
+
+func TestFormat_Empty(t *testing.T) {
+	out := Format(nil)
+	if !strings.Contains(out, "No role recommendations") {
+		t.Errorf("unexpected output for empty recommendations: %s", out)
+	}
+}
+
+func TestFormat_WithRecommendations(t *testing.T) {
+	recs := []RoleRecommendation{
+		{
+			Name:          "monitor",
+			Description:   "Check service health.",
+			Schedule:      "*/15 * * * *",
+			OutputExample: "All OK",
+			Rationale:     "Detected 5 monitoring messages.",
+		},
+	}
+	out := Format(recs)
+	if !strings.Contains(out, "monitor") {
+		t.Error("output should contain role name")
+	}
+	if !strings.Contains(out, "*/15 * * * *") {
+		t.Error("output should contain schedule")
+	}
+	if !strings.Contains(out, "All OK") {
+		t.Error("output should contain output example")
+	}
+}
+
+func TestHitThreshold(t *testing.T) {
+	r := &Recommender{}
+	if r.hitThreshold(10) != 2 {
+		t.Error("threshold should be 2 for < 20 messages")
+	}
+	if r.hitThreshold(100) != 3 {
+		t.Error("threshold should be 3 for >= 20 messages")
+	}
+}

--- a/internal/storage/patterns.go
+++ b/internal/storage/patterns.go
@@ -1,0 +1,155 @@
+package storage
+
+import "database/sql"
+
+// ChatActivityRow holds aggregated activity stats for a single chat.
+type ChatActivityRow struct {
+	ChatID       int64
+	AgentID      string
+	MessageCount int
+	LastActive   string
+}
+
+// GetChatActivityStats returns per-chat message counts and last-active times
+// across both legacy and v2 session tables.
+func (s *Store) GetChatActivityStats(limit int) ([]ChatActivityRow, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+
+	rows, err := s.db.Query(`
+		SELECT
+			COALESCE(sr.chat_id, 0) AS chat_id,
+			sv.agent_id,
+			sv.message_count,
+			sv.updated_at
+		FROM sessions_v2 sv
+		LEFT JOIN session_routes sr ON sr.session_key = sv.session_key
+		WHERE sv.message_count > 0
+		ORDER BY sv.updated_at DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ChatActivityRow
+	for rows.Next() {
+		var r ChatActivityRow
+		if err := rows.Scan(&r.ChatID, &r.AgentID, &r.MessageCount, &r.LastActive); err != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// UserMessageRow holds a single user message with its timestamp.
+type UserMessageRow struct {
+	SessionKey string
+	Content    string
+	CreatedAt  string
+}
+
+// GetRecentUserMessages returns the most recent user-role messages across all
+// sessions. This feeds the keyword/topic analysis in the role recommender.
+func (s *Store) GetRecentUserMessages(limit int) ([]UserMessageRow, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+
+	rows, err := s.db.Query(`
+		SELECT session_key, content, created_at
+		FROM session_messages_v2
+		WHERE role = 'user'
+		ORDER BY created_at DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		// Fall back to legacy table if v2 table is empty or broken.
+		return s.getRecentUserMessagesLegacy(limit)
+	}
+	defer rows.Close()
+
+	var out []UserMessageRow
+	for rows.Next() {
+		var r UserMessageRow
+		if err := rows.Scan(&r.SessionKey, &r.Content, &r.CreatedAt); err != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// If v2 is empty, try legacy.
+	if len(out) == 0 {
+		return s.getRecentUserMessagesLegacy(limit)
+	}
+	return out, nil
+}
+
+func (s *Store) getRecentUserMessagesLegacy(limit int) ([]UserMessageRow, error) {
+	rows, err := s.db.Query(`
+		SELECT CAST(chat_id AS TEXT), content, created_at
+		FROM session_messages
+		WHERE role = 'user'
+		ORDER BY created_at DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []UserMessageRow
+	for rows.Next() {
+		var r UserMessageRow
+		if err := rows.Scan(&r.SessionKey, &r.Content, &r.CreatedAt); err != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// CronJobSummary returns all cron jobs (enabled or not). It wraps GetCronJobs
+// so callers in the recommend package need only one import.
+func (s *Store) CronJobSummary() ([]CronJob, error) {
+	return s.GetCronJobs()
+}
+
+// JobKindCounts returns how many durable jobs exist per kind.
+func (s *Store) JobKindCounts(limit int) (map[string]int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+
+	rows, err := s.db.Query(`
+		SELECT kind, COUNT(*) AS cnt
+		FROM jobs
+		GROUP BY kind
+		ORDER BY cnt DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return map[string]int{}, nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]int)
+	for rows.Next() {
+		var kind string
+		var cnt int
+		if err := rows.Scan(&kind, &cnt); err != nil {
+			continue
+		}
+		out[kind] = cnt
+	}
+	return out, rows.Err()
+}

--- a/internal/storage/patterns_test.go
+++ b/internal/storage/patterns_test.go
@@ -1,0 +1,141 @@
+package storage
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func newPatternsTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestGetChatActivityStats_Empty(t *testing.T) {
+	s := newPatternsTestStore(t)
+	rows, err := s.GetChatActivityStats(10)
+	if err != nil {
+		t.Fatalf("GetChatActivityStats: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(rows))
+	}
+}
+
+func TestGetChatActivityStats_WithData(t *testing.T) {
+	s := newPatternsTestStore(t)
+
+	// Insert a v2 session with messages.
+	sess := &SessionV2{
+		SessionKey:   "agent:bot:telegram:group:-100",
+		AgentID:      "bot",
+		MessageCount: 42,
+	}
+	if err := s.UpsertSessionV2(sess); err != nil {
+		t.Fatalf("UpsertSessionV2: %v", err)
+	}
+
+	// Insert a route so chat_id is populated.
+	if err := s.UpsertSessionRoute(SessionRoute{
+		SessionKey: sess.SessionKey,
+		Channel:    "telegram",
+		ChatID:     -100,
+	}); err != nil {
+		t.Fatalf("UpsertSessionRoute: %v", err)
+	}
+
+	rows, err := s.GetChatActivityStats(10)
+	if err != nil {
+		t.Fatalf("GetChatActivityStats: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].ChatID != -100 {
+		t.Errorf("ChatID = %d, want -100", rows[0].ChatID)
+	}
+	if rows[0].MessageCount != 42 {
+		t.Errorf("MessageCount = %d, want 42", rows[0].MessageCount)
+	}
+}
+
+func TestGetRecentUserMessages_Empty(t *testing.T) {
+	s := newPatternsTestStore(t)
+	msgs, err := s.GetRecentUserMessages(10)
+	if err != nil {
+		t.Fatalf("GetRecentUserMessages: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected 0 messages, got %d", len(msgs))
+	}
+}
+
+func TestGetRecentUserMessages_WithData(t *testing.T) {
+	s := newPatternsTestStore(t)
+
+	sess := &SessionV2{
+		SessionKey: "agent:bot:telegram:group:-200",
+		AgentID:    "bot",
+	}
+	if err := s.UpsertSessionV2(sess); err != nil {
+		t.Fatalf("UpsertSessionV2: %v", err)
+	}
+
+	if err := s.SaveSessionMessageV2(sess.SessionKey, "user", "check the status", ""); err != nil {
+		t.Fatalf("SaveSessionMessageV2: %v", err)
+	}
+	if err := s.SaveSessionMessageV2(sess.SessionKey, "assistant", "all good", ""); err != nil {
+		t.Fatalf("SaveSessionMessageV2: %v", err)
+	}
+
+	msgs, err := s.GetRecentUserMessages(10)
+	if err != nil {
+		t.Fatalf("GetRecentUserMessages: %v", err)
+	}
+	// Only user messages should be returned.
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 user message, got %d", len(msgs))
+	}
+	if msgs[0].Content != "check the status" {
+		t.Errorf("Content = %q, want %q", msgs[0].Content, "check the status")
+	}
+}
+
+func TestJobKindCounts_Empty(t *testing.T) {
+	s := newPatternsTestStore(t)
+	counts, err := s.JobKindCounts(10)
+	if err != nil {
+		t.Fatalf("JobKindCounts: %v", err)
+	}
+	if len(counts) != 0 {
+		t.Errorf("expected empty counts, got %v", counts)
+	}
+}
+
+func TestJobKindCounts_WithData(t *testing.T) {
+	s := newPatternsTestStore(t)
+
+	for i := 0; i < 3; i++ {
+		if err := s.CreateJob(Job{
+			JobID:  fmt.Sprintf("job-%d", i),
+			Kind:   "backup",
+			Status: "succeeded",
+		}); err != nil {
+			t.Fatalf("CreateJob: %v", err)
+		}
+	}
+
+	counts, err := s.JobKindCounts(10)
+	if err != nil {
+		t.Fatalf("JobKindCounts: %v", err)
+	}
+	if counts["backup"] != 3 {
+		t.Errorf("backup count = %d, want 3", counts["backup"])
+	}
+}

--- a/internal/tools/recommend_roles.go
+++ b/internal/tools/recommend_roles.go
@@ -1,0 +1,49 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"ok-gobot/internal/recommend"
+)
+
+// RecommendRolesTool analyzes chat and job patterns and proposes new agent
+// roles with schedules and output examples.
+type RecommendRolesTool struct {
+	recommender *recommend.Recommender
+}
+
+// NewRecommendRolesTool creates a recommend_roles tool backed by the given store.
+func NewRecommendRolesTool(store recommend.PatternStore) *RecommendRolesTool {
+	return &RecommendRolesTool{
+		recommender: recommend.New(store),
+	}
+}
+
+func (t *RecommendRolesTool) Name() string {
+	return "recommend_roles"
+}
+
+func (t *RecommendRolesTool) Description() string {
+	return "Analyze chat and job patterns to recommend new agent roles with schedules and output examples."
+}
+
+func (t *RecommendRolesTool) GetSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":       "object",
+		"properties": map[string]interface{}{},
+	}
+}
+
+func (t *RecommendRolesTool) Execute(ctx context.Context, args ...string) (string, error) {
+	if t.recommender == nil {
+		return "", fmt.Errorf("recommender is not configured")
+	}
+
+	recs, err := t.recommender.Analyze()
+	if err != nil {
+		return "", fmt.Errorf("analysis failed: %w", err)
+	}
+
+	return recommend.Format(recs), nil
+}

--- a/internal/tools/recommend_roles_test.go
+++ b/internal/tools/recommend_roles_test.go
@@ -1,0 +1,94 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/storage"
+)
+
+// mockPatternStore implements recommend.PatternStore for tool tests.
+type mockPatternStore struct {
+	messages []storage.UserMessageRow
+}
+
+func (m *mockPatternStore) GetChatActivityStats(limit int) ([]storage.ChatActivityRow, error) {
+	return nil, nil
+}
+
+func (m *mockPatternStore) GetRecentUserMessages(limit int) ([]storage.UserMessageRow, error) {
+	return m.messages, nil
+}
+
+func (m *mockPatternStore) CronJobSummary() ([]storage.CronJob, error) {
+	return nil, nil
+}
+
+func (m *mockPatternStore) JobKindCounts(limit int) (map[string]int, error) {
+	return map[string]int{}, nil
+}
+
+func TestRecommendRolesTool_Name(t *testing.T) {
+	tool := NewRecommendRolesTool(&mockPatternStore{})
+	if tool.Name() != "recommend_roles" {
+		t.Errorf("Name() = %q, want %q", tool.Name(), "recommend_roles")
+	}
+}
+
+func TestRecommendRolesTool_EmptyData(t *testing.T) {
+	tool := NewRecommendRolesTool(&mockPatternStore{})
+	result, err := tool.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(result, "No role recommendations") {
+		t.Errorf("expected 'No role recommendations' in output, got: %s", result)
+	}
+}
+
+func TestRecommendRolesTool_WithPatterns(t *testing.T) {
+	store := &mockPatternStore{
+		messages: []storage.UserMessageRow{
+			{Content: "remind me tomorrow"},
+			{Content: "don't forget to follow up"},
+			{Content: "schedule a reminder"},
+		},
+	}
+	tool := NewRecommendRolesTool(store)
+	result, err := tool.Execute(context.Background())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(result, "reminder") {
+		t.Errorf("expected 'reminder' in output, got: %s", result)
+	}
+	if !strings.Contains(result, "schedule") {
+		t.Errorf("expected 'schedule' in output, got: %s", result)
+	}
+}
+
+func TestRecommendRolesTool_HasSchema(t *testing.T) {
+	tool := NewRecommendRolesTool(&mockPatternStore{})
+	schema := tool.GetSchema()
+	if schema == nil {
+		t.Fatal("GetSchema() returned nil")
+	}
+	if schema["type"] != "object" {
+		t.Errorf("schema type = %v, want 'object'", schema["type"])
+	}
+}
+
+func TestRecommendRolesTool_Registration(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := &mockPatternStore{}
+	registry, err := LoadFromConfigWithOptions(tmpDir, &ToolsConfig{
+		PatternStore: store,
+	})
+	if err != nil {
+		t.Fatalf("LoadFromConfigWithOptions: %v", err)
+	}
+	if _, ok := registry.Get("recommend_roles"); !ok {
+		t.Fatal("recommend_roles tool is not registered")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -12,6 +12,7 @@ import (
 
 	"ok-gobot/internal/ai"
 	"ok-gobot/internal/memory"
+	"ok-gobot/internal/recommend"
 )
 
 // Tool represents an executable tool
@@ -465,6 +466,7 @@ type ToolsConfig struct {
 	Contacts        map[string]int64 // alias -> chatID for message tool allowlist
 	CurrentChatID   int64
 	MemoryManager   *memory.MemoryManager
+	PatternStore    recommend.PatternStore
 	EmergencyStop   EmergencyStopProvider
 }
 
@@ -595,6 +597,11 @@ func LoadFromConfigWithOptions(basePath string, cfg *ToolsConfig) (*Registry, er
 		if cfg.MemoryManager != nil {
 			registry.Register(NewMemorySearchTool(cfg.MemoryManager))
 			registry.Register(NewMemoryGetTool(basePath))
+		}
+
+		// Role recommendation tool
+		if cfg.PatternStore != nil {
+			registry.Register(NewRecommendRolesTool(cfg.PatternStore))
 		}
 	}
 


### PR DESCRIPTION
Implements #181

## Changes

Adds a `recommend_roles` tool that analyzes observed chat and job patterns to propose concrete new agent roles with schedules and output examples.

**New packages/files:**
- `internal/storage/patterns.go` — Analytics queries: session activity stats, recent user messages, job kind counts
- `internal/recommend/recommend.go` — Pattern analysis engine with keyword-based topic detection across 6 built-in role archetypes (monitor, reporter, reminder, researcher, ops, janitor) plus a multi-agent triage detector and job-kind scheduler recommender
- `internal/tools/recommend_roles.go` — `Tool`/`ToolSchema` implementation exposing the recommender to the agent

**Modified files:**
- `internal/tools/tools.go` — Added `PatternStore` to `ToolsConfig`, registered `recommend_roles` tool
- `internal/bot/bot.go` — Wired `store` as `PatternStore` in `ToolsConfig`

**How it works:**
1. Queries recent user messages and scores them against keyword groups for each role archetype
2. Checks existing cron jobs to avoid redundant recommendations
3. Detects frequently-triggered durable job kinds and suggests scheduling them
4. Detects multi-agent activity patterns and suggests a triage coordinator role
5. Returns formatted recommendations with name, description, cron schedule, sample output, and rationale

## Testing

- Unit tests for the recommender (`internal/recommend/recommend_test.go`): empty data, monitor/reporter/reminder pattern detection, cron-overlap suppression, job-kind recommendations, triage from multi-agent activity, formatting
- Storage integration tests (`internal/storage/patterns_test.go`): empty results, activity stats with session routes, user message filtering, job kind counts
- Tool tests (`internal/tools/recommend_roles_test.go`): name, schema, empty/pattern execution, registration in tool registry
- `go fmt`, `go vet`, `go test ./...` — all pass
- `CGO_ENABLED=1 go build ./cmd/ok-gobot/` — binary builds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `recommend_roles` tool that analyzes stored chat history and job patterns to propose new scheduled agent roles. The architecture is clean — a thin storage layer (`patterns.go`) feeds a stateless analysis engine (`recommend.go`) that is exposed through the existing tool registry pattern. Test coverage is solid across all three layers.

Three logic issues are worth addressing before merge:

- **`recommendFromJobKinds` missing cron deduplication** (`internal/recommend/recommend.go:235`): The keyword-based path correctly skips recommendations when existing cron jobs already cover a topic, but `recommendFromJobKinds` never performs this check, so it can suggest automating a job kind that is already scheduled.
- **Over-broad fallback in `GetRecentUserMessages`** (`internal/storage/patterns.go:68`): Any `db.Query` error (transient lock, schema mismatch, etc.) silently triggers a fall-back to the legacy table, masking real database failures from the caller.
- **Dead `sql.ErrNoRows` guard in `JobKindCounts`** (`internal/storage/patterns.go:137`): `db.Query` never returns `sql.ErrNoRows`; the guard is dead code and gives false confidence that the empty-table path is handled.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the three logic issues, particularly the missing cron deduplication in job-kind recommendations and the over-broad error fallback.
- The feature is well-structured and well-tested, but three concrete logic bugs exist: a missing cron-overlap check in `recommendFromJobKinds` (producing the redundant recommendations the design explicitly tries to avoid), an over-broad fallback that swallows real DB errors, and a dead `sql.ErrNoRows` guard. None of these are data-loss risks, but the first directly undermines the correctness of the tool's output in real usage.
- `internal/storage/patterns.go` and `internal/recommend/recommend.go` need attention for the three identified logic issues.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/storage/patterns.go | New analytics queries for the recommender. Two logic issues: `db.Query` never returns `sql.ErrNoRows` (dead guard in `JobKindCounts`), and `GetRecentUserMessages` falls back to the legacy table on any query error rather than only on schema-missing errors. |
| internal/recommend/recommend.go | Core recommendation engine. `recommendFromJobKinds` is missing the cron-overlap check that the keyword path applies, so it can produce redundant recommendations for already-scheduled job kinds. |
| internal/recommend/recommend_test.go | Thorough unit tests covering empty data, each pattern archetype, cron suppression, job-kind recommendations, triage detection, and format output. No issues found. |
| internal/storage/patterns_test.go | Integration tests against a real SQLite DB for all three new query methods. Covers empty and populated cases correctly. |
| internal/tools/recommend_roles.go | Clean tool wrapper exposing the recommender via the tool interface. No issues found. |
| internal/tools/tools.go | Minimal, clean additions: `PatternStore` field added to `ToolsConfig` and the tool is conditionally registered when the store is non-nil. |
| internal/bot/bot.go | One-line wiring of `store` as `PatternStore`. No issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/storage/patterns.go
Line: 137-141

Comment:
**`sql.ErrNoRows` never returned by `db.Query`**

`sql.ErrNoRows` is only returned by `(*Row).Scan()` (i.e. `db.QueryRow().Scan()`), never by `db.Query()`. When the `jobs` table is empty, `db.Query()` succeeds and returns an empty result-set — so this guard is dead code and will never fire.

If the intent is to tolerate a missing `jobs` table gracefully, the check should look for the SQLite "no such table" error string, or the table should be created in the schema migration. As written, if `jobs` doesn't exist yet, the error propagates as-is (which may be the right behavior), but the dead `sql.ErrNoRows` branch gives false confidence that the empty-table case is explicitly handled here.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/storage/patterns.go
Line: 68-72

Comment:
**Fallback triggered on any query error, masking real failures**

The fallback to the legacy table fires on _any_ `db.Query` error, not just "table doesn't exist". If the database is temporarily locked, out of disk, or has a schema mismatch, the function will silently fall back to potentially stale legacy data and return `nil` error — hiding the underlying problem from the caller.

Consider checking the error type/message to distinguish a schema-missing error from a transient database error, and only falling back in the former case:

```go
if err != nil {
    if isTableNotFoundError(err) {
        return s.getRecentUserMessagesLegacy(limit)
    }
    return nil, err
}
```

This ensures real database errors are surfaced rather than being swallowed by the legacy path.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/recommend/recommend.go
Line: 235-254

Comment:
**`recommendFromJobKinds` doesn't check for existing cron coverage**

The function's doc comment says it suggests scheduling jobs "that don't have a matching cron job", but there is no such check in the implementation. The `cronJobs` slice is available in `Analyze()` and `existingCronKeywords` is already built there, but neither is passed to `recommendFromJobKinds`.

As a result, if the user already has a cron job that automates a particular job kind, the tool will still recommend creating a scheduled role for it — exactly the redundant recommendation that the `cronAlreadyCovers` logic prevents for keyword-based recommendations. The `cronJobs` slice should be threaded through so the same deduplication can be applied here.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: recommend next role from observed ..."](https://github.com/befeast/ok-gobot/commit/7d20880fc20bd460e0de1db8dbcbaabad9588dd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25960828)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->