### PR TITLE
feat(safety): operator can restrict agent capabilities beyond allowed_tools (#236)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -22,6 +22,68 @@
             },
             "type": "array"
           },
+          "capabilities": {
+            "additionalProperties": false,
+            "default": {},
+            "description": "Optional fine-grained capability policy. Empty/absent = fully permissive.",
+            "properties": {
+              "cron": {
+                "default": true,
+                "description": "Allow cron scheduling.",
+                "type": "boolean"
+              },
+              "file_write_scope": {
+                "default": "full",
+                "description": "File write scope: full allows read/write, read_only blocks writes.",
+                "enum": [
+                  "full",
+                  "read_only"
+                ],
+                "type": "string"
+              },
+              "filesystem_roots": {
+                "default": [],
+                "description": "Allowed absolute filesystem paths. Empty = no restriction.",
+                "items": {
+                  "default": "",
+                  "description": "Absolute directory path.",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "memory_write": {
+                "default": true,
+                "description": "Allow memory write tools.",
+                "type": "boolean"
+              },
+              "network": {
+                "default": true,
+                "description": "Allow network tools (web_fetch, search, browser).",
+                "type": "boolean"
+              },
+              "network_allowlist": {
+                "default": [],
+                "description": "Allowed hostnames when network is true. Empty = all allowed.",
+                "items": {
+                  "default": "",
+                  "description": "Hostname.",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "shell": {
+                "default": true,
+                "description": "Allow shell execution tools (local, ssh).",
+                "type": "boolean"
+              },
+              "spawn": {
+                "default": true,
+                "description": "Allow sub-agent/job spawning (browser_task).",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
           "model": {
             "default": "",
             "description": "Optional model override for this agent.",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -367,6 +367,64 @@ single source of truth for configuration keys, types, defaults, and descriptions
               "default": "",
               "description": "Tool name."
             }
+          },
+          "capabilities": {
+            "type": "object",
+            "default": {},
+            "description": "Optional fine-grained capability policy. Empty/absent = fully permissive.",
+            "properties": {
+              "shell": {
+                "type": "boolean",
+                "default": true,
+                "description": "Allow shell execution tools (local, ssh)."
+              },
+              "network": {
+                "type": "boolean",
+                "default": true,
+                "description": "Allow network tools (web_fetch, search, browser)."
+              },
+              "network_allowlist": {
+                "type": "array",
+                "default": [],
+                "description": "Allowed hostnames when network is true. Empty = all allowed.",
+                "items": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Hostname."
+                }
+              },
+              "cron": {
+                "type": "boolean",
+                "default": true,
+                "description": "Allow cron scheduling."
+              },
+              "memory_write": {
+                "type": "boolean",
+                "default": true,
+                "description": "Allow memory write tools."
+              },
+              "spawn": {
+                "type": "boolean",
+                "default": true,
+                "description": "Allow sub-agent/job spawning (browser_task)."
+              },
+              "filesystem_roots": {
+                "type": "array",
+                "default": [],
+                "description": "Allowed absolute filesystem paths. Empty = no restriction.",
+                "items": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Absolute directory path."
+                }
+              },
+              "file_write_scope": {
+                "type": "string",
+                "default": "full",
+                "enum": ["full", "read_only"],
+                "description": "File write scope: full allows read/write, read_only blocks writes."
+              }
+            }
           }
         }
       }

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"ok-gobot/internal/config"
+	"ok-gobot/internal/tools"
 )
 
 // AgentProfile holds an agent's configuration and personality
@@ -13,6 +14,7 @@ type AgentProfile struct {
 	Personality  *Personality
 	Model        string
 	AllowedTools []string
+	Policy       *tools.CapabilityPolicy // nil = fully permissive (backward compatible)
 }
 
 // AgentRegistry manages multiple agent profiles
@@ -74,6 +76,7 @@ func NewAgentRegistry(configs []config.AgentConfig, globalModel string, globalSo
 			Personality:  personality,
 			Model:        model,
 			AllowedTools: cfg.AllowedTools,
+			Policy:       resolveCapabilityPolicy(cfg.Capabilities),
 		}
 
 		log.Printf("✅ Agent '%s' loaded (model: %s)", cfg.Name, model)
@@ -133,4 +136,32 @@ func (p *AgentProfile) IsToolAllowed(toolName string) bool {
 		}
 	}
 	return false
+}
+
+// resolveCapabilityPolicy converts config-level capability policy (with *bool
+// defaults) into a concrete runtime policy. Returns nil when no policy is
+// configured (backward compatible).
+func resolveCapabilityPolicy(cfg *config.CapabilityPolicyConfig) *tools.CapabilityPolicy {
+	if cfg == nil {
+		return nil
+	}
+
+	p := &tools.CapabilityPolicy{
+		Shell:            boolDefault(cfg.Shell, true),
+		Network:          boolDefault(cfg.Network, true),
+		NetworkAllowlist: cfg.NetworkAllowlist,
+		Cron:             boolDefault(cfg.Cron, true),
+		MemoryWrite:      boolDefault(cfg.MemoryWrite, true),
+		Spawn:            boolDefault(cfg.Spawn, true),
+		FilesystemRoots:  cfg.FilesystemRoots,
+		FileReadOnly:     cfg.FileWriteScope == "read_only",
+	}
+	return p
+}
+
+func boolDefault(v *bool, def bool) bool {
+	if v == nil {
+		return def
+	}
+	return *v
 }

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -220,5 +220,11 @@ func (r *RunResolver) buildToolRegistry(chatID int64, profile *AgentProfile, isS
 		base = filtered
 	}
 
+	// Apply capability policy last so it covers all tools including
+	// per-chat injected ones (cron, browser_task) and job-filtered ones.
+	if profile.Policy != nil {
+		base = tools.ApplyPolicy(base, profile.Policy)
+	}
+
 	return base
 }

