### PR TITLE
feat: migration emits a durable report artifact (#162)

### DIFF
--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -61,12 +61,33 @@ Example (dry-run first, then apply):
 
 			printMigrateHeader(dryRun)
 
-			report, err := migrate.Run(opts)
-			if err != nil {
-				return err
+			report, runErr := migrate.Run(opts)
+
+			// Write report even on partial failure for debugging.
+			if report != nil {
+				reportPath, writeErr := migrate.WriteReport(report, opts, "")
+				if writeErr != nil {
+					fmt.Printf("%sWarning: could not write report: %v%s\n", colorYellow, writeErr, colorReset)
+				} else {
+					report.ReportPath = reportPath
+				}
+			}
+
+			if runErr != nil {
+				// If we have a partial report, print what we have before returning the error.
+				if report != nil {
+					printReport(report, opts)
+					if report.ReportPath != "" {
+						fmt.Printf("\nPartial report saved to: %s\n", report.ReportPath)
+					}
+				}
+				return runErr
 			}
 
 			printReport(report, opts)
+			if report.ReportPath != "" {
+				fmt.Printf("\nReport saved to: %s\n", report.ReportPath)
+			}
 			return nil
 		},
 	}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -70,6 +70,8 @@ type Report struct {
 	WorkspaceFiles   int
 	KeyMapping       []KeyMapping
 	Errors           []string
+	DryRun           bool
+	ReportPath       string
 }
 
 // KeyMapping shows how an OpenClaw chat_id maps to a gobot canonical session key.
@@ -120,7 +122,7 @@ func Run(opts Options) (*Report, error) {
 		opts.AgentID = "default"
 	}
 
-	report := &Report{}
+	report := &Report{DryRun: opts.DryRun}
 
 	// --- Open source database (read-only) ---
 	srcDB, err := sql.Open("sqlite3", "file:"+opts.SourceDB+"?mode=ro")
