### PR TITLE
feat: codex and claude workers run through shared job API (#170)

### DIFF
--- a/internal/worker/bridge.go
+++ b/internal/worker/bridge.go
@@ -1,0 +1,35 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"ok-gobot/internal/runtime"
+	"ok-gobot/internal/storage"
+)
+
+// AdapterJobRunner returns a runtime.JobRunner that delegates to the given
+// Adapter with a pre-built Request.  The adapter's normalized Result is
+// mapped onto the job's summary and persisted as a text artifact.
+func AdapterJobRunner(adapter Adapter, req Request) runtime.JobRunner {
+	return func(ctx context.Context, job *storage.Job, svc *runtime.JobService) (runtime.JobRunResult, error) {
+		_ = svc.AppendEvent(job.JobID, runtime.JobEventProgress, fmt.Sprintf("running %s task", job.Worker), nil)
+
+		result, err := adapter.Run(ctx, req)
+		if err != nil {
+			return runtime.JobRunResult{}, err
+		}
+
+		return runtime.JobRunResult{
+			Summary: result.Content,
+			Artifacts: []runtime.JobArtifactSpec{
+				{
+					Name:     "output",
+					Type:     "text",
+					MimeType: "text/plain",
+					Content:  result.Content,
+				},
+			},
+		}, nil
+	}
+}

