### PR TITLE
feat(web): replace session-centric view with job/worker dashboard (#175)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -307,6 +307,7 @@ func (a *App) Start(ctx context.Context) error {
 		}
 		adapter := &stateAdapter{b: a.bot}
 		a.controlServer = control.New(ctrlCfg, adapter)
+		a.controlServer.SetStore(a.store)
 		a.bot.SetControlHub(a.controlServer.Hub())
 		go func() {
 			if err := a.controlServer.Start(ctx); err != nil {

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gobwas/ws"
 
 	runtimepkg "ok-gobot/internal/runtime"
+	"ok-gobot/internal/storage"
 )
 
 // StateProvider is the interface the control server uses to interact with the
@@ -65,6 +66,7 @@ type Server struct {
 	cfg        Config
 	hub        *Hub
 	state      StateProvider
+	store      *storage.Store
 	httpSrv    *http.Server
 	runtimeHub *runtimepkg.Hub
 	tuiMu      sync.Mutex
@@ -82,6 +84,11 @@ func New(cfg Config, state StateProvider) *Server {
 			byID: make(map[string]*tuiSessionState),
 		},
 	}
+}
+
+// SetStore attaches a storage.Store for job/artifact queries.
+func (s *Server) SetStore(store *storage.Store) {
+	s.store = store
 }
 
 // Hub returns the event hub so callers can emit events from elsewhere in the

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -14,6 +14,7 @@ import (
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/ai"
 	runtimepkg "ok-gobot/internal/runtime"
+	"ok-gobot/internal/storage"
 )
 
 const (
@@ -34,7 +35,13 @@ func isTUICommand(cmdType string) bool {
 		CmdNewSession,
 		CmdSwitch,
 		CmdSpawnSubagent,
-		CmdBotCommand:
+		CmdBotCommand,
+		CmdListJobs,
+		CmdGetJob,
+		CmdListJobEvents,
+		CmdListJobArtifacts,
+		CmdCancelJob,
+		CmdListWorkers:
 		return true
 	default:
 		return false
@@ -363,6 +370,19 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 			SessionID:       sessionID,
 			ChildSessionKey: handle.SessionKey,
 		})
+
+	case CmdListJobs:
+		s.handleListJobs(c, cmd)
+	case CmdGetJob:
+		s.handleGetJob(c, cmd)
+	case CmdListJobEvents:
+		s.handleListJobEvents(c, cmd)
+	case CmdListJobArtifacts:
+		s.handleListJobArtifacts(c, cmd)
+	case CmdCancelJob:
+		s.handleCancelJob(c, cmd)
+	case CmdListWorkers:
+		s.handleListWorkers(c)
 
 	default:
 		c.sendTUIError("unknown command type: " + cmd.Type)
@@ -886,6 +906,189 @@ func (s *Server) bridgeRuntimeEvents(ctx context.Context, evCh <-chan runtimepkg
 				Message:         msg,
 			})
 		}
+	}
+}
+
+// ─── job/worker dashboard handlers ───────────────────────────────────────────
+
+func (s *Server) handleListJobs(c *client, cmd ClientMsg) {
+	if s.store == nil {
+		c.sendTUIError("job storage not configured")
+		return
+	}
+	limit := cmd.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	jobs, err := s.store.ListJobs(limit)
+	if err != nil {
+		c.sendTUIError("list jobs: " + err.Error())
+		return
+	}
+	infos := make([]JobInfo, len(jobs))
+	for i, j := range jobs {
+		infos[i] = jobToInfo(j)
+	}
+	c.sendTUIMsg(ServerMsg{Type: MsgTypeJobs, Jobs: infos})
+}
+
+func (s *Server) handleGetJob(c *client, cmd ClientMsg) {
+	if s.store == nil {
+		c.sendTUIError("job storage not configured")
+		return
+	}
+	jobID := strings.TrimSpace(cmd.JobID)
+	if jobID == "" {
+		c.sendTUIError("job_id is required")
+		return
+	}
+	job, err := s.store.GetJob(jobID)
+	if err != nil {
+		c.sendTUIError("get job: " + err.Error())
+		return
+	}
+	if job == nil {
+		c.sendTUIError("job not found")
+		return
+	}
+	info := jobToInfo(*job)
+	c.sendTUIMsg(ServerMsg{Type: MsgTypeJobDetail, Job: &info})
+}
+
+func (s *Server) handleListJobEvents(c *client, cmd ClientMsg) {
+	if s.store == nil {
+		c.sendTUIError("job storage not configured")
+		return
+	}
+	jobID := strings.TrimSpace(cmd.JobID)
+	if jobID == "" {
+		c.sendTUIError("job_id is required")
+		return
+	}
+	limit := cmd.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	events, err := s.store.ListJobEvents(jobID, limit)
+	if err != nil {
+		c.sendTUIError("list job events: " + err.Error())
+		return
+	}
+	infos := make([]JobEventInfo, len(events))
+	for i, e := range events {
+		infos[i] = JobEventInfo{
+			ID:        e.ID,
+			JobID:     e.JobID,
+			EventType: e.EventType,
+			Message:   e.Message,
+			Payload:   e.Payload,
+			CreatedAt: e.CreatedAt,
+		}
+	}
+	c.sendTUIMsg(ServerMsg{Type: MsgTypeJobEvents, Events: infos})
+}
+
+func (s *Server) handleListJobArtifacts(c *client, cmd ClientMsg) {
+	if s.store == nil {
+		c.sendTUIError("job storage not configured")
+		return
+	}
+	jobID := strings.TrimSpace(cmd.JobID)
+	if jobID == "" {
+		c.sendTUIError("job_id is required")
+		return
+	}
+	limit := cmd.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	artifacts, err := s.store.ListJobArtifacts(jobID, limit)
+	if err != nil {
+		c.sendTUIError("list job artifacts: " + err.Error())
+		return
+	}
+	infos := make([]ArtifactInfo, len(artifacts))
+	for i, a := range artifacts {
+		infos[i] = ArtifactInfo{
+			ID:           a.ID,
+			JobID:        a.JobID,
+			Name:         a.Name,
+			ArtifactType: a.ArtifactType,
+			MimeType:     a.MimeType,
+			Content:      a.Content,
+			URI:          a.URI,
+			Metadata:     a.Metadata,
+			CreatedAt:    a.CreatedAt,
+		}
+	}
+	c.sendTUIMsg(ServerMsg{Type: MsgTypeJobArtifacts, Artifacts: infos})
+}
+
+func (s *Server) handleCancelJob(c *client, cmd ClientMsg) {
+	if s.store == nil {
+		c.sendTUIError("job storage not configured")
+		return
+	}
+	jobID := strings.TrimSpace(cmd.JobID)
+	if jobID == "" {
+		c.sendTUIError("job_id is required")
+		return
+	}
+	if err := s.store.UpdateJobCancelRequested(jobID, true); err != nil {
+		c.sendTUIError("cancel job: " + err.Error())
+		return
+	}
+	// Return updated job
+	job, err := s.store.GetJob(jobID)
+	if err != nil {
+		c.sendTUIError("get job after cancel: " + err.Error())
+		return
+	}
+	if job == nil {
+		c.sendTUIError("job not found after cancel")
+		return
+	}
+	info := jobToInfo(*job)
+	c.sendTUIMsg(ServerMsg{Type: MsgTypeJobDetail, Job: &info})
+}
+
+func (s *Server) handleListWorkers(c *client) {
+	if s.runtimeHub == nil {
+		c.sendTUIMsg(ServerMsg{Type: MsgTypeWorkers, Workers: []WorkerInfo{}})
+		return
+	}
+	snapshots := s.runtimeHub.ListWorkers()
+	infos := make([]WorkerInfo, len(snapshots))
+	for i, w := range snapshots {
+		infos[i] = WorkerInfo{
+			SessionKey: w.SessionKey,
+			Running:    w.Running,
+			QueueDepth: w.QueueDepth,
+		}
+	}
+	c.sendTUIMsg(ServerMsg{Type: MsgTypeWorkers, Workers: infos})
+}
+
+func jobToInfo(j storage.Job) JobInfo {
+	return JobInfo{
+		JobID:              j.JobID,
+		Kind:               j.Kind,
+		Worker:             j.Worker,
+		SessionKey:         j.SessionKey,
+		DeliverySessionKey: j.DeliverySessionKey,
+		RetryOfJobID:       j.RetryOfJobID,
+		Description:        j.Description,
+		Status:             j.Status,
+		CancelRequested:    j.CancelRequested,
+		Attempt:            j.Attempt,
+		MaxAttempts:        j.MaxAttempts,
+		TimeoutSeconds:     j.TimeoutSeconds,
+		Summary:            j.Summary,
+		Error:              j.Error,
+		CreatedAt:          j.CreatedAt,
+		StartedAt:          j.StartedAt,
+		CompletedAt:        j.CompletedAt,
+		UpdatedAt:          j.UpdatedAt,
 	}
 }
 

--- a/internal/control/tui_types.go
+++ b/internal/control/tui_types.go
@@ -2,10 +2,15 @@ package control
 
 // Message type constants for server→client messages.
 const (
-	MsgTypeEvent     = "event"
-	MsgTypeSessions  = "sessions"
-	MsgTypeError     = "error"
-	MsgTypeConnected = "connected"
+	MsgTypeEvent        = "event"
+	MsgTypeSessions     = "sessions"
+	MsgTypeError        = "error"
+	MsgTypeConnected    = "connected"
+	MsgTypeJobs         = "jobs"
+	MsgTypeJobDetail    = "job_detail"
+	MsgTypeJobEvents    = "job_events"
+	MsgTypeJobArtifacts = "job_artifacts"
+	MsgTypeWorkers      = "workers"
 )
 
 // Event kind constants (embedded in MsgTypeEvent messages).
