### PR TITLE
process: require tracked default-behavior issues for configurable features (#164)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What changed and why? Link the issue: Implements #NNN -->
+
+## Changes
+
+-
+
+## Testing
+
+-
+
+## Default Behavior Checklist
+
+<!-- If this PR adds or changes a configurable option with modes, defaults, or
+     enumerated values, all boxes below must be checked before merge.
+     See docs/PROCESS-DEFAULTS.md for the full policy. -->
+
+- [ ] Does this PR add or change a configurable option?
+- [ ] Is the default value documented and justified in the PR description?
+- [ ] Is there a separate issue tracking the default choice? (titled "Set default X to Y")

--- a/docs/PROCESS-DEFAULTS.md
+++ b/docs/PROCESS-DEFAULTS.md
@@ -1,0 +1,56 @@
+# Process: Default Behavior for Configurable Features
+
+## Problem
+
+Queue modes were added in a grab-bag commit (`a5bca2d`, Jan 29 2026) with
+`collect` as the default. No issue tracked that default choice. The wrong
+default shipped and went unnoticed for 6 weeks until it was corrected to
+`interrupt`.
+
+Burying default choices inside implementation commits makes them invisible
+to review and impossible to find later when the default turns out to be wrong.
+
+## Rule
+
+When a feature has modes, options, or configurable behavior:
+
+1. Create a **separate issue** titled **"Set default X to Y"** with rationale.
+2. The issue body must answer: **"Why is this default correct for the project
+   goals?"**
+3. Do not bury default choices in implementation commits.
+
+The issue does not need to block the implementation PR, but the default must
+be an explicit, reviewable decision — not a side-effect of whatever value
+happened to appear first in an enum.
+
+## PR Review Checklist
+
+Every PR that adds or changes a configurable option must satisfy:
+
+- [ ] Does this PR add or change a configurable option?
+- [ ] Is the default value documented and justified?
+- [ ] Is there a separate issue tracking the default choice?
+
+The checklist is enforced via `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Inventory of Current Defaults
+
+All configurable options with modes/enums as of the canonical config in
+`docs/ARCHITECTURE.md` Section 9, plus runtime defaults in code.
+
+| Option | Default | Modes | Rationale |
+|---|---|---|---|
+| `ai.provider` | `openrouter` | openrouter, openai, anthropic, chatgpt, droid, custom | Widest model access for a single key |
+| `ai.droid.auto_level` | `""` (off) | low, medium, high | Conservative: no autonomy unless operator opts in |
+| `auth.mode` | `open` | open, allowlist, pairing | Lowest friction for single-operator setup |
+| `session.dm_scope` | `main` | main, per_user | Single shared session matches single-operator use case |
+| `groups.default_mode` | `standby` | active, standby | Bot should not speak in groups unless explicitly activated |
+| `tts.provider` | `openai` | openai, edge | Higher voice quality out of the box |
+| `log_level` | `info` | debug, info, warn, error | Standard observability level |
+| Queue mode | `interrupt` | collect, steer, interrupt | Most responsive UX — new message cancels stale run (fixed from original `collect` default) |
+| estop | off (all tools enabled) | on, off | Operator starts with full capability; kill-switch is opt-in |
+| `control.enabled` | `false` | true, false | Security: no network listener unless operator enables it |
+| `api.enabled` | `false` | true, false | Security: no HTTP surface unless operator enables it |
+| `memory.enabled` | `false` | true, false | Requires embeddings API key; off until configured |
+
+Future features with modes must follow this process before merge.


### PR DESCRIPTION
Implements #164

## Summary

- Add `.github/PULL_REQUEST_TEMPLATE.md` with a default-behavior checklist that gates every PR adding configurable options
- Add `docs/PROCESS-DEFAULTS.md` codifying the rule that every feature with modes/options must have a separate issue tracking the default choice with rationale
- Include an inventory of all current defaults (queue mode, auth mode, estop, group mode, etc.) with their justifications

## Changes

**`.github/PULL_REQUEST_TEMPLATE.md`** — PR template with three-item checklist:
1. Does this PR add or change a configurable option?
2. Is the default documented and justified?
3. Is there a separate issue tracking the default choice?

**`docs/PROCESS-DEFAULTS.md`** — Process document covering:
- The incident that motivated this rule (queue mode default shipped as `collect` instead of `interrupt`)
- The rule: separate issue titled "Set default X to Y" with rationale
- Full inventory of all current configurable defaults with modes and justifications

## Testing

- `go fmt`, `go vet`, `go test ./...` all pass
- `CGO_ENABLED=1 go build ./cmd/ok-gobot/` succeeds
- Documentation-only change — no runtime behavior affected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a documentation-only PR that introduces a PR template and a process document to enforce explicit tracking of default-behavior decisions for configurable features, motivated by a past incident where the wrong queue-mode default shipped unreviewed.

- Adds `.github/PULL_REQUEST_TEMPLATE.md` with a three-item "Default Behavior Checklist" that applies to any PR touching configurable options.
- Adds `docs/PROCESS-DEFAULTS.md` explaining the motivating incident, the rule (a separate "Set default X to Y" issue with rationale), and an inventory of all current defaults with their justifications.
- No runtime behavior is affected — `go fmt`, `go vet`, `go test`, and `go build` all pass unchanged.

<h3>Confidence Score: 5/5</h3>

- Documentation-only change with no runtime impact; safe to merge.
- Both files are purely additive documentation. The PR template and process doc are internally consistent, the inventory table matches the described codebase defaults, and no code paths are modified.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/PULL_REQUEST_TEMPLATE.md | Adds a PR template with a Default Behavior Checklist that gates any PR touching configurable options; content is clear and consistent with the companion process doc. |
| docs/PROCESS-DEFAULTS.md | New process document codifying the rule for tracking default-behavior decisions; the inventory table of current defaults is well-reasoned and consistent with the described runtime behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["process: require tracked default-behavio..."](https://github.com/befeast/ok-gobot/commit/a5a3f3f466c5c06ae0199a9781b9c25372c94785) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25961218)</sub>

<!-- /greptile_comment -->