### PR TITLE
feat(safety): blocked tools show clear reason in Telegram, TUI, and API (#158)

### DIFF
--- a/internal/agent/resolver_estop_test.go
+++ b/internal/agent/resolver_estop_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -58,8 +57,8 @@ func TestRunResolverBuildToolRegistry_PreservesEstopForJobToolAllowlist(t *testi
 	if err == nil {
 		t.Fatal("expected estop to block dangerous tool selected by job allowlist")
 	}
-	if !strings.Contains(err.Error(), "estop is ON") {
-		t.Fatalf("unexpected error: %v", err)
+	if tools.IsToolDenial(err) == nil {
+		t.Fatalf("expected ToolDenial error, got %v", err)
 	}
 	if messageTool.called != 0 {
 		t.Fatalf("expected dangerous tool not to execute, called=%d", messageTool.called)
@@ -83,8 +82,8 @@ func TestRunResolverBuildToolRegistry_PreservesEstopWhenInjectingChatTools(t *te
 	if err == nil {
 		t.Fatal("expected estop to block dangerous tool in chat-specific registry")
 	}
-	if !strings.Contains(err.Error(), "estop is ON") {
-		t.Fatalf("unexpected error: %v", err)
+	if tools.IsToolDenial(err) == nil {
+		t.Fatalf("expected ToolDenial error, got %v", err)
 	}
 	if messageTool.called != 0 {
 		t.Fatalf("expected dangerous tool not to execute, called=%d", messageTool.called)

--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -31,6 +31,7 @@ type ToolEvent struct {
 	Input    string // raw JSON arguments (populated on Started)
 	Output   string // truncated result text (populated on Finished)
 	Err      error  // non-nil if Type is ToolEventFinished and tool failed
+	Denied   bool   // true when the tool was blocked by policy (estop, etc.)
 }
 
 // ToolTimeoutSpawnFunc is called when a tool execution exceeds ToolTimeout.
@@ -250,12 +251,16 @@ iterationLoop:
 
 				// Execute tool with optional timeout-triggered subagent spawn.
 				result, err := a.executeToolWithTimeout(ctx, functionName, arguments)
+				denied := false
 				if err != nil {
 					if ctx.Err() != nil {
 						return nil, ctx.Err()
 					}
 					logger.Debugf("ToolAgent: tool %s error: %v", functionName, err)
-					if strings.TrimSpace(result) == "" {
+					if denial := tools.IsToolDenial(err); denial != nil {
+						denied = true
+						result = denial.FormatPlain()
+					} else if strings.TrimSpace(result) == "" {
 						result = fmt.Sprintf("Error executing tool: %v", err)
 					}
 				}
@@ -266,7 +271,7 @@ iterationLoop:
 					if len(out) > 300 {
 						out = out[:300] + "…"
 					}
-					a.onToolEvent(ToolEvent{ToolName: functionName, Type: ToolEventFinished, Output: out, Err: err})
+					a.onToolEvent(ToolEvent{ToolName: functionName, Type: ToolEventFinished, Output: out, Err: err, Denied: denied})
 				}
 				logger.Tracef("ToolAgent: tool %s result (%d chars): %.500s", functionName, len(result), result)
 

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -13,6 +13,7 @@ import (
 	"ok-gobot/internal/ai"
 	"ok-gobot/internal/control"
 	"ok-gobot/internal/logger"
+	"ok-gobot/internal/tools"
 )
 
 // sessionKeyForChat returns the canonical session key for a Telegram chat.
@@ -121,6 +122,17 @@ func (b *Bot) processViaHubWithContent(
 						p.Error = event.Err.Error()
 					}
 					ctrlHub.Emit(control.EvtToolFinished, p)
+					if event.Denied {
+						if denial := tools.IsToolDenial(event.Err); denial != nil {
+							ctrlHub.Emit(control.EvtToolDenied, control.ToolDeniedPayload{
+								ChatID:   chatID,
+								ToolName: denial.ToolName,
+								Family:   denial.Family,
+								Reason:   denial.Reason,
+								Hint:     denial.Hint,
+							})
+						}
+					}
 				}
 			}
 		}
@@ -153,6 +165,17 @@ func (b *Bot) processViaHubWithContent(
 					p.Error = event.Err.Error()
 				}
 				ctrlHub.Emit(control.EvtToolFinished, p)
+				if event.Denied {
+					if denial := tools.IsToolDenial(event.Err); denial != nil {
+						ctrlHub.Emit(control.EvtToolDenied, control.ToolDeniedPayload{
+							ChatID:   chatID,
+							ToolName: denial.ToolName,
+							Family:   denial.Family,
+							Reason:   denial.Reason,
+							Hint:     denial.Hint,
+						})
+					}
+				}
 			}
 		}
 		onDelta = func(delta string) {

--- a/internal/bot/live_editor.go
+++ b/internal/bot/live_editor.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/telebot.v4"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/tools"
 )
 
 // LiveStreamEditor manages rate-limited placeholder edits combining live token streaming
@@ -58,6 +59,9 @@ func (e *LiveStreamEditor) OnToolEvent(event agent.ToolEvent) {
 			if e.toolLines[i].name == event.ToolName && !e.toolLines[i].done && !e.toolLines[i].failed {
 				if event.Err != nil {
 					e.toolLines[i].failed = true
+					if denial := tools.IsToolDenial(event.Err); denial != nil {
+						e.toolLines[i].denialMsg = denial.FormatTelegram()
+					}
 				} else {
 					e.toolLines[i].done = true
 				}
@@ -154,6 +158,8 @@ func (e *LiveStreamEditor) formatStatusLocked() string {
 	for i := start; i < len(e.toolLines); i++ {
 		l := e.toolLines[i]
 		switch {
+		case l.denialMsg != "":
+			sb.WriteString(fmt.Sprintf("🚫 %s\n", l.denialMsg))
 		case l.failed:
 			sb.WriteString(fmt.Sprintf("❌ %s\n", l.name))
 		case l.done:

--- a/internal/bot/tool_status.go
+++ b/internal/bot/tool_status.go
@@ -9,15 +9,17 @@ import (
 	"gopkg.in/telebot.v4"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/tools"
 )
 
 const maxToolStatusLines = 5
 
 // toolStatusLine tracks the state of a single tool invocation
 type toolStatusLine struct {
-	name   string
-	done   bool
-	failed bool
+	name      string
+	done      bool
+	failed    bool
+	denialMsg string // non-empty when tool was blocked by policy
 }
 
 // ToolStatusTracker records tool started/finished events and formats them as status lines
@@ -33,14 +35,17 @@ func (t *ToolStatusTracker) OnStarted(name string) {
 	t.lines = append(t.lines, toolStatusLine{name: name})
 }
 
-// OnFinished marks the last pending entry for name as done or failed
-func (t *ToolStatusTracker) OnFinished(name string, failed bool) {
+// OnFinished marks the last pending entry for name as done or failed.
+// If denialMsg is non-empty, the tool was blocked by policy and the message
+// is shown in place of the generic failure icon.
+func (t *ToolStatusTracker) OnFinished(name string, failed bool, denialMsg string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	for i := len(t.lines) - 1; i >= 0; i-- {
 		if t.lines[i].name == name && !t.lines[i].done && !t.lines[i].failed {
 			t.lines[i].done = !failed
 			t.lines[i].failed = failed
+			t.lines[i].denialMsg = denialMsg
 			return
 		}
 	}
@@ -71,6 +76,8 @@ func (t *ToolStatusTracker) Format() string {
 	for i := start; i < len(t.lines); i++ {
 		l := t.lines[i]
 		switch {
+		case l.denialMsg != "":
+			sb.WriteString(fmt.Sprintf("🚫 %s\n", l.denialMsg))
 		case l.failed:
 			sb.WriteString(fmt.Sprintf("❌ %s\n", l.name))
 		case l.done:
@@ -109,7 +116,11 @@ func (p *PlaceholderEditor) OnToolEvent(event agent.ToolEvent) {
 	case agent.ToolEventStarted:
 		p.tracker.OnStarted(event.ToolName)
 	case agent.ToolEventFinished:
-		p.tracker.OnFinished(event.ToolName, event.Err != nil)
+		var denialMsg string
+		if denial := tools.IsToolDenial(event.Err); denial != nil {
+			denialMsg = denial.FormatTelegram()
+		}
+		p.tracker.OnFinished(event.ToolName, event.Err != nil, denialMsg)
 	}
 	p.schedule()
 }

--- a/internal/bot/tool_status_test.go
+++ b/internal/bot/tool_status_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/tools"
 )
 
 func TestToolStatusTracker_Empty(t *testing.T) {
@@ -35,7 +36,7 @@ func TestToolStatusTracker_StartedLine(t *testing.T) {
 func TestToolStatusTracker_FinishedSuccess(t *testing.T) {
 	var tr ToolStatusTracker
 	tr.OnStarted("search")
-	tr.OnFinished("search", false)
+	tr.OnFinished("search", false, "")
 	out := tr.Format()
 	if !strings.Contains(out, "✅ search") {
 		t.Errorf("expected success line, got %q", out)
@@ -45,7 +46,7 @@ func TestToolStatusTracker_FinishedSuccess(t *testing.T) {
 func TestToolStatusTracker_FinishedError(t *testing.T) {
 	var tr ToolStatusTracker
 	tr.OnStarted("patch")
-	tr.OnFinished("patch", true)
+	tr.OnFinished("patch", true, "")
 	out := tr.Format()
 	if !strings.Contains(out, "❌ patch") {
 		t.Errorf("expected error line, got %q", out)
@@ -58,7 +59,7 @@ func TestToolStatusTracker_MaxLines(t *testing.T) {
 	tools := []string{"a", "b", "c", "d", "e", "f", "g"}
 	for _, name := range tools {
 		tr.OnStarted(name)
-		tr.OnFinished(name, false)
+		tr.OnFinished(name, false, "")
 	}
 	out := tr.Format()
 	lines := strings.Split(strings.TrimSpace(out), "\n")
@@ -82,7 +83,7 @@ func TestToolStatusTracker_MultipleConcurrent(t *testing.T) {
 	if !strings.Contains(out, "⚙️ parse…") {
 		t.Errorf("expected parse in-progress, got %q", out)
 	}
-	tr.OnFinished("fetch", false)
+	tr.OnFinished("fetch", false, "")
 	out = tr.Format()
 	if !strings.Contains(out, "✅ fetch") {
 		t.Errorf("expected fetch done, got %q", out)
@@ -95,7 +96,7 @@ func TestToolStatusTracker_MultipleConcurrent(t *testing.T) {
 func TestToolStatusTracker_OnFinished_NoMatchingEntry(t *testing.T) {
 	// OnFinished with no prior OnStarted should be a no-op (not panic).
 	var tr ToolStatusTracker
-	tr.OnFinished("ghost", false)
+	tr.OnFinished("ghost", false, "")
 	if tr.HasAny() {
 		t.Error("expected tracker to be empty after OnFinished with no prior OnStarted")
 	}
@@ -105,8 +106,8 @@ func TestToolStatusTracker_SameName_MarksLastPending(t *testing.T) {
 	// When the same tool is called twice, OnFinished should mark the last pending entry.
 	var tr ToolStatusTracker
 	tr.OnStarted("search")
-	tr.OnFinished("search", false) // first call done
-	tr.OnStarted("search")         // second call started
+	tr.OnFinished("search", false, "") // first call done
+	tr.OnStarted("search")             // second call started
 	out := tr.Format()
 	// Should show one done and one in-progress.
 	if !strings.Contains(out, "✅ search") {
@@ -163,6 +164,45 @@ func TestPlaceholderEditor_OnToolEvent_errorDelegation(t *testing.T) {
 
 	if !strings.Contains(editor.tracker.Format(), "❌ patch") {
 		t.Errorf("expected error line, got %q", editor.tracker.Format())
+	}
+
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestToolStatusTracker_DenialMessage(t *testing.T) {
+	var tr ToolStatusTracker
+	tr.OnStarted("local")
+	tr.OnFinished("local", true, `🚫 Tool "local" is disabled (estop active)`)
+	out := tr.Format()
+	if !strings.Contains(out, "🚫") {
+		t.Errorf("expected denial emoji in output, got %q", out)
+	}
+	if !strings.Contains(out, "estop active") {
+		t.Errorf("expected denial reason in output, got %q", out)
+	}
+	// Should NOT show the generic ❌
+	if strings.Contains(out, "❌") {
+		t.Errorf("expected no generic error icon when denial message present, got %q", out)
+	}
+}
+
+func TestPlaceholderEditor_OnToolEvent_denialDelegation(t *testing.T) {
+	editor := &PlaceholderEditor{minInterval: 0}
+
+	editor.OnToolEvent(agent.ToolEvent{Type: agent.ToolEventStarted, ToolName: "browser"})
+	editor.OnToolEvent(agent.ToolEvent{
+		Type:     agent.ToolEventFinished,
+		ToolName: "browser",
+		Err:      &tools.ToolDenial{ToolName: "browser", Family: "browser", Reason: "estop active", Hint: "Run /estop off"},
+		Denied:   true,
+	})
+
+	out := editor.tracker.Format()
+	if !strings.Contains(out, "🚫") {
+		t.Errorf("expected denial emoji in tracker output, got %q", out)
+	}
+	if !strings.Contains(out, "estop active") {
+		t.Errorf("expected denial reason in tracker output, got %q", out)
 	}
 
 	time.Sleep(10 * time.Millisecond)

--- a/internal/control/protocol.go
+++ b/internal/control/protocol.go
@@ -7,6 +7,7 @@ const (
 	EvtRunDelta         = "run.delta"
 	EvtToolStarted      = "tool.started"
 	EvtToolFinished     = "tool.finished"
+	EvtToolDenied       = "tool.denied"
 	EvtRunCompleted     = "run.completed"
 	EvtRunFailed        = "run.failed"
 	EvtApprovalRequest  = "approval.request"
@@ -31,6 +32,14 @@ type ToolEventPayload struct {
 	Input    string `json:"input,omitempty"`
 	Output   string `json:"output,omitempty"`
 	Error    string `json:"error,omitempty"`
+}
+
+type ToolDeniedPayload struct {
+	ChatID   int64  `json:"chat_id"`
+	ToolName string `json:"tool_name"`
+	Family   string `json:"family,omitempty"`
+	Reason   string `json:"reason"`
+	Hint     string `json:"hint,omitempty"`
 }
 
 type RunEventPayload struct {

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -15,6 +15,7 @@ import (
 	"ok-gobot/internal/ai"
 	runtimepkg "ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
+	"ok-gobot/internal/tools"
 )
 
 const (
@@ -209,6 +210,19 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 						msg.ToolError = event.Err.Error()
 					}
 					s.hub.BroadcastTUI(msg)
+					if event.Denied {
+						if denial := tools.IsToolDenial(event.Err); denial != nil {
+							s.hub.BroadcastTUI(ServerMsg{
+								Type:         MsgTypeEvent,
+								Kind:         KindToolDenied,
+								SessionID:    sessionID,
+								ToolName:     denial.ToolName,
+								ToolFamily:   denial.Family,
+								DenialReason: denial.Reason,
+								DenialHint:   denial.Hint,
+							})
+						}
+					}
 				}
 			},
 		}

--- a/internal/control/tui_bridge.go
+++ b/internal/control/tui_bridge.go
@@ -93,6 +93,20 @@ func legacyEventToTUI(evtType string, payload interface{}) []ServerMsg {
 			ApprovalID: p.ApprovalID,
 			Command:    p.Command,
 		}}
+	case EvtToolDenied:
+		p, ok := asToolDeniedPayload(payload)
+		if !ok {
+			return nil
+		}
+		return []ServerMsg{{
+			Type:         MsgTypeEvent,
+			Kind:         KindToolDenied,
+			SessionID:    sessionIDForChat(p.ChatID),
+			ToolName:     p.ToolName,
+			ToolFamily:   p.Family,
+			DenialReason: p.Reason,
+			DenialHint:   p.Hint,
+		}}
 	case EvtSessionQueued:
 		p, ok := asSessionInfo(payload)
 		if !ok {
@@ -162,6 +176,20 @@ func asApprovalRequestPayload(payload interface{}) (ApprovalRequestPayload, bool
 		return *p, true
 	default:
 		return ApprovalRequestPayload{}, false
+	}
+}
+
+func asToolDeniedPayload(payload interface{}) (ToolDeniedPayload, bool) {
+	switch p := payload.(type) {
+	case ToolDeniedPayload:
+		return p, true
+	case *ToolDeniedPayload:
+		if p == nil {
+			return ToolDeniedPayload{}, false
+		}
+		return *p, true
+	default:
+		return ToolDeniedPayload{}, false
 	}
 }
 

--- a/internal/control/tui_bridge_test.go
+++ b/internal/control/tui_bridge_test.go
@@ -1,0 +1,65 @@
+package control
+
+import "testing"
+
+func TestLegacyEventToTUI_ToolDenied(t *testing.T) {
+	t.Parallel()
+
+	payload := ToolDeniedPayload{
+		ChatID:   42,
+		ToolName: "local",
+		Family:   "local",
+		Reason:   "estop active",
+		Hint:     "Run /estop off to re-enable.",
+	}
+
+	msgs := legacyEventToTUI(EvtToolDenied, payload)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	msg := msgs[0]
+	if msg.Kind != KindToolDenied {
+		t.Errorf("expected Kind=%s, got %s", KindToolDenied, msg.Kind)
+	}
+	if msg.ToolName != "local" {
+		t.Errorf("expected ToolName=local, got %s", msg.ToolName)
+	}
+	if msg.ToolFamily != "local" {
+		t.Errorf("expected ToolFamily=local, got %s", msg.ToolFamily)
+	}
+	if msg.DenialReason != "estop active" {
+		t.Errorf("expected DenialReason='estop active', got %s", msg.DenialReason)
+	}
+	if msg.DenialHint != "Run /estop off to re-enable." {
+		t.Errorf("expected DenialHint, got %s", msg.DenialHint)
+	}
+}
+
+func TestLegacyEventToTUI_ToolDenied_PointerPayload(t *testing.T) {
+	t.Parallel()
+
+	payload := &ToolDeniedPayload{
+		ChatID:   42,
+		ToolName: "ssh",
+		Family:   "ssh",
+		Reason:   "estop active",
+	}
+
+	msgs := legacyEventToTUI(EvtToolDenied, payload)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].ToolName != "ssh" {
+		t.Errorf("expected ToolName=ssh, got %s", msgs[0].ToolName)
+	}
+}
+
+func TestLegacyEventToTUI_ToolDenied_WrongPayload(t *testing.T) {
+	t.Parallel()
+
+	msgs := legacyEventToTUI(EvtToolDenied, "not a payload")
+	if msgs != nil {
+		t.Fatalf("expected nil for wrong payload type, got %v", msgs)
+	}
+}

--- a/internal/control/tui_types.go
+++ b/internal/control/tui_types.go
@@ -19,6 +19,7 @@ const (
 	KindMessage     = "message"
 	KindToolStart   = "tool_start"
 	KindToolEnd     = "tool_end"
+	KindToolDenied  = "tool_denied"
 	KindRunStart    = "run_start"
 	KindRunEnd      = "run_end"
 	KindError       = "error"
@@ -63,6 +64,9 @@ type ServerMsg struct {
 	ToolArgs         string           `json:"tool_args,omitempty"`
 	ToolResult       string           `json:"tool_result,omitempty"`
 	ToolError        string           `json:"tool_error,omitempty"`
+	ToolFamily       string           `json:"tool_family,omitempty"`
+	DenialReason     string           `json:"denial_reason,omitempty"`
+	DenialHint       string           `json:"denial_hint,omitempty"`
 	ApprovalID       string           `json:"approval_id,omitempty"`
 	Command          string           `json:"command,omitempty"`
 	QueueDepth       int              `json:"queue_depth,omitempty"`

--- a/internal/tools/denial.go
+++ b/internal/tools/denial.go
@@ -1,0 +1,51 @@
+package tools
+
+import "fmt"
+
+// ToolDenial is a structured error returned when a tool call is blocked by
+// policy (e.g. estop). It carries enough context for every rendering surface
+// (Telegram, TUI, API, AI model) to produce a clear, actionable message.
+type ToolDenial struct {
+	ToolName string // the tool that was called
+	Family   string // the dangerous-tool family (e.g. "local", "browser")
+	Reason   string // human-readable reason (e.g. "estop active")
+	Hint     string // how to re-enable (e.g. `/estop off`)
+}
+
+func (d *ToolDenial) Error() string {
+	return fmt.Sprintf("tool %q denied: %s", d.ToolName, d.Reason)
+}
+
+// FormatTelegram returns the denial formatted as a Telegram-friendly message.
+func (d *ToolDenial) FormatTelegram() string {
+	msg := fmt.Sprintf("🚫 Tool %q is disabled (%s)", d.ToolName, d.Reason)
+	if d.Hint != "" {
+		msg += "\n" + d.Hint
+	}
+	return msg
+}
+
+// FormatPlain returns a plain-text rendering suitable for the AI model tool
+// result so the model can explain the denial to the user.
+func (d *ToolDenial) FormatPlain() string {
+	msg := fmt.Sprintf("DENIED: Tool %q is disabled (%s).", d.ToolName, d.Reason)
+	if d.Family != "" {
+		msg += fmt.Sprintf(" Tool family: %s.", d.Family)
+	}
+	if d.Hint != "" {
+		msg += " " + d.Hint
+	}
+	return msg
+}
+
+// IsToolDenial extracts a *ToolDenial from an error, returning nil if the
+// error is not a denial.
+func IsToolDenial(err error) *ToolDenial {
+	if err == nil {
+		return nil
+	}
+	if d, ok := err.(*ToolDenial); ok {
+		return d
+	}
+	return nil
+}

--- a/internal/tools/denial_test.go
+++ b/internal/tools/denial_test.go
@@ -1,0 +1,135 @@
+package tools
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestToolDenial_Error(t *testing.T) {
+	t.Parallel()
+
+	d := &ToolDenial{
+		ToolName: "local",
+		Family:   "local",
+		Reason:   "estop active",
+		Hint:     "Run `/estop off` to re-enable.",
+	}
+
+	got := d.Error()
+	if !strings.Contains(got, `"local"`) {
+		t.Errorf("Error() should contain tool name, got %q", got)
+	}
+	if !strings.Contains(got, "estop active") {
+		t.Errorf("Error() should contain reason, got %q", got)
+	}
+}
+
+func TestToolDenial_FormatTelegram(t *testing.T) {
+	t.Parallel()
+
+	d := &ToolDenial{
+		ToolName: "browser",
+		Family:   "browser",
+		Reason:   "estop active",
+		Hint:     "Run `/estop off` or `ok-gobot estop off` to re-enable.",
+	}
+
+	got := d.FormatTelegram()
+	if !strings.Contains(got, "🚫") {
+		t.Errorf("FormatTelegram() should contain prohibited emoji, got %q", got)
+	}
+	if !strings.Contains(got, `"browser"`) {
+		t.Errorf("FormatTelegram() should contain tool name, got %q", got)
+	}
+	if !strings.Contains(got, "estop active") {
+		t.Errorf("FormatTelegram() should contain reason, got %q", got)
+	}
+	if !strings.Contains(got, "/estop off") {
+		t.Errorf("FormatTelegram() should contain re-enable hint, got %q", got)
+	}
+}
+
+func TestToolDenial_FormatPlain(t *testing.T) {
+	t.Parallel()
+
+	d := &ToolDenial{
+		ToolName: "ssh",
+		Family:   "ssh",
+		Reason:   "estop active",
+		Hint:     "Run `/estop off` to re-enable.",
+	}
+
+	got := d.FormatPlain()
+	if !strings.HasPrefix(got, "DENIED:") {
+		t.Errorf("FormatPlain() should start with DENIED:, got %q", got)
+	}
+	if !strings.Contains(got, "ssh") {
+		t.Errorf("FormatPlain() should contain tool family, got %q", got)
+	}
+	if !strings.Contains(got, "/estop off") {
+		t.Errorf("FormatPlain() should contain hint, got %q", got)
+	}
+}
+
+func TestIsToolDenial_WithDenial(t *testing.T) {
+	t.Parallel()
+
+	d := &ToolDenial{ToolName: "cron", Reason: "estop active"}
+	got := IsToolDenial(d)
+	if got == nil {
+		t.Fatal("expected IsToolDenial to return non-nil for *ToolDenial")
+	}
+	if got.ToolName != "cron" {
+		t.Errorf("expected ToolName=cron, got %s", got.ToolName)
+	}
+}
+
+func TestIsToolDenial_WithOtherError(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("something else")
+	got := IsToolDenial(err)
+	if got != nil {
+		t.Fatal("expected IsToolDenial to return nil for non-denial error")
+	}
+}
+
+func TestIsToolDenial_Nil(t *testing.T) {
+	t.Parallel()
+
+	got := IsToolDenial(nil)
+	if got != nil {
+		t.Fatal("expected IsToolDenial to return nil for nil error")
+	}
+}
+
+func TestEstopGuardReturnsDenial(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistryWithEmergencyStop(stubEmergencyStopProvider{enabled: true})
+	tool := &stubTool{name: "local"}
+	reg.Register(tool)
+
+	_, err := reg.Execute(nil, "local", "ls")
+	if err == nil {
+		t.Fatal("expected error from blocked tool")
+	}
+
+	denial := IsToolDenial(err)
+	if denial == nil {
+		t.Fatal("expected ToolDenial error from estop guard")
+	}
+	if denial.ToolName != "local" {
+		t.Errorf("expected ToolName=local, got %s", denial.ToolName)
+	}
+	if denial.Family != "local" {
+		t.Errorf("expected Family=local, got %s", denial.Family)
+	}
+	if denial.Reason != "estop active" {
+		t.Errorf("expected Reason='estop active', got %s", denial.Reason)
+	}
+	if denial.Hint == "" {
+		t.Error("expected non-empty Hint")
+	}
+}

--- a/internal/tools/estop_test.go
+++ b/internal/tools/estop_test.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"strings"
 	"testing"
 )
 
@@ -53,8 +52,15 @@ func TestRegistryBlocksDangerousToolsWhenEmergencyStopEnabled(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected estop to block message tool")
 	}
-	if !strings.Contains(err.Error(), `estop is ON`) {
-		t.Fatalf("unexpected error: %v", err)
+	denial := IsToolDenial(err)
+	if denial == nil {
+		t.Fatalf("expected ToolDenial error, got %v", err)
+	}
+	if denial.ToolName != "message" {
+		t.Fatalf("expected ToolName=message, got %s", denial.ToolName)
+	}
+	if denial.Family != "message" {
+		t.Fatalf("expected Family=message, got %s", denial.Family)
 	}
 	if tool.called != 0 {
 		t.Fatalf("expected wrapped tool not to execute, called=%d", tool.called)
@@ -85,8 +91,12 @@ func TestChildRegistryPreservesEmergencyStopForJSONTools(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected estop to block browser_task")
 	}
-	if !strings.Contains(err.Error(), `"browser"`) {
-		t.Fatalf("expected browser family in error, got %v", err)
+	denial := IsToolDenial(err)
+	if denial == nil {
+		t.Fatalf("expected ToolDenial error, got %v", err)
+	}
+	if denial.Family != "browser" {
+		t.Fatalf("expected Family=browser, got %s", denial.Family)
 	}
 	if tool.jsonCalled != 0 {
 		t.Fatalf("expected wrapped JSON tool not to execute, called=%d", tool.jsonCalled)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -374,7 +374,12 @@ func (g *emergencyStopGuard) check() error {
 		return fmt.Errorf("failed to read estop state: %w", err)
 	}
 	if enabled {
-		return fmt.Errorf("estop is ON: tool family %q is disabled (tool: %s)", g.family, g.tool.Name())
+		return &ToolDenial{
+			ToolName: g.tool.Name(),
+			Family:   g.family,
+			Reason:   "estop active",
+			Hint:     "Run `/estop off` or `ok-gobot estop off` to re-enable.",
+		}
 	}
 	return nil
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -46,7 +46,9 @@ type chatEntry struct {
 	toolArgs  string
 	toolRes   string
 	toolErr   string
-	streaming bool // true while tokens are still arriving
+	denied    bool   // true when tool was blocked by policy
+	denialMsg string // formatted denial reason + hint
+	streaming bool   // true while tokens are still arriving
 	timestamp time.Time
 	model     string
 	tokens    int
@@ -661,6 +663,23 @@ func (m *Model) handleEvent(msg controlserver.ServerMsg) tea.Cmd {
 		}
 		m.refreshViewport()
 
+	case controlserver.KindToolDenied:
+		// Mark the matching tool entry as denied and set the denial details.
+		reason := msg.DenialReason
+		hint := msg.DenialHint
+		denialText := fmt.Sprintf("DENIED (%s)", reason)
+		if hint != "" {
+			denialText += " — " + hint
+		}
+		for i := len(m.entries) - 1; i >= 0; i-- {
+			if m.entries[i].role == "tool" && m.entries[i].toolName == msg.ToolName {
+				m.entries[i].denied = true
+				m.entries[i].denialMsg = denialText
+				break
+			}
+		}
+		m.refreshViewport()
+
 	case controlserver.KindError:
 		m.addEntry(chatEntry{role: "error", content: msg.Message})
 		m.refreshViewport()
@@ -938,6 +957,13 @@ func (m *Model) focusedToolEntryIndex() int {
 
 // toolCardSummary returns a brief one-line summary for a collapsed tool card.
 func toolCardSummary(e chatEntry) string {
+	if e.denied && e.denialMsg != "" {
+		first := e.denialMsg
+		if nl := strings.IndexByte(first, '\n'); nl >= 0 {
+			first = first[:nl]
+		}
+		return truncate(first, 60)
+	}
 	if e.toolRes != "" {
 		first := e.toolRes
 		if nl := strings.IndexByte(first, '\n'); nl >= 0 {
@@ -961,9 +987,11 @@ func (m *Model) renderToolCard(idx int, e chatEntry) string {
 	isFocused := m.toolCardNav && idx == m.focusedToolEntryIndex()
 
 	if m.isToolCardCollapsed(idx, e) {
-		// Collapsed view: ⚙ tool_name [✓|✗] → brief summary
+		// Collapsed view: ⚙ tool_name [✓|✗|🚫] → brief summary
 		status := "✓"
-		if e.toolErr != "" {
+		if e.denied {
+			status = "🚫"
+		} else if e.toolErr != "" {
 			status = "✗"
 		}
 		line := "⚙ " + e.toolName + " [" + status + "]"
@@ -994,10 +1022,12 @@ func (m *Model) renderToolCard(idx int, e chatEntry) string {
 	if inProgress {
 		sb.WriteString("\n" + toolArgStyle.Render("  running…"))
 	}
-	if e.toolRes != "" {
+	if e.denied && e.denialMsg != "" {
+		sb.WriteString("\n" + toolErrorStyle.Render("  🚫 "+e.denialMsg))
+	} else if e.toolRes != "" {
 		sb.WriteString("\n" + toolResultStyle.Render("  → "+truncate(e.toolRes, 200)))
 	}
-	if e.toolErr != "" {
+	if !e.denied && e.toolErr != "" {
 		sb.WriteString("\n" + toolErrorStyle.Render("  ✗ "+e.toolErr))
 	}
 	inner := sb.String()


### PR DESCRIPTION
Implements #158

## Changes

- **Structured `ToolDenial` error type** (`internal/tools/denial.go`): replaces the plain `fmt.Errorf` in the estop guard with a typed error carrying tool name, family, reason, and re-enable hint. Provides `FormatTelegram()`, `FormatPlain()`, and `IsToolDenial()` helpers.

- **`tool.denied` control hub event** (`internal/control/protocol.go`): new `EvtToolDenied` event with `ToolDeniedPayload` containing structured denial fields. Emitted from both the Telegram bot hub handler and the TUI server runtime.

- **AI model receives denial as tool result**: when a tool is blocked, `tool_agent.go` detects the `ToolDenial` error and sends a clear plain-text denial message as the `RoleTool` result, so the model can explain the situation to the user.

- **Telegram rendering**: tool status lines in both `PlaceholderEditor` and `LiveStreamEditor` show `🚫 Tool "X" is disabled (reason) + hint` instead of the generic `❌` icon.

- **TUI rendering**: tool cards show `🚫` icon with denial message in both collapsed and expanded views. New `KindToolDenied` event type bridges denial payloads to TUI clients.

- **Tests**: comprehensive tests for `ToolDenial` formatting, `IsToolDenial` extraction, estop guard denial output, TUI bridge conversion, and Telegram tracker rendering with denial messages. Existing estop tests updated to verify structured error.

## Example Output

Telegram:
```
🚫 Tool "local" is disabled (estop active)
Run `/estop off` or `ok-gobot estop off` to re-enable.
```

AI model sees:
```
DENIED: Tool "local" is disabled (estop active). Tool family: local. Run `/estop off` or `ok-gobot estop off` to re-enable.
```

## Testing

- `go test ./...` — all 26 packages pass
- `go vet ./...` — clean
- `CGO_ENABLED=1 go build ./cmd/ok-gobot/` — binary builds and runs
- New tests cover: ToolDenial formatting, IsToolDenial extraction, estop guard structured error, TUI bridge event conversion, Telegram status tracker denial rendering

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a structured `ToolDenial` error type to replace the plain `fmt.Errorf` in the estop guard, and plumbs the denial details through all rendering surfaces (Telegram, TUI, AI model tool result). The architecture is clean and the feature is well-tested overall.

One concrete rendering bug is present across both Telegram formatters:

- **Double `🚫` emoji** in `internal/bot/tool_status.go` and `internal/bot/live_editor.go`: `denialMsg` is populated by `denial.FormatTelegram()`, which already includes the `🚫` prefix (e.g. `🚫 Tool "local" is disabled (estop active)`). Both `Format()` and `formatStatusLocked()` then wrap this value with `fmt.Sprintf("🚫 %s\n", ...)`, producing `🚫 🚫 Tool …` in every blocked-tool status line. The tests don't catch this because they only assert the emoji is *present*, not that it appears only once. The fix is to replace `fmt.Sprintf("🚫 %s\n", l.denialMsg)` with `l.denialMsg + "\n"` in both formatters.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the double emoji rendering bug in the two Telegram formatters.
- The PR is well-structured with comprehensive tests and correct TUI/AI-model paths. One targeted one-line fix (applied in two places) is needed before the Telegram output matches the intended format shown in the PR description.
- `internal/bot/tool_status.go` line 80 and `internal/bot/live_editor.go` line 162 — both emit `🚫 <denialMsg>` where `denialMsg` already starts with `🚫`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tools/denial.go | New structured `ToolDenial` error type with `FormatTelegram()`, `FormatPlain()`, and `IsToolDenial()` helpers. Clean, well-documented implementation. `IsToolDenial` uses a direct type assertion rather than `errors.As`, which is safe given current usage but would miss wrapped errors. |
| internal/bot/tool_status.go | Double `🚫` emoji bug: `denialMsg` is set to `denial.FormatTelegram()` (which already contains the emoji), but `Format()` wraps it with another `"🚫 %s\n"` prefix, producing `🚫 🚫 Tool …` in the output. |
| internal/bot/live_editor.go | Same double `🚫` emoji bug as `tool_status.go`: `denialMsg` is set to `FormatTelegram()` output, but `formatStatusLocked()` wraps it again with `"🚫 %s\n"`. |
| internal/agent/tool_agent.go | Detects `ToolDenial` errors and sends `FormatPlain()` as the tool result to the AI model; adds `Denied` flag to `ToolEvent`. Logic is correct and ordering is safe. |
| internal/control/tui_bridge.go | Adds `legacyEventToTUI` case for `EvtToolDenied` and a typed `asToolDeniedPayload` helper. Well-tested with value, pointer, and wrong-type cases. |
| internal/tui/model.go | Handles `KindToolDenied` event to set `denied`/`denialMsg` on the matching tool entry. Collapsed and expanded rendering both correctly check `e.denied` first, hiding the generic error icon when denied. |
| internal/bot/tool_status_test.go | New denial tests pass the pre-emoji'd `FormatTelegram()` string through the tracker but only assert `🚫` presence, not absence of a second one — so the double-emoji bug in `Format()` goes undetected by the test suite. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/bot/tool_status.go
Line: 80

Comment:
**Double `🚫` emoji in Telegram output**

`denialMsg` is populated by `denial.FormatTelegram()`, which already prepends `🚫` (e.g. `🚫 Tool "local" is disabled (estop active)\nRun …`). Wrapping that value in `fmt.Sprintf("🚫 %s\n", l.denialMsg)` produces a double `🚫 🚫` prefix in every Telegram status line, contradicting the example in the PR description.

The same duplication exists in `internal/bot/live_editor.go` line 162 where `l.denialMsg` (also set via `FormatTelegram()`) is wrapped the same way.

Fix: drop the redundant emoji prefix from both formatters and use the `denialMsg` value directly.

```suggestion
		case l.denialMsg != "":
			sb.WriteString(l.denialMsg + "\n")
```

Apply the same change at `internal/bot/live_editor.go:162`:
```go
case l.denialMsg != "":
    sb.WriteString(l.denialMsg + "\n")
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(safety): blocked tools show clear r..."](https://github.com/befeast/ok-gobot/commit/0d55a4c5efd6d7393b80080a0b85de5bac1dc3d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25978546)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->