--- a/internal/agent/resolver_policy_test.go
+++ b/internal/agent/resolver_policy_test.go
@@ -1,0 +1,254 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"ok-gobot/internal/tools"
+)
+
+func TestBuildToolRegistry_PolicyDeniesShell(t *testing.T) {
+	t.Parallel()
+
+	base := tools.NewRegistry()
+	base.Register(&resolverDangerousTool{name: "local"})
+	base.Register(&resolverDangerousTool{name: "file"})
+
+	resolver := &RunResolver{ToolRegistry: base}
+	profile := &AgentProfile{
+		Policy: &tools.CapabilityPolicy{
+			Shell:       false,
+			Network:     true,
+			Cron:        true,
+			MemoryWrite: true,
+			Spawn:       true,
+		},
+	}
+
+	reg := resolver.buildToolRegistry(0, profile, false, nil)
+
+	// local should be denied.
+	_, err := reg.Execute(context.Background(), "local", "ls")
+	if err == nil {
+		t.Fatal("expected policy to block local tool")
+	}
+	denial, isDenial := tools.IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.Family != "shell" {
+		t.Errorf("denial.Family = %q, want shell", denial.Family)
+	}
+
+	// file should work.
+	_, err = reg.Execute(context.Background(), "file", "read")
+	if err != nil {
+		t.Fatalf("expected file tool to be allowed: %v", err)
+	}
+}
+
+func TestBuildToolRegistry_PolicyDeniesNetwork(t *testing.T) {
+	t.Parallel()
+
+	base := tools.NewRegistry()
+	base.Register(&resolverDangerousTool{name: "web_fetch"})
+	base.Register(&resolverDangerousTool{name: "local"})
+
+	resolver := &RunResolver{ToolRegistry: base}
+	profile := &AgentProfile{
+		Policy: &tools.CapabilityPolicy{
+			Shell:       true,
+			Network:     false,
+			Cron:        true,
+			MemoryWrite: true,
+			Spawn:       true,
+		},
+	}
+
+	reg := resolver.buildToolRegistry(0, profile, false, nil)
+
+	// web_fetch should be denied.
+	_, err := reg.Execute(context.Background(), "web_fetch", "https://example.com")
+	if err == nil {
+		t.Fatal("expected policy to block web_fetch")
+	}
+	if _, ok := tools.IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+
+	// local should work.
+	_, err = reg.Execute(context.Background(), "local", "echo hi")
+	if err != nil {
+		t.Fatalf("expected local to be allowed: %v", err)
+	}
+}
+
+func TestBuildToolRegistry_PolicyDeniesPerChatCronTool(t *testing.T) {
+	t.Parallel()
+
+	base := tools.NewRegistry()
+	base.Register(&resolverDangerousTool{name: "local"})
+
+	resolver := &RunResolver{
+		ToolRegistry: base,
+		Scheduler:    noopCronScheduler{},
+	}
+	profile := &AgentProfile{
+		Policy: &tools.CapabilityPolicy{
+			Shell:       true,
+			Network:     true,
+			Cron:        false,
+			MemoryWrite: true,
+			Spawn:       true,
+		},
+	}
+
+	// chatID != 0 triggers per-chat tool injection (cron).
+	reg := resolver.buildToolRegistry(123, profile, false, nil)
+
+	// cron should be denied even though it was injected per-chat.
+	_, err := reg.Execute(context.Background(), "cron", "list")
+	if err == nil {
+		t.Fatal("expected policy to block per-chat cron tool")
+	}
+	if _, ok := tools.IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+}
+
+func TestBuildToolRegistry_NilPolicyAllowsAll(t *testing.T) {
+	t.Parallel()
+
+	base := tools.NewRegistry()
+	base.Register(&resolverDangerousTool{name: "local"})
+	base.Register(&resolverDangerousTool{name: "web_fetch"})
+
+	resolver := &RunResolver{ToolRegistry: base}
+	profile := &AgentProfile{} // nil Policy
+
+	reg := resolver.buildToolRegistry(0, profile, false, nil)
+
+	for _, name := range []string{"local", "web_fetch"} {
+		if _, err := reg.Execute(context.Background(), name, "test"); err != nil {
+			t.Errorf("expected %q to be allowed with nil policy: %v", name, err)
+		}
+	}
+}
+
+func TestBuildToolRegistry_PolicyWithAllowedTools(t *testing.T) {
+	t.Parallel()
+
+	base := tools.NewRegistry()
+	base.Register(&resolverDangerousTool{name: "local"})
+	base.Register(&resolverDangerousTool{name: "file"})
+	base.Register(&resolverDangerousTool{name: "web_fetch"})
+
+	resolver := &RunResolver{ToolRegistry: base}
+	profile := &AgentProfile{
+		AllowedTools: []string{"file", "web_fetch"}, // local filtered out by allowlist
+		Policy: &tools.CapabilityPolicy{
+			Shell:       true,
+			Network:     false, // denies web_fetch via policy
+			Cron:        true,
+			MemoryWrite: true,
+			Spawn:       true,
+		},
+	}
+
+	reg := resolver.buildToolRegistry(0, profile, false, nil)
+
+	// local filtered by allowed_tools — not in registry at all.
+	_, ok := reg.Get("local")
+	if ok {
+		t.Error("expected local to be filtered out by allowed_tools")
+	}
+
+	// web_fetch is in allowed_tools but denied by policy.
+	_, err := reg.Execute(context.Background(), "web_fetch", "https://example.com")
+	if err == nil {
+		t.Fatal("expected web_fetch denied by policy even though in allowed_tools")
+	}
+	if _, ok := tools.IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+
+	// file should work.
+	_, err = reg.Execute(context.Background(), "file", "read")
+	if err != nil {
+		t.Fatalf("expected file to be allowed: %v", err)
+	}
+}
+
+func TestBuildToolRegistry_PolicyAndEstopStack(t *testing.T) {
+	t.Parallel()
+
+	// Estop is OFF but policy denies shell.
+	base := tools.NewRegistryWithEmergencyStop(testEmergencyStopProvider{enabled: false})
+	localTool := &resolverDangerousTool{name: "local"}
+	base.Register(localTool)
+
+	resolver := &RunResolver{ToolRegistry: base}
+	profile := &AgentProfile{
+		Policy: &tools.CapabilityPolicy{
+			Shell:       false,
+			Network:     true,
+			Cron:        true,
+			MemoryWrite: true,
+			Spawn:       true,
+		},
+	}
+
+	reg := resolver.buildToolRegistry(0, profile, false, nil)
+
+	_, err := reg.Execute(context.Background(), "local", "ls")
+	if err == nil {
+		t.Fatal("expected policy to block local even with estop off")
+	}
+	denial, isDenial := tools.IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	// Policy denial should reference capability, not estop.
+	if denial.Family != "shell" {
+		t.Errorf("denial.Family = %q, want shell", denial.Family)
+	}
+	if localTool.called != 0 {
+		t.Errorf("expected local tool not to execute, called=%d", localTool.called)
+	}
+}
+
+func TestBuildToolRegistry_FileReadOnlyViaBuildToolRegistry(t *testing.T) {
+	t.Parallel()
+
+	base := tools.NewRegistry()
+	base.Register(&resolverDangerousTool{name: "file"})
+
+	resolver := &RunResolver{ToolRegistry: base}
+	profile := &AgentProfile{
+		Policy: &tools.CapabilityPolicy{
+			Shell:        true,
+			Network:      true,
+			Cron:         true,
+			MemoryWrite:  true,
+			Spawn:        true,
+			FileReadOnly: true,
+		},
+	}
+
+	reg := resolver.buildToolRegistry(0, profile, false, nil)
+
+	// Read should work.
+	_, err := reg.Execute(context.Background(), "file", "read", "/tmp/test")
+	if err != nil {
+		t.Fatalf("expected file read to pass: %v", err)
+	}
+
+	// Write should be denied.
+	_, err = reg.Execute(context.Background(), "file", "write", "/tmp/test", "data")
+	if err == nil {
+		t.Fatal("expected file write to be denied by policy")
+	}
+	if _, ok := tools.IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,12 +179,27 @@ type MemoryMCPConfig struct {
 	AllowWrites bool   `mapstructure:"allow_writes"` // Allow write tools such as memory_capture
 }
 
+// CapabilityPolicyConfig defines per-agent capability restrictions in config.
+// All *bool fields default to true (permissive) when nil.
+// A nil *CapabilityPolicyConfig on an agent means no restrictions (backward compatible).
+type CapabilityPolicyConfig struct {
+	Shell            *bool    `mapstructure:"shell"`             // Allow shell execution (local, ssh). Default: true.
+	Network          *bool    `mapstructure:"network"`           // Allow network tools (web_fetch, search, browser). Default: true.
+	NetworkAllowlist []string `mapstructure:"network_allowlist"` // Allowed hostnames when network is true. Empty = all.
+	Cron             *bool    `mapstructure:"cron"`              // Allow cron scheduling. Default: true.
+	MemoryWrite      *bool    `mapstructure:"memory_write"`      // Allow memory write tools. Default: true.
+	Spawn            *bool    `mapstructure:"spawn"`             // Allow sub-agent/job spawning. Default: true.
+	FilesystemRoots  []string `mapstructure:"filesystem_roots"`  // Allowed absolute filesystem paths. Empty = no restriction.
+	FileWriteScope   string   `mapstructure:"file_write_scope"`  // "full" (default) or "read_only".
+}
+
 // AgentConfig holds configuration for a single agent
 type AgentConfig struct {
-	Name         string   `mapstructure:"name"`
-	SoulPath     string   `mapstructure:"soul_path"`
-	Model        string   `mapstructure:"model"`         // Empty = use global ai.model
-	AllowedTools []string `mapstructure:"allowed_tools"` // Empty = all tools allowed
+	Name         string                  `mapstructure:"name"`
+	SoulPath     string                  `mapstructure:"soul_path"`
+	Model        string                  `mapstructure:"model"`         // Empty = use global ai.model
+	AllowedTools []string                `mapstructure:"allowed_tools"` // Empty = all tools allowed
+	Capabilities *CapabilityPolicyConfig `mapstructure:"capabilities"`  // Optional fine-grained capability policy
 }
 
 // OpenAIConfig holds OpenAI API configuration (legacy, use AIConfig)
@@ -446,6 +461,16 @@ func (c *Config) Validate() error {
 		validTTSProviders := map[string]bool{"openai": true, "edge": true}
 		if !validTTSProviders[c.TTS.Provider] {
 			return fmt.Errorf("invalid tts.provider: %s (must be 'openai' or 'edge')", c.TTS.Provider)
+		}
+	}
+
+	// Validate agent capability policies.
+	validFileWriteScopes := map[string]bool{"": true, "full": true, "read_only": true}
+	for _, agent := range c.Agents {
+		if agent.Capabilities != nil {
+			if !validFileWriteScopes[agent.Capabilities.FileWriteScope] {
+				return fmt.Errorf("agents[%s].capabilities.file_write_scope: invalid value %q (must be \"full\" or \"read_only\")", agent.Name, agent.Capabilities.FileWriteScope)
+			}
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -251,3 +251,168 @@ storage_path: "/tmp/test.db"
 		t.Fatal("expected validation error for invalid session.dm_scope")
 	}
 }
+
+func TestLoadFromAgentCapabilities(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-capabilities-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+  provider: "openrouter"
+storage_path: "/tmp/test.db"
+agents:
+  - name: "restricted"
+    soul_path: "/tmp/soul"
+    allowed_tools:
+      - "file"
+      - "grep"
+    capabilities:
+      shell: false
+      network: false
+      cron: false
+      memory_write: true
+      spawn: false
+      file_write_scope: "read_only"
+      filesystem_roots:
+        - "/home/bot/workspace"
+      network_allowlist:
+        - "example.com"
+  - name: "open"
+    soul_path: "/tmp/soul"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+
+	if len(cfg.Agents) != 2 {
+		t.Fatalf("expected 2 agents, got %d", len(cfg.Agents))
+	}
+
+	// Restricted agent has capabilities set.
+	restricted := cfg.Agents[0]
+	if restricted.Capabilities == nil {
+		t.Fatal("expected restricted agent to have capabilities")
+	}
+	if restricted.Capabilities.Shell == nil || *restricted.Capabilities.Shell != false {
+		t.Error("expected shell=false")
+	}
+	if restricted.Capabilities.Network == nil || *restricted.Capabilities.Network != false {
+		t.Error("expected network=false")
+	}
+	if restricted.Capabilities.Cron == nil || *restricted.Capabilities.Cron != false {
+		t.Error("expected cron=false")
+	}
+	if restricted.Capabilities.MemoryWrite == nil || *restricted.Capabilities.MemoryWrite != true {
+		t.Error("expected memory_write=true")
+	}
+	if restricted.Capabilities.Spawn == nil || *restricted.Capabilities.Spawn != false {
+		t.Error("expected spawn=false")
+	}
+	if restricted.Capabilities.FileWriteScope != "read_only" {
+		t.Errorf("expected file_write_scope=read_only, got %q", restricted.Capabilities.FileWriteScope)
+	}
+	if len(restricted.Capabilities.FilesystemRoots) != 1 || restricted.Capabilities.FilesystemRoots[0] != "/home/bot/workspace" {
+		t.Errorf("unexpected filesystem_roots: %v", restricted.Capabilities.FilesystemRoots)
+	}
+	if len(restricted.Capabilities.NetworkAllowlist) != 1 || restricted.Capabilities.NetworkAllowlist[0] != "example.com" {
+		t.Errorf("unexpected network_allowlist: %v", restricted.Capabilities.NetworkAllowlist)
+	}
+
+	// Open agent has no capabilities set.
+	open := cfg.Agents[1]
+	if open.Capabilities != nil {
+		t.Error("expected open agent to have nil capabilities")
+	}
+
+	// Validation should pass.
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected validation to pass, got %v", err)
+	}
+}
+
+func TestValidateRejectsInvalidFileWriteScope(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-fws-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+storage_path: "/tmp/test.db"
+agents:
+  - name: "bad"
+    soul_path: "/tmp/soul"
+    capabilities:
+      file_write_scope: "invalid"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for invalid file_write_scope")
+	}
+}
+
+func TestLoadFromAgentWithoutCapabilitiesBackwardCompat(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-nocp-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+storage_path: "/tmp/test.db"
+agents:
+  - name: "legacy"
+    soul_path: "/tmp/soul"
+    allowed_tools:
+      - "file"
+      - "local"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(cfg.Agents))
+	}
+	agent := cfg.Agents[0]
+	if agent.Capabilities != nil {
+		t.Error("expected nil capabilities for legacy agent config")
+	}
+	if len(agent.AllowedTools) != 2 {
+		t.Errorf("expected 2 allowed_tools, got %d", len(agent.AllowedTools))
+	}
+}

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -1,0 +1,317 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CapabilityPolicy controls which capabilities an agent is allowed to exercise.
+// A nil *CapabilityPolicy is fully permissive (backward compatible with no config).
+type CapabilityPolicy struct {
+	Shell            bool     // Allow shell execution tools (local, ssh). Default: true.
+	Network          bool     // Allow network tools (web_fetch, search, browser). Default: true.
+	NetworkAllowlist []string // Allowed hostnames when Network is true. Empty = all. Future per-request enforcement.
+	Cron             bool     // Allow cron scheduling. Default: true.
+	MemoryWrite      bool     // Allow memory write tools. Default: true. Ready for future memory_capture tools.
+	Spawn            bool     // Allow sub-agent/job spawning (browser_task). Default: true.
+	FilesystemRoots  []string // Allowed absolute filesystem paths. Empty = no restriction.
+	FileReadOnly     bool     // Deny file/patch write operations.
+}
+
+// capabilitiesForTool maps tool names to the capabilities that govern them.
+// A tool requires ALL listed capabilities to be allowed.
+var capabilitiesForTool = map[string][]string{
+	"local":        {"shell"},
+	"ssh":          {"shell"},
+	"web_fetch":    {"network"},
+	"search":       {"network"},
+	"browser":      {"network"},
+	"browser_task": {"network", "spawn"},
+	"cron":         {"cron"},
+}
+
+// CapabilityForTool returns the capabilities governing the named tool.
+// Returns nil if the tool is not governed by any capability.
+func CapabilityForTool(toolName string) []string {
+	caps, ok := capabilitiesForTool[toolName]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(caps))
+	copy(out, caps)
+	return out
+}
+
+// IsAllowed reports whether the named capability is permitted.
+func (p *CapabilityPolicy) IsAllowed(capability string) bool {
+	switch capability {
+	case "shell":
+		return p.Shell
+	case "network":
+		return p.Network
+	case "cron":
+		return p.Cron
+	case "memory_write":
+		return p.MemoryWrite
+	case "spawn":
+		return p.Spawn
+	default:
+		return true
+	}
+}
+
+// DeniedCapability returns the first denied capability for the named tool,
+// or "" if the tool is fully allowed by capability checks.
+func (p *CapabilityPolicy) DeniedCapability(toolName string) string {
+	caps, ok := capabilitiesForTool[toolName]
+	if !ok {
+		return ""
+	}
+	for _, cap := range caps {
+		if !p.IsAllowed(cap) {
+			return cap
+		}
+	}
+	return ""
+}
+
+// ApplyPolicy returns a new registry with tools wrapped according to the
+// given capability policy. Tools denied by policy return ToolDenial on
+// execution. File tools are wrapped for filesystem/write-scope restrictions.
+// A nil policy returns the registry unchanged.
+func ApplyPolicy(registry *Registry, policy *CapabilityPolicy) *Registry {
+	if policy == nil {
+		return registry
+	}
+
+	result := &Registry{tools: make(map[string]Tool)}
+	for _, tool := range registry.List() {
+		result.tools[tool.Name()] = wrapForPolicy(tool, policy)
+	}
+	return result
+}
+
+func wrapForPolicy(tool Tool, policy *CapabilityPolicy) Tool {
+	name := tool.Name()
+
+	// Boolean capability denial.
+	if denied := policy.DeniedCapability(name); denied != "" {
+		return wrapToolWithPolicyDenial(tool, denied)
+	}
+
+	// File-specific restrictions.
+	needsWriteGuard := (name == "file" || name == "patch") && policy.FileReadOnly
+	needsRootsGuard := (name == "file" || name == "patch" || name == "grep") && len(policy.FilesystemRoots) > 0
+	if needsWriteGuard || needsRootsGuard {
+		return wrapToolWithFilePolicy(tool, policy)
+	}
+
+	return tool
+}
+
+// ---------------------------------------------------------------------------
+// Policy denial guard — blocks the tool entirely.
+// ---------------------------------------------------------------------------
+
+type policyDenialGuard struct {
+	tool       Tool
+	capability string
+}
+
+func (g *policyDenialGuard) Name() string        { return g.tool.Name() }
+func (g *policyDenialGuard) Description() string { return g.tool.Description() }
+func (g *policyDenialGuard) Unwrap() Tool        { return g.tool }
+
+func (g *policyDenialGuard) Execute(_ context.Context, _ ...string) (string, error) {
+	return "", g.denial()
+}
+
+func (g *policyDenialGuard) denial() *ToolDenial {
+	return &ToolDenial{
+		ToolName:    g.tool.Name(),
+		Family:      g.capability,
+		Reason:      fmt.Sprintf("capability %q denied by agent policy", g.capability),
+		Remediation: "Ask the operator to update the agent's capability policy.",
+	}
+}
+
+// Variants that preserve ToolSchema and/or jsonExecutor interfaces.
+
+type policyDenialGuardWithSchema struct {
+	*policyDenialGuard
+	schema ToolSchema
+}
+
+func (g *policyDenialGuardWithSchema) GetSchema() map[string]interface{} {
+	return g.schema.GetSchema()
+}
+
+type policyDenialGuardWithJSON struct {
+	*policyDenialGuard
+	json jsonExecutor
+}
+
+func (g *policyDenialGuardWithJSON) ExecuteJSON(_ context.Context, _ map[string]string) (string, error) {
+	return "", g.denial()
+}
+
+type policyDenialGuardWithSchemaAndJSON struct {
+	*policyDenialGuard
+	schema ToolSchema
+	json   jsonExecutor
+}
+
+func (g *policyDenialGuardWithSchemaAndJSON) GetSchema() map[string]interface{} {
+	return g.schema.GetSchema()
+}
+
+func (g *policyDenialGuardWithSchemaAndJSON) ExecuteJSON(_ context.Context, _ map[string]string) (string, error) {
+	return "", g.denial()
+}
+
+func wrapToolWithPolicyDenial(tool Tool, capability string) Tool {
+	base := &policyDenialGuard{tool: tool, capability: capability}
+	schema, hasSchema := tool.(ToolSchema)
+	jsonExec, hasJSON := tool.(jsonExecutor)
+
+	switch {
+	case hasSchema && hasJSON:
+		return &policyDenialGuardWithSchemaAndJSON{
+			policyDenialGuard: base,
+			schema:            schema,
+			json:              jsonExec,
+		}
+	case hasSchema:
+		return &policyDenialGuardWithSchema{
+			policyDenialGuard: base,
+			schema:            schema,
+		}
+	case hasJSON:
+		return &policyDenialGuardWithJSON{
+			policyDenialGuard: base,
+			json:              jsonExec,
+		}
+	default:
+		return base
+	}
+}
+
+// ---------------------------------------------------------------------------
+// File policy guard — enforces write scope and filesystem roots.
+// ---------------------------------------------------------------------------
+
+type filePolicyGuard struct {
+	tool            Tool
+	readOnly        bool
+	filesystemRoots []string
+}
+
+func (g *filePolicyGuard) Name() string        { return g.tool.Name() }
+func (g *filePolicyGuard) Description() string { return g.tool.Description() }
+func (g *filePolicyGuard) Unwrap() Tool        { return g.tool }
+
+func (g *filePolicyGuard) Execute(ctx context.Context, args ...string) (string, error) {
+	if denial := g.check(args); denial != nil {
+		return "", denial
+	}
+	return g.tool.Execute(ctx, args...)
+}
+
+func (g *filePolicyGuard) check(args []string) *ToolDenial {
+	name := g.tool.Name()
+
+	// Write-scope check.
+	if g.readOnly {
+		switch name {
+		case "file":
+			if len(args) > 0 && args[0] == "write" {
+				return &ToolDenial{
+					ToolName:    name,
+					Family:      "file_write",
+					Reason:      "file writes denied by agent policy (read-only mode)",
+					Remediation: "Ask the operator to set file_write_scope to \"full\".",
+				}
+			}
+		case "patch":
+			// Patch is always a write operation.
+			return &ToolDenial{
+				ToolName:    name,
+				Family:      "file_write",
+				Reason:      "file writes denied by agent policy (read-only mode)",
+				Remediation: "Ask the operator to set file_write_scope to \"full\".",
+			}
+		}
+	}
+
+	// Filesystem roots check.
+	if len(g.filesystemRoots) > 0 {
+		var path string
+		switch name {
+		case "file":
+			if len(args) > 1 {
+				path = args[1]
+			}
+		case "patch":
+			if len(args) > 0 {
+				path = args[0]
+			}
+		case "grep":
+			if len(args) > 1 {
+				path = args[1]
+			}
+		}
+
+		if path != "" && filepath.IsAbs(path) && !isPathInRoots(path, g.filesystemRoots) {
+			return &ToolDenial{
+				ToolName:    name,
+				Family:      "filesystem",
+				Reason:      fmt.Sprintf("path %q is outside allowed filesystem roots", path),
+				Remediation: "Ask the operator to update filesystem_roots in the capability policy.",
+			}
+		}
+	}
+
+	return nil
+}
+
+// isPathInRoots reports whether the given absolute path falls under any of the roots.
+func isPathInRoots(path string, roots []string) bool {
+	cleanPath := filepath.Clean(path)
+	for _, root := range roots {
+		cleanRoot := filepath.Clean(root)
+		if cleanPath == cleanRoot || strings.HasPrefix(cleanPath, cleanRoot+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// Variants that preserve ToolSchema interface.
+
+type filePolicyGuardWithSchema struct {
+	*filePolicyGuard
+	schema ToolSchema
+}
+
+func (g *filePolicyGuardWithSchema) GetSchema() map[string]interface{} {
+	return g.schema.GetSchema()
+}
+
+func wrapToolWithFilePolicy(tool Tool, policy *CapabilityPolicy) Tool {
+	base := &filePolicyGuard{
+		tool:            tool,
+		readOnly:        policy.FileReadOnly,
+		filesystemRoots: policy.FilesystemRoots,
+	}
+
+	if schema, ok := tool.(ToolSchema); ok {
+		return &filePolicyGuardWithSchema{
+			filePolicyGuard: base,
+			schema:          schema,
+		}
+	}
+	return base
+}

--- a/internal/tools/policy_test.go
+++ b/internal/tools/policy_test.go
@@ -1,0 +1,347 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCapabilityPolicy_DeniedCapability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		policy   CapabilityPolicy
+		tool     string
+		wantDeny string
+	}{
+		{"shell denied blocks local", CapabilityPolicy{Network: true, Cron: true, MemoryWrite: true, Spawn: true}, "local", "shell"},
+		{"shell denied blocks ssh", CapabilityPolicy{Network: true, Cron: true, MemoryWrite: true, Spawn: true}, "ssh", "shell"},
+		{"network denied blocks web_fetch", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "web_fetch", "network"},
+		{"network denied blocks search", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "search", "network"},
+		{"network denied blocks browser", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "browser", "network"},
+		{"network denied blocks browser_task", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true}, "browser_task", "network"},
+		{"spawn denied blocks browser_task", CapabilityPolicy{Shell: true, Network: true, Cron: true, MemoryWrite: true}, "browser_task", "spawn"},
+		{"cron denied blocks cron", CapabilityPolicy{Shell: true, Network: true, MemoryWrite: true, Spawn: true}, "cron", "cron"},
+		{"all allowed passes file", CapabilityPolicy{Shell: true, Network: true, Cron: true, MemoryWrite: true, Spawn: true}, "file", ""},
+		{"unmapped tool allowed", CapabilityPolicy{}, "image", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.policy.DeniedCapability(tt.tool)
+			if got != tt.wantDeny {
+				t.Errorf("DeniedCapability(%q) = %q, want %q", tt.tool, got, tt.wantDeny)
+			}
+		})
+	}
+}
+
+func TestApplyPolicy_DeniedToolReturnsDenial(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "local"})
+	reg.Register(&stubTool{name: "file"})
+
+	policy := &CapabilityPolicy{
+		Shell:       false,
+		Network:     true,
+		Cron:        true,
+		MemoryWrite: true,
+		Spawn:       true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// local should be denied.
+	_, err := result.Execute(context.Background(), "local", "ls")
+	if err == nil {
+		t.Fatal("expected policy denial for local tool")
+	}
+	denial, isDenial := IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.ToolName != "local" {
+		t.Errorf("denial.ToolName = %q, want local", denial.ToolName)
+	}
+	if denial.Family != "shell" {
+		t.Errorf("denial.Family = %q, want shell", denial.Family)
+	}
+
+	// file should pass through.
+	got, err := result.Execute(context.Background(), "file", "read", "/tmp/test")
+	if err != nil {
+		t.Fatalf("expected file tool to be allowed, got error: %v", err)
+	}
+	if got != "ok" {
+		t.Errorf("file tool result = %q, want ok", got)
+	}
+}
+
+func TestApplyPolicy_NilPolicyReturnsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "local"})
+
+	result := ApplyPolicy(reg, nil)
+	if result != reg {
+		t.Error("nil policy should return the same registry")
+	}
+}
+
+func TestApplyPolicy_PreservesToolSchema(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	schemaTool := &stubSchemaAndJSONTool{
+		stubTool: &stubTool{name: "browser_task"},
+		schema:   map[string]interface{}{"type": "object"},
+	}
+	reg.Register(schemaTool)
+
+	policy := &CapabilityPolicy{
+		Shell:   true,
+		Network: true,
+		Cron:    true,
+		Spawn:   false, // denies browser_task
+	}
+
+	result := ApplyPolicy(reg, policy)
+	tool, ok := result.Get("browser_task")
+	if !ok {
+		t.Fatal("expected browser_task to be in registry")
+	}
+
+	// Schema should be preserved.
+	ts, ok := tool.(ToolSchema)
+	if !ok {
+		t.Fatal("expected wrapped tool to preserve ToolSchema")
+	}
+	schema := ts.GetSchema()
+	if schema["type"] != "object" {
+		t.Errorf("schema type = %v, want object", schema["type"])
+	}
+
+	// ExecuteJSON should be denied.
+	je, ok := tool.(interface {
+		ExecuteJSON(context.Context, map[string]string) (string, error)
+	})
+	if !ok {
+		t.Fatal("expected wrapped tool to preserve ExecuteJSON")
+	}
+	_, err := je.ExecuteJSON(context.Background(), map[string]string{"task": "test"})
+	if err == nil {
+		t.Fatal("expected policy denial via ExecuteJSON")
+	}
+	if _, ok := IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial from ExecuteJSON, got %v", err)
+	}
+}
+
+func TestApplyPolicy_FileReadOnlyBlocksWrites(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "file"})
+	reg.Register(&stubTool{name: "patch"})
+
+	policy := &CapabilityPolicy{
+		Shell:        true,
+		Network:      true,
+		Cron:         true,
+		MemoryWrite:  true,
+		Spawn:        true,
+		FileReadOnly: true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// file read should work.
+	_, err := result.Execute(context.Background(), "file", "read", "/tmp/test")
+	if err != nil {
+		t.Fatalf("expected file read to be allowed: %v", err)
+	}
+
+	// file write should be denied.
+	_, err = result.Execute(context.Background(), "file", "write", "/tmp/test", "content")
+	if err == nil {
+		t.Fatal("expected file write to be denied")
+	}
+	denial, isDenial := IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial for file write, got %v", err)
+	}
+	if denial.Family != "file_write" {
+		t.Errorf("denial.Family = %q, want file_write", denial.Family)
+	}
+
+	// patch should be denied entirely (always a write).
+	_, err = result.Execute(context.Background(), "patch", "/tmp/test", "diff content")
+	if err == nil {
+		t.Fatal("expected patch to be denied")
+	}
+	denial, isDenial = IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial for patch, got %v", err)
+	}
+	if denial.Family != "file_write" {
+		t.Errorf("denial.Family = %q, want file_write", denial.Family)
+	}
+}
+
+func TestApplyPolicy_FilesystemRootsBlocksAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "file"})
+
+	policy := &CapabilityPolicy{
+		Shell:           true,
+		Network:         true,
+		Cron:            true,
+		MemoryWrite:     true,
+		Spawn:           true,
+		FilesystemRoots: []string{"/home/bot/workspace"},
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// Allowed path.
+	_, err := result.Execute(context.Background(), "file", "read", "/home/bot/workspace/test.txt")
+	if err != nil {
+		t.Fatalf("expected path under workspace to be allowed: %v", err)
+	}
+
+	// Disallowed absolute path.
+	_, err = result.Execute(context.Background(), "file", "read", "/etc/passwd")
+	if err == nil {
+		t.Fatal("expected path outside workspace to be denied")
+	}
+	denial, isDenial := IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial for path outside roots, got %v", err)
+	}
+	if denial.Family != "filesystem" {
+		t.Errorf("denial.Family = %q, want filesystem", denial.Family)
+	}
+
+	// Relative path should be allowed (tool's own BasePath scopes it).
+	_, err = result.Execute(context.Background(), "file", "read", "relative/file.txt")
+	if err != nil {
+		t.Fatalf("expected relative path to be allowed: %v", err)
+	}
+}
+
+func TestApplyPolicy_BrowserTaskDeniedByEitherCapability(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "browser_task"})
+
+	// Deny network but allow spawn.
+	policy1 := &CapabilityPolicy{
+		Shell:   true,
+		Network: false,
+		Cron:    true,
+		Spawn:   true,
+	}
+	r1 := ApplyPolicy(reg, policy1)
+	_, err := r1.Execute(context.Background(), "browser_task", "test")
+	if err == nil {
+		t.Fatal("expected browser_task denied when network=false")
+	}
+	d, ok := IsToolDenial(err)
+	if !ok || d.Family != "network" {
+		t.Fatalf("expected denial Family=network, got %v", d)
+	}
+
+	// Allow network but deny spawn.
+	policy2 := &CapabilityPolicy{
+		Shell:   true,
+		Network: true,
+		Cron:    true,
+		Spawn:   false,
+	}
+	r2 := ApplyPolicy(reg, policy2)
+	_, err = r2.Execute(context.Background(), "browser_task", "test")
+	if err == nil {
+		t.Fatal("expected browser_task denied when spawn=false")
+	}
+	d, ok = IsToolDenial(err)
+	if !ok || d.Family != "spawn" {
+		t.Fatalf("expected denial Family=spawn, got %v", d)
+	}
+}
+
+func TestApplyPolicy_FullyPermissivePolicyAllowsAll(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "local"})
+	reg.Register(&stubTool{name: "web_fetch"})
+	reg.Register(&stubTool{name: "cron"})
+	reg.Register(&stubTool{name: "browser_task"})
+
+	policy := &CapabilityPolicy{
+		Shell:       true,
+		Network:     true,
+		Cron:        true,
+		MemoryWrite: true,
+		Spawn:       true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+	for _, name := range []string{"local", "web_fetch", "cron", "browser_task"} {
+		if _, err := result.Execute(context.Background(), name, "test"); err != nil {
+			t.Errorf("expected %q to be allowed with permissive policy, got %v", name, err)
+		}
+	}
+}
+
+func TestIsPathInRoots(t *testing.T) {
+	t.Parallel()
+
+	roots := []string{"/home/bot/workspace", "/tmp/data"}
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/home/bot/workspace/file.txt", true},
+		{"/home/bot/workspace", true},
+		{"/tmp/data/deep/file", true},
+		{"/etc/passwd", false},
+		{"/home/bot", false},
+		{"/home/bot/workspacex", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			got := isPathInRoots(tt.path, roots)
+			if got != tt.want {
+				t.Errorf("isPathInRoots(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// Test helpers.
+
+type stubSchemaAndJSONTool struct {
+	*stubTool
+	schema     map[string]interface{}
+	jsonCalled int
+}
+
+func (s *stubSchemaAndJSONTool) GetSchema() map[string]interface{} {
+	return s.schema
+}
+
+func (s *stubSchemaAndJSONTool) ExecuteJSON(_ context.Context, _ map[string]string) (string, error) {
+	s.jsonCalled++
+	return "ok", nil
+}


### PR DESCRIPTION
Implements #236

## Changes

Adds a `capabilities` block to agent config for fine-grained, per-agent capability policy. This complements the existing `allowed_tools` list with structured restrictions that operators can set without editing Go code.

**Supported capabilities:**
- `shell` — controls `local` and `ssh` tools
- `network` — controls `web_fetch`, `search`, `browser`, `browser_task`
- `cron` — controls cron scheduling
- `memory_write` — controls future memory write tools
- `spawn` — controls sub-agent/job spawning (`browser_task`)
- `filesystem_roots` — limits absolute paths for `file`/`patch`/`grep` tools
- `file_write_scope` — `"read_only"` blocks file writes and patch operations

**Key design decisions:**
- Denied tools remain in the registry but return `ToolDenial` on execution, flowing through the existing Telegram/TUI/API denial path (same as estop)
- `nil` capabilities = fully permissive — existing `allowed_tools` configs are unaffected
- Policy is applied last in the resolver pipeline, after allowed_tools filtering and per-chat tool injection, so all tools are covered
- `browser_task` requires both `network` and `spawn` capabilities

**Files changed:**
- `internal/tools/policy.go` — new: `CapabilityPolicy` type, tool-to-capability mapping, guard wrappers, `ApplyPolicy()`
- `internal/config/config.go` — `CapabilityPolicyConfig` struct, added to `AgentConfig`
- `internal/agent/registry.go` — `Policy` field on `AgentProfile`, config-to-policy resolution
- `internal/agent/resolver.go` — applies policy in `buildToolRegistry`
- `docs/ARCHITECTURE.md` + `config.schema.json` — canonical config schema updated

## Testing

- `internal/tools/policy_test.go` — 8 tests covering boolean capability denial, file write scope, filesystem roots, interface preservation, multi-capability tools
- `internal/agent/resolver_policy_test.go` — 7 integration tests covering policy+estop stacking, policy+allowed_tools interaction, per-chat tool denial, nil policy passthrough
- `internal/config/config_test.go` — 3 tests for config loading with capabilities, validation, and backward compatibility
- All existing tests pass (`go test ./...`)
- Binary builds successfully (`CGO_ENABLED=1 go build ./cmd/ok-gobot/`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a structured `capabilities` block for per-agent capability policy, complementing the existing `allowed_tools` list. The design is solid — policy is applied last in the resolver pipeline, nil policy is fully permissive, and the guard wrappers correctly preserve `ToolSchema` and `jsonExecutor` interfaces. Test coverage across unit and integration layers is thorough.

Two logic issues in `internal/tools/policy.go` need attention before merge:

- **Symlink bypass in `isPathInRoots`**: The `filesystem_roots` restriction uses `filepath.Clean` but not `filepath.EvalSymlinks`. A symlink inside an allowed root pointing outside it bypasses the check. `resolvePath` in `tools.go` already demonstrates the correct pattern.
- **`ApplyPolicy` drops `stopStateProvider`**: The result registry is constructed with `&Registry{tools: ...}` rather than `registry.Child()`, silently losing the emergency-stop provider. Currently benign (source tools are already wrapped), but a latent invariant violation if `Register` is ever called on the result.

<h3>Confidence Score: 3/5</h3>

- The PR is close to merge-ready but the symlink-escape bypass in `isPathInRoots` is a concrete security gap in the new `filesystem_roots` feature that should be fixed first.
- The overall design and test coverage are high quality. However, `filesystem_roots` is a security-facing feature and `isPathInRoots` has a symlink bypass that contradicts the existing defence in `resolvePath`. Since this is the primary purpose of that config field, the gap is significant enough to block merge. The `stopStateProvider` loss is currently benign but is also a straightforward fix. Both issues are in one file and have clear remediation.
- internal/tools/policy.go — isPathInRoots and ApplyPolicy functions

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tools/policy.go | New capability policy enforcement layer. Two logic issues: isPathInRoots skips symlink resolution (allowing symlink escape of filesystem_roots), and ApplyPolicy drops the stopStateProvider from the result registry. |
| internal/agent/registry.go | Adds Policy field to AgentProfile and resolveCapabilityPolicy helper. Clean, correct config-to-policy mapping with proper nil/default handling. |
| internal/agent/resolver.go | Applies capability policy as the last step in buildToolRegistry, correctly covering per-chat injected tools. Minimal and correct change. |
| internal/config/config.go | Adds CapabilityPolicyConfig struct and Validate() extension. Correct use of *bool for optional fields with proper validation of file_write_scope values. |
| internal/tools/policy_test.go | Good unit test coverage for capability denial, file read-only, filesystem roots, interface preservation, and nil-policy passthrough. |
| internal/agent/resolver_policy_test.go | Integration tests covering estop+policy stacking, allowed_tools interaction, per-chat cron denial, nil policy passthrough, and file read-only. Well-structured. |
| internal/config/config_test.go | Three new tests for config loading with capabilities, validation rejection of invalid file_write_scope, and backward compat with nil capabilities. Correct. |
| config.schema.json | Schema correctly documents the new capabilities block with proper types, defaults, and enums. |
| docs/ARCHITECTURE.md | Documentation updated with canonical capability policy schema. Consistent with config.schema.json. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tools/policy.go
Line: 281-290

Comment:
**`filesystem_roots` restriction bypassable via symlinks**

`isPathInRoots` uses `filepath.Clean` but does not resolve symlinks. If an allowed root contains a symlink pointing outside the allowed roots (e.g. `/home/bot/workspace/link -> /etc`), a path like `/home/bot/workspace/link/passwd` passes this check — because it string-prefixes with the allowed root — but the OS will follow the symlink and access `/etc/passwd`.

Contrast with `resolvePath` in `tools.go`, which explicitly calls `filepath.EvalSymlinks` on both the root and the target path precisely to prevent this class of escape. The same defence should be applied here.

```go
func isPathInRoots(path string, roots []string) bool {
	// Resolve symlinks before comparing so a symlink inside an allowed root
	// cannot point outside it.
	resolvedPath, err := filepath.EvalSymlinks(path)
	if err != nil {
		// File may not exist yet — resolve the parent directory.
		parent := filepath.Dir(path)
		resolvedParent, perr := filepath.EvalSymlinks(parent)
		if perr != nil {
			resolvedPath = filepath.Clean(path)
		} else {
			resolvedPath = filepath.Join(resolvedParent, filepath.Base(path))
		}
	}
	for _, root := range roots {
		cleanRoot := filepath.Clean(root)
		resolvedRoot, err := filepath.EvalSymlinks(cleanRoot)
		if err != nil {
			resolvedRoot = cleanRoot
		}
		if resolvedPath == resolvedRoot || strings.HasPrefix(resolvedPath, resolvedRoot+string(os.PathSeparator)) {
			return true
		}
	}
	return false
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tools/policy.go
Line: 90

Comment:
**`ApplyPolicy` drops `stopStateProvider` from the result registry**

The new registry is constructed directly as `&Registry{tools: make(map[string]Tool)}`, so `stopStateProvider` is `nil` on the returned registry. If any code path later calls `Register` on this result (e.g. in a refactor or a new per-chat tool injection), newly registered dangerous tools will not receive their emergency-stop guard.

The existing `Child()` helper exists exactly for this purpose — it creates an empty registry that inherits the emergency-stop provider:

```go
result := registry.Child()
for _, tool := range registry.List() {
    result.tools[tool.Name()] = wrapForPolicy(tool, policy)
}
return result
```

Note: because `result.tools` is set directly (bypassing `Register`), the estop auto-wrap in `Register` is not triggered even with `Child()`, so existing already-wrapped tools remain unaffected. The fix ensures the provider is present for any future `Register` calls on the returned registry.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(safety): add per-agent capability p..."](https://github.com/befeast/ok-gobot/commit/907e556e45a9796ed6520a60493b4cdef276cb0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26109932)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->