### PR TITLE
feat(role): ship prebuilt markdown-first roles for scheduled operator workflows (#238)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -121,6 +121,11 @@ session:
 # Optional model alias overrides (empty = built-in defaults)
 model_aliases: {}
 
+# Scheduled roles (optional)
+# Scaffold bundled roles: ok-gobot roles init --dir ~/ok-gobot-assets/roles
+# roles_dir: "~/ok-gobot-assets/roles"  # Directory of role manifest .md files
+# roles_chat: 0                          # Telegram chat ID for scheduled role reports
+
 # Storage and logging
 storage_path: "~/.ok-gobot/ok-gobot.db"
 soul_path: "~/ok-gobot-soul"  # Default personality directory (deprecated, use agents)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -398,6 +398,81 @@ Windows requires MinGW-w64 for the CGO SQLite dependency during build.
 
 ---
 
+## Scheduled Roles
+
+ok-gobot ships prebuilt role manifests that run on schedule via the cron/jobs
+pipeline and deliver bounded markdown reports to Telegram.
+
+### Bundled Roles
+
+| Role | Schedule | Worker | Description |
+|------|----------|--------|-------------|
+| `researcher` | `0 8 * * 1` (Mon 08:00) | standard | Weekly web research brief on Go, SQLite, Telegram Bot API |
+| `monitor` | `0 */6 * * *` (every 6h) | cheap | Lightweight endpoint health checks |
+| `release-watch` | `0 9 * * *` (daily 09:00) | cheap | Track new GitHub releases for key projects |
+
+### Setup
+
+```bash
+# 1. Scaffold bundled roles into a directory
+ok-gobot roles init --dir ~/ok-gobot-assets/roles
+
+# 2. List available roles
+ok-gobot roles list
+
+# 3. Edit scaffolded files to customize endpoints, projects, or schedules
+vim ~/ok-gobot-assets/roles/monitor.md
+```
+
+Add to `config.yaml`:
+
+```yaml
+roles_dir: "~/ok-gobot-assets/roles"
+roles_chat: 123456789  # Telegram chat ID where reports are delivered
+```
+
+Or via environment:
+
+```bash
+export OKGOBOT_ROLES_DIR="~/ok-gobot-assets/roles"
+export OKGOBOT_ROLES_CHAT="123456789"
+```
+
+### How It Works
+
+1. At startup, ok-gobot loads all `.md` files from `roles_dir`
+2. Roles with a `schedule` field are registered as cron jobs
+3. When a schedule fires, the role's prompt runs as an LLM task
+4. Reports are delivered to the configured `roles_chat`
+5. If `roles_chat` is not set, `auth.admin_id` is used as fallback
+
+### Writing Custom Roles
+
+Each role is a markdown file with YAML frontmatter:
+
+```markdown
+---
+worker: standard          # cost tier: premium, standard, cheap, local
+tools: [web_fetch, search] # allowed tools (empty = all)
+schedule: "0 9 * * *"     # 5-field cron expression
+report_template: |
+  ## {{.Title}}
+  {{.Body}}
+approval: auto             # auto, always, or never
+---
+# My Custom Role
+
+Your system prompt goes here. Keep it concise and bounded.
+```
+
+Roles respect estop (emergency stop disables dangerous tool families),
+delegated job budgets, and denial rendering.
+
+No roles are enabled by default. Shipped files serve as examples — copy and
+customize them for your deployment.
+
+---
+
 ## Environment Variables
 
 All config keys can be overridden via `OKGOBOT_` prefix:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -18,6 +18,7 @@ import (
 	"ok-gobot/internal/logger"
 	"ok-gobot/internal/memory"
 	"ok-gobot/internal/memorymcp"
+	"ok-gobot/internal/role"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -239,6 +240,11 @@ func (a *App) Start(ctx context.Context) error {
 		log.Println("📅 Cron scheduler started")
 	}
 
+	// Load role manifests and register scheduled roles
+	if a.config.RolesDir != "" {
+		a.loadRoles()
+	}
+
 	// Initialize semantic memory manager if enabled
 	if a.config.Memory.Enabled {
 		apiKey := a.config.Memory.EmbeddingsAPIKey
@@ -395,6 +401,57 @@ func (a *App) Stop() error {
 		}
 	}
 	return nil
+}
+
+// loadRoles reads role manifests from the configured directory and registers
+// cron schedules for any role that defines one. Reports are delivered to
+// config.RolesChat.
+func (a *App) loadRoles() {
+	manifests, errs := role.LoadDirLenient(a.config.RolesDir)
+	for _, err := range errs {
+		log.Printf("[roles] %v", err)
+	}
+
+	if len(manifests) == 0 {
+		log.Printf("[roles] no role manifests found in %s", a.config.RolesDir)
+		return
+	}
+
+	log.Printf("[roles] loaded %d role manifest(s) from %s", len(manifests), a.config.RolesDir)
+
+	chatID := a.config.RolesChat
+	if chatID == 0 {
+		chatID = a.config.Auth.AdminID
+	}
+	if chatID == 0 {
+		log.Println("[roles] skipping schedule registration: no roles_chat or admin_id configured")
+		return
+	}
+
+	scheduled := 0
+	for _, m := range manifests {
+		if !m.HasSchedule() {
+			continue
+		}
+
+		// Pad 5-field cron expressions to 6-field (add seconds).
+		expr := m.Schedule
+		if len(strings.Fields(expr)) == 5 {
+			expr = "0 " + expr
+		}
+
+		_, err := a.scheduler.AddJob(expr, m.Prompt, chatID)
+		if err != nil {
+			log.Printf("[roles] failed to schedule %q: %v", m.Name, err)
+			continue
+		}
+		scheduled++
+		log.Printf("[roles] scheduled %q (%s)", m.Name, m.Schedule)
+	}
+
+	if scheduled > 0 {
+		log.Printf("[roles] %d role(s) registered with cron scheduler", scheduled)
+	}
 }
 
 func (a *App) startBootstrapWatcher(name string, personality *agent.Personality) {

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/role"
+)
+
+func newRolesCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "roles",
+		Short: "Manage prebuilt role manifests",
+		Long:  `List bundled roles and scaffold them into a directory for customization.`,
+	}
+
+	cmd.AddCommand(newRolesListCommand())
+	cmd.AddCommand(newRolesInitCommand(cfg))
+
+	return cmd
+}
+
+func newRolesListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List bundled role manifests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			manifests, err := role.LoadBundled()
+			if err != nil {
+				return fmt.Errorf("loading bundled roles: %w", err)
+			}
+
+			if len(manifests) == 0 {
+				fmt.Println("No bundled roles found.")
+				return nil
+			}
+
+			fmt.Printf("Bundled roles (%d):\n\n", len(manifests))
+			for _, m := range manifests {
+				schedule := "(no schedule)"
+				if m.HasSchedule() {
+					schedule = m.Schedule
+				}
+				worker := "default"
+				if m.Worker != "" {
+					worker = m.Worker
+				}
+				tools := "all"
+				if m.HasToolRestrictions() {
+					tools = strings.Join(m.Tools, ", ")
+				}
+
+				fmt.Printf("  %-16s  schedule=%-14s  worker=%-10s  tools=%s\n",
+					m.Name, schedule, worker, tools)
+			}
+
+			fmt.Println()
+			fmt.Println("Run 'ok-gobot roles init --dir <path>' to scaffold these into a directory.")
+			return nil
+		},
+	}
+}
+
+func newRolesInitCommand(cfg *config.Config) *cobra.Command {
+	var dir string
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Scaffold bundled role manifests into a directory",
+		Long: `Copy all bundled role manifests into the specified directory.
+Existing files are not overwritten. Edit the copied files to customize
+roles for your deployment.
+
+After scaffolding, set roles_dir in config.yaml to point at the directory:
+
+  roles_dir: "/path/to/roles"
+  roles_chat: 123456789  # Telegram chat ID for reports`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dir == "" {
+				if cfg.RolesDir != "" {
+					dir = cfg.RolesDir
+				} else {
+					return fmt.Errorf("--dir is required (or set roles_dir in config)")
+				}
+			}
+
+			written, err := role.Scaffold(dir)
+			if err != nil {
+				return fmt.Errorf("scaffolding roles: %w", err)
+			}
+
+			if len(written) == 0 {
+				fmt.Printf("All bundled roles already exist in %s — nothing to do.\n", dir)
+				return nil
+			}
+
+			fmt.Printf("Scaffolded %d role(s) into %s:\n", len(written), dir)
+			for _, path := range written {
+				fmt.Printf("  %s\n", path)
+			}
+
+			// Check if roles_dir is configured
+			if cfg.RolesDir == "" {
+				fmt.Fprintf(os.Stderr, "\nHint: add to config.yaml:\n  roles_dir: %q\n  roles_chat: <your-chat-id>\n", dir)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&dir, "dir", "", "Target directory for role manifests")
+
+	return cmd
+}