--- a/internal/worker/bridge_test.go
+++ b/internal/worker/bridge_test.go
@@ -1,0 +1,143 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"ok-gobot/internal/runtime"
+	"ok-gobot/internal/storage"
+)
+
+type stubAdapter struct {
+	runResult *Result
+	runErr    error
+}
+
+func (s *stubAdapter) Run(_ context.Context, _ Request) (*Result, error) {
+	return s.runResult, s.runErr
+}
+
+func (s *stubAdapter) Stream(_ context.Context, _ Request) <-chan Event {
+	ch := make(chan Event)
+	close(ch)
+	return ch
+}
+
+func newBridgeTestStore(t *testing.T) *storage.Store {
+	t.Helper()
+	store, err := storage.New(filepath.Join(t.TempDir(), "bridge-test.db"))
+	if err != nil {
+		t.Fatalf("storage.New failed: %v", err)
+	}
+	return store
+}
+
+func TestAdapterJobRunnerSuccess(t *testing.T) {
+	t.Parallel()
+
+	store := newBridgeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const routeKey = "agent:test:telegram:group:200"
+	if err := store.SaveSessionRoute(storage.SessionRoute{
+		SessionKey: routeKey,
+		Channel:    "telegram",
+		ChatID:     200,
+	}); err != nil {
+		t.Fatalf("SaveSessionRoute failed: %v", err)
+	}
+
+	adapter := &stubAdapter{
+		runResult: &Result{Content: "task completed", SessionID: "sess-42"},
+	}
+	runner := AdapterJobRunner(adapter, Request{Task: "build project", Model: "test-model"})
+
+	svc := runtime.NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), runtime.JobSpec{
+		Kind:               "worker_task",
+		Worker:             "stub",
+		SessionKey:         "agent:test:main",
+		DeliverySessionKey: routeKey,
+		Description:        "test bridge",
+		Timeout:            2 * time.Second,
+	}, runner)
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	finished := waitForBridgeJobStatus(t, store, job.JobID, string(runtime.JobStatusSucceeded))
+	if finished.Summary != "task completed" {
+		t.Fatalf("summary = %q, want %q", finished.Summary, "task completed")
+	}
+
+	artifacts, err := store.ListJobArtifacts(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("artifact count = %d, want 1", len(artifacts))
+	}
+	if artifacts[0].Name != "output" || artifacts[0].Content != "task completed" {
+		t.Fatalf("unexpected artifact: %+v", artifacts[0])
+	}
+}
+
+func TestAdapterJobRunnerFailure(t *testing.T) {
+	t.Parallel()
+
+	store := newBridgeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const routeKey = "agent:test:telegram:group:201"
+	if err := store.SaveSessionRoute(storage.SessionRoute{
+		SessionKey: routeKey,
+		Channel:    "telegram",
+		ChatID:     201,
+	}); err != nil {
+		t.Fatalf("SaveSessionRoute failed: %v", err)
+	}
+
+	adapter := &stubAdapter{
+		runErr: errors.New("binary not found"),
+	}
+	runner := AdapterJobRunner(adapter, Request{Task: "fail task"})
+
+	svc := runtime.NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), runtime.JobSpec{
+		Kind:               "worker_task",
+		Worker:             "stub",
+		SessionKey:         "agent:test:main",
+		DeliverySessionKey: routeKey,
+		Description:        "test failure bridge",
+		Timeout:            2 * time.Second,
+	}, runner)
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	finished := waitForBridgeJobStatus(t, store, job.JobID, string(runtime.JobStatusFailed))
+	if finished.Error == "" {
+		t.Fatal("expected error to be stored")
+	}
+}
+
+func waitForBridgeJobStatus(t *testing.T, store *storage.Store, jobID, want string) *storage.Job {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		job, err := store.GetJob(jobID)
+		if err != nil {
+			t.Fatalf("GetJob failed: %v", err)
+		}
+		if job != nil && job.Status == want {
+			return job
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for job %s to reach status %s", jobID, want)
+	return nil
+}

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -1,0 +1,209 @@
+package worker
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"ok-gobot/internal/logger"
+)
+
+// ClaudeConfig holds Claude CLI-specific configuration.
+type ClaudeConfig struct {
+	BinaryPath string `mapstructure:"binary_path"` // Path to claude binary (default: "claude")
+	WorkDir    string `mapstructure:"work_dir"`    // Working directory for claude execution
+}
+
+// ClaudeAdapter executes worker tasks through the Anthropic Claude CLI.
+type ClaudeAdapter struct {
+	config ClaudeConfig
+}
+
+var _ Adapter = (*ClaudeAdapter)(nil)
+
+// NewClaudeAdapter creates a Claude CLI-backed worker adapter.
+func NewClaudeAdapter(cfg ClaudeConfig) *ClaudeAdapter {
+	if cfg.BinaryPath == "" {
+		cfg.BinaryPath = "claude"
+	}
+	return &ClaudeAdapter{config: cfg}
+}
+
+// claudeResult is the JSON envelope returned by `claude -p --output-format json`.
+type claudeResult struct {
+	Result    string `json:"result"`
+	IsError   bool   `json:"is_error"`
+	SessionID string `json:"session_id"`
+}
+
+// claudeStreamEvent is one JSONL line from `claude -p --output-format stream-json`.
+type claudeStreamEvent struct {
+	Type    string `json:"type"`              // "assistant", "result", "system", "error"
+	Subtype string `json:"subtype,omitempty"` // "text", "success", "error"
+	Content string `json:"content,omitempty"`
+	Result  string `json:"result,omitempty"`
+
+	SessionID string `json:"session_id,omitempty"`
+	IsError   bool   `json:"is_error,omitempty"`
+}
+
+func (a *ClaudeAdapter) buildArgs(req Request, outputFmt string) []string {
+	args := []string{"-p", "--output-format", outputFmt}
+
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
+	}
+
+	args = append(args, req.Task)
+	return args
+}
+
+func (a *ClaudeAdapter) workDir(req Request) string {
+	workDir := strings.TrimSpace(req.WorkDir)
+	if workDir == "" {
+		workDir = strings.TrimSpace(a.config.WorkDir)
+	}
+	return workDir
+}
+
+// Run executes a claude task and returns its final output.
+func (a *ClaudeAdapter) Run(ctx context.Context, req Request) (*Result, error) {
+	args := a.buildArgs(req, "json")
+	cmd := exec.CommandContext(ctx, a.config.BinaryPath, args...)
+	if dir := a.workDir(req); dir != "" {
+		cmd.Dir = dir
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("claude exec failed (exit %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("claude exec failed: %w", err)
+	}
+
+	var result claudeResult
+	if err := json.Unmarshal(output, &result); err != nil {
+		return &Result{Content: strings.TrimSpace(string(output))}, nil
+	}
+
+	if result.IsError {
+		return nil, fmt.Errorf("claude error: %s", result.Result)
+	}
+
+	return &Result{
+		Content:   result.Result,
+		SessionID: result.SessionID,
+	}, nil
+}
+
+// Stream executes a claude task in stream-json mode.
+func (a *ClaudeAdapter) Stream(ctx context.Context, req Request) <-chan Event {
+	ch := make(chan Event, 100)
+
+	go func() {
+		defer close(ch)
+
+		args := a.buildArgs(req, "stream-json")
+		cmd := exec.CommandContext(ctx, a.config.BinaryPath, args...)
+		if dir := a.workDir(req); dir != "" {
+			cmd.Dir = dir
+		}
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			ch <- Event{Error: fmt.Errorf("failed to create stdout pipe: %w", err)}
+			return
+		}
+
+		if err := cmd.Start(); err != nil {
+			ch <- Event{Error: fmt.Errorf("failed to start claude: %w", err)}
+			return
+		}
+
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				_ = cmd.Process.Kill()
+				ch <- Event{Error: ctx.Err(), Done: true}
+				return
+			default:
+			}
+
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+
+			var evt claudeStreamEvent
+			if err := json.Unmarshal([]byte(line), &evt); err != nil {
+				continue
+			}
+
+			switch evt.Type {
+			case "assistant":
+				text := evt.Content
+				if text != "" {
+					ch <- Event{Content: text}
+				}
+
+			case "result":
+				if evt.IsError {
+					errMsg := evt.Result
+					if errMsg == "" {
+						errMsg = "unknown claude error"
+					}
+					ch <- Event{Error: fmt.Errorf("claude: %s", errMsg), Done: true}
+					_ = cmd.Wait()
+					return
+				}
+				text := evt.Result
+				if text != "" {
+					ch <- Event{Content: text}
+				}
+				ch <- Event{Done: true}
+				_ = cmd.Wait()
+				return
+
+			case "error":
+				errMsg := evt.Content
+				if errMsg == "" {
+					errMsg = evt.Result
+				}
+				if errMsg == "" {
+					errMsg = "unknown claude error"
+				}
+				ch <- Event{Error: fmt.Errorf("claude: %s", errMsg), Done: true}
+				_ = cmd.Wait()
+				return
+
+			default:
+				logger.Debugf("Claude stream event: type=%s subtype=%s", evt.Type, evt.Subtype)
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			ch <- Event{Error: fmt.Errorf("stream read error: %w", err), Done: true}
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				ch <- Event{
+					Error: fmt.Errorf("claude exited with code %d: %s",
+						exitErr.ExitCode(), string(exitErr.Stderr)),
+					Done: true,
+				}
+			}
+		} else {
+			ch <- Event{Done: true}
+		}
+	}()
+
+	return ch
+}

