### PR TITLE
feat: utility score tracking and skill router (#244)

### DIFF
--- a/internal/agent/personality.go
+++ b/internal/agent/personality.go
@@ -10,13 +10,20 @@ import (
 // SkillEntry represents a discovered skill.
 type SkillEntry = bootstrap.SkillEntry
 
+// SkillScoreProvider returns current utility scores keyed by skill name.
+// Implement this interface to inject live scores into the system prompt.
+type SkillScoreProvider interface {
+	GetSkillScores() (map[string]int, error)
+}
+
 // Personality wraps the canonical bootstrap loader.
 type Personality struct {
-	mu       sync.RWMutex
-	BasePath string
-	Files    map[string]string
-	Skills   []SkillEntry
-	loader   *bootstrap.Loader
+	mu            sync.RWMutex
+	BasePath      string
+	Files         map[string]string
+	Skills        []SkillEntry
+	loader        *bootstrap.Loader
+	scoreProvider SkillScoreProvider
 }
 
 // NewPersonality creates a new personality loader.
@@ -34,7 +41,18 @@ func NewPersonality(basePath string) (*Personality, error) {
 	}, nil
 }
 
-// Loader exposes the canonical bootstrap loader snapshot.
+// SetScoreProvider sets the source of live utility scores for skill ordering.
+// When set, scores are applied to the loader snapshot on every Loader() call.
+func (p *Personality) SetScoreProvider(sp SkillScoreProvider) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.scoreProvider = sp
+}
+
+// Loader exposes the canonical bootstrap loader snapshot, with scores applied.
 func (p *Personality) Loader() *bootstrap.Loader {
 	if p == nil {
 		return nil
@@ -42,7 +60,13 @@ func (p *Personality) Loader() *bootstrap.Loader {
 
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return p.loaderSnapshotLocked()
+	snap := p.loaderSnapshotLocked()
+	if p.scoreProvider != nil {
+		if scores, err := p.scoreProvider.GetSkillScores(); err == nil {
+			snap.ApplyScores(scores)
+		}
+	}
+	return snap
 }
 
 // GetSystemPrompt builds the complete system prompt from all loaded files.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -145,6 +145,7 @@ func (a *App) Start(ctx context.Context) error {
 		personality = &agent.Personality{}
 	}
 	a.personality = personality
+	personality.SetScoreProvider(a.store)
 	log.Printf("🦞 Personality loaded: %s %s", personality.GetName(), personality.GetEmoji())
 	a.startBootstrapWatcher("default", personality)
 
@@ -162,6 +163,7 @@ func (a *App) Start(ctx context.Context) error {
 			if profile == nil || profile.Personality == nil {
 				continue
 			}
+			profile.Personality.SetScoreProvider(a.store)
 			a.startBootstrapWatcher(name, profile.Personality)
 		}
 	} else {

--- a/internal/bootstrap/loader.go
+++ b/internal/bootstrap/loader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -40,9 +41,10 @@ var filesToLoad = []string{
 
 // SkillEntry represents a discovered skill.
 type SkillEntry struct {
-	Name        string
-	Description string
-	Path        string
+	Name         string
+	Description  string
+	Path         string
+	UtilityScore int
 }
 
 // Loader loads and exposes bootstrap context files.
@@ -280,19 +282,37 @@ func (l *Loader) Emoji() string {
 	return "🕯️"
 }
 
-// SkillsSummary returns a formatted list of available skills.
+// SkillsSummary returns a formatted list of available skills, sorted by utility score descending.
 func (l *Loader) SkillsSummary() string {
 	if l == nil || len(l.Skills) == 0 {
 		return ""
 	}
 
+	sorted := make([]SkillEntry, len(l.Skills))
+	copy(sorted, l.Skills)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].UtilityScore > sorted[j].UtilityScore
+	})
+
 	var summary strings.Builder