--- a/internal/cli/roles_test.go
+++ b/internal/cli/roles_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/role"
+)
+
+func TestRolesListCommand(t *testing.T) {
+	cfg := &config.Config{}
+	cmd := newRolesCommand(cfg)
+	cmd.SetArgs([]string{"list"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("roles list: %v", err)
+	}
+}
+
+func TestRolesInitCommand_NoDirFlag(t *testing.T) {
+	cfg := &config.Config{}
+	cmd := newRolesInitCommand(cfg)
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --dir not set and no config")
+	}
+}
+
+func TestRolesInitCommand_WithDir(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cmd := newRolesCommand(cfg)
+	cmd.SetArgs([]string{"init", "--dir", dir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("roles init --dir %s: %v", dir, err)
+	}
+
+	// Verify files were scaffolded
+	names, _ := role.BundledNames()
+	for _, name := range names {
+		path := filepath.Join(dir, name+".md")
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected file %s to exist after init", path)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -42,6 +42,7 @@ Supports Telegram bot integration with personality and memory.`,
 	root.AddCommand(newJobsCommand(cfg))
 	root.AddCommand(newProvidersCommand(cfg))
 	root.AddCommand(newModelsCommand(cfg))
+	root.AddCommand(newRolesCommand(cfg))
 
 	return root
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,7 +101,9 @@ type Config struct {
 	Agents       []AgentConfig     `mapstructure:"agents"`
 	Models       []string          `mapstructure:"models"` // list of models for TUI/web picker
 	ModelAliases map[string]string `mapstructure:"model_aliases"`
-	Contacts     map[string]int64  `mapstructure:"contacts"` // alias -> chatID for message tool allowlist
+	Contacts     map[string]int64  `mapstructure:"contacts"`   // alias -> chatID for message tool allowlist
+	RolesDir     string            `mapstructure:"roles_dir"`  // Directory of role manifest .md files
+	RolesChat    int64             `mapstructure:"roles_chat"` // Telegram chat ID for scheduled role reports
 	StoragePath  string            `mapstructure:"storage_path"`
 	LogLevel     string            `mapstructure:"log_level"`
 	SoulPath     string            `mapstructure:"soul_path"` // Path to agent personality files (deprecated, use agents)
@@ -274,6 +276,7 @@ func Load() (*Config, error) {
 	// Expand paths
 	cfg.StoragePath = expandPath(cfg.StoragePath)
 	cfg.SoulPath = expandPath(cfg.SoulPath)
+	cfg.RolesDir = expandPath(cfg.RolesDir)
 	cfg.ConfigPath = v.ConfigFileUsed()
 
 	// Migrate legacy openai config to ai config
@@ -353,6 +356,7 @@ func LoadFrom(configPath string) (*Config, error) {
 	// Expand paths
 	cfg.StoragePath = expandPath(cfg.StoragePath)
 	cfg.SoulPath = expandPath(cfg.SoulPath)
+	cfg.RolesDir = expandPath(cfg.RolesDir)
 	cfg.ConfigPath = configPath
 
 	// Migrate legacy openai config to ai config
@@ -510,6 +514,12 @@ func (c *Config) Save() error {
 		v.Set("runtime.roles", c.Runtime.Roles)
 	}
 	v.Set("session.dm_scope", c.Session.DMScope)
+	if c.RolesDir != "" {
+		v.Set("roles_dir", c.RolesDir)
+	}
+	if c.RolesChat != 0 {
+		v.Set("roles_chat", c.RolesChat)
+	}
 
 	// Persist fields that were previously omitted causing lossy round-trips.
 	if len(c.Models) > 0 {

--- a/internal/role/bundled.go
+++ b/internal/role/bundled.go
@@ -1,0 +1,105 @@
+package role
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+//go:embed bundled/*.md
+var bundledFS embed.FS
+
+// BundledNames returns the names of all bundled role manifests, sorted.
+func BundledNames() ([]string, error) {
+	entries, err := fs.ReadDir(bundledFS, "bundled")
+	if err != nil {
+		return nil, fmt.Errorf("reading bundled roles: %w", err)
+	}
+
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(entry.Name(), ".md"))
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// LoadBundled parses all bundled role manifests and returns them sorted by name.
+func LoadBundled() ([]*Manifest, error) {
+	entries, err := fs.ReadDir(bundledFS, "bundled")
+	if err != nil {
+		return nil, fmt.Errorf("reading bundled roles: %w", err)
+	}
+
+	var manifests []*Manifest
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		data, err := fs.ReadFile(bundledFS, "bundled/"+entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("reading bundled %s: %w", entry.Name(), err)
+		}
+
+		name := strings.TrimSuffix(entry.Name(), ".md")
+		m, err := Parse(name, data)
+		if err != nil {
+			return nil, fmt.Errorf("parsing bundled %s: %w", entry.Name(), err)
+		}
+
+		manifests = append(manifests, m)
+	}
+
+	sort.Slice(manifests, func(i, j int) bool {
+		return manifests[i].Name < manifests[j].Name
+	})
+
+	return manifests, nil
+}
+
+// Scaffold copies all bundled role manifests into dir.
+// Existing files are not overwritten. Returns the list of files written.
+func Scaffold(dir string) ([]string, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating roles directory %s: %w", dir, err)
+	}
+
+	entries, err := fs.ReadDir(bundledFS, "bundled")
+	if err != nil {
+		return nil, fmt.Errorf("reading bundled roles: %w", err)
+	}
+
+	var written []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		dest := filepath.Join(dir, entry.Name())
+		if _, err := os.Stat(dest); err == nil {
+			continue // already exists, skip
+		}
+
+		data, err := fs.ReadFile(bundledFS, "bundled/"+entry.Name())
+		if err != nil {
+			return written, fmt.Errorf("reading bundled %s: %w", entry.Name(), err)
+		}
+
+		if err := os.WriteFile(dest, data, 0o644); err != nil {
+			return written, fmt.Errorf("writing %s: %w", dest, err)
+		}
+
+		written = append(written, dest)
+	}
+
+	sort.Strings(written)
+	return written, nil
+}

--- a/internal/role/bundled/monitor.md
+++ b/internal/role/bundled/monitor.md
@@ -1,0 +1,49 @@
+---
+worker: cheap
+tools: [web_fetch]
+schedule: "0 */6 * * *"
+report_template: |
+  ## Health Check
+  {{.Body}}
+approval: never
+---
+# Monitor
+
+You are a lightweight monitoring agent that runs every 6 hours. Your job is to
+check a set of endpoints and report their status.
+
+## Instructions
+
+1. Use **web_fetch** to send a GET request to each endpoint listed below.
+2. Record the HTTP status code and approximate response time.
+3. If any endpoint returns a non-2xx status or times out, flag it clearly.
+4. Do **not** follow redirects beyond one hop.
+
+## Default Endpoints
+
+Check these unless the operator has overridden them in the prompt:
+
+- `https://api.telegram.org` — Telegram API reachability
+- `https://api.anthropic.com` — Anthropic API reachability
+
+Operators: replace or extend this list by editing the prompt section above.
+
+## Output Format
+
+Keep the report under 2000 characters. Use this structure:
+
+```
+All systems operational.
+- api.telegram.org: 200 OK (120ms)
+- api.anthropic.com: 200 OK (95ms)
+```
+
+Or, if something is down:
+
+```
+ALERT: 1 endpoint unreachable.
+- api.telegram.org: 200 OK (120ms)
+- api.anthropic.com: TIMEOUT after 10s ⚠️
+```
+
+Only report what changed or what is failing. Keep it terse.

--- a/internal/role/bundled/release-watch.md
+++ b/internal/role/bundled/release-watch.md
@@ -1,0 +1,54 @@
+---
+worker: cheap
+tools: [web_fetch]
+schedule: "0 9 * * *"
+report_template: |
+  ## Release Watch
+  {{.Body}}
+approval: never
+---
+# Release Watch
+
+You are a release-tracking agent that runs daily. Your job is to check for new
+releases of key projects and report any changes since the last run.
+
+## Instructions
+
+1. Use **web_fetch** to query the GitHub releases API for each tracked project.
+   Use the URL pattern: `https://api.github.com/repos/{owner}/{repo}/releases/latest`
+2. Compare the latest tag name against what you reported previously.
+3. Only report releases that are new since your last run. If nothing changed,
+   say so in one line.
+
+## Default Projects
+
+Track these unless the operator has overridden the list:
+
+- `golang/go` — Go language releases
+- `nicholasgasior/gopher-sqlite3` — SQLite Go driver
+- `go-telegram-bot-api/telegram-bot-api` — Telegram Bot API Go bindings
+
+Operators: replace or extend this list by editing the prompt section above.
+
+## Output Format
+
+Keep the report under 2000 characters. Use this structure when there are new
+releases:
+
+```
+New releases detected:
+
+1. **golang/go** v1.24.1
+   Highlights: security fix for net/http, minor stdlib improvements.
+
+2. **telegram-bot-api** v5.6.0
+   Highlights: support for Telegram Bot API 8.1 reactions.
+```
+
+When nothing changed:
+
+```
+No new releases. All tracked projects unchanged.
+```
+
+Do not speculate about upcoming releases. Only report what is published.

--- a/internal/role/bundled/researcher.md
+++ b/internal/role/bundled/researcher.md
@@ -1,0 +1,43 @@
+---
+worker: standard
+tools: [web_fetch, search, memory_search]
+schedule: "0 8 * * 1"
+report_template: |
+  ## Weekly Research Brief
+  {{.Body}}
+approval: auto
+---
+# Researcher
+
+You are a research agent running on a weekly schedule. Your job is to scan the
+web for notable developments relevant to the operator's stack and compile a
+concise brief.
+
+## Instructions
+
+1. Use the **search** and **web_fetch** tools to check for updates on:
+   - Go releases and proposals
+   - SQLite releases and changelogs
+   - Telegram Bot API changes
+   - Dependencies listed in go.mod (major/minor bumps only)
+2. Use **memory_search** to recall prior briefs and avoid repeating old news.
+3. Compile findings into a short, scannable report.
+
+## Output Format
+
+Keep the report under 3000 characters so it fits in a single Telegram message.
+Use this structure:
+
+```
+### Findings
+
+1. **[Topic]** — one-line summary
+   Detail sentence if needed.
+
+2. **[Topic]** — one-line summary
+
+### No Change
+- [Area]: nothing new since last check.
+```
+
+If there is nothing noteworthy, say so in one line. Do not pad the report.

--- a/internal/role/bundled_test.go
+++ b/internal/role/bundled_test.go
@@ -1,0 +1,145 @@
+package role
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBundledNames(t *testing.T) {
+	names, err := BundledNames()
+	if err != nil {
+		t.Fatalf("BundledNames: %v", err)
+	}
+
+	want := []string{"monitor", "release-watch", "researcher"}
+	if len(names) != len(want) {
+		t.Fatalf("BundledNames returned %d names, want %d: %v", len(names), len(want), names)
+	}
+	for i, name := range names {
+		if name != want[i] {
+			t.Errorf("BundledNames[%d] = %q, want %q", i, name, want[i])
+		}
+	}
+}
+
+func TestLoadBundled(t *testing.T) {
+	manifests, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled: %v", err)
+	}
+
+	if len(manifests) != 3 {
+		t.Fatalf("LoadBundled returned %d manifests, want 3", len(manifests))
+	}
+
+	// Verify sorted order
+	for i := 1; i < len(manifests); i++ {
+		if manifests[i].Name < manifests[i-1].Name {
+			t.Errorf("manifests not sorted: %q before %q", manifests[i-1].Name, manifests[i].Name)
+		}
+	}
+
+	// Check each manifest has required fields
+	for _, m := range manifests {
+		if m.Prompt == "" {
+			t.Errorf("role %q: empty prompt", m.Name)
+		}
+		if !m.HasSchedule() {
+			t.Errorf("role %q: expected a schedule", m.Name)
+		}
+		if m.Worker == "" {
+			t.Errorf("role %q: expected a worker tier", m.Name)
+		}
+		if !m.HasToolRestrictions() {
+			t.Errorf("role %q: expected tool restrictions", m.Name)
+		}
+	}
+}
+
+func TestLoadBundled_ReportTemplatesValid(t *testing.T) {
+	manifests, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled: %v", err)
+	}
+
+	type reportData struct {
+		Title string
+		Body  string
+	}
+
+	for _, m := range manifests {
+		if m.ReportTemplate == "" {
+			t.Errorf("role %q: no report template", m.Name)
+			continue
+		}
+
+		rendered, err := m.RenderReport(reportData{
+			Title: "Test Report",
+			Body:  "Test body content.",
+		})
+		if err != nil {
+			t.Errorf("role %q: RenderReport failed: %v", m.Name, err)
+			continue
+		}
+		if rendered == "" {
+			t.Errorf("role %q: RenderReport returned empty string", m.Name)
+		}
+	}
+}
+
+func TestLoadBundled_PromptsBounded(t *testing.T) {
+	manifests, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled: %v", err)
+	}
+
+	const maxPromptLen = 3000 // keep prompts bounded for Telegram readability
+	for _, m := range manifests {
+		if len(m.Prompt) > maxPromptLen {
+			t.Errorf("role %q: prompt length %d exceeds %d", m.Name, len(m.Prompt), maxPromptLen)
+		}
+	}
+}
+
+func TestScaffold(t *testing.T) {
+	dir := t.TempDir()
+	rolesDir := filepath.Join(dir, "roles")
+
+	// First scaffold — all files should be written
+	written, err := Scaffold(rolesDir)
+	if err != nil {
+		t.Fatalf("Scaffold: %v", err)
+	}
+
+	names, _ := BundledNames()
+	if len(written) != len(names) {
+		t.Fatalf("Scaffold wrote %d files, want %d", len(written), len(names))
+	}
+
+	// Verify files exist and are parseable
+	for _, name := range names {
+		path := filepath.Join(rolesDir, name+".md")
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected file %s to exist", path)
+			continue
+		}
+
+		m, err := LoadFile(path)
+		if err != nil {
+			t.Errorf("LoadFile(%s): %v", path, err)
+		}
+		if m.Name != name {
+			t.Errorf("loaded name = %q, want %q", m.Name, name)
+		}
+	}
+
+	// Second scaffold — nothing should be written (no overwrite)
+	written2, err := Scaffold(rolesDir)
+	if err != nil {
+		t.Fatalf("Scaffold (second run): %v", err)
+	}
+	if len(written2) != 0 {
+		t.Errorf("second Scaffold wrote %d files, want 0 (no overwrite)", len(written2))
+	}
+}


