### PR TITLE
feat: decompose features by user outcome, not infrastructure layer (#165)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Propose a new feature framed as a user outcome
+title: ''
+labels: feature
+assignees: ''
+---
+
+## User Story
+
+As a [role], I want [behavior] so that [benefit].
+
+## Acceptance Criteria
+
+- [ ] [Observable behavior 1]
+- [ ] [Observable behavior 2]
+
+## Default Behavior
+
+[What happens out of the box, and why this default is correct.]
+
+## Notes
+
+[Optional: implementation hints, links to prior art, or constraints.]

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -1,0 +1,52 @@
+# Process Rules
+
+## 1. Decompose Features by User Outcome
+
+Every feature must have at least one issue phrased as a user outcome.
+Infrastructure work is fine as a sub-task, but the parent issue must describe
+what a user can observe when it ships.
+
+### Why
+
+v2.0 decomposed 23 issues by technical phase (wiring, sessions, Telegram UX,
+TUI, subagents). The subagent mechanism shipped, but no issue ever said "the
+model should use /task for long operations" or "tools should auto-spawn on
+timeout." Infrastructure was built; policy was never specified. The result was
+working plumbing with no defined user-facing behavior.
+
+### Rule
+
+| Bad (infrastructure-layer) | Good (user-outcome) |
+|---|---|
+| Implement sub-agent spawn API | When a tool call takes >20 s, auto-spawn it as a subagent and notify the user |
+| Add queue modes | User can interrupt the bot mid-operation and get an immediate response |
+| Extend AgentConfig into capability policy | Operator can restrict an agent to read-only tools without editing Go code |
+| Enforce policy at tool execution boundaries | Denied tool calls show a clear reason in Telegram instead of silently failing |
+
+### Template
+
+Use the GitHub issue template at `.github/ISSUE_TEMPLATE/feature.md`:
+
+```
+## User Story
+As a [role], I want [behavior] so that [benefit].
+
+## Acceptance Criteria
+- [ ] [Observable behavior 1]
+- [ ] [Observable behavior 2]
+
+## Default Behavior
+[What happens out of the box, and why this default is correct.]
+```
+
+### Checklist Before Filing a Feature Issue
+
+1. **Title** names a user-visible outcome, not an internal component.
+2. **User Story** identifies a role (operator, end-user, developer) and a
+   concrete behavior.
+3. **Acceptance Criteria** are observable — a tester can verify each one
+   without reading source code.
+4. **Default Behavior** states what happens if the operator does zero
+   configuration.
+5. Infrastructure sub-tasks may reference internal components, but each must
+   link back to the parent outcome issue.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,218 +6,265 @@ This roadmap turns the findings from [Competitive Landscape](./COMPETITORS.md) i
 
 The goal is not to copy OpenFang or ZeroClaw wholesale. The goal is to borrow the parts that improve `ok-gobot` without destroying its main advantage: a small, understandable, Telegram-first single-binary operator bot.
 
+Every backlog item is phrased as a user outcome per [PROCESS.md](./PROCESS.md). Infrastructure sub-tasks may reference internals, but the parent item describes what a user can observe when it ships.
+
 ## Sequencing
 
 ### Phase 1: Quick Wins
 
-1. Emergency stop / safe mode
-2. Provider and model catalog
-3. OpenClaw migration report
+1. Operator can kill dangerous tools instantly without restarting the bot
+2. User can list available models and see which providers are healthy
+3. Operator gets a detailed report after migrating from OpenClaw
 
 ### Phase 2: Safety and Extensibility Foundation
 
-4. Capability policy per agent
-5. Runtime policy enforcement in tools
-6. Skills install and audit
+4. Operator can restrict an agent to read-only tools without editing Go code
+5. Denied tool calls show a clear reason in Telegram instead of silently failing
+6. Operator can install and audit third-party skills from the CLI
 
 ### Phase 3: Productized Autonomy
 
-7. Structured sub-agent contracts and budgets
-8. Packaged autonomous roles
-9. Role manifests and autonomous report loop
+7. Operator can cap a background task's tool calls, duration, and model cost
+8. Operator can enable a prebuilt role that runs on schedule and posts a report
+9. Operator can define new roles declaratively without writing Go code
 
 ## Backlog
 
-### 1. Add `estop` and Safe Mode
+### 1. Operator can kill dangerous tools instantly without restarting the bot
 
-**Why:** This is the highest-ROI idea to borrow from ZeroClaw. It gives operators a fast kill switch without redesigning the whole runtime.
+**User Story**
+As an operator, I want to disable dangerous tool families (shell, SSH, browser,
+cron, message, fetch) with a single command so that I can respond to incidents
+without restarting the process or losing in-flight sessions.
 
-**Scope**
-- Add a runtime stop-state that can disable tool families: `local`, `ssh`, `browser`, `cron`, `message`, and networked fetch/search.
-- Expose CLI commands such as `ok-gobot estop on|off|status`.
-- Expose admin controls via Telegram and the control/TUI surface.
-- Make blocked tools fail fast with a clear explanation instead of silently no-oping.
+**Why:** Highest-ROI safety feature. Gives operators a fast kill switch.
+
+**Acceptance Criteria**
+- [ ] `/estop on` disables dangerous tool families; `/estop off` re-enables them.
+- [ ] Blocked tools return a user-visible reason in Telegram, TUI, and API.
+- [ ] `/status` and the TUI show current estop state.
+- [ ] CLI equivalent: `ok-gobot estop on|off|status`.
+
+**Default Behavior**
+Estop is off. All configured tools are available. This is correct because most
+operators run the bot in a trusted environment and should not pay an opt-in cost
+for normal operation.
 
 **Likely files**
-- [internal/cli/root.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/cli/root.go)
 - `internal/cli/estop.go` (new)
-- [internal/control/server.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/control/server.go)
-- [internal/bot/approval.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/bot/approval.go)
-- [internal/tools/tools.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/tools/tools.go)
-- [internal/config/config.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/config/config.go)
+- `internal/control/server.go`
+- `internal/bot/approval.go`
+- `internal/tools/tools.go`
+- `internal/config/config.go`
 
-**Acceptance criteria**
-- An operator can disable dangerous execution paths without restarting the process.
-- Blocked tools return a user-visible reason in Telegram, TUI, and API flows.
-- `/status` or the TUI shows current `estop` state.
+### 2. User can list available models and see which providers are healthy
 
-### 2. Add Provider and Model Catalog Commands
+**User Story**
+As a user, I want to see which models and providers are available so that I can
+pick the right model for my task and diagnose failures without reading config files.
 
-**Why:** This is the best near-term borrow from ZeroClaw's provider docs and commands. It improves multi-provider usability without changing the core product.
+**Why:** Multi-provider usability. Users currently have no way to discover models
+or understand why a request failed at the provider level.
 
-**Scope**
-- Add `ok-gobot providers` and `ok-gobot models refresh`.
-- Cache discovered models per provider.
-- Show provider/model health in `doctor`.
-- Reuse existing model alias support instead of inventing another abstraction layer.
+**Acceptance Criteria**
+- [ ] `ok-gobot providers` lists configured providers with health status.
+- [ ] `ok-gobot models refresh` fetches and caches remote model catalogs.
+- [ ] `ok-gobot doctor` distinguishes auth failure, endpoint failure, and model lookup failure.
+- [ ] Model picker flows use cached catalogs when available.
+
+**Default Behavior**
+Provider list shows whatever is configured in `config.yaml`. Model catalog is
+fetched on first `models refresh` and cached locally. No automatic background
+fetching.
 
 **Likely files**
-- [internal/cli/root.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/cli/root.go)
 - `internal/cli/providers.go` (new)
 - `internal/cli/models.go` (new)
-- [internal/cli/doctor.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/cli/doctor.go)
-- [internal/ai/client.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/ai/client.go)
-- [internal/config/config.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/config/config.go)
+- `internal/cli/doctor.go`
+- `internal/ai/client.go`
 
-**Acceptance criteria**
-- Users can list supported providers and refresh remote model catalogs.
-- `doctor` distinguishes auth failure, endpoint failure, and model lookup failure.
-- Model picker flows use cached catalogs when available.
+### 3. Operator gets a detailed report after migrating from OpenClaw
 
-### 3. Write a Migration Report for `ok-gobot migrate`
+**User Story**
+As an operator migrating from OpenClaw, I want a durable report of what was
+copied, skipped, and deduplicated so that I can trust the migration and debug
+problems without re-running it.
 
-**Why:** OpenFang is right about this UX detail. Imports without an artifact are harder to trust and harder to debug.
+**Why:** Imports without an artifact are harder to trust and harder to debug.
 
-**Scope**
-- Write a markdown or JSON report after migration.
-- Include copied files, skipped sessions, duplicates, backup path, and canonical key mapping.
-- Keep `--dry-run` output consistent with the saved report format.
+**Acceptance Criteria**
+- [ ] Every migration run emits a report (markdown or JSON) listing copied files, skipped sessions, duplicates, backup path, and key mapping.
+- [ ] `--dry-run` prints the same categories as the real report.
+- [ ] Failed migrations preserve enough detail for rollback and debugging.
 
-**Likely files**
-- [internal/cli/migrate.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/cli/migrate.go)
-- [internal/migrate/migrate.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/migrate/migrate.go)
-
-**Acceptance criteria**
-- Every migration run emits a durable report artifact.
-- `--dry-run` prints the same categories of actions as the real report.
-- Failed migrations still preserve enough detail for rollback/debugging.
-
-### 4. Extend `AgentConfig` into Capability Policy
-
-**Why:** This is the most valuable architectural idea from OpenFang. `AllowedTools` is too coarse once you add more autonomy.
-
-**Scope**
-- Extend agent config beyond `allowed_tools` with explicit permissions for shell, filesystem roots, network allowlists, cron, memory writes, and sub-agent spawn.
-- Preserve current config compatibility so existing agents keep working.
-- Keep the first version simple and declarative. Do not build a WASM sandbox.
+**Default Behavior**
+Report is written to `~/.ok-gobot/migration-report-<timestamp>.md` alongside
+the database. `--dry-run` prints to stdout only.
 
 **Likely files**
-- [internal/config/config.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/config/config.go)
-- [internal/agent/registry.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/agent/registry.go)
-- [internal/agent/resolver.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/agent/resolver.go)
-- [docs/ARCHITECTURE.md](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/docs/ARCHITECTURE.md)
+- `internal/cli/migrate.go`
+- `internal/migrate/migrate.go`
 
-**Acceptance criteria**
-- An agent can be configured with narrower rights than another agent.
-- Existing `allowed_tools` configs still load without breakage.
-- Runtime components receive a structured policy object, not ad-hoc booleans.
+### 4. Operator can restrict an agent to read-only tools without editing Go code
 
-### 5. Enforce Policy at Tool Execution Boundaries
+**User Story**
+As an operator, I want to give an agent narrower permissions (no shell, no
+network, read-only filesystem) through config so that I can run less-trusted
+models safely without changing source code.
 
-**Why:** Capability policy is useless if it only filters registry wiring. The checks must live close to execution.
+**Why:** `AllowedTools` is too coarse once you add more autonomy. Operators need
+declarative, fine-grained capability control.
 
-**Scope**
-- Enforce policy in tool entry points, not just in agent selection logic.
-- Add consistent denied-action errors.
-- Cover at least `local`, `ssh`, `browser`, `web_fetch`, `search`, `cron`, and `message`.
+**Acceptance Criteria**
+- [ ] Agent config accepts explicit permissions: shell, filesystem roots, network allowlists, cron, memory writes, sub-agent spawn.
+- [ ] Existing `allowed_tools` configs still load without breakage.
+- [ ] Runtime receives a structured policy object, not ad-hoc booleans.
+- [ ] A restricted agent cannot escalate to a tool outside its policy.
 
-**Likely files**
-- [internal/tools/tools.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/tools/tools.go)
-- [internal/tools/browser_tool.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/tools/browser_tool.go)
-- [internal/tools/web_fetch.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/tools/web_fetch.go)
-- [internal/tools/search.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/tools/search.go)
-- [internal/tools/cron.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/tools/cron.go)
-- [internal/tools/message.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/tools/message.go)
-
-**Acceptance criteria**
-- Tool denial behavior is consistent across all restricted tools.
-- Tests cover both allowed and denied flows.
-- Policy checks survive direct tool invocation paths, not only agent-mediated runs.
-
-### 6. Add Skills Install and Audit
-
-**Why:** This is the cleanest piece to borrow from ZeroClaw's skills story. `ok-gobot` already has the workspace shape for it.
-
-**Scope**
-- Add `skills list|install|remove|audit`.
-- Support install from local path or git URL.
-- Run a static safety audit before accepting a skill: reject symlinks, scripts, pipe-to-shell patterns, and markdown links escaping the skill root.
-- Keep skills markdown-first and compatible with the current workspace model.
+**Default Behavior**
+If no policy block is set, all tools in the agent's `allowed_tools` list remain
+available (full backward compatibility). An empty `allowed_tools` still means
+"all tools."
 
 **Likely files**
-- [internal/cli/root.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/cli/root.go)
+- `internal/config/config.go`
+- `internal/agent/registry.go`
+- `internal/agent/resolver.go`
+- `docs/ARCHITECTURE.md`
+
+### 5. Denied tool calls show a clear reason in Telegram instead of silently failing
+
+**User Story**
+As a user, I want to see why a tool call was blocked so that I understand the
+bot's limitations and can ask an operator to adjust permissions if needed.
+
+**Why:** Capability policy is useless if denied actions are silent. Users lose
+trust when the bot ignores requests without explanation.
+
+**Acceptance Criteria**
+- [ ] Every denied tool call returns a consistent, human-readable reason.
+- [ ] The denial message appears in Telegram, TUI, and API responses.
+- [ ] Tests cover both allowed and denied flows for `local`, `ssh`, `browser`, `web_fetch`, `search`, `cron`, and `message`.
+- [ ] Policy checks survive direct tool invocation, not only agent-mediated runs.
+
+**Default Behavior**
+No tools are denied unless the operator configures capability policy or activates
+estop. When a tool is denied, the user sees: "Tool [name] blocked: [reason]."
+
+**Likely files**
+- `internal/tools/tools.go`
+- `internal/tools/browser_tool.go`
+- `internal/tools/web_fetch.go`
+- `internal/tools/search.go`
+- `internal/tools/cron.go`
+- `internal/tools/message.go`
+
+### 6. Operator can install and audit third-party skills from the CLI
+
+**User Story**
+As an operator, I want to install, list, and remove skills from the CLI so that
+I can extend the bot's capabilities without editing source code, and audit
+installed skills for safety.
+
+**Why:** `ok-gobot` already has the workspace shape for skills. A safe
+install/audit path makes the extension model usable in practice.
+
+**Acceptance Criteria**
+- [ ] `ok-gobot skills list|install|remove|audit` works from the CLI.
+- [ ] Install accepts a local path or git URL.
+- [ ] Static safety audit rejects symlinks, scripts, pipe-to-shell patterns, and markdown links escaping the skill root.
+- [ ] Installed skills are markdown-first and compatible with the workspace model.
+
+**Default Behavior**
+No skills installed out of the box. `skills list` shows an empty list.
+`skills install` runs the safety audit before accepting; unsafe packages are
+rejected with actionable error messages.
+
+**Likely files**
 - `internal/cli/skills.go` (new)
-- [internal/tools/tools.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/tools/tools.go)
-- [docs/INSTALL.md](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/docs/INSTALL.md)
+- `internal/tools/tools.go`
+- `docs/INSTALL.md`
 
-**Acceptance criteria**
-- A skill can be installed from a local path or git source into the workspace.
-- Unsafe skill packages are rejected with actionable error messages.
-- Installed skills are discoverable and removable via CLI.
+### 7. Operator can cap a background task's tool calls, duration, and model cost
 
-### 7. Add Structured Sub-Agent Contracts and Budgets
+**User Story**
+As an operator, I want to set limits on background tasks (max tool calls, max
+duration, model override) so that a runaway subagent cannot consume unbounded
+resources or time.
 
-**Why:** Before shipping autonomous role packs, sub-agents need clearer boundaries.
+**Why:** Subagents currently have no budget constraints. A stuck or recursive
+subagent can exhaust API quota silently.
 
-**Scope**
-- Add task types or templates instead of raw free-form sub-agent spawning only.
-- Add explicit budgets: max tool calls, max duration, model override, and optional memory write permission.
-- Normalize sub-agent results into structured summaries for Telegram and TUI.
+**Acceptance Criteria**
+- [ ] Operator can set max tool calls, max duration, and model override per task.
+- [ ] A task that hits its limit stops and returns a structured summary, not raw output.
+- [ ] Failed or timed-out tasks produce understandable feedback in Telegram and TUI.
+- [ ] Memory writes from subagents can be disabled by policy.
 
-**Likely files**
-- [internal/agent/subagent.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/agent/subagent.go)
-- [internal/bot/task_command.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/bot/task_command.go)
-- [internal/control/server_tui.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/control/server_tui.go)
-- [internal/bot/subagent_notifier.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/bot/subagent_notifier.go)
-
-**Acceptance criteria**
-- Operators can set limits on a sub-agent run.
-- Sub-agent outcomes are rendered as structured summaries instead of only raw text.
-- Failed or timed-out sub-agents produce understandable operator feedback.
-
-### 8. Ship Packaged Autonomous Roles
-
-**Why:** This is the good part of OpenFang's `Hands` idea. The win is not platform theater; the win is prebuilt, useful workflows.
-
-**Scope**
-- Start with 3-5 roles that fit `ok-gobot` and Telegram:
-- `researcher`
-- `monitor`
-- `release-watch`
-- `competitor-watch`
-- `inbox-triage`
-- Roles should run through existing cron + runtime infrastructure, not through a second orchestration system.
+**Default Behavior**
+Default budget: 50 tool calls, 5-minute wall-clock timeout. Model inherits from
+the parent agent. Memory writes allowed unless the agent's capability policy
+disables them.
 
 **Likely files**
-- [internal/cron/scheduler.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/cron/scheduler.go)
-- [internal/agent/subagent.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/agent/subagent.go)
-- [internal/bot/hub_handler.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/bot/hub_handler.go)
-- [internal/bot/subagent_notifier.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/bot/subagent_notifier.go)
+- `internal/agent/subagent.go`
+- `internal/bot/task_command.go`
+- `internal/control/server_tui.go`
+- `internal/bot/subagent_notifier.go`
 
-**Acceptance criteria**
-- A role can be enabled with minimal config.
-- A role runs on schedule and posts a bounded, readable report back to Telegram.
-- A role respects capability policy and `estop`.
+### 8. Operator can enable a prebuilt role that runs on schedule and posts a report
 
-### 9. Add Role Manifests and an Autonomous Report Loop
+**User Story**
+As an operator, I want to enable a prebuilt role (researcher, monitor,
+release-watch) with minimal config so that useful autonomous workflows run on
+schedule and post bounded, readable reports to Telegram.
 
-**Why:** Once the first packaged roles exist, they need a small declarative format and repeatable output contract.
+**Why:** The value of autonomy features is prebuilt, useful workflows — not
+platform infrastructure.
 
-**Scope**
-- Add a lightweight role manifest format describing prompt, tools, schedule, output template, and approval mode.
-- Store role definitions in the workspace so they stay hackable.
-- Persist outputs to markdown memory only when explicitly allowed.
+**Acceptance Criteria**
+- [ ] At least 3 prebuilt roles ship: `researcher`, `monitor`, `release-watch`.
+- [ ] A role can be enabled by adding its name to config — no Go code needed.
+- [ ] Each role runs on schedule via existing cron infrastructure.
+- [ ] Reports are bounded in length and formatted for Telegram readability.
+- [ ] Roles respect capability policy and estop.
+
+**Default Behavior**
+No roles enabled out of the box. Enabling a role requires explicit config. Roles
+run through existing cron + runtime infrastructure, not a second orchestration
+system.
 
 **Likely files**
-- [internal/agent/memory.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/agent/memory.go)
-- [internal/agent/registry.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/agent/registry.go)
-- [internal/bot/hub_handler.go](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/internal/bot/hub_handler.go)
-- [docs/FEATURES.md](/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/docs/FEATURES.md)
+- `internal/cron/scheduler.go`
+- `internal/agent/subagent.go`
+- `internal/bot/hub_handler.go`
+- `internal/bot/subagent_notifier.go`
 
-**Acceptance criteria**
-- Roles are defined declaratively, not hardcoded one by one in Go.
-- Role outputs have a stable report structure.
-- Memory writes from roles can be disabled by policy.
+### 9. Operator can define new roles declaratively without writing Go code
+
+**User Story**
+As an operator, I want to define custom autonomous roles using a simple manifest
+format (prompt, tools, schedule, output template) so that I can create new
+workflows without modifying the bot's source.
+
+**Why:** Hardcoded roles do not scale. Operators need a hackable, workspace-local
+format for role definitions.
+
+**Acceptance Criteria**
+- [ ] Role manifests are defined in a lightweight declarative format stored in the workspace.
+- [ ] A manifest specifies: prompt, tools, schedule, output template, and approval mode.
+- [ ] Role outputs have a stable, structured report format.
+- [ ] Memory writes from roles can be disabled by policy.
+
+**Default Behavior**
+No custom roles defined. Prebuilt roles (item 8) use the same manifest format
+internally, serving as examples.
+
+**Likely files**
+- `internal/agent/memory.go`
+- `internal/agent/registry.go`
+- `internal/bot/hub_handler.go`
+- `docs/FEATURES.md`
 
 ## Non-Goals for Now
 
@@ -231,10 +278,10 @@ The goal is not to copy OpenFang or ZeroClaw wholesale. The goal is to borrow th
 
 If only the first five things get done, the order should be:
 
-1. `estop`
-2. provider/model catalog
-3. migration report
-4. capability policy
-5. skills audit/install
+1. estop — operator can kill dangerous tools instantly
+2. provider/model catalog — user can see what's available and healthy
+3. migration report — operator gets a trustworthy import artifact
+4. capability policy — operator restricts agents through config
+5. tool denial messages — users see why something was blocked
 
 That sequence improves safety, operator UX, and extensibility without pushing `ok-gobot` into platform bloat.


### PR DESCRIPTION
Implements #165

## Changes

**Problem:** v2.0 milestone decomposed 23 issues by technical phase. Infrastructure was built but user-facing policy was never specified — no issue said "the model should use /task for long operations" or "tools should auto-spawn on timeout."

**Solution:** Codify the rule that every feature must have at least one issue phrased as a user outcome, and apply it retroactively to the roadmap.

- **`.github/ISSUE_TEMPLATE/feature.md`** — New GitHub issue template enforcing user-story format with acceptance criteria and default behavior sections.
- **`docs/PROCESS.md`** — Process rule with rationale, bad-vs-good examples table, and a checklist for filing feature issues.
- **`docs/ROADMAP.md`** — Rewrote all 9 backlog items from infrastructure-layer titles to user-outcome titles. Each item now includes a User Story, Acceptance Criteria, and Default Behavior section. Examples:
  - "Add `estop` and Safe Mode" → "Operator can kill dangerous tools instantly without restarting the bot"
  - "Extend `AgentConfig` into Capability Policy" → "Operator can restrict an agent to read-only tools without editing Go code"
  - "Enforce Policy at Tool Execution Boundaries" → "Denied tool calls show a clear reason in Telegram instead of silently failing"

## Testing

- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass
- `CGO_ENABLED=1 go build ./cmd/ok-gobot/` — binary builds successfully
- Documentation-only change; no runtime behavior affected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation-only change that introduces a process rule and applies it retroactively to the roadmap. It adds a GitHub issue template (`.github/ISSUE_TEMPLATE/feature.md`), a new `docs/PROCESS.md` codifying the "decompose by user outcome" rule, and rewrites all 9 `docs/ROADMAP.md` backlog items from infrastructure-layer titles into user-story format with Acceptance Criteria and Default Behavior sections.

- All three files are internally consistent with each other; the process doc's examples, the issue template, and the roadmap items all follow the same structure.
- As a side effect, the old `docs/ROADMAP.md` contained broken absolute local-machine hyperlinks (e.g. `/Users/i065699/work/projects/personal/AI/cli-agents/ok-gobot/...`) in every "Likely files" section; this PR correctly replaces them with backtick-quoted relative paths.
- No runtime code is changed; `go fmt`, `go vet`, and `go test` are unaffected.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — documentation-only change with no runtime impact.
- All changes are Markdown documentation. No logic, code, or configuration is modified. The three new/updated files are internally consistent, broken local file paths from the old roadmap are fixed, and the issue template uses valid GitHub frontmatter. No issues were found.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/feature.md | New GitHub issue template with valid frontmatter enforcing user-story format; no issues found. |
| docs/PROCESS.md | New process doc codifying the user-outcome decomposition rule; content is internally consistent with the roadmap and issue template. |
| docs/ROADMAP.md | All 9 backlog items rewritten with User Story / Acceptance Criteria / Default Behavior sections; broken absolute local-machine file paths replaced with relative backtick references; sequencing section updated consistently. |

</details>

<sub>Reviews (1): Last reviewed commit: ["process: decompose features by user outc..."](https://github.com/befeast/ok-gobot/commit/f24c88117e0ccdc0a225d92b772c5b0c5dca2af7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25961075)</sub>

<!-- /greptile_comment -->