### PR TITLE
feat(safety): /status shows estop state (#159)

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -762,6 +762,11 @@ func (b *Bot) GetStatus() map[string]interface{} {
 	// Note: This would require adding a method to storage to count sessions
 	status["sessions"] = 0
 
+	// Estop state
+	if enabled, err := b.store.IsEmergencyStopEnabled(); err == nil {
+		status["estop_enabled"] = enabled
+	}
+
 	return status
 }
 

--- a/internal/bot/status.go
+++ b/internal/bot/status.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/telebot.v4"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/tools"
 	"ok-gobot/internal/version"
 )
 
@@ -79,6 +80,18 @@ func (b *Bot) buildStatusString(chatID int64) string {
 	}
 	queueDepth := b.debouncer.GetPendingCount()
 	sb.WriteString(fmt.Sprintf("⚙️ Think: %s · 🪢 Queue: %s (depth %d)\n", thinkLevel, queueMode, queueDepth))
+
+	// Estop state
+	estopEnabled, err := b.store.IsEmergencyStopEnabled()
+	if err != nil {
+		log.Printf("Failed to load estop state: %v", err)
+		sb.WriteString("⚠️ estop: unknown (error)\n")
+	} else if estopEnabled {
+		families := strings.Join(tools.DangerousToolFamilies(), ", ")
+		sb.WriteString(fmt.Sprintf("🛑 estop: ON — blocked: %s\n", families))
+	} else {
+		sb.WriteString("✅ estop: off\n")
+	}
 
 	// Uptime
 	uptime := time.Since(startTime)

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -81,18 +81,20 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 		}
 		c.tuiSessionID = target
 		c.sendTUIMsg(ServerMsg{
-			Type:      MsgTypeConnected,
-			SessionID: c.tuiSessionID,
-			Sessions:  sessions,
+			Type:         MsgTypeConnected,
+			SessionID:    c.tuiSessionID,
+			Sessions:     sessions,
+			EstopEnabled: s.estopEnabledPtr(),
 		})
 
 	case CmdNewSession:
 		created := s.newTUISession(cmd.Name, cmd.Model)
 		c.tuiSessionID = created.ID
 		c.sendTUIMsg(ServerMsg{
-			Type:      MsgTypeConnected,
-			SessionID: created.ID,
-			Sessions:  s.listTUISessions(),
+			Type:         MsgTypeConnected,
+			SessionID:    created.ID,
+			Sessions:     s.listTUISessions(),
+			EstopEnabled: s.estopEnabledPtr(),
 		})
 
 	case CmdSend:
@@ -487,6 +489,18 @@ func (s *Server) buildStatusText() string {
 	return sb.String()
 }
 