### PR DESCRIPTION
Implements #238

## Changes

Ships 3 prebuilt role manifests (researcher, monitor, release-watch) that operators can scaffold into their workspace, customize, and enable via config. Roles run on schedule via the existing cron/jobs pipeline and deliver bounded markdown reports to Telegram.

### New files
- `internal/role/bundled/` — 3 embedded `.md` role manifests (researcher, monitor, release-watch)
- `internal/role/bundled.go` — `LoadBundled()`, `BundledNames()`, `Scaffold()` for listing/extracting bundled roles
- `internal/cli/roles.go` — `ok-gobot roles list` and `ok-gobot roles init --dir <path>` CLI commands

### Modified files
- `internal/config/config.go` — added `roles_dir` and `roles_chat` config fields
- `internal/app/app.go` — loads role manifests at startup, registers scheduled roles as cron jobs
- `internal/cli/root.go` — registers `roles` command
- `config.example.yaml` — documents new roles config fields
- `docs/INSTALL.md` — new "Scheduled Roles" section with setup instructions

### Bundled roles

| Role | Schedule | Worker | Tools |
|------|----------|--------|-------|
| `researcher` | `0 8 * * 1` (Mon 08:00) | standard | web_fetch, search, memory_search |
| `monitor` | `0 */6 * * *` (every 6h) | cheap | web_fetch |
| `release-watch` | `0 9 * * *` (daily 09:00) | cheap | web_fetch |