@@ -25,15 +30,21 @@ const (
 
 // Command type constants for client→server messages.
 const (
-	CmdSend          = "send"
-	CmdAbort         = "abort"
-	CmdApprove       = "approve"
-	CmdSetModel      = "set_model"
-	CmdListSessions  = "list_sessions"
-	CmdNewSession    = "new_session"
-	CmdSwitch        = "switch_session"
-	CmdSpawnSubagent = "spawn_subagent"
-	CmdBotCommand    = "bot_command" // slash commands routed directly to bot handlers
+	CmdSend             = "send"
+	CmdAbort            = "abort"
+	CmdApprove          = "approve"
+	CmdSetModel         = "set_model"
+	CmdListSessions     = "list_sessions"
+	CmdNewSession       = "new_session"
+	CmdSwitch           = "switch_session"
+	CmdSpawnSubagent    = "spawn_subagent"
+	CmdBotCommand       = "bot_command" // slash commands routed directly to bot handlers
+	CmdListJobs         = "list_jobs"
+	CmdGetJob           = "get_job"
+	CmdListJobEvents    = "list_job_events"
+	CmdListJobArtifacts = "list_job_artifacts"
+	CmdCancelJob        = "cancel_job"
+	CmdListWorkers      = "list_workers"
 )
 
 // ServerMsg is sent from the control server to TUI clients.
@@ -59,6 +70,64 @@ type ServerMsg struct {
 	Message          string           `json:"message,omitempty"`
 	// Sub-agent spawn fields.
 	ChildSessionKey string `json:"child_session_key,omitempty"`
+	// Job dashboard fields.
+	Jobs      []JobInfo      `json:"jobs,omitempty"`
+	Job       *JobInfo       `json:"job,omitempty"`
+	Events    []JobEventInfo `json:"events,omitempty"`
+	Artifacts []ArtifactInfo `json:"artifacts,omitempty"`
+	Workers   []WorkerInfo   `json:"workers,omitempty"`
+}
+
+// JobInfo is the JSON-friendly representation of a durable job for the dashboard.
+type JobInfo struct {
+	JobID              string `json:"job_id"`
+	Kind               string `json:"kind"`
+	Worker             string `json:"worker,omitempty"`
+	SessionKey         string `json:"session_key,omitempty"`
+	DeliverySessionKey string `json:"delivery_session_key,omitempty"`
+	RetryOfJobID       string `json:"retry_of_job_id,omitempty"`
+	Description        string `json:"description"`
+	Status             string `json:"status"`
+	CancelRequested    bool   `json:"cancel_requested,omitempty"`
+	Attempt            int    `json:"attempt"`
+	MaxAttempts        int    `json:"max_attempts"`
+	TimeoutSeconds     int    `json:"timeout_seconds,omitempty"`
+	Summary            string `json:"summary,omitempty"`
+	Error              string `json:"error,omitempty"`
+	CreatedAt          string `json:"created_at"`
+	StartedAt          string `json:"started_at,omitempty"`
+	CompletedAt        string `json:"completed_at,omitempty"`
+	UpdatedAt          string `json:"updated_at"`
+}
+
+// JobEventInfo is the JSON-friendly representation of a job lifecycle event.
+type JobEventInfo struct {
+	ID        int64  `json:"id"`
+	JobID     string `json:"job_id"`
+	EventType string `json:"event_type"`
+	Message   string `json:"message,omitempty"`
+	Payload   string `json:"payload,omitempty"`
+	CreatedAt string `json:"created_at"`
+}
+
+// ArtifactInfo is the JSON-friendly representation of a job artifact.
+type ArtifactInfo struct {
+	ID           int64  `json:"id"`
+	JobID        string `json:"job_id"`
+	Name         string `json:"name"`
+	ArtifactType string `json:"artifact_type"`
+	MimeType     string `json:"mime_type,omitempty"`
+	Content      string `json:"content,omitempty"`
+	URI          string `json:"uri,omitempty"`
+	Metadata     string `json:"metadata,omitempty"`
+	CreatedAt    string `json:"created_at"`
+}
+
+// WorkerInfo describes an active session worker for the dashboard.
+type WorkerInfo struct {
+	SessionKey string `json:"session_key"`
+	Running    bool   `json:"running"`
+	QueueDepth int    `json:"queue_depth"`
 }
 
 // ClientMsg is sent from TUI clients to the control server.
@@ -84,6 +153,9 @@ type ClientMsg struct {
 	OutputSchema  string   `json:"output_schema,omitempty"`
 	MemoryPolicy  string   `json:"memory_policy,omitempty"`
 	DeliverBack   bool     `json:"deliver_back,omitempty"`
+	// Job dashboard fields.
+	JobID string `json:"job_id,omitempty"`
+	Limit int    `json:"limit,omitempty"`
 }
 
 // TUISessionInfo describes a session for the TUI session list.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -105,6 +105,28 @@ func NewHub(ctx context.Context, queueDepth int) *Hub {
 	}
 }
 
+// WorkerSnapshot describes the current state of a session worker.
+type WorkerSnapshot struct {
+	SessionKey string
+	Running    bool
+	QueueDepth int
+}
+
+// ListWorkers returns a snapshot of all active session workers.
+func (h *Hub) ListWorkers() []WorkerSnapshot {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]WorkerSnapshot, 0, len(h.workers))
+	for key, w := range h.workers {
+		out = append(out, WorkerSnapshot{
+			SessionKey: key,
+			Running:    w.isRunning(),
+			QueueDepth: len(w.queue),
+		})
+	}
+	return out
+}
+
 // RegisterParent records that childKey is a sub-session of parentKey.
 // When the child's run completes (EventDone or EventError), an additional
 // EventChildDone or EventChildFailed event is emitted with SessionKey = parentKey.

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>🦞 ok-gobot</title>
+<title>ok-gobot</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" integrity="sha512-rNoGnSFJ7z+LA4GGIDscuP3MIodND9tO4ujZuBj7AXDlPBoBLlLWup7OwNMnib/xFnXwGVqpOdn6UBG8LmDzQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.1/marked.min.js" integrity="sha512-MYIDlGN+AUFnLGo6KOoA/OM6pI8VLliMBSJBdszOftAHKWWmRnCEZzqheaBWP8eifKz2JHVYKAfjHiYhzV1UQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha512-D9gUyxqja7hBtkWpPWGt9wfbfaMGVt9gnyCvYa+jojwwPHLCzUm5i8rpk7vD7wNee9bA35eYIjobYPaQuKS1MQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
@@ -14,47 +14,115 @@
   --bg: #0d1117; --bg2: #161b22; --bg3: #21262d;
   --fg: #c9d1d9; --fg2: #8b949e; --fg3: #484f58;
   --accent: #58a6ff; --green: #3fb950; --red: #f85149;
-  --orange: #d29922; --border: #30363d;
+  --orange: #d29922; --border: #30363d; --purple: #bc8cff;
 }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--fg); height: 100vh; display: flex; overflow: hidden; }