-	for _, skill := range l.Skills {
+	for _, skill := range sorted {
 		dir := filepath.Dir(skill.Path)
-		summary.WriteString(fmt.Sprintf("- %s (SKILL.md: %s, baseDir: %s): %s\n", skill.Name, skill.Path, dir, skill.Description))
+		summary.WriteString(fmt.Sprintf("- %s (SKILL.md: %s, baseDir: %s, score: %d): %s\n", skill.Name, skill.Path, dir, skill.UtilityScore, skill.Description))
 	}
 
 	return summary.String()
+}
+
+// ApplyScores sets the UtilityScore on each skill by name from the provided map.
+func (l *Loader) ApplyScores(scores map[string]int) {
+	if l == nil {
+		return
+	}
+	for i := range l.Skills {
+		if score, ok := scores[l.Skills[i].Name]; ok {
+			l.Skills[i].UtilityScore = score
+		}
+	}
 }
 
 // FileContent returns the raw content of a loaded file.

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -2,10 +2,13 @@ package bot
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
+	"sync"
 
 	"gopkg.in/telebot.v4"
 
@@ -92,6 +95,9 @@ func (b *Bot) processViaHubWithContent(
 	b.setCurrentChatID(chatID)
 	defer b.setCurrentChatID(0)
 
+	// Track which skills are read during this run so scores can be updated on completion.
+	tracker := newSkillTracker()
+
 	// Wire LiveStreamEditor for real-time token streaming and tool-event status lines.
 	// The ⏳ ack message (sent upfront in the message handler) is continuously updated
 	// while the run is active; processViaHub performs the authoritative final edit once
@@ -106,6 +112,7 @@ func (b *Bot) processViaHubWithContent(
 		liveEditor.Flush()
 		ctrlHub := b.controlHub
 		onToolEvent = func(event agent.ToolEvent) {
+			tracker.observe(event)
 			liveEditor.OnToolEvent(event)
 			if ctrlHub != nil {
 				switch event.Type {
@@ -150,6 +157,7 @@ func (b *Bot) processViaHubWithContent(
 		// No ack message, but we still want control hub events.
 		ctrlHub := b.controlHub
 		onToolEvent = func(event agent.ToolEvent) {
+			tracker.observe(event)
 			switch event.Type {
 			case agent.ToolEventStarted:
 				ctrlHub.Emit(control.EvtToolStarted, control.ToolEventPayload{
@@ -183,6 +191,13 @@ func (b *Bot) processViaHubWithContent(
 				ChatID: chatID,
 				Delta:  delta,
 			})
+		}
+	}
+
+	// Ensure skill tracker observes events even when no other listeners are wired.
+	if onToolEvent == nil {
+		onToolEvent = func(event agent.ToolEvent) {
+			tracker.observe(event)
 		}
 	}
 
@@ -239,6 +254,7 @@ func (b *Bot) processViaHubWithContent(
 			profileName = ev.ProfileName
 
 		case agent.RunEventError:
+			tracker.flush(b.store, false)
 			stopTyping()
 			if liveEditor != nil {
 				liveEditor.Stop()
@@ -289,6 +305,9 @@ func (b *Bot) processViaHubWithContent(
 		}
 		return nil
 	}
+
+	// Flush skill score updates — run completed successfully.
+	tracker.flush(b.store, true)
 
 	// Emit run.completed to control hub.
 	if b.controlHub != nil {
@@ -460,4 +479,71 @@ func splitMessage(msg string, maxLen int) []string {
 		}
 	}
 	return chunks
+}
+
+// skillTracker records which skills were invoked during a run so their
+// utility scores can be updated once the outcome is known.
+type skillTracker struct {
+	mu     sync.Mutex
+	skills map[string]struct{}
+}
+
+func newSkillTracker() *skillTracker {
+	return &skillTracker{skills: make(map[string]struct{})}
+}
+
+// observe checks whether a finished tool event corresponds to reading a
+// SKILL.md file and, if so, records the skill name.
+func (t *skillTracker) observe(event agent.ToolEvent) {
+	if event.Type != agent.ToolEventFinished {
+		return
+	}
+	if event.ToolName != "file" {
+		return
+	}
+	// Extract path from the JSON arguments stored in event.Input.
+	// The file tool receives e.g. {"command":"read","path":"…/SKILL.md"}.
+	var params struct {
+		Command string `json:"command"`
+		Path    string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(event.Input), &params); err != nil {
+		return
+	}
+	if params.Command != "read" {
+		return
+	}
+	if filepath.Base(params.Path) != "SKILL.md" {
+		return
+	}
+	// The skill name is the parent directory of SKILL.md.
+	skillName := filepath.Base(filepath.Dir(params.Path))
+	if skillName == "" || skillName == "." {
+		return
+	}
+	t.mu.Lock()
+	t.skills[skillName] = struct{}{}
+	t.mu.Unlock()
+}
+
+// flush records the outcome for all observed skills in the provided store.
+// It is safe to call even when no skills were observed.
+func (t *skillTracker) flush(store skillScoreRecorder, success bool) {
+	t.mu.Lock()
+	names := make([]string, 0, len(t.skills))
+	for name := range t.skills {
+		names = append(names, name)
+	}
+	t.mu.Unlock()
+
+	for _, name := range names {
+		if err := store.RecordSkillResult(name, success); err != nil {
+			log.Printf("[skills] failed to record result for %q: %v", name, err)
+		}
+	}
+}
+
+// skillScoreRecorder is the subset of storage.Store needed for skill tracking.
+type skillScoreRecorder interface {
+	RecordSkillResult(skillName string, success bool) error
 }

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -10,6 +10,7 @@ import (
 
 	"ok-gobot/internal/bootstrap"
 	"ok-gobot/internal/config"
+	"ok-gobot/internal/storage"
 )
 
 func newSkillsCommand(cfg *config.Config) *cobra.Command {
@@ -32,25 +33,71 @@ func newSkillsCommand(cfg *config.Config) *cobra.Command {
 func newSkillsListCommand(cfg *config.Config) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "List installed skills",
+		Short: "List installed skills with utility scores",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			soulPath := cfg.GetSoulPath()
-			skills, err := bootstrap.ListSkills(soulPath)
+			store, err := storage.New(cfg.StoragePath)
 			if err != nil {
-				return fmt.Errorf("failed to list skills: %w", err)
+				return fmt.Errorf("failed to open storage: %w", err)
+			}
+			defer store.Close() //nolint:errcheck
+
+			// Load discovered skills from the soul directory.
+			soulPath := cfg.GetSoulPath()
+			loader, err := bootstrap.NewLoader(soulPath)
+			if err != nil {
+				return fmt.Errorf("failed to load skills: %w", err)
 			}
 
-			if len(skills) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "No skills installed.")
-				fmt.Fprintln(cmd.OutOrStdout(), "\nInstall a skill with: ok-gobot skills install <path-or-git-url>")
+			// Load scores from DB and apply to the loader.
+			scores, err := store.GetSkillScores()
+			if err != nil {
+				return fmt.Errorf("failed to load skill scores: %w", err)
+			}
+			loader.ApplyScores(scores)
+
+			// Also load any skills that have been scored but are no longer on disk.
+			dbScores, err := store.ListSkillScores()
+			if err != nil {
+				return fmt.Errorf("failed to list skill scores: %w", err)
+			}
+
+			out := cmd.OutOrStdout()
+
+			if len(loader.Skills) == 0 && len(dbScores) == 0 {
+				fmt.Fprintln(out, "No skills installed.")
+				fmt.Fprintln(out, "\nInstall a skill with: ok-gobot skills install <path-or-git-url>")
 				return nil
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Installed skills (%d):\n\n", len(skills))
-			for _, skill := range skills {
-				fmt.Fprintf(cmd.OutOrStdout(), "  %-20s %s\n", skill.Name, skill.Description)
+			// Build a set of skill names already shown via the loader.
+			shown := make(map[string]struct{}, len(loader.Skills))
+
+			dbByName := make(map[string]storage.SkillScore, len(dbScores))
+			for _, ss := range dbScores {
+				dbByName[ss.Name] = ss
 			}
-			return nil
+
+			w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "SKILL\tSCORE\tUSES\tSUCCESSES\tFAILURES\tDESCRIPTION")
+
+			for _, skill := range loader.Skills {
+				shown[skill.Name] = struct{}{}
+				ss := dbByName[skill.Name]
+				fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t%s\n",
+					skill.Name, skill.UtilityScore, ss.Uses, ss.Successes, ss.Failures,
+					truncate(skill.Description, 50))
+			}
+
+			// Show DB-only entries (skills that existed previously but are now removed).
+			for _, ss := range dbScores {
+				if _, ok := shown[ss.Name]; ok {
+					continue
+				}
+				fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t(not on disk)\n",
+					ss.Name, ss.Score, ss.Uses, ss.Successes, ss.Failures)
+			}
+
+			return w.Flush()
 		},
 	}
 }

--- a/internal/storage/skill_scores.go
+++ b/internal/storage/skill_scores.go
@@ -1,0 +1,85 @@
+package storage
+
+// SkillScore holds the utility tracking data for a single skill.
+type SkillScore struct {
+	Name      string
+	Score     int
+	Uses      int
+	Successes int
+	Failures  int
+	UpdatedAt string
+}
+
+// RecordSkillResult records a skill use outcome. On success the score is
+// incremented; on failure it is decremented (floor 0).
+func (s *Store) RecordSkillResult(skillName string, success bool) error {
+	delta := 1
+	if !success {
+		delta = -1
+	}
+
+	_, err := s.db.Exec(`
+		INSERT INTO skill_scores (name, score, uses, successes, failures, updated_at)
+		VALUES (?, MAX(0, ?), 1, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(name) DO UPDATE SET
+			score      = MAX(0, score + ?),
+			uses       = uses + 1,
+			successes  = successes + ?,
+			failures   = failures + ?,
+			updated_at = CURRENT_TIMESTAMP`,
+		skillName, delta,
+		boolToInt(success), boolToInt(!success),
+		delta,
+		boolToInt(success), boolToInt(!success),
+	)
+	return err
+}
+
+// GetSkillScores returns a map of skill name → current score for all tracked skills.
+func (s *Store) GetSkillScores() (map[string]int, error) {
+	rows, err := s.db.Query(`SELECT name, score FROM skill_scores`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	scores := make(map[string]int)
+	for rows.Next() {
+		var name string
+		var score int
+		if err := rows.Scan(&name, &score); err != nil {
+			return nil, err
+		}
+		scores[name] = score
+	}
+	return scores, rows.Err()
+}
+
+// ListSkillScores returns all skill score records ordered by score descending.
+func (s *Store) ListSkillScores() ([]SkillScore, error) {
+	rows, err := s.db.Query(`
+		SELECT name, score, uses, successes, failures, updated_at
+		FROM skill_scores
+		ORDER BY score DESC, name ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var out []SkillScore
+	for rows.Next() {
+		var ss SkillScore
+		if err := rows.Scan(&ss.Name, &ss.Score, &ss.Uses, &ss.Successes, &ss.Failures, &ss.UpdatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, ss)
+	}
+	return out, rows.Err()
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -224,6 +224,15 @@ func (s *Store) migrate() error {
 		`ALTER TABLE cron_jobs ADD COLUMN type TEXT NOT NULL DEFAULT 'llm';`,
 		// Cron job timeout in seconds (0 = use default)
 		`ALTER TABLE cron_jobs ADD COLUMN timeout_seconds INTEGER NOT NULL DEFAULT 0;`,
+		// Skill utility scores table — tracks per-skill success/failure counters.
+		`CREATE TABLE IF NOT EXISTS skill_scores (
+			name       TEXT PRIMARY KEY,
+			score      INTEGER NOT NULL DEFAULT 0,
+			uses       INTEGER NOT NULL DEFAULT 0,
+			successes  INTEGER NOT NULL DEFAULT 0,
+			failures   INTEGER NOT NULL DEFAULT 0,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);`,
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
Implements #244

## Changes

### Core
- **`bootstrap.SkillEntry`**: added `UtilityScore int` field
- **`bootstrap.Loader`**: `SkillsSummary()` now sorts skills by score descending (higher-scored skills appear first in the system prompt, making the LLM prefer them); added `ApplyScores(map[string]int)` method

### Persistence
- **`storage/sqlite.go`**: added `skill_scores` migration — table tracks `score`, `uses`, `successes`, `failures` per skill name; uses SQLite UPSERT so scores are updated atomically
- **`storage/skill_scores.go`**: new file with `RecordSkillResult`, `GetSkillScores`, `ListSkillScores` methods

### Tracking
- **`agent.Personality`**: added `SkillScoreProvider` interface and `SetScoreProvider()` — on every `Loader()` call, live scores from the DB are applied to the skill snapshot before building the system prompt
- **`bot/hub_handler.go`**: `skillTracker` observes `ToolEventFinished` for the `file` tool; detects reads of `SKILL.md` paths; calls `RecordSkillResult(name, success/failure)` after each hub run completes

### CLI
- **`cli/skills.go`**: enhanced `list` subcommand shows `SKILL | SCORE | USES | SUCCESSES | FAILURES | DESCRIPTION`; merged with existing `install/remove/audit/history/rollback` commands from main

### Wiring
- **`app/app.go`**: `personality.SetScoreProvider(store)` called after personality load for all agents

## Testing

- All `storage`, `bootstrap`, `agent`, `cli`, `bot` package tests pass
- Build: `CGO_ENABLED=1 go build ./cmd/ok-gobot/` ✓
- Pre-existing `TestAnthropicClientOAuthHeadersAndBetaQuery` failure in `internal/ai` is unrelated to this PR (OAuth token test was failing before these changes)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements utility score tracking for skills (#244): scores are persisted in a new `skill_scores` SQLite table, applied to the bootstrap loader snapshot on every system-prompt build (so higher-scored skills appear first for the LLM), and updated after each hub run via a `skillTracker` that watches `ToolEventFinished` events for `SKILL.md` reads. The CLI `skills list` command is also enhanced to display the full score table.

The architecture is clean — snapshot cloning in `Personality.Loader()` ensures the canonical loader is never mutated, the UPSERT SQL correctly floors scores at 0, and the storage interface keeps `hub_handler.go` decoupled from the concrete store type.

**One logic issue to address before merging:**
- In `hub_handler.go`, `tracker.flush(b.store, false)` is called at the top of the `RunEventError` case, before the code checks whether the error was caused by a user cancellation. This means skills consulted during a cancelled run have their scores decremented as if they failed, which will corrupt utility scores over time for any skill that is regularly invoked in long or interrupted requests.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the cancellation-vs-failure distinction in the skill score flush.
- All components (storage, loader, personality, CLI) are implemented correctly. The single P1 issue — cancelled runs silently decrementing skill scores — will cause score data to drift over time as users cancel requests, biasing the system prompt ordering against useful skills.
- internal/bot/hub_handler.go — the RunEventError flush path needs to skip recording a failure when the run was cancelled.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/hub_handler.go | Adds skillTracker that observes ToolEventFinished for SKILL.md reads and flushes outcomes on run completion or error; the flush-on-error path fires before the cancellation check, incorrectly decrementing skill scores on user-cancelled runs. |
| internal/storage/skill_scores.go | New file implementing RecordSkillResult (atomic UPSERT with floor-0 score), GetSkillScores, and ListSkillScores; SQL parameter ordering and MAX(0,…) guard are correct. |
| internal/storage/sqlite.go | Appends skill_scores migration (CREATE TABLE IF NOT EXISTS) to the existing sequential migration list; idempotent and consistent with the project's migration pattern. |
| internal/bootstrap/loader.go | Adds UtilityScore field to SkillEntry, ApplyScores method, and score-descending sort inside SkillsSummary; all changes are correct and well-isolated. |
| internal/agent/personality.go | Adds SkillScoreProvider interface and SetScoreProvider; Loader() creates a deep-cloned snapshot via loaderSnapshotLocked then applies scores to the clone, so the canonical loader is never mutated — correct. |
| internal/app/app.go | Wires personality.SetScoreProvider(a.store) for both the default personality and every profile personality; straightforward and safe. |
| internal/cli/skills.go | Upgrades the list subcommand to show a tabwriter table with score/uses/successes/failures; also surfaces DB-only (removed) skills; logic and DB calls are correct. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/bot/hub_handler.go`, line 257-263 ([link](https://github.com/befeast/ok-gobot/blob/557dc03d3193603609ec183a73d1d3981907bb71/internal/bot/hub_handler.go#L257-L263)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Cancelled runs incorrectly penalise skills**

   `tracker.flush(b.store, false)` is called unconditionally at line 257, before the cancellation check at line 263. This means that when a user cancels a run (`ctx.Err() != nil` or `errors.Is(ev.Err, context.Canceled)`), every skill whose `SKILL.md` was read during that run has its score decremented. A cancel is not a skill failure — over time, any skill invoked by a long-running request that users tend to interrupt will have its score degraded, causing it to sort lower in the system prompt even though nothing about the skill itself is defective.

   The flush should only record a failure for genuine agent errors, not for user-initiated cancellations:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/bot/hub_handler.go
   Line: 257-263

   Comment:
   **Cancelled runs incorrectly penalise skills**

   `tracker.flush(b.store, false)` is called unconditionally at line 257, before the cancellation check at line 263. This means that when a user cancels a run (`ctx.Err() != nil` or `errors.Is(ev.Err, context.Canceled)`), every skill whose `SKILL.md` was read during that run has its score decremented. A cancel is not a skill failure — over time, any skill invoked by a long-running request that users tend to interrupt will have its score degraded, causing it to sort lower in the system prompt even though nothing about the skill itself is defective.

   The flush should only record a failure for genuine agent errors, not for user-initiated cancellations:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/bot/hub_handler.go
Line: 257-263

Comment:
**Cancelled runs incorrectly penalise skills**

`tracker.flush(b.store, false)` is called unconditionally at line 257, before the cancellation check at line 263. This means that when a user cancels a run (`ctx.Err() != nil` or `errors.Is(ev.Err, context.Canceled)`), every skill whose `SKILL.md` was read during that run has its score decremented. A cancel is not a skill failure — over time, any skill invoked by a long-running request that users tend to interrupt will have its score degraded, causing it to sort lower in the system prompt even though nothing about the skill itself is defective.

The flush should only record a failure for genuine agent errors, not for user-initiated cancellations:

```suggestion
		case agent.RunEventError:
			stopTyping()
			if liveEditor != nil {
				liveEditor.Stop()
			}
			ackHandle := b.takeAckHandle(chatID)
			if ctx.Err() != nil || errors.Is(ev.Err, context.Canceled) {
				// Cancelled by the user — do not penalise skills.
				if ackHandle != nil {
					b.updateAckStatus(ackHandle, jobStatusCancelled, "Job stopped before completion.")
				}
				if b.controlHub != nil {
					b.controlHub.Emit(control.EvtRunFailed, control.RunEventPayload{
						ChatID: chatID,
						Error:  "cancelled",
					})
				}
				return nil
			}
			tracker.flush(b.store, false)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(skills): add utility score tracking..."](https://github.com/befeast/ok-gobot/commit/557dc03d3193603609ec183a73d1d3981907bb71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26819147)</sub>

<!-- /greptile_comment -->