### How it works
1. Operator runs `ok-gobot roles init --dir ~/roles` to scaffold bundled roles
2. Operator sets `roles_dir` and `roles_chat` in config.yaml
3. At startup, app loads `.md` files from `roles_dir` and registers cron jobs for scheduled roles
4. Reports are delivered to the configured chat (falls back to `auth.admin_id`)
5. No roles are enabled by default — shipped files serve as examples

## Testing
- `go test ./internal/role/` — tests bundled role loading, parsing, template rendering, prompt bounds, scaffold idempotency
- `go test ./internal/cli/ -run TestRoles` — tests CLI list and init commands
- `go vet ./...` and `go fmt ./...` pass clean
- `CGO_ENABLED=1 go build ./cmd/ok-gobot/` succeeds
- Manual verification: `ok-gobot roles list` and `ok-gobot roles init --dir /tmp/test` produce expected output

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships three prebuilt markdown-first role manifests (`researcher`, `monitor`, `release-watch`) along with the scaffolding CLI (`roles list` / `roles init`) and startup wiring that registers scheduled roles as cron jobs. The role package itself (`bundled.go`, `manifest.go`, `loader.go`) and CLI layer are well-implemented and thoroughly tested. However, the startup integration in `loadRoles()` has two concrete logic bugs that will cause incorrect runtime behavior:

- **Duplicate job accumulation on restart**: `scheduler.AddJob` always inserts a new row into the database. Because `loadRoles()` is called every startup, each restart appends another copy of every scheduled role to the DB. After K restarts each role fires K times per interval — silently and without error.
- **Manifest metadata fields are discarded**: The `worker`, `tools`, `approval`, and `report_template` frontmatter fields are parsed and validated but never forwarded to the scheduler or executor. The cron scheduler's `AddJob` only accepts `(expression, task, chatID)`, so tool restrictions, worker tier routing, approval mode, and report formatting described in the manifests (and in `docs/INSTALL.md`) have no effect at runtime.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — duplicate cron job accumulation on restart will cause repeated role executions that compound silently after each deployment.
- Two concrete logic bugs in the startup integration path block a clean merge: (1) `AddJob` always inserts a new DB row, so every restart duplicates all scheduled roles — a silent operational hazard; (2) the manifest's `worker`, `tools`, `approval`, and `report_template` fields are fully parsed and documented but never applied at execution time. The rest of the PR (role package, CLI, config, bundled manifests, tests) is well-implemented.
- internal/app/app.go requires fixes before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/app/app.go | Adds `loadRoles()` called at startup; has two logic bugs: `AddJob` writes to the DB on every restart causing duplicate job accumulation, and all manifest metadata (Worker, Tools, Approval, ReportTemplate) is silently dropped at scheduling time. |
| internal/role/bundled.go | Clean implementation of `LoadBundled`, `BundledNames`, and `Scaffold` using the embedded FS; no issues found. |
| internal/role/bundled_test.go | Comprehensive tests covering names, loading, template validity, prompt bounds, scaffold idempotency; all look correct. |
| internal/cli/roles.go | Adds `roles list` and `roles init` CLI commands; logic is straightforward and correct, including the fallback to `cfg.RolesDir` when `--dir` is not provided. |
| internal/config/config.go | Adds `RolesDir` and `RolesChat` config fields with proper path expansion and `Save()` round-trip support; clean change. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/app/app.go
Line: 443