@@ -204,29 +206,29 @@ func Run(opts Options) (*Report, error) {
 	if opts.TargetDB != "" {
 		backupPath, err := backupDB(opts.TargetDB, opts.BackupDir)
 		if err != nil {
-			return nil, fmt.Errorf("migrate: backup target DB: %w", err)
+			return report, fmt.Errorf("migrate: backup target DB: %w", err)
 		}
 		report.BackupPath = backupPath
 	}
 
 	// --- Open target database (read-write) ---
 	if opts.TargetDB == "" {
-		return nil, fmt.Errorf("migrate: target database path is required for apply mode")
+		return report, fmt.Errorf("migrate: target database path is required for apply mode")
 	}
 
 	dstDB, err := sql.Open("sqlite3", opts.TargetDB)
 	if err != nil {
-		return nil, fmt.Errorf("migrate: open target DB: %w", err)
+		return report, fmt.Errorf("migrate: open target DB: %w", err)
 	}
 	defer dstDB.Close()
 
 	if err := dstDB.Ping(); err != nil {
-		return nil, fmt.Errorf("migrate: cannot access target DB %q: %w", opts.TargetDB, err)
+		return report, fmt.Errorf("migrate: cannot access target DB %q: %w", opts.TargetDB, err)
 	}
 
 	// Ensure target schema is compatible.
 	if err := ensureTargetSchema(dstDB); err != nil {
-		return nil, fmt.Errorf("migrate: ensure target schema: %w", err)
+		return report, fmt.Errorf("migrate: ensure target schema: %w", err)
 	}
 
 	// --- Migrate sessions ---

--- a/internal/migrate/report.go
+++ b/internal/migrate/report.go
@@ -1,0 +1,145 @@
+package migrate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// WriteReport renders the migration report as markdown and writes it to
+// ~/.ok-gobot/migration-report-YYYY-MM-DD.md. It returns the path written.
+// When reportDir is non-empty it overrides the default directory (useful for tests).
+func WriteReport(r *Report, opts Options, reportDir string) (string, error) {
+	if reportDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("report: resolve home dir: %w", err)
+		}
+		reportDir = filepath.Join(homeDir, ".ok-gobot")
+	}
+	if err := os.MkdirAll(reportDir, 0750); err != nil {
+		return "", fmt.Errorf("report: create dir: %w", err)
+	}
+
+	datestamp := time.Now().Format("2006-01-02")
+	reportPath := filepath.Join(reportDir, "migration-report-"+datestamp+".md")
+
+	content := renderReport(r, opts)
+
+	if err := os.WriteFile(reportPath, []byte(content), 0640); err != nil {
+		return "", fmt.Errorf("report: write file: %w", err)
+	}
+	return reportPath, nil
+}
+
+// renderReport builds the markdown string for a migration report.
+func renderReport(r *Report, opts Options) string {
+	var b strings.Builder
+
+	// Header
+	b.WriteString("# Migration Report\n\n")
+	if r.DryRun {
+		b.WriteString("**Mode:** dry-run (no files were modified)\n\n")
+	} else {
+		b.WriteString("**Mode:** apply\n\n")
+	}
+	b.WriteString(fmt.Sprintf("**Date:** %s\n\n", time.Now().Format("2006-01-02 15:04:05 UTC")))
+	b.WriteString(fmt.Sprintf("**Source DB:** `%s`\n\n", opts.SourceDB))
+	if opts.TargetDB != "" {
+		b.WriteString(fmt.Sprintf("**Target DB:** `%s`\n\n", opts.TargetDB))
+	}
+	if opts.AgentID != "" {
+		b.WriteString(fmt.Sprintf("**Agent ID:** `%s`\n\n", opts.AgentID))
+	}
+
+	// Backup
+	if r.BackupPath != "" {
+		b.WriteString("## Backup\n\n")
+		b.WriteString(fmt.Sprintf("- Path: `%s`\n", r.BackupPath))
+		b.WriteString(fmt.Sprintf("- Rollback: `cp %q %q`\n", r.BackupPath, opts.TargetDB))
+		b.WriteString("\n")
+	}
+
+	// Summary
+	b.WriteString("## Summary\n\n")
+	b.WriteString("| Metric | Total | Migrated | Skipped |\n")
+	b.WriteString("|--------|------:|---------:|--------:|\n")
+	b.WriteString(fmt.Sprintf("| Sessions | %d | %d | %d |\n", r.SessionsTotal, r.SessionsMigrated, r.SessionsSkipped))
+	b.WriteString(fmt.Sprintf("| Messages | %d | %d | %d |\n", r.MessagesTotal, r.MessagesMigrated, r.MessagesSkipped))
+	b.WriteString(fmt.Sprintf("| Workspace files | %d | — | — |\n", r.WorkspaceFiles))
+	b.WriteString("\n")
+
+	// Workspace files (copied)
+	if opts.SourceWorkspace != "" {
+		b.WriteString("## Workspace Files\n\n")
+		b.WriteString(fmt.Sprintf("- Source: `%s`\n", opts.SourceWorkspace))
+		if opts.TargetWorkspace != "" {
+			b.WriteString(fmt.Sprintf("- Target: `%s`\n", opts.TargetWorkspace))
+		}
+		fileActions := filterActions(r.Actions, "workspace_file")
+		if len(fileActions) > 0 {
+			b.WriteString("\n")
+			for _, a := range fileActions {
+				b.WriteString(fmt.Sprintf("- %s\n", a.Summary))
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	// Canonical key mapping
+	if len(r.KeyMapping) > 0 {
+		b.WriteString("## Key Mapping\n\n")
+		b.WriteString("| chat_id | type | canonical key |\n")
+		b.WriteString("|--------:|------|---------------|\n")
+		for _, km := range r.KeyMapping {
+			b.WriteString(fmt.Sprintf("| %d | %s | `%s` |\n", km.ChatID, km.ChatType, km.CanonicalKey))
+		}
+		b.WriteString("\n")
+	}
+
+	// Sessions imported
+	sessionActions := filterActions(r.Actions, "session")
+	if len(sessionActions) > 0 {
+		b.WriteString("## Sessions\n\n")
+		for _, a := range sessionActions {
+			b.WriteString(fmt.Sprintf("- %s\n", a.Summary))
+		}
+		b.WriteString("\n")
+	}
+
+	// Entries skipped (dedup / errors)
+	if r.SessionsSkipped > 0 || r.MessagesSkipped > 0 {
+		b.WriteString("## Entries Skipped\n\n")
+		if r.SessionsSkipped > 0 {
+			b.WriteString(fmt.Sprintf("- **%d session(s)** skipped (already exist in target)\n", r.SessionsSkipped))
+		}
+		if r.MessagesSkipped > 0 {
+			b.WriteString(fmt.Sprintf("- **%d message(s)** skipped (duplicate or missing session)\n", r.MessagesSkipped))
+		}
+		b.WriteString("\n")
+	}
+
+	// Errors
+	if len(r.Errors) > 0 {
+		b.WriteString("## Errors\n\n")
+		for _, e := range r.Errors {
+			b.WriteString(fmt.Sprintf("- %s\n", strings.TrimSpace(e)))
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// filterActions returns actions matching the given kind.
+func filterActions(actions []Action, kind string) []Action {
+	var out []Action
+	for _, a := range actions {
+		if a.Kind == kind {
+			out = append(out, a)
+		}
+	}
+	return out
+}

--- a/internal/migrate/report_test.go
+++ b/internal/migrate/report_test.go
@@ -1,0 +1,215 @@
+package migrate_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/migrate"
+)
+
+func TestWriteReport_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	report := &migrate.Report{
+		BackupPath:       "/tmp/backup/gobot-20260322.db",
+		SessionsTotal:    5,
+		SessionsMigrated: 3,
+		SessionsSkipped:  2,
+		MessagesTotal:    20,
+		MessagesMigrated: 15,
+		MessagesSkipped:  5,
+		WorkspaceFiles:   2,
+		KeyMapping: []migrate.KeyMapping{
+			{ChatID: -100123456, ChatType: "group", CanonicalKey: "agent:default:telegram:group:-100123456"},
+			{ChatID: 987654321, ChatType: "private", CanonicalKey: "agent:default:telegram:dm:987654321"},
+		},
+		Actions: []migrate.Action{
+			{Kind: "session", Summary: "import session chat_id=-100123456"},
+			{Kind: "message", Summary: "import message chat_id=-100123456 role=user"},
+			{Kind: "workspace_file", Summary: "copy workspace file SOUL.md"},
+		},
+		Errors: []string{"session chat_id=999: some error"},
+		DryRun: false,
+	}
+
+	opts := migrate.Options{
+		SourceDB:        "/path/to/openclaw.db",
+		TargetDB:        "/path/to/gobot.db",
+		SourceWorkspace: "/path/to/openclaw-ws",
+		TargetWorkspace: "/path/to/gobot-ws",
+		AgentID:         "default",
+	}
+
+	path, err := migrate.WriteReport(report, opts, dir)
+	if err != nil {
+		t.Fatalf("WriteReport: %v", err)
+	}
+
+	if !strings.HasPrefix(filepath.Base(path), "migration-report-") {
+		t.Errorf("unexpected report filename: %s", filepath.Base(path))
+	}
+	if !strings.HasSuffix(path, ".md") {
+		t.Errorf("report should be markdown, got: %s", path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	content := string(data)
+
+	// Verify structured sections exist.
+	requiredSections := []string{
+		"# Migration Report",
+		"## Summary",
+		"## Key Mapping",
+		"## Sessions",
+		"## Workspace Files",
+		"## Entries Skipped",
+		"## Errors",
+		"## Backup",
+	}
+	for _, s := range requiredSections {
+		if !strings.Contains(content, s) {
+			t.Errorf("report missing section %q", s)
+		}
+	}
+
+	// Verify key data is present.
+	requiredData := []string{
+		"openclaw.db",
+		"gobot.db",
+		"-100123456",
+		"987654321",
+		"agent:default:telegram:group:-100123456",
+		"agent:default:telegram:dm:987654321",
+		"SOUL.md",
+		"some error",
+	}
+	for _, d := range requiredData {
+		if !strings.Contains(content, d) {
+			t.Errorf("report missing data %q", d)
+		}
+	}
+
+	// Verify summary table.
+	if !strings.Contains(content, "| Sessions |") {
+		t.Error("report missing sessions summary row")
+	}
+	if !strings.Contains(content, "| Messages |") {
+		t.Error("report missing messages summary row")
+	}
+}
+
+func TestWriteReport_DryRunMode(t *testing.T) {
+	dir := t.TempDir()
+
+	report := &migrate.Report{
+		SessionsTotal:    3,
+		SessionsMigrated: 3,
+		MessagesTotal:    10,
+		MessagesMigrated: 10,
+		DryRun:           true,
+	}
+
+	opts := migrate.Options{
+		SourceDB: "/path/to/openclaw.db",
+		TargetDB: "/path/to/gobot.db",
+		DryRun:   true,
+	}
+
+	path, err := migrate.WriteReport(report, opts, dir)
+	if err != nil {
+		t.Fatalf("WriteReport: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "dry-run") {
+		t.Error("dry-run report should indicate dry-run mode")
+	}
+	if !strings.Contains(content, "# Migration Report") {
+		t.Error("dry-run report missing header")
+	}
+}
+
+func TestWriteReport_PartialReport(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate a partial report from a failed migration.
+	report := &migrate.Report{
+		SessionsTotal: 5,
+		MessagesTotal: 20,
+		Errors:        []string{"target DB not accessible"},
+	}
+
+	opts := migrate.Options{
+		SourceDB: "/path/to/openclaw.db",
+		TargetDB: "/path/to/gobot.db",
+	}
+
+	path, err := migrate.WriteReport(report, opts, dir)
+	if err != nil {
+		t.Fatalf("WriteReport: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "## Errors") {
+		t.Error("partial report should contain errors section")
+	}
+	if !strings.Contains(content, "target DB not accessible") {
+		t.Error("partial report should contain error message")
+	}
+}
+
+func TestWriteReport_MachineParseable(t *testing.T) {
+	dir := t.TempDir()
+
+	report := &migrate.Report{
+		SessionsTotal:    2,
+		SessionsMigrated: 1,
+		SessionsSkipped:  1,
+		MessagesTotal:    5,
+		MessagesMigrated: 3,
+		MessagesSkipped:  2,
+		KeyMapping: []migrate.KeyMapping{
+			{ChatID: -100, ChatType: "group", CanonicalKey: "agent:test:telegram:group:-100"},
+		},
+	}
+
+	opts := migrate.Options{
+		SourceDB: "/path/to/src.db",
+		TargetDB: "/path/to/dst.db",
+		AgentID:  "test",
+	}
+
+	path, err := migrate.WriteReport(report, opts, dir)
+	if err != nil {
+		t.Fatalf("WriteReport: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	content := string(data)
+
+	// Verify markdown table structure for machine parsing.
+	if !strings.Contains(content, "| Metric | Total | Migrated | Skipped |") {
+		t.Error("report missing summary table header")
+	}
+	if !strings.Contains(content, "| chat_id | type | canonical key |") {
+		t.Error("report missing key mapping table header")
+	}
+}


### PR DESCRIPTION
Implements #162

## Changes

Every `ok-gobot migrate` run now writes a structured markdown report to `~/.ok-gobot/migration-report-YYYY-MM-DD.md`.

- **New file `internal/migrate/report.go`** — `WriteReport()` renders a markdown report with structured sections: summary table, key mapping table, sessions imported, entries skipped (with reasons), workspace files copied, backup path, and errors
- **Modified `internal/cli/migrate.go`** — calls `WriteReport()` after migration completes; on failure, writes and prints a partial report for debugging
- **Modified `internal/migrate/migrate.go`** — added `DryRun` and `ReportPath` fields to `Report`; mid-migration errors now return the partial report instead of nil
- **`--dry-run` output** uses the same markdown report format as real runs
- Report is human-readable (markdown headings, tables) and machine-parseable (consistent table structure per section)
- No new dependencies

## Testing

- 4 new tests in `internal/migrate/report_test.go`:
  - `TestWriteReport_CreatesFile` — verifies all sections and data are present
  - `TestWriteReport_DryRunMode` — verifies dry-run indicator in report
  - `TestWriteReport_PartialReport` — verifies failed migrations preserve error info
  - `TestWriteReport_MachineParseable` — verifies structured table headers
- All 12 migrate tests pass
- Full test suite passes (`go test ./...`)
- Binary builds and runs (`CGO_ENABLED=1 go build ./cmd/ok-gobot/`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a durable markdown report artifact to `ok-gobot migrate`, writing structured migration results to `~/.ok-gobot/migration-report-YYYY-MM-DD.md` after every run (including partial failures). The implementation is clean, well-tested, and integrates naturally with the existing `Report` struct and CLI flow.

Two logic issues were found:

- **Incorrect UTC timestamp**: `time.Now()` (local time) is formatted with a hard-coded `"UTC"` suffix in `renderReport`, producing a misleading timestamp in the persisted report file on non-UTC systems.
- **Dry-run writes a file**: `WriteReport` is called regardless of the `--dry-run` flag, which contradicts the explicit user-facing banner `[DRY-RUN] No files will be written.` and the report's own `**Mode:** dry-run (no files were modified)` line. Both issues are straightforward to fix.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after the UTC timestamp fix and the dry-run/file-write contradiction are resolved.
- Two concrete logic bugs remain: a misleading UTC label on local time, and dry-run mode writing a file while claiming it won't. The dry-run contradiction is a correctness issue that violates a clear user-facing contract. Neither bug is data-loss or security risk, but both should be fixed before merging.
- `internal/migrate/report.go` (UTC timestamp), `internal/cli/migrate.go` (unconditional write in dry-run)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/migrate/report.go | New file implementing markdown report rendering and writing. Contains a logic bug where `time.Now()` (local time) is labeled as "UTC" in the report header. Otherwise the structure is clean and well-organized. |
| internal/cli/migrate.go | Wires `WriteReport` into the migrate command. The write is unconditional regardless of `--dry-run`, contradicting the "No files will be written" banner shown to users in dry-run mode. |
| internal/migrate/migrate.go | Minimal changes: adds `DryRun` and `ReportPath` fields to `Report`, initializes `DryRun` from opts, and returns partial reports on mid-migration errors instead of `nil`. All changes are correct. |
| internal/migrate/report_test.go | Four well-structured tests covering file creation, dry-run mode, partial/failed reports, and machine-parseability of table headers. Good coverage of the new functionality. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/migrate/report.go
Line: 56

Comment:
**Incorrect UTC label on local time**

`time.Now()` returns the machine's local time, but the format string appends the literal string `"UTC"` rather than the actual timezone. On a system whose local timezone is, say, `America/New_York`, the report will record `2026-03-22 10:04:05 UTC` when the real UTC time was `14:04:05`. This makes the timestamp in the persisted report incorrect and potentially misleading for debugging.

Fix by converting to UTC before formatting:

```suggestion
	b.WriteString(fmt.Sprintf("**Date:** %s\n\n", time.Now().UTC().Format("2006-01-02 15:04:05 UTC")))
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/cli/migrate.go
Line: 66-74

Comment:
**Dry-run writes a file despite "No files will be written"**

`WriteReport` is called unconditionally regardless of the `dryRun` flag. This means a `--dry-run` invocation still creates `~/.ok-gobot/migration-report-YYYY-MM-DD.md` on disk, which directly contradicts the banner printed by `printMigrateHeader`: `[DRY-RUN] No files will be written.`

The report itself also reinforces this promise (`**Mode:** dry-run (no files were modified)`), so the written file is a lie about its own contents.

Consider guarding the write with the dry-run flag, or updating the user-facing messaging to acknowledge that the report artifact is always written:

```go
// Write report even on partial failure for debugging.
if report != nil && !opts.DryRun {
    reportPath, writeErr := migrate.WriteReport(report, opts, "")
    ...
}
```

Alternatively, if writing the report in dry-run mode is intentional, the header message and the `**Mode:** dry-run (no files were modified)` line in `renderReport` should be updated to say something like "no *database or workspace* files were modified" to avoid the contradiction.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: migration emits a durable markdown..."](https://github.com/befeast/ok-gobot/commit/c1589d250eb7f83ea3d198c18d1e35b9e0480b58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25961276)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->