### PR TITLE
feat(role): markdown-first role manifests (#178)

### DIFF
--- a/internal/role/loader.go
+++ b/internal/role/loader.go
@@ -1,0 +1,107 @@
+package role
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// LoadDir reads all .md files from dir and returns a slice of parsed manifests.
+// Files that are not valid manifests return an error; use LoadDirLenient to skip
+// invalid files instead.
+func LoadDir(dir string) ([]*Manifest, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading role directory %s: %w", dir, err)
+	}
+
+	var manifests []*Manifest
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", path, err)
+		}
+
+		name := strings.TrimSuffix(entry.Name(), ".md")
+		m, err := Parse(name, data)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, err)
+		}
+
+		m.SourcePath = path
+		manifests = append(manifests, m)
+	}
+
+	sort.Slice(manifests, func(i, j int) bool {
+		return manifests[i].Name < manifests[j].Name
+	})
+
+	return manifests, nil
+}
+
+// LoadDirLenient reads all .md files from dir and returns the successfully
+// parsed manifests alongside any per-file errors. Processing continues past
+// individual failures so that one bad file does not block the rest.
+func LoadDirLenient(dir string) ([]*Manifest, []error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, []error{fmt.Errorf("reading role directory %s: %w", dir, err)}
+	}
+
+	var manifests []*Manifest
+	var errs []error
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("reading %s: %w", path, err))
+			continue
+		}
+
+		name := strings.TrimSuffix(entry.Name(), ".md")
+		m, err := Parse(name, data)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("parsing %s: %w", path, err))
+			continue
+		}
+
+		m.SourcePath = path
+		manifests = append(manifests, m)
+	}
+
+	sort.Slice(manifests, func(i, j int) bool {
+		return manifests[i].Name < manifests[j].Name
+	})
+
+	return manifests, errs
+}
+
+// LoadFile reads and parses a single role manifest from path.
+// The role name is derived from the filename stem.
+func LoadFile(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	name := strings.TrimSuffix(filepath.Base(path), ".md")
+	m, err := Parse(name, data)
+	if err != nil {
+		return nil, err
+	}
+
+	m.SourcePath = path
+	return m, nil
+}