Comment:
**Duplicate cron jobs accumulate on every restart**

`AddJob` always calls `s.store.SaveCronJob(expression, task, chatID)`, which unconditionally writes a new database row. There is no deduplication check. Each app restart appends N more rows for every scheduled role. Once the scheduler starts, `loadJobs()` reads all rows from the DB and schedules every copy — so after K restarts the same role prompt fires K times per interval.

This will silently compound with each restart without any obvious error. A fix is to query existing cron jobs before registering and skip (or update) any entry whose `(expression, task)` pair already exists, or to clear and re-register role-sourced jobs rather than appending blindly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/app/app.go
Line: 443-450

Comment:
**Manifest metadata fields silently discarded at scheduling time**

`AddJob` only accepts `(expression, task string, chatID int64)`. The `Manifest`'s `Worker`, `Tools`, `Approval`, and `ReportTemplate` fields are never forwarded to the scheduler or executor. Concretely:

- `Worker` (e.g. `"cheap"`) never routes the job to a cheaper model tier.
- `Tools` restrictions (e.g. `[web_fetch]`) are never enforced — the executor runs with all tools available.
- `Approval` mode (`"never"`) has no effect on actual execution.
- `ReportTemplate` is never rendered; delivery uses `JobReport.FormatTelegram()` unconditionally.

This means the manifest frontmatter advertises constraints that are never actually applied, which is a correctness gap between documentation and runtime behaviour. The role `.md` files and `docs/INSTALL.md` describe these fields as functional, but none of them influence the job as scheduled via the existing `storage.CronJob` path.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(role): ship prebuilt markdown-first..."](https://github.com/befeast/ok-gobot/commit/adca71408bf5bc07ee731fa0e75a5ff5ed7d8574) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26108629)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->