+// estopEnabledPtr returns the estop state from the state provider, or nil on error.
+func (s *Server) estopEnabledPtr() *bool {
+	status := s.state.GetStatus()
+	if status == nil {
+		return nil
+	}
+	if v, ok := status["estop_enabled"].(bool); ok {
+		return &v
+	}
+	return nil
+}
+
 func (s *Server) ensureTUIConnected(c *client, requestedID string) ([]TUISessionInfo, bool) {
 	sessions := s.listTUISessions()
 
@@ -494,9 +508,10 @@ func (s *Server) ensureTUIConnected(c *client, requestedID string) ([]TUISession
 		c.tuiConnected = true
 		c.tuiSessionID = selectSessionID(sessions, requestedID, c.tuiSessionID)
 		c.sendTUIMsg(ServerMsg{
-			Type:      MsgTypeConnected,
-			SessionID: c.tuiSessionID,
-			Sessions:  sessions,
+			Type:         MsgTypeConnected,
+			SessionID:    c.tuiSessionID,
+			Sessions:     sessions,
+			EstopEnabled: s.estopEnabledPtr(),
 		})
 	}
 

--- a/internal/control/tui_types.go
+++ b/internal/control/tui_types.go
@@ -76,6 +76,8 @@ type ServerMsg struct {
 	Events    []JobEventInfo `json:"events,omitempty"`
 	Artifacts []ArtifactInfo `json:"artifacts,omitempty"`
 	Workers   []WorkerInfo   `json:"workers,omitempty"`
+	// Estop state (included in connected messages).
+	EstopEnabled *bool `json:"estop_enabled,omitempty"`
 }
 
 // JobInfo is the JSON-friendly representation of a durable job for the dashboard.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -105,6 +105,9 @@ type Model struct {
 	// slash command completion
 	completion completionState
 
+	// safety
+	estopEnabled bool
+
 	// misc
 	statusMsg string
 	statusAt  time.Time
@@ -561,6 +564,9 @@ func (m *Model) handleServerMsg(msg controlserver.ServerMsg) tea.Cmd {
 		if len(msg.Sessions) > 0 {
 			m.sessions = msg.Sessions
 		}
+		if msg.EstopEnabled != nil {
+			m.estopEnabled = *msg.EstopEnabled
+		}
 
 	case controlserver.MsgTypeSessions:
 		m.sessions = msg.Sessions
@@ -803,14 +809,18 @@ func (m *Model) renderStatus() string {
 		stateStyle = statusRunBusyStyle
 	}
 
-	left := lipgloss.JoinHorizontal(lipgloss.Top,
+	parts := []string{
 		statusKeyStyle.Render("session"),
-		statusValueStyle.Render(" "+sessionName+" "),
+		statusValueStyle.Render(" " + sessionName + " "),
 		statusKeyStyle.Render("model"),
-		statusValueStyle.Render(" "+model+" "),
+		statusValueStyle.Render(" " + model + " "),
 		statusKeyStyle.Render("state"),
-		stateStyle.Render(" "+stateLabel+" "),
-	)
+		stateStyle.Render(" " + stateLabel + " "),
+	}
+	if m.estopEnabled {
+		parts = append(parts, statusRunBusyStyle.Render(" 🛑 estop ON "))
+	}
+	left := lipgloss.JoinHorizontal(lipgloss.Top, parts...)
 
 	// Character count for the current input.
 	charCount := utf8.RuneCountInString(m.input.Value())


### PR DESCRIPTION
Implements #159

## Changes
- `/status` output now includes estop state: "🛑 estop: ON — blocked: local, ssh, browser, cron, message" when enabled, "✅ estop: off" when disabled, or "⚠️ estop: unknown (error)" on store failure
- `Bot.GetStatus()` API map includes `estop_enabled` boolean for downstream consumers
- WebSocket `connected` messages include `estop_enabled` field so TUI clients receive estop state on connect, session switch, and new session creation
- TUI bottom status bar shows a red "🛑 estop ON" pill when estop is active

## Testing
- All existing tests pass (`go test ./...`, `go vet ./...`)
- Built successfully with `CGO_ENABLED=1 go build ./cmd/ok-gobot/`
- Verified estop state flows through: storage → bot status string → `/status` output, and storage → GetStatus map → control server → WebSocket → TUI model → status bar

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements #159 by surfacing emergency-stop (estop) state across all major interfaces: the `/status` text command, the `GetStatus()` API map, WebSocket `connected` messages, and the TUI bottom status bar. The implementation is well-structured and consistent with the existing codebase patterns.

- `/status` text output correctly handles all three states: enabled (with blocked tool families listed), disabled, and store error (explicit warning).
- `GetStatus()` adds `estop_enabled` to the status map when the store read succeeds.
- `ServerMsg` gains an `EstopEnabled *bool` field; the pointer type correctly models nil-as-unknown.
- All three `MsgTypeConnected` send sites are updated consistently via the new `estopEnabledPtr()` helper.
- TUI model adds an `estopEnabled bool` field and renders a "🛑 estop ON" pill in the status bar.
- **One inconsistency**: when `IsEmergencyStopEnabled()` fails, `GetStatus()` silently omits the key, `estopEnabledPtr()` returns `nil`, and the TUI keeps `estopEnabled = false`. On initial connection with a store error the status bar shows nothing (implying estop is off), while the text `/status` command would correctly display "⚠️ estop: unknown (error)". Representing the error state with a `*bool` in the model would resolve this.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the one identified issue is a display inconsistency that doesn't affect safety enforcement.
- The implementation is clean and all three send sites are updated consistently. The only issue is that the TUI `bool` zero value silently presents as "estop off" when the store cannot be read, whereas the text `/status` shows an explicit error indicator. This is a display-layer inconsistency, not a safety bypass (estop enforcement lives at the tool level). A targeted follow-up or small fix in this PR would bring it to a clean 5.
- internal/tui/model.go — `estopEnabled bool` should be `*bool` to distinguish unknown/error from off.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/bot/bot.go | Adds `estop_enabled` boolean to `GetStatus()` map; silently omits the key on store error, which propagates as a nil to TUI clients and defaults them to "off". |
| internal/bot/status.go | Adds estop block to `/status` text output; handles all three states (enabled, disabled, error) correctly and explicitly. |
| internal/control/server_tui.go | Adds `estopEnabledPtr()` helper and populates `EstopEnabled` on all three `MsgTypeConnected` send sites; logic is clean and consistent. |
| internal/control/tui_types.go | Adds `EstopEnabled *bool` to `ServerMsg`; pointer type correctly enables nil-as-unknown semantics. |
| internal/tui/model.go | Adds `estopEnabled bool` field, updates it from connected messages, and renders the status bar pill; `bool` zero value causes a silent "off" appearance when the server omits the field due to a store error. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tui/model.go
Line: 567-569

Comment:
**Stale estop state on store error during initial connect**

When `IsEmergencyStopEnabled()` fails inside `GetStatus()`, `estop_enabled` is silently omitted from the map (see `bot.go:766-768`), so `estopEnabledPtr()` returns `nil`. On initial TUI connection, `msg.EstopEnabled == nil` means this branch is skipped and `m.estopEnabled` stays at its zero value (`false`). The TUI therefore shows no estop pill — implying estop is OFF — when the actual state is unknown.

This is inconsistent with the text `/status` command, which explicitly renders `⚠️ estop: unknown (error)` in the same failure scenario, giving the operator a clear signal. A user watching the TUI status bar would have no indication that the estop state could not be read.

One way to handle this is to model the three states (`on` / `off` / `unknown`) in the TUI, e.g. by using a `*bool` field instead of `bool`:

```go
// in Model struct
estopEnabled *bool   // nil = unknown/error, false = off, true = on
```

Then update the render logic accordingly so a nil value shows a distinct "unknown" indicator rather than silently defaulting to the "off" appearance.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(safety): /status shows estop state ..."](https://github.com/befeast/ok-gobot/commit/e309578058470eee1bd88348c15f8a1e74e10edb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25978318)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->