-
-/* Sidebar */
-#sidebar { width: 260px; background: var(--bg2); border-right: 1px solid var(--border); display: flex; flex-direction: column; flex-shrink: 0; }
-#sidebar-header { padding: 16px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; }
-#sidebar-header h2 { font-size: 16px; font-weight: 600; }
-#new-session-btn { background: var(--bg3); border: 1px solid var(--border); color: var(--fg); padding: 4px 10px; border-radius: 6px; cursor: pointer; font-size: 13px; }
-#new-session-btn:hover { border-color: var(--accent); color: var(--accent); }
-#session-list { flex: 1; overflow-y: auto; padding: 8px; }
-.session-item { padding: 10px 12px; border-radius: 6px; cursor: pointer; margin-bottom: 2px; font-size: 14px; display: flex; align-items: center; gap: 8px; }
-.session-item:hover { background: var(--bg3); }
-.session-item.active { background: var(--bg3); border-left: 2px solid var(--accent); }
-.session-item .dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-.session-item .dot.running { background: var(--green); animation: pulse 1.5s infinite; }
-.session-item .dot.idle { background: var(--fg3); }
-.session-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.session-model { font-size: 11px; color: var(--fg2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 80px; }
-@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-
-/* Main area */
-#main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--fg); height: 100vh; display: flex; flex-direction: column; overflow: hidden; }
 
 /* Top bar */
-#topbar { padding: 12px 20px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; background: var(--bg2); }
+#topbar { padding: 10px 20px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; background: var(--bg2); flex-shrink: 0; }
+#topbar h1 { font-size: 16px; font-weight: 600; }
 #status { display: flex; align-items: center; gap: 8px; font-size: 13px; }
 #status-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fg3); }
 #status-dot.connected { background: var(--green); }
-#status-dot.running { background: var(--orange); animation: pulse 1s infinite; }
 #status-text { color: var(--fg2); }
-#model-display { font-size: 12px; color: var(--fg2); background: var(--bg3); padding: 3px 8px; border-radius: 4px; cursor: pointer; position: relative; user-select: none; }
-#model-display:hover { background: var(--bg1); }
-#model-picker { display: none; position: absolute; top: 100%; right: 0; margin-top: 4px; background: var(--bg2); border: 1px solid var(--border); border-radius: 6px; min-width: 260px; max-height: 320px; overflow-y: auto; z-index: 100; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
-#model-picker.open { display: block; }
-#model-picker .model-option { padding: 8px 12px; font-size: 12px; color: var(--fg); cursor: pointer; white-space: nowrap; }
-#model-picker .model-option:hover { background: var(--bg3); }
-#model-picker .model-option.active { color: var(--green); font-weight: bold; }
 
-/* Chat */
-#chat { flex: 1; overflow-y: auto; padding: 20px; }
+/* Tabs */
+#tabs { display: flex; border-bottom: 1px solid var(--border); background: var(--bg2); flex-shrink: 0; }
+.tab { padding: 10px 20px; font-size: 14px; color: var(--fg2); cursor: pointer; border-bottom: 2px solid transparent; user-select: none; }
+.tab:hover { color: var(--fg); background: var(--bg3); }
+.tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+.tab .badge { display: inline-block; background: var(--accent); color: #fff; font-size: 11px; padding: 1px 6px; border-radius: 10px; margin-left: 6px; font-weight: 600; }
+.tab .badge.running { background: var(--orange); }
+.tab .badge.empty { display: none; }
+
+/* Panels */
+#panels { flex: 1; overflow: hidden; position: relative; }
+.panel { position: absolute; inset: 0; overflow-y: auto; padding: 20px; display: none; }
+.panel.active { display: block; }
+
+/* Dashboard summary cards */
+.summary-row { display: flex; gap: 12px; margin-bottom: 20px; flex-wrap: wrap; }
+.summary-card { background: var(--bg2); border: 1px solid var(--border); border-radius: 8px; padding: 16px 20px; flex: 1; min-width: 140px; }
+.summary-card .label { font-size: 12px; color: var(--fg2); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px; }
+.summary-card .value { font-size: 28px; font-weight: 700; }
+.summary-card .value.green { color: var(--green); }
+.summary-card .value.orange { color: var(--orange); }
+.summary-card .value.red { color: var(--red); }
+
+/* Table styles */
+.data-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.data-table th { text-align: left; padding: 8px 12px; color: var(--fg2); font-weight: 600; border-bottom: 1px solid var(--border); font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; position: sticky; top: 0; background: var(--bg); }
+.data-table td { padding: 8px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+.data-table tr:hover td { background: var(--bg2); }
+.data-table tr.clickable { cursor: pointer; }
+
+/* Status badges */
+.status-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; text-transform: uppercase; }
+.status-badge.pending { background: rgba(139,148,158,0.2); color: var(--fg2); }
+.status-badge.running { background: rgba(210,153,34,0.2); color: var(--orange); }
+.status-badge.succeeded { background: rgba(63,185,80,0.2); color: var(--green); }
+.status-badge.failed { background: rgba(248,81,73,0.2); color: var(--red); }
+.status-badge.cancelled { background: rgba(139,148,158,0.2); color: var(--fg3); }
+.status-badge.timed_out { background: rgba(248,81,73,0.15); color: var(--red); }
+
+/* Filter bar */
+.filter-bar { display: flex; gap: 8px; margin-bottom: 16px; align-items: center; flex-wrap: wrap; }
+.filter-btn { background: var(--bg3); border: 1px solid var(--border); color: var(--fg2); padding: 4px 12px; border-radius: 16px; cursor: pointer; font-size: 12px; }
+.filter-btn:hover { border-color: var(--fg3); color: var(--fg); }
+.filter-btn.active { border-color: var(--accent); color: var(--accent); background: rgba(88,166,255,0.1); }
+.refresh-btn { background: var(--bg3); border: 1px solid var(--border); color: var(--fg2); padding: 4px 10px; border-radius: 6px; cursor: pointer; font-size: 13px; margin-left: auto; }
+.refresh-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+/* Job detail */
+#job-detail { display: none; }
+#job-detail.active { display: block; }
+.detail-header { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
+.detail-header .back-btn { background: none; border: none; color: var(--accent); cursor: pointer; font-size: 14px; padding: 4px 8px; border-radius: 4px; }
+.detail-header .back-btn:hover { background: var(--bg3); }
+.detail-header h2 { font-size: 16px; font-weight: 600; flex: 1; }
+.detail-meta { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; margin-bottom: 20px; }
+.meta-item { background: var(--bg2); border: 1px solid var(--border); border-radius: 6px; padding: 10px 14px; }
+.meta-item .meta-label { font-size: 11px; color: var(--fg2); text-transform: uppercase; margin-bottom: 2px; }
+.meta-item .meta-value { font-size: 13px; word-break: break-all; }
+.cancel-btn { background: var(--red); color: #fff; border: none; padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 12px; }
+.cancel-btn:hover { opacity: 0.8; }
+.cancel-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* Timeline */
+.section-title { font-size: 14px; font-weight: 600; margin: 20px 0 12px; color: var(--fg2); }
+.timeline { border-left: 2px solid var(--border); margin-left: 8px; padding-left: 16px; }
+.timeline-item { position: relative; padding-bottom: 16px; }
+.timeline-item::before { content: ''; position: absolute; left: -21px; top: 4px; width: 10px; height: 10px; border-radius: 50%; background: var(--fg3); border: 2px solid var(--bg); }
+.timeline-item.created::before { background: var(--fg2); }
+.timeline-item.started::before { background: var(--orange); }
+.timeline-item.progress::before { background: var(--accent); }
+.timeline-item.succeeded::before { background: var(--green); }
+.timeline-item.failed::before, .timeline-item.timed_out::before { background: var(--red); }
+.timeline-item.cancelled::before, .timeline-item.cancel_requested::before { background: var(--fg3); }
+.timeline-item.artifact_added::before { background: var(--purple); }
+.timeline-item.retry_requested::before { background: var(--orange); }
+.timeline-item .ev-type { font-size: 12px; font-weight: 600; color: var(--fg); }
+.timeline-item .ev-time { font-size: 11px; color: var(--fg3); margin-left: 8px; }
+.timeline-item .ev-msg { font-size: 12px; color: var(--fg2); margin-top: 2px; word-break: break-word; }
+
+/* Artifacts list */
+.artifact-card { background: var(--bg2); border: 1px solid var(--border); border-radius: 6px; padding: 12px 16px; margin-bottom: 8px; }
+.artifact-card .art-name { font-weight: 600; font-size: 13px; }
+.artifact-card .art-meta { font-size: 12px; color: var(--fg2); margin-top: 2px; }
+.artifact-card .art-content { font-size: 12px; background: var(--bg3); border-radius: 4px; padding: 8px; margin-top: 8px; max-height: 200px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
+
+/* Workers */
+.worker-card { background: var(--bg2); border: 1px solid var(--border); border-radius: 6px; padding: 12px 16px; margin-bottom: 8px; display: flex; align-items: center; gap: 12px; }
+.worker-card .w-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+.worker-card .w-dot.active { background: var(--green); animation: pulse 1.5s infinite; }
+.worker-card .w-dot.idle { background: var(--fg3); }
+.worker-card .w-key { font-size: 13px; font-family: monospace; flex: 1; word-break: break-all; }
+.worker-card .w-queue { font-size: 12px; color: var(--fg2); }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+/* Chat panel (secondary) */
+#chat-area { display: flex; flex-direction: column; height: 100%; }
+#chat-messages { flex: 1; overflow-y: auto; padding: 20px; }
 .message { margin-bottom: 16px; max-width: 800px; }
 .message.user .bubble { background: var(--bg3); border-radius: 12px 12px 4px 12px; padding: 10px 14px; display: inline-block; max-width: 80%; float: right; }
 .message.user { text-align: right; clear: both; }
@@ -63,8 +131,6 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .message.assistant .bubble { line-height: 1.6; }
 .message .role { font-size: 11px; color: var(--fg2); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
 .message.assistant .role { color: var(--accent); }
-
-/* Markdown content */
 .bubble p { margin-bottom: 8px; }
 .bubble p:last-child { margin-bottom: 0; }
 .bubble code { background: var(--bg3); padding: 2px 5px; border-radius: 3px; font-size: 13px; }
@@ -77,8 +143,6 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .bubble table { border-collapse: collapse; margin: 8px 0; }
 .bubble th, .bubble td { border: 1px solid var(--border); padding: 6px 10px; }
 .bubble th { background: var(--bg3); }
-
-/* Tool calls */
 .tool-call { margin: 8px 0; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
 .tool-header { display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--bg3); cursor: pointer; font-size: 13px; }
 .tool-header:hover { background: var(--border); }
@@ -92,41 +156,9 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .tool-body .label { color: var(--fg2); font-weight: 600; margin-top: 6px; }
 .tool-body .label:first-child { margin-top: 0; }
 .tool-error { color: var(--red); }
-
-/* Streaming cursor */
-.streaming-cursor::after { content: '▊'; animation: blink 0.8s step-end infinite; color: var(--accent); }
+.streaming-cursor::after { content: '\u2588'; animation: blink 0.8s step-end infinite; color: var(--accent); }
 @keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
-
-/* Error messages */
 .error-msg { background: rgba(248,81,73,0.1); border: 1px solid var(--red); border-radius: 6px; padding: 8px 12px; color: var(--red); font-size: 13px; margin-bottom: 12px; }
-
-/* Input area */
-#input-area { padding: 16px 20px; border-top: 1px solid var(--border); background: var(--bg2); display: flex; gap: 10px; align-items: flex-end; }
-#input { flex: 1; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; color: var(--fg); padding: 10px 14px; font-size: 14px; font-family: inherit; resize: none; min-height: 42px; max-height: 200px; outline: none; line-height: 1.4; }
-#input:focus { border-color: var(--accent); }
-#input::placeholder { color: var(--fg3); }
-.btn { padding: 8px 16px; border-radius: 8px; border: none; font-size: 14px; cursor: pointer; font-weight: 500; }
-#send-btn { background: var(--accent); color: #fff; }
-#send-btn:hover { background: #79c0ff; }
-#send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-#abort-btn { background: var(--red); color: #fff; display: none; }
-#abort-btn:hover { background: #ff6e6e; }
-
-/* Scrollbar */
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--fg3); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: var(--fg2); }
-
-/* Image paste preview */
-#image-preview { display: none; padding: 8px 20px; background: var(--bg2); border-top: 1px solid var(--border); }
-#image-preview.active { display: flex; align-items: center; gap: 10px; }
-#image-preview img { max-height: 80px; max-width: 120px; border-radius: 6px; border: 1px solid var(--border); object-fit: cover; }
-#image-preview .remove-btn { background: var(--bg3); border: 1px solid var(--border); color: var(--fg2); width: 24px; height: 24px; border-radius: 50%; cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 14px; flex-shrink: 0; }
-#image-preview .remove-btn:hover { border-color: var(--red); color: var(--red); }
-#image-preview .img-info { font-size: 12px; color: var(--fg2); }
-
-/* Approval dialog */
 .approval { margin: 8px 0; border: 1px solid var(--orange); border-radius: 6px; padding: 12px; background: rgba(210,153,34,0.08); }
 .approval .cmd { font-family: monospace; font-size: 13px; background: var(--bg3); padding: 6px 10px; border-radius: 4px; margin: 6px 0; white-space: pre-wrap; }
 .approval .actions { display: flex; gap: 8px; margin-top: 8px; }
@@ -134,141 +166,119 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .approval .deny-btn { background: var(--red); color: #fff; padding: 4px 12px; border: none; border-radius: 4px; cursor: pointer; font-size: 13px; }
 .approval.resolved { opacity: 0.5; }
 .approval.resolved .actions { display: none; }
+#chat-input-area { padding: 16px 20px; border-top: 1px solid var(--border); background: var(--bg2); display: flex; gap: 10px; align-items: flex-end; position: relative; }
+#chat-input { flex: 1; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; color: var(--fg); padding: 10px 14px; font-size: 14px; font-family: inherit; resize: none; min-height: 42px; max-height: 200px; outline: none; line-height: 1.4; }
+#chat-input:focus { border-color: var(--accent); }
+#chat-input::placeholder { color: var(--fg3); }
+.btn { padding: 8px 16px; border-radius: 8px; border: none; font-size: 14px; cursor: pointer; font-weight: 500; }
+#send-btn { background: var(--accent); color: #fff; }
+#send-btn:hover { background: #79c0ff; }
+#send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+#abort-btn { background: var(--red); color: #fff; display: none; }
+#abort-btn:hover { background: #ff6e6e; }
+#session-bar { padding: 8px 20px; background: var(--bg2); border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 8px; font-size: 13px; }
+#session-bar select { background: var(--bg3); color: var(--fg); border: 1px solid var(--border); border-radius: 4px; padding: 3px 8px; font-size: 12px; }
+#session-bar .new-btn { background: var(--bg3); border: 1px solid var(--border); color: var(--fg2); padding: 3px 10px; border-radius: 4px; cursor: pointer; font-size: 12px; }
+#session-bar .new-btn:hover { border-color: var(--accent); color: var(--accent); }
+.empty-state { text-align: center; padding: 60px 20px; color: var(--fg2); }
+.empty-state .icon { font-size: 48px; margin-bottom: 12px; }
+.empty-state .title { font-size: 16px; font-weight: 600; color: var(--fg); margin-bottom: 4px; }
+.empty-state .subtitle { font-size: 13px; }
 
-/* Slash command autocomplete */
-#slash-popup {
-  display: none; position: absolute; bottom: 100%; left: 0; right: 0;
-  background: var(--bg2); border: 1px solid var(--border); border-radius: 8px;
-  margin-bottom: 4px; max-height: 320px; overflow-y: auto; z-index: 100;
-  box-shadow: 0 -4px 16px rgba(0,0,0,0.4);
-}
-#slash-popup.active { display: block; }
-.slash-item {
-  padding: 8px 14px; cursor: pointer; display: flex; justify-content: space-between;
-  font-size: 13px; border-bottom: 1px solid var(--border);
-}
-.slash-item:last-child { border-bottom: none; }
-.slash-item:hover, .slash-item.selected { background: var(--bg3); }
-.slash-item .cmd { color: var(--accent); font-weight: 600; font-family: monospace; }
-.slash-item .desc { color: var(--fg2); font-size: 12px; }
-
-/* Session delete button */
-.session-delete {
-  display: none; background: none; border: none; color: var(--fg3);
-  cursor: pointer; font-size: 14px; padding: 2px 4px; border-radius: 4px; flex-shrink: 0;
-}
-.session-item:hover .session-delete { display: block; }
-.session-delete:hover { color: var(--red); background: rgba(248,81,73,0.1); }
-
-/* View tabs */
-#view-tabs { display: flex; gap: 0; border-bottom: 1px solid var(--border); background: var(--bg2); }
-.view-tab { padding: 8px 16px; font-size: 13px; color: var(--fg2); cursor: pointer; border: none; background: none; border-bottom: 2px solid transparent; }
-.view-tab:hover { color: var(--fg); }
-.view-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
-
-/* Mission control */
-#mission { display: none; flex: 1; overflow-y: auto; padding: 20px; }
-#mission.active { display: block; }
-.mc-section { margin-bottom: 24px; }
-.mc-section h3 { font-size: 14px; font-weight: 600; color: var(--accent); margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
-.mc-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; }
-.mc-card { background: var(--bg2); border: 1px solid var(--border); border-radius: 8px; padding: 14px; }
-.mc-card .title { font-weight: 600; font-size: 14px; margin-bottom: 4px; }
-.mc-card .subtitle { font-size: 12px; color: var(--fg2); }
-.mc-card .meta { font-size: 11px; color: var(--fg3); margin-top: 6px; }
-.mc-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-.mc-table th { text-align: left; padding: 8px 10px; background: var(--bg2); color: var(--fg2); font-weight: 600; border-bottom: 1px solid var(--border); }
-.mc-table td { padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
-.mc-table tr:hover { background: var(--bg2); }
-.mc-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
-.mc-badge.succeeded { background: rgba(63,185,80,0.15); color: var(--green); }
-.mc-badge.failed { background: rgba(248,81,73,0.15); color: var(--red); }
-.mc-badge.running { background: rgba(210,153,34,0.15); color: var(--orange); }
-.mc-badge.pending { background: rgba(139,148,158,0.15); color: var(--fg2); }
-.mc-badge.cancelled, .mc-badge.timed_out { background: rgba(139,148,158,0.15); color: var(--fg3); }
-.mc-badge.llm { background: rgba(88,166,255,0.15); color: var(--accent); }
-.mc-badge.exec { background: rgba(210,153,34,0.15); color: var(--orange); }
-.mc-stat-row { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
-.mc-stat { background: var(--bg2); border: 1px solid var(--border); border-radius: 8px; padding: 14px 18px; min-width: 140px; }
-.mc-stat .value { font-size: 24px; font-weight: 700; }
-.mc-stat .label { font-size: 11px; color: var(--fg2); text-transform: uppercase; letter-spacing: 0.5px; margin-top: 2px; }
-.mc-bar-row { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; font-size: 12px; }
-.mc-bar-row .day { width: 70px; color: var(--fg2); text-align: right; flex-shrink: 0; }
-.mc-bar { height: 18px; border-radius: 3px; min-width: 2px; }
-.mc-bar.ok { background: var(--green); }
-.mc-bar.fail { background: var(--red); }
-.mc-bar.msg { background: var(--accent); opacity: 0.6; }
-.mc-empty { color: var(--fg3); font-style: italic; font-size: 13px; padding: 12px 0; }
-.mc-task-text { max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.mc-error-text { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--red); font-size: 12px; }
+/* Scrollbar */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--fg3); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--fg2); }
 </style>
 </head>
 <body>
 
-<div id="sidebar">
-  <div id="sidebar-header">
-    <h2>🦞 ok-gobot</h2>
-    <button id="new-session-btn" onclick="newSession()">+ New</button>
+<div id="topbar">
+  <h1>ok-gobot</h1>
+  <div id="status">
+    <div id="status-dot"></div>
+    <span id="status-text">disconnected</span>
   </div>
-  <div id="session-list"></div>
 </div>
 
-<div id="main">
-  <div id="topbar">
-    <div id="status">
-      <div id="status-dot"></div>
-      <span id="status-text">disconnected</span>
+<div id="tabs">
+  <div class="tab active" data-tab="jobs" onclick="switchTab('jobs')">Jobs <span class="badge empty" id="badge-running"></span></div>
+  <div class="tab" data-tab="workers" onclick="switchTab('workers')">Workers <span class="badge empty" id="badge-workers"></span></div>
+  <div class="tab" data-tab="chat" onclick="switchTab('chat')">Chat</div>
+</div>
+
+<div id="panels">
+  <!-- Jobs panel -->
+  <div class="panel active" id="panel-jobs">
+    <div class="summary-row" id="job-summary"></div>
+    <div id="job-list-view">
+      <div class="filter-bar">
+        <button class="filter-btn active" data-filter="all" onclick="setJobFilter('all')">All</button>
+        <button class="filter-btn" data-filter="running" onclick="setJobFilter('running')">Running</button>
+        <button class="filter-btn" data-filter="pending" onclick="setJobFilter('pending')">Pending</button>
+        <button class="filter-btn" data-filter="succeeded" onclick="setJobFilter('succeeded')">Succeeded</button>
+        <button class="filter-btn" data-filter="failed" onclick="setJobFilter('failed')">Failed</button>
+        <button class="refresh-btn" onclick="refreshJobs()">Refresh</button>
+      </div>
+      <div id="jobs-table-container"></div>
     </div>
-    <div id="model-display" onclick="toggleModelPicker(event)"><span id="model-text"></span><div id="model-picker"></div></div>
+    <div id="job-detail">
+      <div class="detail-header">
+        <button class="back-btn" onclick="closeJobDetail()">&larr; Back</button>
+        <h2 id="detail-title"></h2>
+        <button class="cancel-btn" id="detail-cancel-btn" onclick="cancelSelectedJob()" style="display:none">Cancel Job</button>
+      </div>
+      <div class="detail-meta" id="detail-meta"></div>
+      <div class="section-title">Events</div>
+      <div class="timeline" id="detail-events"></div>
+      <div class="section-title">Artifacts</div>
+      <div id="detail-artifacts"></div>
+    </div>
   </div>
-  <div id="view-tabs">
-    <button class="view-tab active" onclick="switchView('chat')">Chat</button>
-    <button class="view-tab" onclick="switchView('mission')">Mission Control</button>
+
+  <!-- Workers panel -->
+  <div class="panel" id="panel-workers">
+    <div class="filter-bar">
+      <span style="color:var(--fg2);font-size:13px;">Active session workers</span>
+      <button class="refresh-btn" onclick="refreshWorkers()">Refresh</button>
+    </div>
+    <div id="workers-container"></div>
   </div>
-  <div id="chat"></div>
-  <div id="mission"></div>
-  <div id="image-preview">
-    <img id="preview-img" src="" alt="preview">
-    <span class="img-info" id="preview-info"></span>
-    <button class="remove-btn" onclick="clearImagePreview()" title="Remove image">✕</button>
-  </div>
-  <div id="input-area" style="position:relative;">
-    <div id="slash-popup"></div>
-    <textarea id="input" placeholder="Type a message..." rows="1" onkeydown="handleKey(event)" oninput="handleInput(this)"></textarea>
-    <button class="btn" id="send-btn" onclick="sendMessage()">Send</button>
-    <button class="btn" id="abort-btn" onclick="abortRun()">Abort</button>
+
+  <!-- Chat panel -->
+  <div class="panel" id="panel-chat" style="padding:0;display:none;">
+    <div id="chat-area">
+      <div id="session-bar">
+        <span style="color:var(--fg2);">Session:</span>
+        <select id="session-select" onchange="switchSession(this.value)"></select>
+        <button class="new-btn" onclick="newSession()">+ New</button>
+      </div>
+      <div id="chat-messages"></div>
+      <div id="chat-input-area">
+        <textarea id="chat-input" placeholder="Type a message..." rows="1" onkeydown="handleKey(event)" oninput="autoResize(this)"></textarea>
+        <button class="btn" id="send-btn" onclick="sendMessage()">Send</button>
+        <button class="btn" id="abort-btn" onclick="abortRun()">Abort</button>
+      </div>
+    </div>
   </div>
 </div>
 
 <script>
-// State
+// ─── State ───────────────────────────────────────────────────────────
 let ws = null;
 let currentSessionId = null;
 let sessions = [];
 let isRunning = false;
-let streamBuf = '';     // accumulates tokens for the current streaming response
-let streamEl = null;    // the DOM element being streamed into
+let streamBuf = '';
+let streamEl = null;
 let currentModel = '';
 let reconnectDelay = 1000;
-let pendingImageData = null; // base64 data-URL of pasted image
-let hiddenSessions = new Set(); // locally hidden sessions
-
-// Slash command definitions
-const SLASH_COMMANDS = [
-  { cmd: '/status',  desc: 'bot status',        bot: true },
-  { cmd: '/usage',   desc: 'token usage',        bot: true },
-  { cmd: '/context', desc: 'context window info', bot: true },
-  { cmd: '/whoami',  desc: 'user info',           bot: true },
-  { cmd: '/commands',desc: 'list all commands',   bot: true },
-  { cmd: '/think',   desc: 'thinking level (off|low|medium|high)', bot: false },
-  { cmd: '/verbose', desc: 'toggle verbose',      bot: false },
-  { cmd: '/compact', desc: 'compact context',     bot: false },
-  { cmd: '/new',     desc: 'new session [name]',  bot: false },
-  { cmd: '/abort',   desc: 'abort run',           bot: false },
-];
-const BOT_COMMANDS = new Set(SLASH_COMMANDS.filter(c => c.bot).map(c => c.cmd.slice(1)));
-let slashSelectedIdx = 0;
-let slashFiltered = [];
+let activeTab = 'jobs';
+let jobFilter = 'all';
+let allJobs = [];
+let selectedJobId = null;
+let selectedJobDetail = null;
 
 // Marked config
 marked.setOptions({
@@ -276,35 +286,32 @@ marked.setOptions({
     if (lang && hljs.getLanguage(lang)) return hljs.highlight(code, { language: lang }).value;
     return hljs.highlightAuto(code).value;
   },
-  breaks: true,
-  gfm: true
+  breaks: true, gfm: true
 });
 
-// Sanitize markdown output to prevent XSS via model/tool output
-function safeMarkdown(md) {
-  return DOMPurify.sanitize(marked.parse(md));
-}
+function safeMarkdown(md) { return DOMPurify.sanitize(marked.parse(md)); }
 
-// Connect
+// ─── WebSocket ───────────────────────────────────────────────────────
 function connect() {
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   const host = location.hostname || '127.0.0.1';
   const port = window.CONTROL_PORT || location.port || '8787';
-  const wsUrl = `${proto}://${host}:${port}/ws`;
-  ws = new WebSocket(wsUrl);
-  
+  ws = new WebSocket(`${proto}://${host}:${port}/ws`);
+
   ws.onopen = () => {
     setStatus('connected');
     reconnectDelay = 1000;
     ws.send(JSON.stringify({ type: 'list_sessions' }));
+    refreshJobs();
+    refreshWorkers();
   };
-  
+
   ws.onclose = () => {
     setStatus('disconnected');
     setTimeout(connect, reconnectDelay);
     reconnectDelay = Math.min(reconnectDelay * 2, 30000);
   };
-  
+
   ws.onerror = () => {};
   ws.onmessage = (e) => handleMessage(JSON.parse(e.data));
 }
@@ -315,443 +322,474 @@ function handleMessage(msg) {
       currentSessionId = msg.session_id;
       if (msg.sessions) updateSessions(msg.sessions);
       break;
-      
     case 'sessions':
       if (msg.sessions) updateSessions(msg.sessions);
       break;
-      
     case 'error':
-      appendError(msg.message);
+      if (activeTab === 'chat') appendError(msg.message);
       break;
-      
     case 'event':
       handleEvent(msg);
+      break;
+    case 'jobs':
+      allJobs = msg.jobs || [];
+      renderJobSummary();
+      renderJobsTable();
+      updateRunningBadge();
+      break;
+    case 'job_detail':
+      if (msg.job) {
+        selectedJobDetail = msg.job;
+        renderJobDetail(msg.job);
+      }
+      break;
+    case 'job_events':
+      renderJobEvents(msg.events || []);
+      break;
+    case 'job_artifacts':
+      renderJobArtifacts(msg.artifacts || []);
+      break;
+    case 'workers':
+      renderWorkers(msg.workers || []);
       break;
   }
 }
 
 function handleEvent(msg) {
-  // Only show events for current session
+  // On job-related events, refresh job list
+  if (msg.kind === 'run_start' || msg.kind === 'run_end' || msg.kind === 'child_done' || msg.kind === 'child_failed') {
+    refreshJobs();
+    refreshWorkers();
+  }
+
+  // Chat events scoped to current session
   if (msg.session_id && msg.session_id !== currentSessionId) {
-    // Still update session running state
     if (msg.kind === 'run_start' || msg.kind === 'run_end') {
       ws.send(JSON.stringify({ type: 'list_sessions' }));
     }
     return;
   }
-  
+
   switch (msg.kind) {
     case 'message':
-      if (msg.role === 'user') {
-        appendUserMessage(msg.content);
-      } else if (msg.role === 'assistant') {
-        finalizeStream(msg.content, msg.model);
-      }
+      if (msg.role === 'user') appendUserMessage(msg.content);
+      else if (msg.role === 'assistant') finalizeStream(msg.content, msg.model);
       break;
-      
     case 'run_start':
       isRunning = true;
       currentModel = msg.model || currentModel;
-      setStatus('running');
-      updateButtons();
-      // Start a new stream buffer
+      updateChatButtons();
       streamBuf = '';
       streamEl = null;
       break;
-      
     case 'run_end':
       isRunning = false;
-      setStatus('connected');
-      updateButtons();
-      // If there's unfinalised stream content, render it
-      if (streamBuf && !streamEl?.classList.contains('finalized')) {
-        finalizeStream(streamBuf, msg.model);
-      }
+      updateChatButtons();
+      if (streamBuf && !streamEl?.classList.contains('finalized')) finalizeStream(streamBuf, msg.model);
       streamBuf = '';
       streamEl = null;
       ws.send(JSON.stringify({ type: 'list_sessions' }));
       break;
-      
     case 'token':
       appendToken(msg.content);
       break;
-      
     case 'tool_start':
       appendToolStart(msg.tool_name, msg.tool_args);
       break;
-      
     case 'tool_end':
       appendToolEnd(msg.tool_name, msg.tool_result, msg.tool_error);
       break;
-      
     case 'error':
       appendError(msg.message || msg.content);
       break;
-
     case 'approval_request':
       appendApproval(msg.approval_id, msg.command);
       break;
   }
 }
 
-// Session management
+// ─── Tab navigation ──────────────────────────────────────────────────
+function switchTab(tab) {
+  activeTab = tab;
+  document.querySelectorAll('.tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tab));
+  document.querySelectorAll('.panel').forEach(p => {
+    const isActive = p.id === 'panel-' + tab;
+    p.classList.toggle('active', isActive);
+    p.style.display = isActive ? (tab === 'chat' ? 'flex' : 'block') : 'none';
+  });
+  if (tab === 'jobs') refreshJobs();
+  if (tab === 'workers') refreshWorkers();
+  if (tab === 'chat') document.getElementById('chat-input')?.focus();
+}
+
+// ─── Jobs ────────────────────────────────────────────────────────────
+function refreshJobs() {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: 'list_jobs', limit: 100 }));
+}
+
+function setJobFilter(filter) {
+  jobFilter = filter;
+  document.querySelectorAll('.filter-btn[data-filter]').forEach(b =>
+    b.classList.toggle('active', b.dataset.filter === filter)
+  );
+  renderJobsTable();
+}
+
+function renderJobSummary() {
+  const counts = { total: allJobs.length, running: 0, pending: 0, succeeded: 0, failed: 0 };
+  allJobs.forEach(j => { if (counts[j.status] !== undefined) counts[j.status]++; });
+
+  document.getElementById('job-summary').innerHTML = `
+    <div class="summary-card"><div class="label">Total Jobs</div><div class="value">${counts.total}</div></div>
+    <div class="summary-card"><div class="label">Running</div><div class="value orange">${counts.running}</div></div>
+    <div class="summary-card"><div class="label">Pending</div><div class="value">${counts.pending}</div></div>
+    <div class="summary-card"><div class="label">Succeeded</div><div class="value green">${counts.succeeded}</div></div>
+    <div class="summary-card"><div class="label">Failed</div><div class="value red">${counts.failed}</div></div>
+  `;
+}
+
+function updateRunningBadge() {
+  const running = allJobs.filter(j => j.status === 'running').length;
+  const badge = document.getElementById('badge-running');
+  if (running > 0) {
+    badge.textContent = running;
+    badge.className = 'badge running';
+  } else {
+    badge.className = 'badge empty';
+  }
+}
+
+function renderJobsTable() {
+  const filtered = jobFilter === 'all' ? allJobs : allJobs.filter(j => j.status === jobFilter);
+  const container = document.getElementById('jobs-table-container');
+
+  if (filtered.length === 0) {
+    container.innerHTML = `<div class="empty-state"><div class="title">No jobs${jobFilter !== 'all' ? ' with status "' + esc(jobFilter) + '"' : ''}</div><div class="subtitle">Jobs will appear here when background work is started</div></div>`;
+    return;
+  }
+
+  let html = `<table class="data-table"><thead><tr>
+    <th>Status</th><th>Kind</th><th>Description</th><th>Worker</th><th>Attempt</th><th>Created</th><th>Duration</th>
+  </tr></thead><tbody>`;
+
+  for (const j of filtered) {
+    const duration = jobDuration(j);
+    html += `<tr class="clickable" onclick="openJobDetail('${esc(j.job_id)}')">
+      <td><span class="status-badge ${j.status}">${j.status}</span></td>
+      <td>${esc(j.kind)}</td>
+      <td>${esc(truncate(j.description, 80))}</td>
+      <td>${esc(j.worker || '-')}</td>
+      <td>${j.attempt}/${j.max_attempts}</td>
+      <td>${formatTime(j.created_at)}</td>
+      <td>${duration}</td>
+    </tr>`;
+  }
+  html += '</tbody></table>';
+  container.innerHTML = html;
+}
+
+function openJobDetail(jobId) {
+  selectedJobId = jobId;
+  document.getElementById('job-list-view').style.display = 'none';
+  document.getElementById('job-detail').classList.add('active');
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ type: 'get_job', job_id: jobId }));
+    ws.send(JSON.stringify({ type: 'list_job_events', job_id: jobId }));
+    ws.send(JSON.stringify({ type: 'list_job_artifacts', job_id: jobId }));
+  }
+}
+
+function closeJobDetail() {
+  selectedJobId = null;
+  selectedJobDetail = null;
+  document.getElementById('job-detail').classList.remove('active');
+  document.getElementById('job-list-view').style.display = '';
+}
+
+function renderJobDetail(job) {
+  document.getElementById('detail-title').textContent = job.description || job.job_id;
+
+  const cancelBtn = document.getElementById('detail-cancel-btn');
+  if (job.status === 'running' || job.status === 'pending') {
+    cancelBtn.style.display = '';
+    cancelBtn.disabled = job.cancel_requested;
+    cancelBtn.textContent = job.cancel_requested ? 'Cancel Requested' : 'Cancel Job';
+  } else {
+    cancelBtn.style.display = 'none';
+  }
+
+  const meta = [
+    { label: 'Job ID', value: job.job_id },
+    { label: 'Status', value: `<span class="status-badge ${job.status}">${job.status}</span>` },
+    { label: 'Kind', value: job.kind },
+    { label: 'Worker', value: job.worker || '-' },
+    { label: 'Attempt', value: `${job.attempt} / ${job.max_attempts}` },
+    { label: 'Timeout', value: job.timeout_seconds ? job.timeout_seconds + 's' : 'none' },
+    { label: 'Created', value: formatTime(job.created_at) },
+    { label: 'Started', value: job.started_at ? formatTime(job.started_at) : '-' },
+    { label: 'Completed', value: job.completed_at ? formatTime(job.completed_at) : '-' },
+    { label: 'Duration', value: jobDuration(job) },
+  ];
+  if (job.summary) meta.push({ label: 'Summary', value: esc(job.summary) });
+  if (job.error) meta.push({ label: 'Error', value: `<span style="color:var(--red)">${esc(job.error)}</span>` });
+  if (job.session_key) meta.push({ label: 'Session', value: esc(job.session_key) });
+  if (job.retry_of_job_id) meta.push({ label: 'Retry Of', value: `<a href="#" onclick="openJobDetail('${esc(job.retry_of_job_id)}');return false" style="color:var(--accent)">${esc(job.retry_of_job_id)}</a>` });
+
+  document.getElementById('detail-meta').innerHTML = meta.map(m =>
+    `<div class="meta-item"><div class="meta-label">${m.label}</div><div class="meta-value">${m.value}</div></div>`
+  ).join('');
+}
+
+function renderJobEvents(events) {
+  const container = document.getElementById('detail-events');
+  if (!events.length) {
+    container.innerHTML = '<div style="color:var(--fg3);font-size:13px;">No events recorded</div>';
+    return;
+  }
+  container.innerHTML = events.map(e =>
+    `<div class="timeline-item ${e.event_type}">
+      <span class="ev-type">${esc(e.event_type)}</span>
+      <span class="ev-time">${formatTime(e.created_at)}</span>
+      ${e.message ? `<div class="ev-msg">${esc(truncate(e.message, 200))}</div>` : ''}
+    </div>`
+  ).join('');
+}
+
+function renderJobArtifacts(artifacts) {
+  const container = document.getElementById('detail-artifacts');
+  if (!artifacts.length) {
+    container.innerHTML = '<div style="color:var(--fg3);font-size:13px;">No artifacts</div>';
+    return;
+  }
+  container.innerHTML = artifacts.map(a => {
+    let contentHtml = '';
+    if (a.content) {
+      const truncated = a.content.length > 2000 ? a.content.slice(0, 2000) + '\n... (truncated)' : a.content;
+      contentHtml = `<div class="art-content">${esc(truncated)}</div>`;
+    }
+    let uriHtml = '';
+    if (a.uri) {
+      uriHtml = `<div class="art-meta">URI: ${esc(a.uri)}</div>`;
+    }
+    return `<div class="artifact-card">
+      <div class="art-name">${esc(a.name)}</div>
+      <div class="art-meta">${esc(a.artifact_type)}${a.mime_type ? ' \u00B7 ' + esc(a.mime_type) : ''} \u00B7 ${formatTime(a.created_at)}</div>
+      ${uriHtml}
+      ${contentHtml}
+    </div>`;
+  }).join('');
+}
+
+function cancelSelectedJob() {
+  if (!selectedJobId || !ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: 'cancel_job', job_id: selectedJobId }));
+}
+
+// ─── Workers ─────────────────────────────────────────────────────────
+function refreshWorkers() {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: 'list_workers' }));
+}
+
+function renderWorkers(workers) {
+  const badge = document.getElementById('badge-workers');
+  const active = workers.filter(w => w.running).length;
+  if (active > 0) {
+    badge.textContent = active;
+    badge.className = 'badge running';
+  } else {
+    badge.className = 'badge empty';
+  }
+
+  const container = document.getElementById('workers-container');
+  if (!workers.length) {
+    container.innerHTML = '<div class="empty-state"><div class="title">No active workers</div><div class="subtitle">Workers are created when sessions process requests</div></div>';
+    return;
+  }
+
+  // Sort: running first, then by session key
+  workers.sort((a, b) => (b.running ? 1 : 0) - (a.running ? 1 : 0) || a.session_key.localeCompare(b.session_key));
+
+  container.innerHTML = workers.map(w =>
+    `<div class="worker-card">
+      <div class="w-dot ${w.running ? 'active' : 'idle'}"></div>
+      <div class="w-key">${esc(w.session_key)}</div>
+      <div class="w-queue">${w.running ? 'running' : 'idle'}${w.queue_depth > 0 ? ' \u00B7 queue: ' + w.queue_depth : ''}</div>
+    </div>`
+  ).join('');
+}
+
+// ─── Chat (secondary) ───────────────────────────────────────────────
 function updateSessions(list) {
   sessions = list;
-  const container = document.getElementById('session-list');
-  container.innerHTML = '';
-  for (let idx = 0; idx < sessions.length; idx++) {
-    const s = sessions[idx];
-    if (hiddenSessions.has(s.id)) continue;
-    const el = document.createElement('div');
-    el.className = 'session-item' + (s.id === currentSessionId ? ' active' : '');
-    const deleteBtn = idx === 0 ? '' : `<button class="session-delete" onclick="event.stopPropagation();hideSession('${s.id}')" title="Remove">✕</button>`;
-    el.innerHTML = `
-      <div class="dot ${s.running ? 'running' : 'idle'}"></div>
-      <span class="session-name">${esc(s.name || s.id)}</span>
-      <span class="session-model">${esc(s.model || '')}</span>
-      ${deleteBtn}
-    `;
-    el.onclick = () => switchSession(s.id);
-    container.appendChild(el);
-    // Sync running state from server truth for current session
-    if (s.id === currentSessionId) {
-      if (s.model) currentModel = s.model;
-      if (isRunning && !s.running) {
-        // Server says not running but UI thinks it is — recover from dropped run_end
-        isRunning = false;
-        setStatus('connected');
-        updateButtons();
-        // Finalize any pending stream
-        if (streamBuf && streamEl && !streamEl.classList.contains('finalized')) {
-          finalizeStream(streamBuf);
-        }
-        streamBuf = '';
-        streamEl = null;
-      } else if (!isRunning && s.running) {
-        // Server says running but UI missed run_start
-        isRunning = true;
-        setStatus('running');
-        updateButtons();
-      }
+  const select = document.getElementById('session-select');
+  const prev = select.value;
+  select.innerHTML = sessions.map(s =>
+    `<option value="${esc(s.id)}" ${s.id === currentSessionId ? 'selected' : ''}>${esc(s.name || s.id)}${s.running ? ' (running)' : ''}</option>`
+  ).join('');
+  if (prev && sessions.find(s => s.id === prev)) select.value = prev;
+
+  // Sync running state
+  const cur = sessions.find(s => s.id === currentSessionId);
+  if (cur) {
+    if (cur.model) currentModel = cur.model;
+    if (isRunning && !cur.running) {
+      isRunning = false;
+      updateChatButtons();
+      if (streamBuf && streamEl && !streamEl.classList.contains('finalized')) finalizeStream(streamBuf);
+      streamBuf = ''; streamEl = null;
+    } else if (!isRunning && cur.running) {
+      isRunning = true;
+      updateChatButtons();
     }
   }
-  updateModelDisplay();
 }
 
 function switchSession(id) {
   if (id === currentSessionId) return;
   currentSessionId = id;
-  document.getElementById('chat').innerHTML = '';
-  streamBuf = '';
-  streamEl = null;
+  document.getElementById('chat-messages').innerHTML = '';
+  streamBuf = ''; streamEl = null;
   ws.send(JSON.stringify({ type: 'switch_session', session_id: id }));
-  updateSessions(sessions);
 }
 
 function newSession() {
   ws.send(JSON.stringify({ type: 'new_session' }));
 }
 
-function hideSession(id) {
-  hiddenSessions.add(id);
-  // If we're hiding the active session, switch to the first visible one
-  if (id === currentSessionId) {
-    const visible = sessions.find(s => !hiddenSessions.has(s.id));
-    if (visible) switchSession(visible.id);
-  }
-  updateSessions(sessions);
-}
-
-// Chat rendering
 function appendUserMessage(text) {
-  const chat = document.getElementById('chat');
+  const chat = document.getElementById('chat-messages');
   const div = document.createElement('div');
   div.className = 'message user';
   div.innerHTML = `<div class="role">You</div><div class="bubble">${esc(text)}</div>`;
   chat.appendChild(div);
-  scrollToBottom();
+  scrollChat();
 }
 
 function appendToken(delta) {
   streamBuf += delta;
   if (!streamEl) {
-    const chat = document.getElementById('chat');
+    const chat = document.getElementById('chat-messages');
     const div = document.createElement('div');
     div.className = 'message assistant';
-    div.innerHTML = `<div class="role">Assistant</div><div class="bubble streaming-cursor"></div>`;
+    div.innerHTML = '<div class="role">Assistant</div><div class="bubble streaming-cursor"></div>';
     chat.appendChild(div);
     streamEl = div.querySelector('.bubble');
   }
-  // Render partial markdown
   streamEl.innerHTML = safeMarkdown(streamBuf);
   streamEl.classList.add('streaming-cursor');
-  scrollToBottom();
+  scrollChat();
 }
 
 function finalizeStream(content, model) {
   if (!content) return;
-  
   if (streamEl && !streamEl.classList.contains('finalized')) {
     streamEl.classList.remove('streaming-cursor');
     streamEl.classList.add('finalized');
     streamEl.innerHTML = safeMarkdown(content);
-    // Highlight code blocks
-    streamEl.querySelectorAll('pre code').forEach(block => hljs.highlightElement(block));
+    streamEl.querySelectorAll('pre code').forEach(b => hljs.highlightElement(b));
   } else if (!streamEl) {
-    // Message arrived without prior tokens (e.g. non-streaming)
-    const chat = document.getElementById('chat');
+    const chat = document.getElementById('chat-messages');
     const div = document.createElement('div');
     div.className = 'message assistant';
     div.innerHTML = `<div class="role">Assistant</div><div class="bubble finalized">${safeMarkdown(content)}</div>`;
     chat.appendChild(div);
-    div.querySelectorAll('pre code').forEach(block => hljs.highlightElement(block));
+    div.querySelectorAll('pre code').forEach(b => hljs.highlightElement(b));
   }
-  
-  streamBuf = '';
-  streamEl = null;
-  if (model) {
-    currentModel = model;
-    updateModelDisplay();
-  }
-  scrollToBottom();
-}
-
-function toolDisplayName(name, args) {
-  if (!name) return 'tool';
-  // For the "local" shell tool, extract the actual command from args
-  if (name === 'local' && args) {
-    try {
-      const parsed = typeof args === 'string' ? JSON.parse(args) : args;
-      const cmd = parsed.input || parsed.command || '';
-      if (cmd) {
-        // Show a short version: binary + first meaningful arg
-        const parts = cmd.trim().split(/\s+/);
-        const bin = parts[0].split('/').pop();
-        // For common commands show more context
-        const summary = parts.slice(0, 3).join(' ');
-        return summary.length > 60 ? bin : (summary || bin);
-      }
-    } catch {}
-  }
-  return name;
+  streamBuf = ''; streamEl = null;
+  if (model) currentModel = model;
+  scrollChat();
 }
 
 function appendToolStart(name, args) {
-  const chat = document.getElementById('chat');
+  const chat = document.getElementById('chat-messages');
   const div = document.createElement('div');
   div.className = 'tool-call';
   div.dataset.tool = name || '';
-  div.dataset.toolId = Date.now().toString();
-  
-  const displayName = toolDisplayName(name, args);
   let argsHtml = '';
   if (args) {
-    try {
-      const parsed = JSON.parse(args);
-      argsHtml = `<div class="label">Input:</div><pre>${esc(JSON.stringify(parsed, null, 2))}</pre>`;
-    } catch {
-      argsHtml = `<div class="label">Input:</div><pre>${esc(args)}</pre>`;
-    }
+    try { const p = JSON.parse(args); argsHtml = `<div class="label">Input:</div><pre>${esc(JSON.stringify(p, null, 2))}</pre>`; }
+    catch { argsHtml = `<div class="label">Input:</div><pre>${esc(args)}</pre>`; }
   }
-  
   div.innerHTML = `
     <div class="tool-header" onclick="this.parentElement.classList.toggle('open')">
-      <span class="icon">🔧</span>
-      <span class="name">${esc(displayName)}</span>
-      <span class="chevron">▸</span>
+      <span class="icon">T</span><span class="name">${esc(name || 'tool')}</span><span class="chevron">\u25B8</span>
     </div>
-    <div class="tool-body">
-      ${argsHtml}
-      <div class="tool-output"></div>
-    </div>
+    <div class="tool-body">${argsHtml}<div class="tool-output"></div></div>
   `;
   chat.appendChild(div);
-  scrollToBottom();
+  scrollChat();
 }
 
 function appendToolEnd(name, result, error) {
-  // Find the last tool-call matching this tool name that hasn't been completed yet
   const selector = name ? `.tool-call[data-tool="${CSS.escape(name)}"]` : '.tool-call';
   const tools = document.querySelectorAll(selector);
   let tool = null;
   for (let i = tools.length - 1; i >= 0; i--) {
-    if (!tools[i].dataset.completed) {
-      tool = tools[i];
-      break;
-    }
+    if (!tools[i].dataset.completed) { tool = tools[i]; break; }
   }
   if (!tool) return;
-  
   tool.dataset.completed = '1';
   const output = tool.querySelector('.tool-output');
-  if (error) {
-    output.innerHTML = `<div class="label">Error:</div><pre class="tool-error">${esc(error)}</pre>`;
-  } else if (result) {
-    const truncated = result.length > 2000 ? result.slice(0, 2000) + '\n... (truncated)' : result;
-    output.innerHTML = `<div class="label">Output:</div><pre>${esc(truncated)}</pre>`;
+  if (error) output.innerHTML = `<div class="label">Error:</div><pre class="tool-error">${esc(error)}</pre>`;
+  else if (result) {
+    const t = result.length > 2000 ? result.slice(0, 2000) + '\n... (truncated)' : result;
+    output.innerHTML = `<div class="label">Output:</div><pre>${esc(t)}</pre>`;
   }
-  scrollToBottom();
+  scrollChat();
 }
 
 function appendApproval(approvalId, command) {
-  const chat = document.getElementById('chat');
+  const chat = document.getElementById('chat-messages');
   const div = document.createElement('div');
   div.className = 'approval';
   div.id = `approval-${approvalId}`;
   div.innerHTML = `
-    <div style="font-size:13px;color:var(--orange);font-weight:600;">⚠️ Approval Required</div>
+    <div style="font-size:13px;color:var(--orange);font-weight:600;">Approval Required</div>
     <div class="cmd">${esc(command)}</div>
     <div class="actions">
-      <button class="approve-btn" onclick="respondApproval('${approvalId}', true)">✓ Approve</button>
-      <button class="deny-btn" onclick="respondApproval('${approvalId}', false)">✗ Deny</button>
+      <button class="approve-btn" onclick="respondApproval('${approvalId}', true)">Approve</button>
+      <button class="deny-btn" onclick="respondApproval('${approvalId}', false)">Deny</button>
     </div>
   `;
   chat.appendChild(div);
-  scrollToBottom();
+  scrollChat();
 }
 
-function respondApproval(approvalId, approved) {
-  ws.send(JSON.stringify({ type: 'approve', approval_id: approvalId, approved }));
-  const el = document.getElementById(`approval-${approvalId}`);
+function respondApproval(id, approved) {
+  ws.send(JSON.stringify({ type: 'approve', approval_id: id, approved }));
+  const el = document.getElementById(`approval-${id}`);
   if (el) el.classList.add('resolved');
 }
 
 function appendError(msg) {
-  const chat = document.getElementById('chat');
+  const chat = document.getElementById('chat-messages');
   const div = document.createElement('div');
   div.className = 'error-msg';
   div.textContent = msg;
   chat.appendChild(div);
-  scrollToBottom();
+  scrollChat();
 }
 
-// Input handling
-let lastSendTime = 0;
 function sendMessage() {
-  const now = Date.now();
-  if (now - lastSendTime < 200) return; // debounce
-  lastSendTime = now;
-
-  const input = document.getElementById('input');
+  const input = document.getElementById('chat-input');
   const text = input.value.trim();
-  if (!text && !pendingImageData) return;
-  if (!ws) return;
-
-  closeSlashPopup();
-
-  // Check if it's a bot command (e.g. /status, /usage)
-  const cmdMatch = text.match(/^\/(\w+)/);
-  const isBotCmd = cmdMatch && BOT_COMMANDS.has(cmdMatch[1].toLowerCase());
-
-  if (isBotCmd) {
-    // Show as user message locally
-    appendUserMessage(text);
-    ws.send(JSON.stringify({
-      type: 'bot_command',
-      session_id: currentSessionId,
-      text: text
-    }));
-  } else {
-    const msg = {
-      type: 'send',
-      session_id: currentSessionId,
-      text: text
-    };
-    if (pendingImageData) {
-      msg.image_data = pendingImageData;
-    }
-    ws.send(JSON.stringify(msg));
-  }
-  
+  if (!text || !ws) return;
+  const msg = { type: 'send', session_id: currentSessionId, text };
+  ws.send(JSON.stringify(msg));
   input.value = '';
   autoResize(input);
-  clearImagePreview();
   input.focus();
 }
 
 function abortRun() {
   if (!ws) return;
-  ws.send(JSON.stringify({
-    type: 'abort',
-    session_id: currentSessionId
-  }));
+  ws.send(JSON.stringify({ type: 'abort', session_id: currentSessionId }));
 }
 
 function handleKey(e) {
-  const popup = document.getElementById('slash-popup');
-  if (popup.classList.contains('active')) {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      slashSelectedIdx = Math.min(slashSelectedIdx + 1, slashFiltered.length - 1);
-      renderSlashPopup();
-      return;
-    }
-    if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      slashSelectedIdx = Math.max(slashSelectedIdx - 1, 0);
-      renderSlashPopup();
-      return;
-    }
-    if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
-      e.preventDefault();
-      if (slashFiltered.length > 0) {
-        selectSlashCommand(slashFiltered[slashSelectedIdx]);
-      }
-      return;
-    }
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      closeSlashPopup();
-      return;
-    }
-  }
-  if (e.key === 'Enter' && !e.shiftKey) {
-    e.preventDefault();
-    sendMessage();
-  }
-}
-
-function handleInput(el) {
-  autoResize(el);
-  updateSlashPopup(el.value);
-}
-
-function updateSlashPopup(text) {
-  const popup = document.getElementById('slash-popup');
-  if (!text.startsWith('/') || text.includes('\n')) {
-    closeSlashPopup();
-    return;
-  }
-  const query = text.toLowerCase();
-  slashFiltered = SLASH_COMMANDS.filter(c => c.cmd.startsWith(query));
-  if (slashFiltered.length === 0) {
-    closeSlashPopup();
-    return;
-  }
-  slashSelectedIdx = Math.min(slashSelectedIdx, slashFiltered.length - 1);
-  popup.classList.add('active');
-  renderSlashPopup();
-}
-
-function renderSlashPopup() {
-  const popup = document.getElementById('slash-popup');
-  popup.innerHTML = slashFiltered.map((c, i) =>
-    `<div class="slash-item${i === slashSelectedIdx ? ' selected' : ''}" onmousedown="selectSlashCommand(SLASH_COMMANDS.find(s=>s.cmd==='${c.cmd}'))">
-      <span class="cmd">${c.cmd}</span><span class="desc">${c.desc}</span>
-    </div>`
-  ).join('');
-}
-
-function selectSlashCommand(item) {
-  const input = document.getElementById('input');
-  input.value = item.cmd + (item.cmd === '/think' || item.cmd === '/new' ? ' ' : '');
-  closeSlashPopup();
-  input.focus();
-}
-
-function closeSlashPopup() {
-  document.getElementById('slash-popup').classList.remove('active');
-  slashSelectedIdx = 0;
+  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
 }
 
 function autoResize(el) {
@@ -759,291 +797,81 @@ function autoResize(el) {
   el.style.height = Math.min(el.scrollHeight, 200) + 'px';
 }
 
-// UI helpers
+function updateChatButtons() {
+  document.getElementById('send-btn').style.display = isRunning ? 'none' : '';
+  document.getElementById('abort-btn').style.display = isRunning ? '' : 'none';
+}
+
+function scrollChat() {
+  const chat = document.getElementById('chat-messages');
+  chat.scrollTop = chat.scrollHeight;
+}
+
+// ─── Utilities ───────────────────────────────────────────────────────
 function setStatus(state) {
   const dot = document.getElementById('status-dot');
   const text = document.getElementById('status-text');
   dot.className = '';
   dot.id = 'status-dot';
-  
-  switch (state) {
-    case 'connected':
-      dot.classList.add('connected');
-      text.textContent = 'connected';
-      break;
-    case 'running':
-      dot.classList.add('running');
-      text.textContent = 'running...';
-      break;
-    default:
-      text.textContent = 'disconnected';
-  }
-}
-
-function updateButtons() {
-  document.getElementById('send-btn').style.display = isRunning ? 'none' : '';
-  document.getElementById('abort-btn').style.display = isRunning ? '' : 'none';
-}
-
-let availableModels = [];
-
-// Fetch model list from server
-fetch('/api/models')
-  .then(r => r.json())
-  .then(models => { if (Array.isArray(models) && models.length) availableModels = models; })
-  .catch(() => {});
-
-function updateModelDisplay() {
-  document.getElementById('model-text').textContent = currentModel || '(no model)';
-}
-
-function toggleModelPicker(e) {
-  // Don't toggle if clicking on an option (it handles itself)
-  if (e.target.classList.contains('model-option')) return;
-  const picker = document.getElementById('model-picker');
-  const isOpen = picker.classList.contains('open');
-  if (isOpen) { picker.classList.remove('open'); return; }
-  // Build options
-  picker.innerHTML = '';
-  if (!availableModels.length) {
-    picker.innerHTML = '<div class="model-option" style="color:var(--fg3)">no models configured</div>';
-    picker.classList.add('open');
-    return;
-  }
-  availableModels.forEach(m => {
-    const div = document.createElement('div');
-    div.className = 'model-option' + (m === currentModel ? ' active' : '');
-    div.textContent = m;
-    div.onclick = (ev) => { ev.stopPropagation(); selectModel(m); };
-    picker.appendChild(div);
-  });
-  picker.classList.add('open');
-}
-
-function selectModel(model) {
-  document.getElementById('model-picker').classList.remove('open');
-  if (!ws || ws.readyState !== WebSocket.OPEN || !currentSessionId) return;
-  // Send /model command via chat
-  const chatID = parseInt(currentSessionId, 10);
-  ws.send(JSON.stringify({ type: 'model_set', payload: { chat_id: chatID, model: model } }));
-  currentModel = model;
-  updateModelDisplay();
-}
-
-// Close picker on outside click
-document.addEventListener('click', (e) => {
-  const picker = document.getElementById('model-picker');
-  if (picker && !document.getElementById('model-display').contains(e.target)) {
-    picker.classList.remove('open');
-  }
-});
-
-function scrollToBottom() {
-  const chat = document.getElementById('chat');
-  chat.scrollTop = chat.scrollHeight;
+  if (state === 'connected') { dot.classList.add('connected'); text.textContent = 'connected'; }
+  else { text.textContent = 'disconnected'; }
 }
 
 function esc(s) {
   if (!s) return '';
-  const div = document.createElement('div');
-  div.textContent = s;
-  return div.innerHTML;
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
 }
 
-// Image paste handling
-document.addEventListener('paste', (e) => {
-  const items = e.clipboardData?.items;
-  if (!items) return;
-  for (const item of items) {
-    if (item.type.startsWith('image/')) {
-      e.preventDefault();
-      const file = item.getAsFile();
-      if (!file) return;
-      const reader = new FileReader();
-      reader.onload = () => {
-        pendingImageData = reader.result; // data:image/...;base64,...
-        const preview = document.getElementById('image-preview');
-        const img = document.getElementById('preview-img');
-        const info = document.getElementById('preview-info');
-        img.src = pendingImageData;
-        const kb = Math.round(file.size / 1024);
-        info.textContent = `${file.type} · ${kb} KB`;
-        preview.classList.add('active');
-      };
-      reader.readAsDataURL(file);
-      return;
-    }
-  }
-});
-
-function clearImagePreview() {
-  pendingImageData = null;
-  const preview = document.getElementById('image-preview');
-  preview.classList.remove('active');
-  document.getElementById('preview-img').src = '';
-  document.getElementById('preview-info').textContent = '';
+function truncate(s, len) {
+  if (!s) return '';
+  return s.length > len ? s.slice(0, len) + '...' : s;
 }
 
-// Periodic session state sync (recovers from dropped run_end events)
+function formatTime(ts) {
+  if (!ts) return '-';
+  try {
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return ts;
+    const now = new Date();
+    const diff = now - d;
+    if (diff < 60000) return Math.floor(diff / 1000) + 's ago';
+    if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago';
+    if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago';
+    return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
+  } catch { return ts; }
+}
+
+function jobDuration(j) {
+  const start = j.started_at ? new Date(j.started_at) : null;
+  if (!start || isNaN(start.getTime())) return '-';
+  const end = j.completed_at ? new Date(j.completed_at) : new Date();
+  if (isNaN(end.getTime())) return '-';
+  const ms = end - start;
+  if (ms < 1000) return ms + 'ms';
+  if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
+  if (ms < 3600000) return Math.floor(ms / 60000) + 'm ' + Math.floor((ms % 60000) / 1000) + 's';
+  return Math.floor(ms / 3600000) + 'h ' + Math.floor((ms % 3600000) / 60000) + 'm';
+}
+
+// Periodic refresh
 setInterval(() => {
   if (ws && ws.readyState === WebSocket.OPEN) {
     ws.send(JSON.stringify({ type: 'list_sessions' }));
+    if (activeTab === 'jobs') refreshJobs();
+    if (activeTab === 'workers') refreshWorkers();
+    // Refresh open job detail
+    if (selectedJobId && activeTab === 'jobs') {
+      ws.send(JSON.stringify({ type: 'get_job', job_id: selectedJobId }));
+      ws.send(JSON.stringify({ type: 'list_job_events', job_id: selectedJobId }));
+      ws.send(JSON.stringify({ type: 'list_job_artifacts', job_id: selectedJobId }));
+    }
   }
-}, 3000);
-
-// ── View switching ──────────────────────────────────────────────────────────
-let currentView = 'chat';
-
-function switchView(view) {
-  currentView = view;
-  document.querySelectorAll('.view-tab').forEach(t => t.classList.toggle('active', t.textContent.toLowerCase().includes(view === 'chat' ? 'chat' : 'mission')));
-  document.getElementById('chat').style.display = view === 'chat' ? '' : 'none';
-  document.getElementById('mission').style.display = view === 'mission' ? 'block' : 'none';
-  document.getElementById('input-area').style.display = view === 'chat' ? '' : 'none';
-  document.getElementById('image-preview').style.display = view === 'chat' ? '' : 'none';
-  if (view === 'mission') loadMissionControl();
-}
-
-// ── Mission Control ─────────────────────────────────────────────────────────
-function mcApiBase() {
-  const proto = location.protocol;
-  const host = location.hostname || '127.0.0.1';
-  const port = window.CONTROL_PORT || location.port || '8787';
-  return `${proto}//${host}:${port}`;
-}
-
-async function mcFetch(path) {
-  const resp = await fetch(mcApiBase() + path);
-  if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
-  return resp.json();
-}
-
-async function loadMissionControl() {
-  const mc = document.getElementById('mission');
-  mc.innerHTML = '<div style="color:var(--fg2);padding:20px;">Loading...</div>';
-  try {
-    const [roles, schedules, runs, stats] = await Promise.all([
-      mcFetch('/api/mission/roles'),
-      mcFetch('/api/mission/schedules'),
-      mcFetch('/api/mission/runs?limit=50'),
-      mcFetch('/api/mission/stats?days=7'),
-    ]);
-    mc.innerHTML = renderMission(roles, schedules, runs, stats);
-  } catch (e) {
-    mc.innerHTML = `<div class="mc-empty">Failed to load mission data: ${esc(e.message)}</div>`;
-  }
-}
-
-function renderMission(roles, schedules, runs, stats) {
-  return renderStats(stats) + renderRoles(roles) + renderSchedules(schedules) + renderRuns(runs);
-}
-
-function renderStats(stats) {
-  const days = stats.days || [];
-  const maxJobs = Math.max(1, ...days.map(d => d.JobsTotal || 0));
-  const maxMsgs = Math.max(1, ...days.map(d => d.MessageCount || 0));
-
-  let barsHtml = '';
-  for (const d of days) {
-    const okW = Math.round(((d.JobsSucceeded || 0) / maxJobs) * 120);
-    const failW = Math.round(((d.JobsFailed || 0) / maxJobs) * 120);
-    const msgW = Math.round(((d.MessageCount || 0) / maxMsgs) * 120);
-    barsHtml += `<div class="mc-bar-row">
-      <span class="day">${d.Date || '?'}</span>
-      <span class="mc-bar ok" style="width:${okW}px" title="${d.JobsSucceeded || 0} succeeded"></span>
-      <span class="mc-bar fail" style="width:${failW}px" title="${d.JobsFailed || 0} failed"></span>
-      <span class="mc-bar msg" style="width:${msgW}px" title="${d.MessageCount || 0} messages"></span>
-    </div>`;
-  }
-
-  return `<div class="mc-section">
-    <h3>Daily Value Delivered</h3>
-    <div class="mc-stat-row">
-      <div class="mc-stat"><div class="value">${stats.session_count || 0}</div><div class="label">Sessions</div></div>
-      <div class="mc-stat"><div class="value">${formatTokens(stats.total_tokens || 0)}</div><div class="label">Total Tokens</div></div>
-      <div class="mc-stat"><div class="value">${stats.total_messages || 0}</div><div class="label">Messages</div></div>
-    </div>
-    ${barsHtml || '<div class="mc-empty">No activity yet</div>'}
-    <div style="font-size:11px;color:var(--fg3);margin-top:6px;">
-      <span class="mc-bar ok" style="width:10px;display:inline-block;">&nbsp;</span> succeeded &nbsp;
-      <span class="mc-bar fail" style="width:10px;display:inline-block;">&nbsp;</span> failed &nbsp;
-      <span class="mc-bar msg" style="width:10px;display:inline-block;">&nbsp;</span> messages
-    </div>
-  </div>`;
-}
-
-function renderRoles(roles) {
-  if (!roles || !roles.length) return '<div class="mc-section"><h3>Roles</h3><div class="mc-empty">No agents configured</div></div>';
-  const cards = roles.map(r => {
-    const toolsText = r.allowed_tools && r.allowed_tools.length ? r.allowed_tools.join(', ') : 'all tools';
-    return `<div class="mc-card">
-      <div class="title">${esc(r.emoji || '')} ${esc(r.display_name || r.name)}</div>
-      <div class="subtitle">${esc(r.model || 'default model')}</div>
-      <div class="meta">Tools: ${esc(toolsText)}</div>
-    </div>`;
-  }).join('');
-  return `<div class="mc-section"><h3>Roles</h3><div class="mc-grid">${cards}</div></div>`;
-}
-
-function renderSchedules(schedules) {
-  if (!schedules || !schedules.length) return '<div class="mc-section"><h3>Schedules</h3><div class="mc-empty">No scheduled jobs</div></div>';
-  const rows = schedules.map(s => {
-    const nextRun = s.next_run ? new Date(s.next_run).toLocaleString() : '—';
-    return `<tr>
-      <td>${s.id}</td>
-      <td><span class="mc-badge ${s.type || 'llm'}">${esc(s.type || 'llm')}</span></td>
-      <td><code>${esc(s.expression)}</code></td>
-      <td class="mc-task-text" title="${esc(s.task)}">${esc(s.task)}</td>
-      <td>${nextRun}</td>
-    </tr>`;
-  }).join('');
-  return `<div class="mc-section"><h3>Schedules</h3>
-    <table class="mc-table"><thead><tr><th>#</th><th>Type</th><th>Cron</th><th>Task</th><th>Next Run</th></tr></thead>
-    <tbody>${rows}</tbody></table></div>`;
-}
-
-function renderRuns(runs) {
-  if (!runs || !runs.length) return '<div class="mc-section"><h3>Run Log</h3><div class="mc-empty">No runs recorded</div></div>';
-
-  const failCount = runs.filter(r => r.status === 'failed').length;
-  const header = failCount > 0
-    ? `<h3>Run Log <span style="color:var(--red);font-size:12px;font-weight:normal;">(${failCount} failed)</span></h3>`
-    : '<h3>Run Log</h3>';
-
-  const rows = runs.map(r => {
-    const created = r.created_at ? new Date(r.created_at).toLocaleString() : '—';
-    const detail = r.status === 'failed' && r.error
-      ? `<div class="mc-error-text" title="${esc(r.error)}">${esc(r.error)}</div>`
-      : (r.summary ? `<div style="font-size:12px;color:var(--fg2);max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${esc(r.summary)}">${esc(r.summary)}</div>` : '');
-    return `<tr>
-      <td><span class="mc-badge ${r.status}">${esc(r.status)}</span></td>
-      <td>${esc(r.kind || '—')}</td>
-      <td>${esc(r.worker || '—')}</td>
-      <td class="mc-task-text" title="${esc(r.description || '')}">${esc(r.description || '—')}</td>
-      <td>${created}</td>
-      <td>${detail}</td>
-    </tr>`;
-  }).join('');
-
-  return `<div class="mc-section">${header}
-    <table class="mc-table"><thead><tr><th>Status</th><th>Kind</th><th>Worker</th><th>Description</th><th>Created</th><th>Detail</th></tr></thead>
-    <tbody>${rows}</tbody></table></div>`;
-}
-
-function formatTokens(n) {
-  if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
-  if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
-  return n.toString();
-}
-
-// Auto-refresh mission control every 30s when visible
-setInterval(() => {
-  if (currentView === 'mission') loadMissionControl();
-}, 30000);
+}, 5000);
 
 // Init
 connect();