--- a/internal/role/manifest.go
+++ b/internal/role/manifest.go
@@ -1,0 +1,253 @@
+// Package role implements markdown-first role manifests.
+//
+// Each role is a single markdown file with YAML frontmatter. The frontmatter
+// carries structured metadata (worker, tools, schedule, report template,
+// approval mode) while the markdown body is the role's system prompt.
+//
+// Example manifest:
+//
+//	---
+//	worker: standard
+//	tools: [web_fetch, search]
+//	schedule: "0 9 * * *"
+//	report_template: |
+//	  ## {{.Title}}
+//	  {{.Body}}
+//	approval: auto
+//	---
+//	# Researcher
+//	You are a research agent. Your job is to gather information...
+package role
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ApprovalMode controls when a role requires human approval for dangerous actions.
+type ApprovalMode string
+
+const (
+	// ApprovalAuto uses the default heuristic (pattern-match dangerous commands).
+	ApprovalAuto ApprovalMode = "auto"
+	// ApprovalAlways requires approval for every tool call.
+	ApprovalAlways ApprovalMode = "always"
+	// ApprovalNever skips approval entirely (use with caution).
+	ApprovalNever ApprovalMode = "never"
+)
+
+// validApprovalModes is the canonical set of recognised modes.
+var validApprovalModes = map[ApprovalMode]struct{}{
+	ApprovalAuto:   {},
+	ApprovalAlways: {},
+	ApprovalNever:  {},
+}
+
+// ValidApprovalMode reports whether m is a recognised approval mode.
+func ValidApprovalMode(m ApprovalMode) bool {
+	_, ok := validApprovalModes[m]
+	return ok
+}
+
+// frontmatter is the YAML structure parsed from between the --- delimiters.
+type frontmatter struct {
+	Worker         string   `yaml:"worker"`
+	Tools          []string `yaml:"tools"`
+	Schedule       string   `yaml:"schedule"`
+	ReportTemplate string   `yaml:"report_template"`
+	Approval       string   `yaml:"approval"`
+}
+
+// Manifest is a parsed role definition loaded from a markdown file.
+type Manifest struct {
+	// Name is the role identifier, derived from the filename (without .md).
+	Name string
+
+	// Prompt is the markdown body after frontmatter — the role's system prompt.
+	Prompt string
+
+	// Worker selects the cost tier or worker adapter for this role.
+	// Common values: "premium", "standard", "cheap", "local", or a custom adapter name.
+	// Empty means the caller should use its default.
+	Worker string
+
+	// Tools lists the tool names this role is allowed to call.
+	// An empty slice means all tools are allowed.
+	Tools []string
+
+	// Schedule is a cron expression for periodic execution.
+	// Empty means the role is not scheduled.
+	Schedule string
+
+	// ReportTemplate is a Go text/template used to format the role's output.
+	// Empty means raw output is used as-is.
+	ReportTemplate string
+
+	// Approval controls when the role requires human approval.
+	// Defaults to ApprovalAuto when not specified.
+	Approval ApprovalMode
+
+	// SourcePath is the absolute path to the source .md file.
+	SourcePath string
+}
+
+// Parse reads a role manifest from raw markdown bytes.
+// The name argument is used as the role's identifier (typically the filename stem).
+func Parse(name string, data []byte) (*Manifest, error) {
+	fm, body, err := splitFrontmatter(data)
+	if err != nil {
+		return nil, fmt.Errorf("role %q: %w", name, err)
+	}
+
+	approval := ApprovalAuto
+	if fm.Approval != "" {
+		approval = ApprovalMode(strings.ToLower(strings.TrimSpace(fm.Approval)))
+		if !ValidApprovalMode(approval) {
+			return nil, fmt.Errorf("role %q: invalid approval mode %q (want auto, always, or never)", name, fm.Approval)
+		}
+	}
+
+	m := &Manifest{
+		Name:           name,
+		Prompt:         strings.TrimSpace(body),
+		Worker:         strings.TrimSpace(fm.Worker),
+		Tools:          cleanTools(fm.Tools),
+		Schedule:       strings.TrimSpace(fm.Schedule),
+		ReportTemplate: fm.ReportTemplate,
+		Approval:       approval,
+	}
+
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// Validate checks that the manifest fields are internally consistent.
+func (m *Manifest) Validate() error {
+	if m.Name == "" {
+		return fmt.Errorf("role manifest: name is required")
+	}
+
+	if m.ReportTemplate != "" {
+		if _, err := template.New("report").Parse(m.ReportTemplate); err != nil {
+			return fmt.Errorf("role %q: invalid report_template: %w", m.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// HasSchedule reports whether this role defines a cron schedule.
+func (m *Manifest) HasSchedule() bool {
+	return m.Schedule != ""
+}
+
+// HasToolRestrictions reports whether this role restricts available tools.
+func (m *Manifest) HasToolRestrictions() bool {
+	return len(m.Tools) > 0
+}
+
+// IsToolAllowed reports whether toolName is permitted for this role.
+// Returns true if there are no restrictions (empty Tools list).
+func (m *Manifest) IsToolAllowed(toolName string) bool {
+	if !m.HasToolRestrictions() {
+		return true
+	}
+	for _, t := range m.Tools {
+		if t == toolName {
+			return true
+		}
+	}
+	return false
+}
+
+// RenderReport executes the report template against data and returns the result.
+// If no template is set, it returns an empty string and no error.
+func (m *Manifest) RenderReport(data any) (string, error) {
+	if m.ReportTemplate == "" {
+		return "", nil
+	}
+
+	tmpl, err := template.New("report").Parse(m.ReportTemplate)
+	if err != nil {
+		return "", fmt.Errorf("role %q: report template parse error: %w", m.Name, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("role %q: report template execute error: %w", m.Name, err)
+	}
+
+	return buf.String(), nil
+}
+
+// splitFrontmatter separates YAML frontmatter from the markdown body.
+// Frontmatter must be delimited by "---" lines at the start of the document.
+func splitFrontmatter(data []byte) (frontmatter, string, error) {
+	var fm frontmatter
+
+	text := string(data)
+	trimmed := strings.TrimLeftFunc(text, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '\r' || r == '\n'
+	})
+
+	// No frontmatter — the entire document is the prompt body.
+	if !strings.HasPrefix(trimmed, "---") {
+		return fm, text, nil
+	}
+
+	// Find the closing "---".
+	rest := trimmed[3:] // skip opening "---"
+	rest = strings.TrimLeft(rest, " \t")
+	if len(rest) > 0 && rest[0] == '\n' {
+		rest = rest[1:]
+	} else if len(rest) > 1 && rest[0] == '\r' && rest[1] == '\n' {
+		rest = rest[2:]
+	}
+
+	// Handle empty frontmatter: rest starts with "---" immediately.
+	var yamlBlock string
+	var body string
+	if strings.HasPrefix(rest, "---") {
+		yamlBlock = ""
+		body = rest[3:]
+	} else {
+		closingIdx := strings.Index(rest, "\n---")
+		if closingIdx < 0 {
+			// No closing delimiter — treat entire doc as body (no frontmatter).
+			return fm, text, nil
+		}
+		yamlBlock = rest[:closingIdx]
+		body = rest[closingIdx+4:] // skip "\n---"
+	}
+	// Trim the line break after closing ---
+	if len(body) > 0 && body[0] == '\n' {
+		body = body[1:]
+	} else if len(body) > 1 && body[0] == '\r' && body[1] == '\n' {
+		body = body[2:]
+	}
+
+	if err := yaml.Unmarshal([]byte(yamlBlock), &fm); err != nil {
+		return fm, "", fmt.Errorf("invalid frontmatter YAML: %w", err)
+	}
+
+	return fm, body, nil
+}
+
+// cleanTools trims whitespace and removes empty entries from a tool list.
+func cleanTools(tools []string) []string {
+	var out []string
+	for _, t := range tools {
+		t = strings.TrimSpace(t)
+		if t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/role/manifest_test.go
+++ b/internal/role/manifest_test.go
@@ -1,0 +1,421 @@
+package role
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParse_FullManifest(t *testing.T) {
+	data := []byte(`---
+worker: premium
+tools: [web_fetch, search, memory_search]
+schedule: "0 9 * * *"
+report_template: |
+  ## {{.Title}}
+  {{.Body}}
+approval: always
+---
+# Researcher
+
+You are a research agent. Your job is to gather information and compile reports.
+`)
+
+	m, err := Parse("researcher", data)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if m.Name != "researcher" {
+		t.Errorf("Name = %q, want %q", m.Name, "researcher")
+	}
+	if m.Worker != "premium" {
+		t.Errorf("Worker = %q, want %q", m.Worker, "premium")
+	}
+	if len(m.Tools) != 3 {
+		t.Fatalf("Tools length = %d, want 3", len(m.Tools))
+	}
+	if m.Tools[0] != "web_fetch" || m.Tools[1] != "search" || m.Tools[2] != "memory_search" {
+		t.Errorf("Tools = %v, want [web_fetch search memory_search]", m.Tools)
+	}
+	if m.Schedule != "0 9 * * *" {
+		t.Errorf("Schedule = %q, want %q", m.Schedule, "0 9 * * *")
+	}
+	if m.Approval != ApprovalAlways {
+		t.Errorf("Approval = %q, want %q", m.Approval, ApprovalAlways)
+	}
+	if m.ReportTemplate == "" {
+		t.Error("ReportTemplate is empty, want non-empty")
+	}
+	if !m.HasSchedule() {
+		t.Error("HasSchedule() = false, want true")
+	}
+	if !m.HasToolRestrictions() {
+		t.Error("HasToolRestrictions() = false, want true")
+	}
+	if m.IsToolAllowed("web_fetch") != true {
+		t.Error("IsToolAllowed(web_fetch) = false, want true")
+	}
+	if m.IsToolAllowed("dangerous_exec") != false {
+		t.Error("IsToolAllowed(dangerous_exec) = true, want false")
+	}
+
+	expected := "# Researcher\n\nYou are a research agent. Your job is to gather information and compile reports."
+	if m.Prompt != expected {
+		t.Errorf("Prompt = %q, want %q", m.Prompt, expected)
+	}
+}
+
+func TestParse_MinimalManifest(t *testing.T) {
+	data := []byte(`# Simple role
+
+Just a prompt, no frontmatter at all.
+`)
+
+	m, err := Parse("simple", data)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if m.Name != "simple" {
+		t.Errorf("Name = %q, want %q", m.Name, "simple")
+	}
+	if m.Worker != "" {
+		t.Errorf("Worker = %q, want empty", m.Worker)
+	}
+	if len(m.Tools) != 0 {
+		t.Errorf("Tools = %v, want empty", m.Tools)
+	}
+	if m.Schedule != "" {
+		t.Errorf("Schedule = %q, want empty", m.Schedule)
+	}
+	if m.Approval != ApprovalAuto {
+		t.Errorf("Approval = %q, want %q", m.Approval, ApprovalAuto)
+	}
+	if m.HasSchedule() {
+		t.Error("HasSchedule() = true, want false")
+	}
+	if m.HasToolRestrictions() {
+		t.Error("HasToolRestrictions() = true, want false")
+	}
+	if m.IsToolAllowed("anything") != true {
+		t.Error("IsToolAllowed(anything) = false, want true (no restrictions)")
+	}
+}
+
+func TestParse_EmptyFrontmatter(t *testing.T) {
+	data := []byte(`---
+---
+# Role with empty frontmatter
+
+This should work fine.
+`)
+
+	m, err := Parse("empty-fm", data)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if m.Name != "empty-fm" {
+		t.Errorf("Name = %q, want %q", m.Name, "empty-fm")
+	}
+	if m.Approval != ApprovalAuto {
+		t.Errorf("Approval = %q, want %q", m.Approval, ApprovalAuto)
+	}
+	expected := "# Role with empty frontmatter\n\nThis should work fine."
+	if m.Prompt != expected {
+		t.Errorf("Prompt = %q, want %q", m.Prompt, expected)
+	}
+}
+
+func TestParse_InvalidApprovalMode(t *testing.T) {
+	data := []byte(`---
+approval: maybe
+---
+Some prompt.
+`)
+
+	_, err := Parse("bad-approval", data)
+	if err == nil {
+		t.Fatal("Parse should fail for invalid approval mode")
+	}
+}
+
+func TestParse_InvalidReportTemplate(t *testing.T) {
+	data := []byte(`---
+report_template: "{{.Broken"
+---
+Some prompt.
+`)
+
+	_, err := Parse("bad-template", data)
+	if err == nil {
+		t.Fatal("Parse should fail for invalid report template")
+	}
+}
+
+func TestParse_EmptyName(t *testing.T) {
+	data := []byte(`Some prompt.`)
+
+	_, err := Parse("", data)
+	if err == nil {
+		t.Fatal("Parse should fail for empty name")
+	}
+}
+
+func TestParse_ApprovalModeNormalization(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  ApprovalMode
+	}{
+		{"auto", ApprovalAuto},
+		{"AUTO", ApprovalAuto},
+		{"  Always ", ApprovalAlways},
+		{"never", ApprovalNever},
+		{"NEVER", ApprovalNever},
+	} {
+		data := []byte("---\napproval: " + tc.input + "\n---\nPrompt.\n")
+		m, err := Parse("test", data)
+		if err != nil {
+			t.Errorf("Parse(approval=%q) failed: %v", tc.input, err)
+			continue
+		}
+		if m.Approval != tc.want {
+			t.Errorf("approval=%q → %q, want %q", tc.input, m.Approval, tc.want)
+		}
+	}
+}
+
+func TestManifest_RenderReport(t *testing.T) {
+	m := &Manifest{
+		Name:           "test",
+		ReportTemplate: "## {{.Title}}\n{{.Body}}",
+	}
+
+	data := map[string]string{
+		"Title": "Daily Report",
+		"Body":  "All systems operational.",
+	}
+
+	result, err := m.RenderReport(data)
+	if err != nil {
+		t.Fatalf("RenderReport failed: %v", err)
+	}
+
+	expected := "## Daily Report\nAll systems operational."
+	if result != expected {
+		t.Errorf("RenderReport = %q, want %q", result, expected)
+	}
+}
+
+func TestManifest_RenderReport_Empty(t *testing.T) {
+	m := &Manifest{Name: "test"}
+	result, err := m.RenderReport(nil)
+	if err != nil {
+		t.Fatalf("RenderReport failed: %v", err)
+	}
+	if result != "" {
+		t.Errorf("RenderReport = %q, want empty", result)
+	}
+}
+
+func TestValidApprovalMode(t *testing.T) {
+	if !ValidApprovalMode(ApprovalAuto) {
+		t.Error("ApprovalAuto should be valid")
+	}
+	if !ValidApprovalMode(ApprovalAlways) {
+		t.Error("ApprovalAlways should be valid")
+	}
+	if !ValidApprovalMode(ApprovalNever) {
+		t.Error("ApprovalNever should be valid")
+	}
+	if ValidApprovalMode("maybe") {
+		t.Error("'maybe' should not be valid")
+	}
+}
+
+func TestLoadDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write two valid role files.
+	writeFile(t, dir, "monitor.md", `---
+worker: cheap
+schedule: "*/15 * * * *"
+tools: [web_fetch]
+---
+# Monitor
+Check service health.
+`)
+
+	writeFile(t, dir, "reporter.md", `---
+worker: standard
+schedule: "0 9 * * *"
+approval: never
+---
+# Reporter
+Generate daily summaries.
+`)
+
+	// Write a non-md file that should be ignored.
+	writeFile(t, dir, "README.txt", "not a role")
+
+	manifests, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir failed: %v", err)
+	}
+
+	if len(manifests) != 2 {
+		t.Fatalf("LoadDir returned %d manifests, want 2", len(manifests))
+	}
+
+	// Results should be sorted by name.
+	if manifests[0].Name != "monitor" {
+		t.Errorf("manifests[0].Name = %q, want %q", manifests[0].Name, "monitor")
+	}
+	if manifests[1].Name != "reporter" {
+		t.Errorf("manifests[1].Name = %q, want %q", manifests[1].Name, "reporter")
+	}
+
+	// Verify fields on first manifest.
+	m := manifests[0]
+	if m.Worker != "cheap" {
+		t.Errorf("monitor.Worker = %q, want %q", m.Worker, "cheap")
+	}
+	if m.Schedule != "*/15 * * * *" {
+		t.Errorf("monitor.Schedule = %q, want %q", m.Schedule, "*/15 * * * *")
+	}
+	if len(m.Tools) != 1 || m.Tools[0] != "web_fetch" {
+		t.Errorf("monitor.Tools = %v, want [web_fetch]", m.Tools)
+	}
+	if m.SourcePath != filepath.Join(dir, "monitor.md") {
+		t.Errorf("monitor.SourcePath = %q, want %q", m.SourcePath, filepath.Join(dir, "monitor.md"))
+	}
+
+	// Verify second manifest.
+	if manifests[1].Approval != ApprovalNever {
+		t.Errorf("reporter.Approval = %q, want %q", manifests[1].Approval, ApprovalNever)
+	}
+}
+
+func TestLoadDir_InvalidFile(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "bad.md", `---
+approval: invalid_mode
+---
+Bad role.
+`)
+
+	_, err := LoadDir(dir)
+	if err == nil {
+		t.Fatal("LoadDir should fail with invalid manifest")
+	}
+}
+
+func TestLoadDirLenient(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, dir, "good.md", `---
+worker: standard
+---
+# Good role
+Works fine.
+`)
+
+	writeFile(t, dir, "bad.md", `---
+approval: invalid_mode
+---
+Bad role.
+`)
+
+	manifests, errs := LoadDirLenient(dir)
+	if len(manifests) != 1 {
+		t.Errorf("LoadDirLenient returned %d manifests, want 1", len(manifests))
+	}
+	if len(errs) != 1 {
+		t.Errorf("LoadDirLenient returned %d errors, want 1", len(errs))
+	}
+	if len(manifests) > 0 && manifests[0].Name != "good" {
+		t.Errorf("manifests[0].Name = %q, want %q", manifests[0].Name, "good")
+	}
+}
+
+func TestLoadDir_Empty(t *testing.T) {
+	dir := t.TempDir()
+
+	manifests, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir failed on empty dir: %v", err)
+	}
+	if len(manifests) != 0 {
+		t.Errorf("LoadDir returned %d manifests, want 0", len(manifests))
+	}
+}
+
+func TestLoadDir_Missing(t *testing.T) {
+	_, err := LoadDir("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Fatal("LoadDir should fail on missing directory")
+	}
+}
+
+func TestLoadFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ops.md")
+	writeFile(t, dir, "ops.md", `---
+worker: cheap
+tools: [local_exec]
+approval: always
+---
+# Ops
+Run maintenance tasks.
+`)
+
+	m, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile failed: %v", err)
+	}
+
+	if m.Name != "ops" {
+		t.Errorf("Name = %q, want %q", m.Name, "ops")
+	}
+	if m.Worker != "cheap" {
+		t.Errorf("Worker = %q, want %q", m.Worker, "cheap")
+	}
+	if m.Approval != ApprovalAlways {
+		t.Errorf("Approval = %q, want %q", m.Approval, ApprovalAlways)
+	}
+	if m.SourcePath != path {
+		t.Errorf("SourcePath = %q, want %q", m.SourcePath, path)
+	}
+}
+
+func TestParse_WorkerOnly(t *testing.T) {
+	data := []byte(`---
+worker: local
+---
+Run locally.
+`)
+
+	m, err := Parse("local-runner", data)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if m.Worker != "local" {
+		t.Errorf("Worker = %q, want %q", m.Worker, "local")
+	}
+	if m.Schedule != "" {
+		t.Errorf("Schedule = %q, want empty", m.Schedule)
+	}
+	if m.Prompt != "Run locally." {
+		t.Errorf("Prompt = %q, want %q", m.Prompt, "Run locally.")
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Implements #178

## Changes

Adds a new `internal/role` package that implements markdown-first role manifests. Each role is defined as a single `.md` file with YAML frontmatter for structured metadata and a markdown body serving as the role's system prompt.

**Frontmatter fields:**
- `worker` — cost tier or worker adapter (`premium`, `standard`, `cheap`, `local`, or custom)
- `tools` — allowed tool names (empty = all tools)
- `schedule` — cron expression for periodic execution
- `report_template` — Go `text/template` for formatting output
- `approval` — human approval mode (`auto`, `always`, `never`)

**Package API:**
- `Parse(name, data)` — parse a manifest from raw bytes
- `LoadFile(path)` — load a single `.md` file
- `LoadDir(dir)` — load all `.md` files from a directory (strict)
- `LoadDirLenient(dir)` — load all `.md` files, collecting errors without stopping
- `Manifest.Validate()` — check field consistency
- `Manifest.RenderReport(data)` — execute the report template
- `Manifest.IsToolAllowed(name)` — check tool access

**Example role file (`researcher.md`):**
```markdown
---
worker: premium
tools: [web_fetch, search]
schedule: "0 9 * * *"
report_template: |
  ## {{.Title}}
  {{.Body}}
approval: always
---
# Researcher
You are a research agent. Your job is to gather information and compile reports.
```

## Testing

- 17 unit tests covering: full/minimal/empty frontmatter parsing, approval mode validation and case-insensitive normalization, invalid templates, report rendering, LoadDir/LoadDirLenient/LoadFile, empty/missing directories, tool restriction checks
- All existing tests continue to pass (`go test ./...`)
- `go vet ./...` clean
- Binary builds successfully with `CGO_ENABLED=1 go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the new `internal/role` package implementing markdown-first role manifests with YAML frontmatter, providing a clean file-based configuration mechanism for agents with tool restrictions, scheduling, approval modes, and templated report output.

- New `Manifest` struct and `Parse()` function handle frontmatter extraction, approval normalization, tool list cleaning, and template validation in one pass
- `LoadFile`, `LoadDir`, and `LoadDirLenient` cover all loading modes with correct `SourcePath` assignment and deterministic alphabetical ordering
- `Validate()` currently does not check the `Approval` field, creating a gap: a `Manifest` constructed directly (or with `Approval` mutated post-parse) with an invalid mode will silently pass `Validate()`
- 17 unit tests provide solid coverage across parsing, edge cases, directory loading, and template rendering

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one targeted fix recommended before shipping.
- Well-structured new package with thorough test coverage and clean implementation. The single logic gap — `Validate()` not checking the `Approval` field — means directly-constructed `Manifest` values bypass approval validation, which doesn't affect the current parse-based API but breaks the contract of `Validate()` as a standalone correctness check.
- internal/role/manifest.go — `Validate()` method needs the `Approval` mode check added.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/role/manifest.go | Core manifest parsing and validation logic. Well-structured overall; one gap — `Validate()` doesn't check `Approval` mode, so directly-constructed `Manifest` values with invalid approval modes pass `Validate()` silently. |
| internal/role/loader.go | File and directory loading utilities. Clean implementation with consistent error handling, deterministic alphabetical sort, and correct SourcePath assignment. |
| internal/role/manifest_test.go | Comprehensive test suite (17 tests) covering parsing, validation, rendering, approval normalization, directory loading, and edge cases. Good coverage of the happy path and error paths. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/role/manifest.go
Line: 132-144

Comment:
**`Validate()` skips `Approval` mode check**

`Validate()` is the documented contract for checking manifest consistency, but it doesn't validate the `Approval` field. Since `Manifest` is an exported struct, a caller can construct one directly (or mutate `Approval` after loading) and then call `Validate()` expecting full validation — but an invalid `ApprovalMode` would silently pass through.

The approval check currently only lives inside `Parse()`, not in `Validate()`. Adding it to `Validate()` would make the invariant hold regardless of how the manifest was constructed:

```go
func (m *Manifest) Validate() error {
	if m.Name == "" {
		return fmt.Errorf("role manifest: name is required")
	}

	if m.Approval != "" && !ValidApprovalMode(m.Approval) {
		return fmt.Errorf("role %q: invalid approval mode %q (want auto, always, or never)", m.Name, m.Approval)
	}

	if m.ReportTemplate != "" {
		if _, err := template.New("report").Parse(m.ReportTemplate); err != nil {
			return fmt.Errorf("role %q: invalid report_template: %w", m.Name, err)
		}
	}

	return nil
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(role): add markdown-first role mani..."](https://github.com/befeast/ok-gobot/commit/60761c3c5697e5bcd77d666a0444a2a33f22781c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25979552)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->