--- a/internal/worker/claude_test.go
+++ b/internal/worker/claude_test.go
@@ -1,0 +1,251 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNewClaudeAdapter_Defaults(t *testing.T) {
+	adapter := NewClaudeAdapter(ClaudeConfig{})
+	if adapter.config.BinaryPath != "claude" {
+		t.Fatalf("binary_path = %q, want %q", adapter.config.BinaryPath, "claude")
+	}
+}
+
+func TestClaudeAdapterBuildArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   ClaudeConfig
+		req      Request
+		outFmt   string
+		wantArgs []string
+	}{
+		{
+			name:     "minimal json",
+			config:   ClaudeConfig{BinaryPath: "claude"},
+			req:      Request{Task: "hello", Model: "claude-sonnet-4-5"},
+			outFmt:   "json",
+			wantArgs: []string{"-p", "--output-format", "json", "--model", "claude-sonnet-4-5", "hello"},
+		},
+		{
+			name:     "stream-json no model",
+			config:   ClaudeConfig{BinaryPath: "claude"},
+			req:      Request{Task: "do stuff"},
+			outFmt:   "stream-json",
+			wantArgs: []string{"-p", "--output-format", "stream-json", "do stuff"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewClaudeAdapter(tt.config)
+			got := adapter.buildArgs(tt.req, tt.outFmt)
+
+			if len(got) != len(tt.wantArgs) {
+				t.Fatalf("arg count: got %d, want %d\n  got:  %v\n  want: %v", len(got), len(tt.wantArgs), got, tt.wantArgs)
+			}
+			for i, g := range got {
+				if g != tt.wantArgs[i] {
+					t.Fatalf("arg[%d] = %q, want %q", i, g, tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestClaudeAdapterWorkDir(t *testing.T) {
+	t.Run("request overrides adapter", func(t *testing.T) {
+		adapter := NewClaudeAdapter(ClaudeConfig{WorkDir: "/tmp/default"})
+		got := adapter.workDir(Request{WorkDir: "/tmp/override"})
+		if got != "/tmp/override" {
+			t.Fatalf("workDir = %q, want %q", got, "/tmp/override")
+		}
+	})
+
+	t.Run("adapter fallback", func(t *testing.T) {
+		adapter := NewClaudeAdapter(ClaudeConfig{WorkDir: "/tmp/default"})
+		got := adapter.workDir(Request{})
+		if got != "/tmp/default" {
+			t.Fatalf("workDir = %q, want %q", got, "/tmp/default")
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		adapter := NewClaudeAdapter(ClaudeConfig{})
+		got := adapter.workDir(Request{})
+		if got != "" {
+			t.Fatalf("workDir = %q, want empty", got)
+		}
+	})
+}
+
+func TestClaudeAdapterRunBinaryNotFound(t *testing.T) {
+	adapter := NewClaudeAdapter(ClaudeConfig{BinaryPath: "/nonexistent/claude-binary-12345"})
+
+	_, err := adapter.Run(context.Background(), Request{
+		Task:  "test",
+		Model: "claude-sonnet-4-5",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	if !strings.Contains(err.Error(), "claude exec failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClaudeAdapterRunMockJSON(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "claude")
+	mockScript := `#!/bin/sh
+echo '{"result":"Hello from mock claude","is_error":false,"session_id":"sess-claude-1"}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewClaudeAdapter(ClaudeConfig{BinaryPath: mockBinary})
+	result, err := adapter.Run(context.Background(), Request{
+		Task:  "test",
+		Model: "claude-sonnet-4-5",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Content != "Hello from mock claude" {
+		t.Fatalf("content = %q, want %q", result.Content, "Hello from mock claude")
+	}
+	if result.SessionID != "sess-claude-1" {
+		t.Fatalf("session_id = %q, want %q", result.SessionID, "sess-claude-1")
+	}
+}
+
+func TestClaudeAdapterRunErrorResult(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "claude")
+	mockScript := `#!/bin/sh
+echo '{"result":"rate limit","is_error":true,"session_id":""}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewClaudeAdapter(ClaudeConfig{BinaryPath: mockBinary})
+	_, err := adapter.Run(context.Background(), Request{Task: "test"})
+	if err == nil {
+		t.Fatal("expected error for is_error=true result")
+	}
+	if !strings.Contains(err.Error(), "rate limit") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClaudeAdapterStreamMock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "claude")
+	mockScript := `#!/bin/sh
+echo '{"type":"assistant","subtype":"text","content":"Hello "}'
+echo '{"type":"assistant","subtype":"text","content":"world!"}'
+echo '{"type":"result","subtype":"success","result":"Hello world!","session_id":"sess-stream-1","is_error":false}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewClaudeAdapter(ClaudeConfig{BinaryPath: mockBinary})
+	ch := adapter.Stream(context.Background(), Request{
+		Task:  "test",
+		Model: "claude-sonnet-4-5",
+	})
+
+	var events []Event
+	for evt := range ch {
+		events = append(events, evt)
+	}
+
+	if len(events) != 4 {
+		t.Fatalf("event count = %d, want 4\nevents: %+v", len(events), events)
+	}
+	if events[0].Content != "Hello " || events[1].Content != "world!" {
+		t.Fatalf("unexpected content events: %+v", events)
+	}
+	if events[2].Content != "Hello world!" {
+		t.Fatalf("result content = %q, want %q", events[2].Content, "Hello world!")
+	}
+	if !events[3].Done || events[3].Error != nil {
+		t.Fatalf("final event = %+v, want done without error", events[3])
+	}
+}
+
+func TestClaudeAdapterStreamError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "claude")
+	mockScript := `#!/bin/sh
+echo '{"type":"assistant","subtype":"text","content":"partial "}'
+echo '{"type":"error","content":"service unavailable"}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewClaudeAdapter(ClaudeConfig{BinaryPath: mockBinary})
+	ch := adapter.Stream(context.Background(), Request{Task: "test"})
+
+	var gotError bool
+	for evt := range ch {
+		if evt.Error != nil {
+			gotError = true
+			if !strings.Contains(evt.Error.Error(), "service unavailable") {
+				t.Fatalf("unexpected error: %v", evt.Error)
+			}
+		}
+	}
+	if !gotError {
+		t.Fatal("expected error event in stream")
+	}
+}
+
+func TestClaudeAdapterContextCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "claude")
+	mockScript := `#!/bin/sh
+sleep 30
+echo '{"result":"should not reach","is_error":false}'
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewClaudeAdapter(ClaudeConfig{BinaryPath: mockBinary})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := adapter.Run(ctx, Request{Task: "test"})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}

--- a/internal/worker/codex.go
+++ b/internal/worker/codex.go
@@ -1,0 +1,130 @@
+package worker
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// CodexConfig holds Codex CLI-specific configuration.
+type CodexConfig struct {
+	BinaryPath string `mapstructure:"binary_path"` // Path to codex binary (default: "codex")
+	WorkDir    string `mapstructure:"work_dir"`    // Working directory for codex execution
+}
+
+// CodexAdapter executes worker tasks through the OpenAI Codex CLI.
+type CodexAdapter struct {
+	config CodexConfig
+}
+
+var _ Adapter = (*CodexAdapter)(nil)
+
+// NewCodexAdapter creates a Codex CLI-backed worker adapter.
+func NewCodexAdapter(cfg CodexConfig) *CodexAdapter {
+	if cfg.BinaryPath == "" {
+		cfg.BinaryPath = "codex"
+	}
+	return &CodexAdapter{config: cfg}
+}
+
+func (a *CodexAdapter) buildArgs(req Request) []string {
+	args := []string{"--quiet", "--full-auto"}
+
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
+	}
+
+	args = append(args, req.Task)
+	return args
+}
+
+func (a *CodexAdapter) workDir(req Request) string {
+	workDir := strings.TrimSpace(req.WorkDir)
+	if workDir == "" {
+		workDir = strings.TrimSpace(a.config.WorkDir)
+	}
+	return workDir
+}
+
+// Run executes a codex task and returns its final output.
+func (a *CodexAdapter) Run(ctx context.Context, req Request) (*Result, error) {
+	args := a.buildArgs(req)
+	cmd := exec.CommandContext(ctx, a.config.BinaryPath, args...)
+	if dir := a.workDir(req); dir != "" {
+		cmd.Dir = dir
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("codex exec failed (exit %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("codex exec failed: %w", err)
+	}
+
+	return &Result{Content: strings.TrimSpace(string(output))}, nil
+}
+
+// Stream executes a codex task and streams stdout line by line.
+func (a *CodexAdapter) Stream(ctx context.Context, req Request) <-chan Event {
+	ch := make(chan Event, 100)
+
+	go func() {
+		defer close(ch)
+
+		args := a.buildArgs(req)
+		cmd := exec.CommandContext(ctx, a.config.BinaryPath, args...)
+		if dir := a.workDir(req); dir != "" {
+			cmd.Dir = dir
+		}
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			ch <- Event{Error: fmt.Errorf("failed to create stdout pipe: %w", err)}
+			return
+		}
+
+		if err := cmd.Start(); err != nil {
+			ch <- Event{Error: fmt.Errorf("failed to start codex: %w", err)}
+			return
+		}
+
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				_ = cmd.Process.Kill()
+				ch <- Event{Error: ctx.Err(), Done: true}
+				return
+			default:
+			}
+
+			line := scanner.Text()
+			if line != "" {
+				ch <- Event{Content: line}
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			ch <- Event{Error: fmt.Errorf("stream read error: %w", err), Done: true}
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				ch <- Event{
+					Error: fmt.Errorf("codex exited with code %d: %s",
+						exitErr.ExitCode(), string(exitErr.Stderr)),
+					Done: true,
+				}
+			}
+		} else {
+			ch <- Event{Done: true}
+		}
+	}()
+
+	return ch
+}

--- a/internal/worker/codex_test.go
+++ b/internal/worker/codex_test.go
@@ -1,0 +1,214 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNewCodexAdapter_Defaults(t *testing.T) {
+	adapter := NewCodexAdapter(CodexConfig{})
+	if adapter.config.BinaryPath != "codex" {
+		t.Fatalf("binary_path = %q, want %q", adapter.config.BinaryPath, "codex")
+	}
+}
+
+func TestCodexAdapterBuildArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   CodexConfig
+		req      Request
+		wantArgs []string
+	}{
+		{
+			name:     "minimal",
+			config:   CodexConfig{BinaryPath: "codex"},
+			req:      Request{Task: "hello", Model: "o3"},
+			wantArgs: []string{"--quiet", "--full-auto", "--model", "o3", "hello"},
+		},
+		{
+			name:     "no model",
+			config:   CodexConfig{BinaryPath: "codex"},
+			req:      Request{Task: "do stuff"},
+			wantArgs: []string{"--quiet", "--full-auto", "do stuff"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := NewCodexAdapter(tt.config)
+			got := adapter.buildArgs(tt.req)
+
+			if len(got) != len(tt.wantArgs) {
+				t.Fatalf("arg count: got %d, want %d\n  got:  %v\n  want: %v", len(got), len(tt.wantArgs), got, tt.wantArgs)
+			}
+			for i, g := range got {
+				if g != tt.wantArgs[i] {
+					t.Fatalf("arg[%d] = %q, want %q", i, g, tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCodexAdapterWorkDir(t *testing.T) {
+	t.Run("request overrides adapter", func(t *testing.T) {
+		adapter := NewCodexAdapter(CodexConfig{WorkDir: "/tmp/default"})
+		got := adapter.workDir(Request{WorkDir: "/tmp/override"})
+		if got != "/tmp/override" {
+			t.Fatalf("workDir = %q, want %q", got, "/tmp/override")
+		}
+	})
+
+	t.Run("adapter fallback", func(t *testing.T) {
+		adapter := NewCodexAdapter(CodexConfig{WorkDir: "/tmp/default"})
+		got := adapter.workDir(Request{})
+		if got != "/tmp/default" {
+			t.Fatalf("workDir = %q, want %q", got, "/tmp/default")
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		adapter := NewCodexAdapter(CodexConfig{})
+		got := adapter.workDir(Request{})
+		if got != "" {
+			t.Fatalf("workDir = %q, want empty", got)
+		}
+	})
+}
+
+func TestCodexAdapterRunBinaryNotFound(t *testing.T) {
+	adapter := NewCodexAdapter(CodexConfig{BinaryPath: "/nonexistent/codex-binary-12345"})
+
+	_, err := adapter.Run(context.Background(), Request{
+		Task:  "test",
+		Model: "o3",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	if !strings.Contains(err.Error(), "codex exec failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCodexAdapterRunMockScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "codex")
+	mockScript := `#!/bin/sh
+echo "Hello from mock codex"
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewCodexAdapter(CodexConfig{BinaryPath: mockBinary})
+	result, err := adapter.Run(context.Background(), Request{
+		Task:  "test",
+		Model: "o3",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Content != "Hello from mock codex" {
+		t.Fatalf("content = %q, want %q", result.Content, "Hello from mock codex")
+	}
+}
+
+func TestCodexAdapterStreamMockScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "codex")
+	mockScript := `#!/bin/sh
+echo "Hello "
+echo "world!"
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewCodexAdapter(CodexConfig{BinaryPath: mockBinary})
+	ch := adapter.Stream(context.Background(), Request{
+		Task:  "test",
+		Model: "o3",
+	})
+
+	var events []Event
+	for evt := range ch {
+		events = append(events, evt)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("event count = %d, want 3\nevents: %+v", len(events), events)
+	}
+	if events[0].Content != "Hello " || events[1].Content != "world!" {
+		t.Fatalf("unexpected content events: %+v", events)
+	}
+	if !events[2].Done || events[2].Error != nil {
+		t.Fatalf("final event = %+v, want done without error", events[2])
+	}
+}
+
+func TestCodexAdapterStreamExitError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "codex")
+	mockScript := `#!/bin/sh
+echo "partial output"
+exit 1
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewCodexAdapter(CodexConfig{BinaryPath: mockBinary})
+	ch := adapter.Stream(context.Background(), Request{Task: "test"})
+
+	var gotError bool
+	for evt := range ch {
+		if evt.Error != nil {
+			gotError = true
+		}
+	}
+	if !gotError {
+		t.Fatal("expected error event for non-zero exit")
+	}
+}
+
+func TestCodexAdapterContextCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "codex")
+	mockScript := `#!/bin/sh
+sleep 30
+echo "should not reach"
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewCodexAdapter(CodexConfig{BinaryPath: mockBinary})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := adapter.Run(ctx, Request{Task: "test"})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}


### PR DESCRIPTION
Implements #170

## Changes

Adds Codex and Claude CLI adapters behind the shared `worker.Adapter` contract with normalized task and result handling:

- **`ClaudeAdapter`** (`internal/worker/claude.go`): Spawns `claude -p` with `--output-format json` for blocking runs and `--output-format stream-json` for streaming. Parses structured JSON results including session ID and error detection.
- **`CodexAdapter`** (`internal/worker/codex.go`): Spawns `codex --quiet --full-auto` for non-interactive execution. Captures plain text output for blocking runs and streams stdout line-by-line.
- **`AdapterJobRunner`** (`internal/worker/bridge.go`): Bridge function that converts any `worker.Adapter` + `worker.Request` into a `runtime.JobRunner`, enabling use with `JobService.StartDetached()` for durable background execution with lifecycle events and artifact persistence.

Both adapters follow the same patterns as the existing `DroidAdapter`: subprocess lifecycle management, context cancellation, configurable binary path and working directory, and streaming via buffered line scanning.

## Testing

- Unit tests for both adapters: default config, argument building, working directory resolution, mock script execution (Run + Stream), error handling, and context cancellation
- Integration test for the bridge: verifies adapter results flow through `JobService.StartDetached()` with correct status transitions, summary persistence, and artifact storage
- All 27 new tests pass alongside existing test suite
- `go fmt`, `go vet`, `go test ./...`, and `CGO_ENABLED=1 go build ./cmd/ok-gobot/` all pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `ClaudeAdapter` and `CodexAdapter` — two new `worker.Adapter` implementations that spawn the respective CLI tools as subprocesses — along with `AdapterJobRunner`, a bridge that wires any adapter into `JobService.StartDetached()` for durable background execution. The implementation closely mirrors the existing `DroidAdapter` pattern, and the 27-test suite covers defaults, arg construction, workdir resolution, mock-script execution, streaming, error handling, and context cancellation.

Key observations:
- All three adapters (`claude`, `codex`, `droid`) share a missing `cmd.Wait()` call in the context-cancellation path inside the streaming scan loop; killing the process without reaping it leaves a zombie entry in the process table for the life of the parent service.
- The bridge correctly maps `Result.Content` to both job summary and a `text/plain` artifact; `Result.SessionID` is not threaded through (no field in `JobRunResult` for it), which is fine as a starting point.
- Streaming error-handling is consistent with `droid.go`: a non-`ExitError` from `cmd.Wait()` produces neither a `Done` event nor an error event before the channel closes — consumers relying on range-over-channel are unaffected, but explicit `Done`-flag consumers may miss the signal.

<h3>Confidence Score: 4/5</h3>

- PR is safe to merge; one low-severity resource-leak (zombie processes on context cancel) should be fixed but does not block the feature.
- The implementation is well-structured, well-tested, and consistent with existing patterns. The single flagged issue — missing cmd.Wait() after process kill — is a pre-existing pattern inherited from droid.go and represents a minor resource leak rather than a correctness or data-loss bug. Fixing it in all three adapters together would be the clean path forward.
- internal/worker/claude.go and internal/worker/codex.go — both carry the missing cmd.Wait() in the context-cancellation path of Stream().

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/bridge.go | Clean adapter-to-JobRunner bridge; ignores result.SessionID (not stored in JobRunResult), but that's a design limitation of JobRunResult rather than a bug. |
| internal/worker/claude.go | Solid Claude CLI adapter following existing droid patterns; carries over the zombie-process issue from droid.go where context cancellation during streaming does not call cmd.Wait() before returning. |
| internal/worker/codex.go | Straightforward Codex CLI adapter; same missing cmd.Wait() after kill in the context-cancellation path as claude.go and droid.go. |
| internal/worker/bridge_test.go | Good integration tests covering success, failure, artifact storage, and status transitions through JobService.StartDetached(). |
| internal/worker/claude_test.go | Comprehensive tests using shell-script mocks; covers defaults, arg building, workdir resolution, mock JSON run, error result, streaming, and context cancellation. |
| internal/worker/codex_test.go | Mirrors claude_test.go coverage for the Codex adapter; good range of unit and mock-script tests. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/worker/claude.go
Line: 138-141

Comment:
**Zombie process from missing `cmd.Wait()` after kill**

When the context is cancelled mid-scan, the goroutine kills the process and returns immediately without calling `cmd.Wait()`. On Linux/macOS, a killed child process that has never been waited on becomes a zombie — it stays in the process table until the parent itself exits. In a long-running bot service that spawns many tasks this can silently accumulate zombie entries.

The same pattern is present in `codex.go` (lines 98-102) and in the original `droid.go`, so the fix should be applied consistently across all three:

```go
case <-ctx.Done():
    _ = cmd.Process.Kill()
    _ = cmd.Wait() // reap the child so it doesn't become a zombie
    ch <- Event{Error: ctx.Err(), Done: true}
    return
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(runtime): add codex and claude CLI ..."](https://github.com/befeast/ok-gobot/commit/da5e741033175f34db0b255f42f221465092d3be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25961112)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->