-document.getElementById('input').focus();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Implements #175

## Changes

Replace the chat-first operator web UI with a dashboard focused on jobs, workers, artifacts, and queue state.

**Backend (control server):**
- Add 6 new WebSocket commands: `list_jobs`, `get_job`, `list_job_events`, `list_job_artifacts`, `cancel_job`, `list_workers`
- Add `JobInfo`, `JobEventInfo`, `ArtifactInfo`, `WorkerInfo` types to control protocol
- Add `ListWorkers()` to `runtime.Hub` for session worker snapshots
- Wire `storage.Store` into `control.Server` via `SetStore()` for job/artifact queries

**Frontend (web/index.html):**
- Three-tab layout: **Jobs** (default), **Workers**, **Chat**
- Jobs tab: summary cards (total/running/pending/succeeded/failed), filterable status table, job detail view with event timeline and artifact viewer, cancel support
- Workers tab: active session worker cards showing running/idle state and queue depth
- Chat tab: retained session-based chat as secondary view
- Badges on tabs show running job/worker counts
- Auto-refresh every 5s on active tab; relative time formatting

## Testing

- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all tests pass
- `CGO_ENABLED=1 go build ./cmd/ok-gobot/` — binary builds and runs
- Verified rebase on `origin/main` with no conflicts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the session-centric operator UI with a three-tab job/worker dashboard backed by six new WebSocket commands wired into the existing storage and runtime layers. The backend additions are clean and well-structured; the frontend is a substantial rewrite that correctly reuses the existing WebSocket connection and XSS-safe `esc()`/`safeMarkdown` helpers.

