### PR TITLE
feat: operator can list providers and browse available models (#160)

### DIFF
--- a/internal/ai/catalog.go
+++ b/internal/ai/catalog.go
@@ -1,0 +1,237 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"ok-gobot/internal/logger"
+)
+
+// ModelCatalog holds cached model lists fetched from provider APIs.
+type ModelCatalog struct {
+	FetchedAt time.Time           `json:"fetched_at"`
+	Providers map[string][]string `json:"providers"`
+}
+
+// CatalogCacheTTL is how long a cached catalog is considered fresh.
+const CatalogCacheTTL = 24 * time.Hour
+
+// DefaultCachePath returns the default path for the model catalog cache file.
+func DefaultCachePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".ok-gobot", "model-cache.json"), nil
+}
+
+// LoadCatalog reads a cached catalog from disk. Returns nil (no error) if the
+// file does not exist yet.
+func LoadCatalog(path string) (*ModelCatalog, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading catalog cache: %w", err)
+	}
+	var cat ModelCatalog
+	if err := json.Unmarshal(data, &cat); err != nil {
+		return nil, fmt.Errorf("parsing catalog cache: %w", err)
+	}
+	return &cat, nil
+}
+
+// SaveCatalog writes a catalog to disk, creating parent directories as needed.
+func SaveCatalog(path string, cat *ModelCatalog) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating cache directory: %w", err)
+	}
+	data, err := json.MarshalIndent(cat, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling catalog: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// IsFresh reports whether the catalog was fetched within the TTL window.
+func (c *ModelCatalog) IsFresh() bool {
+	return time.Since(c.FetchedAt) < CatalogCacheTTL
+}
+
+// FetchRemoteModels fetches model lists from provider APIs that support
+// enumeration. It returns the merged results. Only providers whose API keys
+// are supplied will be queried.
+func FetchRemoteModels(ctx context.Context, apiKey, provider, baseURL string) (map[string][]string, error) {
+	result := make(map[string][]string)
+	client := &http.Client{Timeout: 15 * time.Second}
+
+	type fetchJob struct {
+		name    string
+		baseURL string
+		headers map[string]string
+	}
+
+	var jobs []fetchJob
+
+	switch provider {
+	case "openrouter":
+		jobs = append(jobs, fetchJob{
+			name:    "openrouter",
+			baseURL: defaultBaseURL("openrouter", baseURL),
+			headers: map[string]string{
+				"HTTP-Referer": "https://github.com/BeFeast/ok-gobot",
+				"X-Title":      "ok-gobot",
+			},
+		})
+	case "openai":
+		jobs = append(jobs, fetchJob{
+			name:    "openai",
+			baseURL: defaultBaseURL("openai", baseURL),
+		})
+	case "anthropic":
+		// Anthropic does not expose a public /models endpoint; static list only.
+	case "chatgpt":
+		// ChatGPT Codex API does not expose a models endpoint.
+	case "droid":
+		// Droid is a local subprocess; no remote catalog.
+	case "custom":
+		// Try the OpenAI-compatible /models endpoint on custom base URLs.
+		if baseURL != "" {
+			jobs = append(jobs, fetchJob{
+				name:    "custom",
+				baseURL: strings.TrimSuffix(baseURL, "/"),
+			})
+		}
+	default:
+		// Unknown provider; try OpenAI-compatible if base URL present.
+		if baseURL != "" {
+			jobs = append(jobs, fetchJob{
+				name:    provider,
+				baseURL: strings.TrimSuffix(baseURL, "/"),
+			})
+		}
+	}
+
+	for _, job := range jobs {
+		models, err := fetchOpenAICompatibleModels(ctx, client, job.baseURL, apiKey, job.headers)
+		if err != nil {
+			logger.Debugf("catalog: failed to fetch models from %s: %v", job.name, err)
+			return result, fmt.Errorf("fetching %s models: %w", job.name, err)
+		}
+		result[job.name] = models
+	}
+
+	return result, nil
+}
+
+// defaultBaseURL returns the provider's base URL, falling back to well-known
+// defaults for recognized providers.
+func defaultBaseURL(provider, override string) string {
+	if override != "" {
+		return strings.TrimSuffix(override, "/")
+	}
+	switch provider {
+	case "openai":
+		return "https://api.openai.com/v1"
+	case "openrouter":
+		return "https://openrouter.ai/api/v1"
+	default:
+		return ""
+	}
+}
+
+// openAIModelsResponse is the envelope returned by GET /models on
+// OpenAI-compatible APIs.
+type openAIModelsResponse struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+// fetchOpenAICompatibleModels queries GET <baseURL>/models and returns a
+// sorted slice of model IDs.
+func fetchOpenAICompatibleModels(ctx context.Context, client *http.Client, baseURL, apiKey string, extraHeaders map[string]string) ([]string, error) {
+	url := baseURL + "/models"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, truncateBody(string(body), 200))
+	}
+
+	var modelsResp openAIModelsResponse
+	if err := json.Unmarshal(body, &modelsResp); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+
+	ids := make([]string, 0, len(modelsResp.Data))
+	for _, m := range modelsResp.Data {
+		if m.ID != "" {
+			ids = append(ids, m.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// MergedModels returns the static model list for each provider, overlaid with
+// any cached remote models. Remote models appear after static ones, deduplicated.
+func MergedModels(cached *ModelCatalog) map[string][]string {
+	static := AvailableModels()
+	if cached == nil {
+		return static
+	}
+
+	merged := make(map[string][]string, len(static)+len(cached.Providers))
+	for p, models := range static {
+		merged[p] = append([]string{}, models...)
+	}
+	for p, remoteModels := range cached.Providers {
+		existing := make(map[string]bool, len(merged[p]))
+		for _, m := range merged[p] {
+			existing[m] = true
+		}
+		for _, m := range remoteModels {
+			if !existing[m] {
+				merged[p] = append(merged[p], m)
+			}
+		}
+	}
+	return merged
+}
+
+// truncateBody shortens s to at most n bytes, appending "..." if truncated.
+func truncateBody(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/ai/catalog_test.go
+++ b/internal/ai/catalog_test.go
@@ -1,0 +1,187 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveAndLoadCatalog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	cat := &ModelCatalog{
+		FetchedAt: time.Now().Truncate(time.Second),
+		Providers: map[string][]string{
+			"openai": {"gpt-4o", "gpt-3.5-turbo"},
+		},
+	}
+
+	if err := SaveCatalog(path, cat); err != nil {
+		t.Fatalf("SaveCatalog: %v", err)
+	}
+
+	loaded, err := LoadCatalog(path)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("LoadCatalog returned nil")
+	}
+
+	if len(loaded.Providers["openai"]) != 2 {
+		t.Errorf("expected 2 openai models, got %d", len(loaded.Providers["openai"]))
+	}
+}
+
+func TestLoadCatalog_NotExist(t *testing.T) {
+	cat, err := LoadCatalog(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cat != nil {
+		t.Error("expected nil catalog for non-existent file")
+	}
+}
+
+func TestModelCatalog_IsFresh(t *testing.T) {
+	fresh := &ModelCatalog{FetchedAt: time.Now()}
+	if !fresh.IsFresh() {
+		t.Error("catalog fetched just now should be fresh")
+	}
+
+	stale := &ModelCatalog{FetchedAt: time.Now().Add(-25 * time.Hour)}
+	if stale.IsFresh() {
+		t.Error("catalog fetched 25h ago should not be fresh")
+	}
+}
+
+func TestMergedModels_NilCache(t *testing.T) {
+	merged := MergedModels(nil)
+	static := AvailableModels()
+
+	if len(merged) != len(static) {
+		t.Errorf("expected %d providers, got %d", len(static), len(merged))
+	}
+}
+
+func TestMergedModels_WithCache(t *testing.T) {
+	cached := &ModelCatalog{
+		FetchedAt: time.Now(),
+		Providers: map[string][]string{
+			"openai": {"gpt-4o", "gpt-4o-mini", "new-model-x"},
+		},
+	}
+
+	merged := MergedModels(cached)
+	openaiModels := merged["openai"]
+
+	// Should contain static models plus the new one.
+	found := false
+	for _, m := range openaiModels {
+		if m == "new-model-x" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'new-model-x' in merged openai models")
+	}
+
+	// Static models should still be present.
+	foundStatic := false
+	for _, m := range openaiModels {
+		if m == "gpt-4-turbo" {
+			foundStatic = true
+			break
+		}
+	}
+	if !foundStatic {
+		t.Error("expected static model 'gpt-4-turbo' in merged openai models")
+	}
+}
+
+func TestMergedModels_NoDuplicates(t *testing.T) {
+	cached := &ModelCatalog{
+		FetchedAt: time.Now(),
+		Providers: map[string][]string{
+			"openai": {"gpt-4o", "gpt-4o-mini"},
+		},
+	}
+
+	merged := MergedModels(cached)
+	seen := make(map[string]bool)
+	for _, m := range merged["openai"] {
+		if seen[m] {
+			t.Errorf("duplicate model in merged list: %s", m)
+		}
+		seen[m] = true
+	}
+}
+
+func TestFetchRemoteModels_OpenAICompatible(t *testing.T) {
+	// Spin up a fake /models endpoint.
+	models := openAIModelsResponse{
+		Data: []struct {
+			ID string `json:"id"`
+		}{
+			{ID: "model-a"},
+			{ID: "model-b"},
+		},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(models)
+	}))
+	defer ts.Close()
+
+	result, err := FetchRemoteModels(context.Background(), "test-key", "custom", ts.URL)
+	if err != nil {
+		t.Fatalf("FetchRemoteModels: %v", err)
+	}
+	if len(result["custom"]) != 2 {
+		t.Errorf("expected 2 models, got %d", len(result["custom"]))
+	}
+}
+
+func TestFetchRemoteModels_AnthropicReturnsEmpty(t *testing.T) {
+	result, err := FetchRemoteModels(context.Background(), "key", "anthropic", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Error("expected empty result for anthropic (no remote endpoint)")
+	}
+}
+
+func TestFetchRemoteModels_DroidReturnsEmpty(t *testing.T) {
+	result, err := FetchRemoteModels(context.Background(), "", "droid", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Error("expected empty result for droid")
+	}
+}
+
+func TestDefaultCachePath(t *testing.T) {
+	path, err := DefaultCachePath()
+	if err != nil {
+		t.Fatalf("DefaultCachePath: %v", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	expected := filepath.Join(home, ".ok-gobot", "model-cache.json")
+	if path != expected {
+		t.Errorf("expected %s, got %s", expected, path)
+	}
+}

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -1,0 +1,220 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"ok-gobot/internal/ai"
+	"ok-gobot/internal/config"
+)
+
+func newModelsCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "models",
+		Short: "Browse available AI models",
+		Long:  `List available models per provider, optionally filtered. Use "models refresh" to fetch remote catalogs.`,
+	}
+
+	cmd.AddCommand(newModelsListCommand(cfg))
+	cmd.AddCommand(newModelsRefreshCommand(cfg))
+
+	return cmd
+}
+
+func newModelsListCommand(cfg *config.Config) *cobra.Command {
+	var providerFlag string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Show available models per provider",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Load cached catalog if available.
+			cachePath, err := ai.DefaultCachePath()
+			if err != nil {
+				return err
+			}
+			cached, err := ai.LoadCatalog(cachePath)
+			if err != nil {
+				// Non-fatal: just use static models.
+				cached = nil
+			}
+
+			models := ai.MergedModels(cached)
+
+			// Build alias reverse map: canonical -> []alias.
+			aliases := effectiveAliases(cfg)
+			reverseAliases := make(map[string][]string)
+			for alias, canonical := range aliases {
+				reverseAliases[canonical] = append(reverseAliases[canonical], alias)
+			}
+			// Sort alias lists for deterministic output.
+			for _, aliasList := range reverseAliases {
+				sort.Strings(aliasList)
+			}
+
+			// Determine which providers to show.
+			providers := sortedProviders(models)
+			if providerFlag != "" {
+				providerFlag = strings.ToLower(providerFlag)
+				if _, ok := models[providerFlag]; !ok {
+					return fmt.Errorf("unknown provider: %s", providerFlag)
+				}
+				providers = []string{providerFlag}
+			}
+
+			cacheNote := ""
+			if cached != nil && cached.IsFresh() {
+				cacheNote = fmt.Sprintf(" (cached %s ago)", shortDurationSince(cached.FetchedAt))
+			} else if cached != nil {
+				cacheNote = " (cache expired — run 'models refresh')"
+			}
+
+			fmt.Printf("Available Models%s\n", cacheNote)
+			fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+			for _, p := range providers {
+				modelList := models[p]
+				fmt.Printf("\n%s%s%s (%d models)\n", colorCyan, strings.ToUpper(p), colorReset, len(modelList))
+				for _, m := range modelList {
+					aliasTags := ""
+					if a, ok := reverseAliases[m]; ok {
+						aliasTags = fmt.Sprintf("  %s[%s]%s", colorYellow, strings.Join(a, ", "), colorReset)
+					}
+					fmt.Printf("  %s%s\n", m, aliasTags)
+				}
+			}
+
+			// Show aliases section.
+			if providerFlag == "" && len(aliases) > 0 {
+				fmt.Printf("\n%sAliases%s\n", colorCyan, colorReset)
+				sortedAliasKeys := make([]string, 0, len(aliases))
+				for k := range aliases {
+					sortedAliasKeys = append(sortedAliasKeys, k)
+				}
+				sort.Strings(sortedAliasKeys)
+				for _, alias := range sortedAliasKeys {
+					fmt.Printf("  %s → %s\n", alias, aliases[alias])
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&providerFlag, "provider", "p", "", "filter by provider name")
+	return cmd
+}
+
+func newModelsRefreshCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "refresh",
+		Short: "Fetch and cache remote model catalogs",
+		Long:  `Query provider APIs for their current model list and cache locally for 24 hours.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			provider := cfg.AI.Provider
+			apiKey := cfg.AI.APIKey
+			baseURL := cfg.AI.BaseURL
+
+			fmt.Printf("Refreshing model catalog for provider %q...\n", provider)
+
+			remote, err := ai.FetchRemoteModels(cmd.Context(), apiKey, provider, baseURL)
+			if err != nil {
+				return fmt.Errorf("refresh failed: %w", err)
+			}
+
+			if len(remote) == 0 {
+				fmt.Println("Provider does not support remote model listing. Using static catalog only.")
+				return nil
+			}
+
+			cachePath, err := ai.DefaultCachePath()
+			if err != nil {
+				return err
+			}
+
+			// Merge with any existing cache (preserve other providers).
+			existing, _ := ai.LoadCatalog(cachePath)
+			cat := buildCatalog(existing, remote)
+
+			if err := ai.SaveCatalog(cachePath, cat); err != nil {
+				return fmt.Errorf("saving cache: %w", err)
+			}
+
+			for p, models := range remote {
+				fmt.Printf("  %s: %d models fetched\n", p, len(models))
+			}
+			fmt.Printf("Cache saved to %s\n", cachePath)
+			return nil
+		},
+	}
+}
+
+// buildCatalog merges newly fetched remote models into an existing cached catalog.
+func buildCatalog(existing *ai.ModelCatalog, remote map[string][]string) *ai.ModelCatalog {
+	cat := &ai.ModelCatalog{
+		FetchedAt: time.Now(),
+		Providers: make(map[string][]string),
+	}
+	// Carry forward existing providers.
+	if existing != nil {
+		for p, models := range existing.Providers {
+			cat.Providers[p] = models
+		}
+	}
+	// Overwrite with freshly fetched data.
+	for p, models := range remote {
+		cat.Providers[p] = models
+	}
+	return cat
+}
+
+// effectiveAliases returns the merged alias map: defaults overlaid with user config.
+func effectiveAliases(cfg *config.Config) map[string]string {
+	merged := make(map[string]string, len(config.DefaultModelAliases))
+	for k, v := range config.DefaultModelAliases {
+		merged[k] = v
+	}
+	for k, v := range cfg.ModelAliases {
+		merged[strings.ToLower(k)] = v
+	}
+	return merged
+}
+
+// sortedProviders returns provider names in a stable display order.
+func sortedProviders(models map[string][]string) []string {
+	order := []string{"openrouter", "openai", "anthropic", "chatgpt", "droid", "custom"}
+	var result []string
+	seen := make(map[string]bool)
+	for _, p := range order {
+		if _, ok := models[p]; ok {
+			result = append(result, p)
+			seen[p] = true
+		}
+	}
+	// Append any providers not in the predefined order.
+	extra := make([]string, 0)
+	for p := range models {
+		if !seen[p] {
+			extra = append(extra, p)
+		}
+	}
+	sort.Strings(extra)
+	return append(result, extra...)
+}
+
+// shortDurationSince formats the elapsed time since t as a compact string.
+func shortDurationSince(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+}

--- a/internal/cli/models_test.go
+++ b/internal/cli/models_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"ok-gobot/internal/ai"
+	"ok-gobot/internal/config"
+)
+
+func TestEffectiveAliases_Defaults(t *testing.T) {
+	cfg := &config.Config{}
+	aliases := effectiveAliases(cfg)
+	if aliases["sonnet"] != config.DefaultModelAliases["sonnet"] {
+		t.Error("expected default sonnet alias")
+	}
+}
+
+func TestEffectiveAliases_Override(t *testing.T) {
+	cfg := &config.Config{
+		ModelAliases: map[string]string{
+			"sonnet": "my-custom-model",
+		},
+	}
+	aliases := effectiveAliases(cfg)
+	if aliases["sonnet"] != "my-custom-model" {
+		t.Errorf("expected override, got %s", aliases["sonnet"])
+	}
+}
+
+func TestEffectiveAliases_CaseInsensitive(t *testing.T) {
+	cfg := &config.Config{
+		ModelAliases: map[string]string{
+			"MyModel": "some-model",
+		},
+	}
+	aliases := effectiveAliases(cfg)
+	if aliases["mymodel"] != "some-model" {
+		t.Error("expected case-insensitive alias key")
+	}
+}
+
+func TestSortedProviders(t *testing.T) {
+	models := map[string][]string{
+		"droid":      {"glm-5"},
+		"openai":     {"gpt-4o"},
+		"openrouter": {"kimi"},
+		"zebra":      {"z-model"},
+	}
+
+	result := sortedProviders(models)
+
+	if result[0] != "openrouter" {
+		t.Errorf("expected openrouter first, got %s", result[0])
+	}
+	if result[1] != "openai" {
+		t.Errorf("expected openai second, got %s", result[1])
+	}
+	// droid should come after the predefined order entries
+	// "zebra" should be appended at the end
+	if result[len(result)-1] != "zebra" {
+		t.Errorf("expected zebra last, got %s", result[len(result)-1])
+	}
+}
+
+func TestBuildCatalog_MergesExisting(t *testing.T) {
+	existing := &ai.ModelCatalog{
+		FetchedAt: time.Now().Add(-1 * time.Hour),
+		Providers: map[string][]string{
+			"openai": {"old-model"},
+		},
+	}
+
+	remote := map[string][]string{
+		"openrouter": {"new-model"},
+	}
+
+	cat := buildCatalog(existing, remote)
+
+	if len(cat.Providers["openai"]) != 1 {
+		t.Error("expected existing openai models to be preserved")
+	}
+	if len(cat.Providers["openrouter"]) != 1 {
+		t.Error("expected remote openrouter models to be added")
+	}
+}
+
+func TestBuildCatalog_OverwritesProvider(t *testing.T) {
+	existing := &ai.ModelCatalog{
+		FetchedAt: time.Now().Add(-1 * time.Hour),
+		Providers: map[string][]string{
+			"openrouter": {"old-model"},
+		},
+	}
+
+	remote := map[string][]string{
+		"openrouter": {"new-model-a", "new-model-b"},
+	}
+
+	cat := buildCatalog(existing, remote)
+
+	if len(cat.Providers["openrouter"]) != 2 {
+		t.Errorf("expected 2 openrouter models, got %d", len(cat.Providers["openrouter"]))
+	}
+}
+
+func TestBuildCatalog_NilExisting(t *testing.T) {
+	remote := map[string][]string{
+		"openai": {"model-x"},
+	}
+	cat := buildCatalog(nil, remote)
+	if cat.Providers["openai"][0] != "model-x" {
+		t.Error("expected model-x")
+	}
+}
+
+func TestShortDurationSince(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		t    time.Time
+		want string
+	}{
+		{now.Add(-30 * time.Second), "30s"},
+		{now.Add(-5 * time.Minute), "5m"},
+		{now.Add(-3 * time.Hour), "3h"},
+	}
+
+	for _, tt := range tests {
+		got := shortDurationSince(tt.t)
+		if got != tt.want {
+			t.Errorf("shortDurationSince(%v ago) = %q, want %q", time.Since(tt.t), got, tt.want)
+		}
+	}
+}

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"ok-gobot/internal/ai"
+	"ok-gobot/internal/config"
+)
+
+// knownProviders is the ordered list of providers we report on.
+var knownProviders = []struct {
+	name string
+	desc string
+}{
+	{"openrouter", "OpenRouter aggregator"},
+	{"openai", "OpenAI API"},
+	{"anthropic", "Anthropic Messages API"},
+	{"chatgpt", "ChatGPT Codex Responses API"},
+	{"droid", "factory.ai droid subprocess"},
+	{"custom", "OpenAI-compatible custom endpoint"},
+}
+
+func newProvidersCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "providers",
+		Short: "List configured AI providers and their status",
+		Long:  `Show all known AI providers, which one is active, and whether credentials are configured.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			active := cfg.AI.Provider
+
+			fmt.Println("AI Providers")
+			fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+			for _, p := range knownProviders {
+				marker := "  "
+				if p.name == active {
+					marker = "> "
+				}
+				status := providerStatus(cfg, p.name)
+				statusColor := statusColorCode(status)
+				fmt.Printf("%s%-12s %s%-8s%s  %s\n", marker, p.name, statusColor, status, colorReset, p.desc)
+			}
+
+			fmt.Println()
+			fmt.Printf("Active provider: %s (model: %s)\n", active, cfg.AI.Model)
+			return nil
+		},
+	}
+}
+
+// providerStatus determines the health status for a provider.
+func providerStatus(cfg *config.Config, provider string) string {
+	isActive := cfg.AI.Provider == provider
+
+	switch provider {
+	case "droid":
+		// Droid doesn't require an API key.
+		if isActive {
+			return "ok"
+		}
+		return "ready"
+	case "anthropic":
+		if isActive {
+			if cfg.AI.APIKey != "" {
+				return "ok"
+			}
+			// Check OAuth credentials.
+			if creds, err := ai.LoadAnthropicOAuthCredentials(""); err == nil && creds != nil {
+				return "ok"
+			}
+			return "no-key"
+		}
+		// Not active — check if OAuth creds exist anyway.
+		if creds, err := ai.LoadAnthropicOAuthCredentials(""); err == nil && creds != nil {
+			return "ready"
+		}
+		return "no-key"
+	case "custom":
+		if isActive {
+			if cfg.AI.APIKey != "" && cfg.AI.BaseURL != "" {
+				return "ok"
+			}
+			if cfg.AI.BaseURL == "" {
+				return "no-url"
+			}
+			return "no-key"
+		}
+		return "-"
+	default:
+		// openrouter, openai, chatgpt
+		if isActive {
+			if cfg.AI.APIKey != "" {
+				return "ok"
+			}
+			return "no-key"
+		}
+		return "-"
+	}
+}
+
+// statusColorCode returns an ANSI color code for a provider status string.
+func statusColorCode(status string) string {
+	switch status {
+	case "ok", "ready":
+		return colorGreen
+	case "no-key", "no-url", "error":
+		return colorRed
+	default:
+		return colorYellow
+	}
+}
+
+// CheckProviderReachable does a quick HEAD request to the provider's base URL.
+// Not called by default (too slow for a list view) but available for doctor-style checks.
+func CheckProviderReachable(provider, baseURL string) error {
+	url := baseURL
+	if url == "" {
+		switch provider {
+		case "openrouter":
+			url = "https://openrouter.ai"
+		case "openai":
+			url = "https://api.openai.com"
+		case "anthropic":
+			url = "https://api.anthropic.com"
+		default:
+			return nil // skip unknown
+		}
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("cannot reach %s: %w", url, err)
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"testing"
+
+	"ok-gobot/internal/config"
+)
+
+func TestProviderStatus_ActiveWithKey(t *testing.T) {
+	cfg := &config.Config{
+		AI: config.AIConfig{
+			Provider: "openrouter",
+			APIKey:   "sk-test",
+		},
+	}
+	if got := providerStatus(cfg, "openrouter"); got != "ok" {
+		t.Errorf("expected ok, got %s", got)
+	}
+}
+
+func TestProviderStatus_ActiveNoKey(t *testing.T) {
+	cfg := &config.Config{
+		AI: config.AIConfig{
+			Provider: "openai",
+		},
+	}
+	if got := providerStatus(cfg, "openai"); got != "no-key" {
+		t.Errorf("expected no-key, got %s", got)
+	}
+}
+
+func TestProviderStatus_Inactive(t *testing.T) {
+	cfg := &config.Config{
+		AI: config.AIConfig{
+			Provider: "openrouter",
+			APIKey:   "sk-test",
+		},
+	}
+	if got := providerStatus(cfg, "openai"); got != "-" {
+		t.Errorf("expected -, got %s", got)
+	}
+}
+
+func TestProviderStatus_DroidAlwaysReady(t *testing.T) {
+	cfg := &config.Config{
+		AI: config.AIConfig{
+			Provider: "openrouter",
+		},
+	}
+	if got := providerStatus(cfg, "droid"); got != "ready" {
+		t.Errorf("expected ready, got %s", got)
+	}
+}
+
+func TestProviderStatus_DroidActiveOk(t *testing.T) {
+	cfg := &config.Config{
+		AI: config.AIConfig{
+			Provider: "droid",
+		},
+	}
+	if got := providerStatus(cfg, "droid"); got != "ok" {
+		t.Errorf("expected ok, got %s", got)
+	}
+}
+
+func TestProviderStatus_CustomNoURL(t *testing.T) {
+	cfg := &config.Config{
+		AI: config.AIConfig{
+			Provider: "custom",
+			APIKey:   "key",
+		},
+	}
+	if got := providerStatus(cfg, "custom"); got != "no-url" {
+		t.Errorf("expected no-url, got %s", got)
+	}
+}
+
+func TestProviderStatus_CustomOk(t *testing.T) {
+	cfg := &config.Config{
+		AI: config.AIConfig{
+			Provider: "custom",
+			APIKey:   "key",
+			BaseURL:  "http://localhost:8080",
+		},
+	}
+	if got := providerStatus(cfg, "custom"); got != "ok" {
+		t.Errorf("expected ok, got %s", got)
+	}
+}
+
+func TestStatusColorCode(t *testing.T) {
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{"ok", colorGreen},
+		{"ready", colorGreen},
+		{"no-key", colorRed},
+		{"no-url", colorRed},
+		{"error", colorRed},
+		{"-", colorYellow},
+	}
+	for _, tt := range tests {
+		if got := statusColorCode(tt.status); got != tt.want {
+			t.Errorf("statusColorCode(%q) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -40,6 +40,8 @@ Supports Telegram bot integration with personality and memory.`,
 	root.AddCommand(newMigrateCommand(cfg))
 	root.AddCommand(newWebCommand(cfg))
 	root.AddCommand(newJobsCommand(cfg))
+	root.AddCommand(newProvidersCommand(cfg))
+	root.AddCommand(newModelsCommand(cfg))
 
 	return root
 }


### PR DESCRIPTION
Implements #160

## Changes

- **`ok-gobot providers`** — lists all known AI providers with status (`ok`/`no-key`/`ready`/`-`), highlights the active provider, and shows the current model
- **`ok-gobot models list [--provider X]`** — displays available models per provider, merging static catalog with any cached remote models; model aliases from config are shown inline as `[alias]` tags, with a full alias table at the bottom
- **`ok-gobot models refresh`** — fetches remote model catalogs from OpenAI-compatible `/models` endpoints (OpenRouter, OpenAI, custom) and caches them locally for 24 hours; providers without enumeration APIs (Anthropic, ChatGPT, droid) use static lists only
- Cache stored at `~/.ok-gobot/model-cache.json`, reused across invocations until TTL expires

### New files
- `internal/ai/catalog.go` — fetch, cache, merge model catalog logic
- `internal/ai/catalog_test.go` — unit tests (save/load, freshness, merge, HTTP mock)
- `internal/cli/providers.go` — `providers` command
- `internal/cli/providers_test.go` — provider status unit tests
- `internal/cli/models.go` — `models list` / `models refresh` commands
- `internal/cli/models_test.go` — alias, sort, build-catalog, duration tests
- `internal/cli/root.go` — register new commands

## Testing
- All existing tests pass (`go test ./...`)
- New unit tests cover catalog load/save/merge, provider status logic, alias resolution, and HTTP-based remote fetch via httptest
- Manual verification: `ok-gobot providers`, `ok-gobot models list`, `ok-gobot models list --provider anthropic`, `ok-gobot models refresh` all produce correct output
- `go vet ./...` clean, `go fmt ./...` clean, `CGO_ENABLED=1 go build` succeeds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new operator-facing CLI commands — `ok-gobot providers` and `ok-gobot models list/refresh` — giving operators visibility into configured AI providers and their available models. The implementation is well-structured: a new `internal/ai/catalog.go` layer handles HTTP fetching, disk caching, and merging with the static `AvailableModels()` catalog, while the CLI layer wires it into Cobra commands with alias display and color-coded status.

Key points from the review:
- **Cache freshness timestamp is global, not per-provider**: `buildCatalog` stamps `FetchedAt = time.Now()` on the entire merged catalog even when only one provider was refreshed and the rest were carried forward from an older snapshot. This means `IsFresh()` (and the user-visible "cached X ago" note) can report incorrect freshness for providers that were not actually refreshed in the latest run. Tracking freshness per-provider, or dropping carried-forward entries that exceed the TTL, would fix this.
- **`CheckProviderReachable` bypasses context**: The utility function uses `http.NewRequest` rather than `http.NewRequestWithContext`, so it cannot be cancelled by callers. Not used in the active command path today, but worth fixing before it is wired into a `doctor`-style command.
- Test coverage is thorough — save/load, freshness, merge, deduplication, HTTP mock, alias overrides, and duration formatting are all exercised.

<h3>Confidence Score: 4/5</h3>

- Safe to merge for operator tooling; the freshness-timestamp issue affects display accuracy but not data integrity or runtime behaviour.
- The feature is additive (read-only CLI commands with a local cache file), tests are comprehensive, and no existing code paths are modified. The one concrete logic bug — global `FetchedAt` reset in `buildCatalog` — misleads the freshness indicator but does not corrupt data or break other functionality. The `http.NewRequest`-without-context issue is in a dead-code utility. Neither issue blocks the primary user path.
- internal/cli/models.go — `buildCatalog` function (lines 127–139)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/ai/catalog.go | New file implementing fetch, cache, and merge logic for model catalogs. Well-structured with proper error handling and context propagation. Minor: `io.ReadAll` has no size cap on the HTTP response body. |
| internal/cli/models.go | Implements `models list` and `models refresh` commands. `buildCatalog` resets the global `FetchedAt` timestamp even for providers carried forward from an older cache, causing `IsFresh()` to report incorrect freshness for unrefreshed providers. |
| internal/cli/providers.go | Implements `providers` list command with status detection. `CheckProviderReachable` uses `http.NewRequest` without a context, limiting future composability, though it is not called in the active command path. |
| internal/cli/root.go | Straightforward registration of the two new subcommands (`providers`, `models`). |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/cli/models.go
Line: 127-139

Comment:
**`buildCatalog` resets global timestamp for unrefreshed providers**

`buildCatalog` stamps `FetchedAt = time.Now()` on the whole catalog even when it only refreshed one provider and carried the rest forward unchanged from an older cache. This means `IsFresh()` will return `true` (and `models list` will show "cached X minutes ago") for providers whose data may actually be close to — or past — the 24 h TTL.

Concrete example:
1. User refreshes at T=0 with openrouter → `FetchedAt = T+0h`.
2. User switches to openai and refreshes at T=23h → `buildCatalog` carries forward the 23 h-old openrouter slice and writes `FetchedAt = T+23h`.
3. `models list` now shows "(cached 0 minutes ago)" even though openrouter's data is 23 h old.
4. The cache won't be marked stale for another 24 h, so openrouter data can become up to 47 h old before the warning appears.

Consider either (a) tracking `FetchedAt` per-provider, or (b) only carrying forward providers whose individual age is within the TTL:

```go
// Option (b): drop stale carried-forward providers
if existing != nil {
    for p, models := range existing.Providers {
        if existing.IsFresh() { // or track per-provider timestamp
            cat.Providers[p] = models
        }
    }
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/cli/providers.go
Line: 121-136

Comment:
**`CheckProviderReachable` creates request without context**

`http.NewRequest` is used here instead of `http.NewRequestWithContext`. The 5 s client timeout still caps the wall-clock wait, but the request cannot be cancelled if the caller acquires a context later (e.g., for a `doctor` command that fans out checks concurrently). Since the function is not called in the hot path this is low-severity, but it silently swallows any context that a future caller might pass.

```suggestion
	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, url, nil)
```

(Add `"context"` to the imports.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add providers and models CLI comma..."](https://github.com/befeast/ok-gobot/commit/2c0034a05307d3025b119b0078884c67df03473a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25961422)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->