- **Backend**: `SetStore()` is called before `Start()`, nil-guards are in place on all handlers, and `ListWorkers()` reads worker state safely (atomics + channel length under the hub mutex).
- **Frontend**: One logic issue — the `'error'` WebSocket message type is only forwarded to `appendError` when `activeTab === 'chat'`, so any server-side error from `list_jobs`, `get_job`, `cancel_job`, etc. is silently dropped when the user is on the Jobs or Workers tab, leaving them with no feedback on failures.
- Auto-refresh (5 s) and event-driven refresh on `run_start`/`run_end` keep summary cards and badges up to date.
- The Chat tab retains full existing functionality including approval dialogs and streaming.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the silent error suppression on non-chat tabs.
- The backend changes are correct and well-tested. The frontend rewrite is solid overall with one concrete usability bug: errors from job/worker WebSocket commands are silently dropped when the user isn't on the Chat tab, making it impossible to diagnose failures from the Jobs or Workers views. A one-line fix (or small addition) resolves this.
- web/index.html — error routing in handleMessage

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/app/app.go | Single-line change: wires storage.Store into control.Server before Start() is called. Correct ordering, no issues. |
| internal/control/server.go | Adds store field and SetStore() mutator. Straightforward, no concurrency concerns since it is called before Start(). |
| internal/control/server_tui.go | Adds six new WebSocket command handlers. All guard against nil store, validate inputs, and use proper error propagation. jobToInfo mapping is complete. |
| internal/control/tui_types.go | Clean additions of new message/command constants and DTO types (JobInfo, JobEventInfo, ArtifactInfo, WorkerInfo). Correct use of omitempty. |
| internal/runtime/runtime.go | ListWorkers() holds hub mutex while reading per-worker state. isRunning() uses atomics and len(w.queue) is safe on a buffered channel — no data race. |
| web/index.html | Large frontend rewrite to three-tab dashboard. One logic bug: error messages from the server are silently discarded when the user is not on the Chat tab, giving no feedback when job/worker commands fail. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/index.html`, line 955-956 ([link](https://github.com/befeast/ok-gobot/blob/dd0b7c168519bb8ea6586d7843cbef1eb8bde42a/web/index.html#L955-L956)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Error messages silently dropped on non-chat tabs**

   In `handleMessage`, the `'error'` case only calls `appendError` when `activeTab === 'chat'`. All server-side errors from the new job/worker commands (`list_jobs`, `get_job`, `cancel_job`, etc.) are sent as `{ type: "error" }` messages via `sendTUIError`. When the user is on the Jobs or Workers tab these messages are silently swallowed — the list simply stays empty (or stale) with no indication of failure.

   For example: if `s.store == nil`, the server sends `"job storage not configured"`, but the user on the Jobs tab will only see an empty table with no explanation.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/index.html
   Line: 955-956

   Comment:
   **Error messages silently dropped on non-chat tabs**

   In `handleMessage`, the `'error'` case only calls `appendError` when `activeTab === 'chat'`. All server-side errors from the new job/worker commands (`list_jobs`, `get_job`, `cancel_job`, etc.) are sent as `{ type: "error" }` messages via `sendTUIError`. When the user is on the Jobs or Workers tab these messages are silently swallowed — the list simply stays empty (or stale) with no indication of failure.

   For example: if `s.store == nil`, the server sends `"job storage not configured"`, but the user on the Jobs tab will only see an empty table with no explanation.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/index.html
Line: 955-956

Comment:
**Error messages silently dropped on non-chat tabs**

In `handleMessage`, the `'error'` case only calls `appendError` when `activeTab === 'chat'`. All server-side errors from the new job/worker commands (`list_jobs`, `get_job`, `cancel_job`, etc.) are sent as `{ type: "error" }` messages via `sendTUIError`. When the user is on the Jobs or Workers tab these messages are silently swallowed — the list simply stays empty (or stale) with no indication of failure.

For example: if `s.store == nil`, the server sends `"job storage not configured"`, but the user on the Jobs tab will only see an empty table with no explanation.

```suggestion
    case 'error':
      if (activeTab === 'chat') appendError(msg.message);
      else {
        // Surface backend errors on non-chat tabs with a transient banner or console warning
        console.warn('[dashboard error]', msg.message);
        // Show inline in the active panel
        const panel = document.getElementById('panel-' + activeTab);
        if (panel) {
          const err = document.createElement('div');
          err.className = 'error-msg';
          err.textContent = msg.message;
          panel.prepend(err);
          setTimeout(() => err.remove(), 8000);
        }
      }
      break;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): replace session-centric view ..."](https://github.com/befeast/ok-gobot/commit/dd0b7c168519bb8ea6586d7843cbef1eb8bde42a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25960862)</sub>

<!-- /greptile_comment -->