### PR TITLE
docs: refresh docs after current-state comparison (#290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ok-gobot
 
-A fast, single-binary Telegram bot with AI agent capabilities. Ground-up Go rewrite of [OpenClaw](https://github.com/openclaw/openclaw) with opinionated defaults for personal use.
+A fast, single-binary Telegram bot and mission-control tool with AI agent capabilities. Ground-up Go rewrite of [OpenClaw](https://github.com/openclaw/openclaw) with opinionated defaults for personal operator use.
 
 Competitive landscape: [docs/COMPETITORS.md](docs/COMPETITORS.md).
 
@@ -41,7 +41,7 @@ ok-gobot doctor
 ok-gobot start
 ```
 
-**Requirements:** Go 1.23+, C compiler (for SQLite CGO).
+**Requirements:** Go 1.24+, C compiler (for SQLite CGO).
 
 ## AI Providers
 
@@ -50,22 +50,48 @@ ok-gobot start
 | Anthropic | OAuth (Claude MAX) | `ok-gobot auth anthropic login` |
 | ChatGPT | OAuth (Plus/Team) | `ok-gobot auth chatgpt login` |
 | OpenAI | API key | `ai.provider: openai` |
+| OpenRouter | API key | `ai.provider: openrouter` |
 | Gemini | API key via custom | `ai.provider: custom` + `ai.base_url` |
 | Droid | CLI agent transport | `ai.provider: droid` |
+
+Multi-model routing: configure per-task-type models (vision, summarize, reasoning, coding) via `[task:type]` tags or config routes.
 
 See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 
 ## Features
 
 ### AI & LLM
-- **Multi-provider** -- Anthropic, ChatGPT, OpenAI, Gemini, Droid, any OpenAI-compatible endpoint
+- **Multi-provider** -- Anthropic, ChatGPT, OpenAI, OpenRouter, Gemini, Droid, any OpenAI-compatible endpoint
 - **Native tool calling** -- structured `tools` API, not text parsing
 - **Model failover** -- automatic fallback chain with cooldown (`ai.fallback_models`)
+- **Multi-model routing** -- route by task type (vision, coding, reasoning, summarize) via config or `[task:type]` tags
 - **Per-session model override** -- `/model claude-sonnet-4-5` per chat
 - **Multi-agent system** -- multiple personalities, models, tool sets per agent (`/agent`)
 - **Context compaction** -- AI-powered summarization when approaching token limits
 - **Streaming responses** -- live message editing with rate limiting
 - **CLI agent transport** -- use Factory Droid, Claude Code, Codex, Gemini CLI, or OpenCode as backends
+- **Reflection loop** -- automatic failure tracking and fix proposals after tool errors
+
+### Roles & Jobs
+- **Prebuilt roles** -- `researcher`, `monitor`, `release-watch` ship as markdown manifests with YAML frontmatter
+- **Declarative role manifests** -- define custom roles (prompt, tools, schedule, approval, report template) without Go code
+- **Chat routing** -- rules-first classification: lightweight replies stay inline, heavy work launches as background jobs, ambiguous requests get clarification
+- **Background jobs** -- `job:`, `task:`, or `background:` prefixes force background execution
+- **Sub-agent spawning** -- isolated task execution with parent-child result delivery
+- **Cost tiers** -- `premium`, `standard`, `cheap`, `local` worker selection per role
+
+### Skills
+- **Markdown-first skills** -- workspace-local skill definitions with SKILL.md
+- **CLI management** -- `ok-gobot skills list|install|remove|audit`
+- **Safety audit** -- static analysis rejects symlinks, scripts, pipe-to-shell, and escaping links
+- **Utility scoring** -- tracks uses, successes, failures per skill; score-sorted prompts
+
+### Self-Evolution
+- **A-Evolve cycle** -- Solve, Observe, Evolve, Gate, Reload
+- **Failure pattern analysis** -- detects high failure rates, excessive token usage, slow completions
+- **Benchmark gating** -- new versions must score higher than current
+- **Version history** -- rollback support, human approval for large diffs
+- **CLI** -- `ok-gobot evolution status|history|rollback|metrics`
 
 ### Tools
 | Tool | Description |
@@ -87,6 +113,8 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 | `cron` | Scheduled tasks |
 
 ### Security & Control
+- **Capability policy** -- per-agent restrictions: shell, network, network_allowlist, cron, memory_write, spawn, filesystem_roots, file_write_scope
+- **Emergency stop** -- `/estop on` kills dangerous tool families instantly; CLI: `ok-gobot estop on|off|status`
 - **Exec approval** -- dangerous commands require inline keyboard confirmation
 - **DM authorization** -- open, allowlist, or pairing code modes (`/auth`, `/pair`)
 - **Group activation** -- active or standby with mention detection (`/activate`, `/standby`)
@@ -96,6 +124,8 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 - **CORS restriction** -- loopback-only origins for API and control server
 - **Log redaction** -- masks API keys and tokens in logs
 - **XSS protection** -- DOMPurify sanitization in web UI
+
+Note: scheduled autonomy (roles running on cron) is functional but does not yet enforce hard token/cost budgets. See [ROADMAP.md](docs/ROADMAP.md) for the budget enforcement plan.
 
 ### Message Processing
 - **Token tracking** -- per-chat prompt/completion token accumulation with optional usage footer
@@ -107,6 +137,7 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 
 ### Infrastructure
 - **HTTP REST API** -- health, status, send, webhook endpoints (port 8080)
+- **Mission Control API** -- `/api/mission/roles`, `/api/mission/schedules`, `/api/mission/runs`, `/api/mission/stats`
 - **WebSocket control protocol** -- real-time session control, streaming, approvals (port 8787)
 - **Config hot-reload** -- fsnotify watcher + `/reload` command
 - **Daemon management** -- launchd (macOS) / systemd (Linux) via `ok-gobot daemon`
@@ -149,14 +180,14 @@ All commands are auto-registered with BotFather for slash autocomplete.
 ## Configuration
 
 Config file: `~/.ok-gobot/config.yaml` (see [config.example.yaml](config.example.yaml))
-Canonical key reference: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#8-configuration-reference-canonical)
+Canonical key reference: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#9-configuration-reference-canonical)
 
 ```yaml
 telegram:
   token: "BOT_TOKEN"
 
 ai:
-  provider: "anthropic"   # anthropic | chatgpt | openai | droid | custom
+  provider: "anthropic"   # anthropic | chatgpt | openai | openrouter | droid | custom
   api_key: "oauth:<auto>" # set by: ok-gobot auth anthropic login
   model: "claude-sonnet-4-5-20250929"
   fallback_models:
@@ -205,6 +236,14 @@ ok-gobot status                   # Show status
 ok-gobot estop on|off|status      # Toggle emergency stop for dangerous tools
 ok-gobot doctor                   # Check config and dependencies
 ok-gobot daemon install|start|stop|status|logs|uninstall
+ok-gobot providers                # List configured AI providers
+ok-gobot skills list|install|remove|audit  # Manage skills
+ok-gobot evolution status|history|rollback|metrics  # Self-evolution
+ok-gobot work <task>              # Spawn worktree + worker for a task
+ok-gobot worktrees list|cleanup|rm  # Manage git worktrees
+ok-gobot jobs                     # Inspect scheduled jobs
+ok-gobot sessions                 # Manage chat sessions
+ok-gobot tui                      # Launch terminal UI
 ok-gobot version
 ```
 
@@ -221,6 +260,8 @@ ok-gobot loads personality files from a configurable directory (default `~/ok-go
 | `TOOLS.md` | Tool configuration (SSH hosts, API keys) |
 | `MEMORY.md` | Long-term memory (private sessions only) |
 | `memory/YYYY-MM-DD.md` | Daily notes |
+| `skills/` | Installed skill definitions |
+| `roles/` | Role manifests for scheduled workflows |
 
 ## Project Structure
 
@@ -228,29 +269,31 @@ ok-gobot loads personality files from a configurable directory (default `~/ok-go
 ok-gobot/
 ├── cmd/ok-gobot/         # Entry point
 ├── internal/
-│   ├── agent/            # Personality, memory, safety, compactor, registry
-│   ├── ai/               # AI client, failover, types
+│   ├── agent/            # Personality, memory, safety, compactor, reflection, registry
+│   ├── ai/               # AI client, failover, router, types
 │   ├── api/              # HTTP API server
 │   ├── app/              # Application orchestrator
-│   ├── bootstrap/        # First-run onboarding
-│   ├── bot/              # Telegram bot, commands, media, queue, status, usage
+│   ├── bootstrap/        # Skills loader, installer, audit
+│   ├── bot/              # Telegram bot, commands, media, queue, status, chat routing
 │   ├── browser/          # Chrome automation
-│   ├── cli/              # Cobra CLI (start, config, doctor, daemon, auth)
+│   ├── cli/              # Cobra CLI (start, config, doctor, daemon, auth, skills, evolution, worktrees)
 │   ├── config/           # YAML config, watcher
 │   ├── configschema/     # Schema generation
-│   ├── control/          # WebSocket control server, hub, TUI protocol
+│   ├── control/          # WebSocket control server, hub, TUI protocol, Mission Control API
 │   ├── cron/             # Job scheduler
 │   ├── errorx/           # Error handling
+│   ├── evolution/        # Self-evolution engine (A-Evolve cycle)
 │   ├── logger/           # Level-aware debug logging
 │   ├── memory/           # Markdown-backed memory index (embeddings, store)
 │   ├── memorymcp/        # Memory MCP server
 │   ├── migrate/          # Database migrations
 │   ├── redact/           # Log redaction
-│   ├── runtime/          # Chat/jobs mailbox runtime, session scheduling
+│   ├── role/             # Role manifests, prebuilt roles, bundled loader
+│   ├── runtime/          # Chat/jobs mailbox runtime, session scheduling, chat router
 │   ├── sanitize/         # Input sanitization
 │   ├── session/          # Context monitoring
 │   ├── storage/          # SQLite persistence
-│   ├── tools/            # All agent tools
+│   ├── tools/            # All agent tools, capability policy
 │   └── tui/              # Terminal UI client
 ├── web/                  # Web UI (HTML/JS)
 ├── docs/                 # Documentation
@@ -259,14 +302,16 @@ ok-gobot/
 
 ## Documentation
 
+- [Mission Control Concept](docs/MISSION-CONTROL.md) -- Mission Control v1 concept and architecture
 - [Competitive Landscape](docs/COMPETITORS.md) -- OpenFang, ZeroClaw, OpenClaw, and ok-gobot comparison
-- [Roadmap](docs/ROADMAP.md) -- Implementation backlog derived from the competitor analysis
+- [Roadmap](docs/ROADMAP.md) -- Shipped features and planned work
 - [Installation Guide](docs/INSTALL.md) -- Setup, configuration, providers, deployment
 - [API Reference](docs/API.md) -- HTTP REST API and WebSocket control protocol
 - [Architecture](docs/ARCHITECTURE.md) -- Chat/jobs architecture contract, legacy-runtime freeze, and canonical config reference
 - [Features](docs/FEATURES.md) -- Detailed feature descriptions
 - [Tools Reference](docs/TOOLS.md) -- All tools with usage examples
 - [Memory](docs/MEMORY.md) -- Semantic memory system
+- [Security](docs/SECURITY.md) -- Security posture, hardening, and threat model
 - [Security Fixes](docs/SECURITY-FIXES.md) -- Security hardening changelog
 - [TTS](docs/TTS_USAGE.md) / [TTS (RU)](docs/TTS_USAGE_RU.md) -- Text-to-speech setup
 - [Changelog](docs/CHANGELOG.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # ok-gobot Architecture Contract
 
+Last updated: April 29, 2026.
+
 ## 1. Scope
 
 This document defines the active architecture contract for the chat/jobs runtime path.
@@ -12,11 +14,12 @@ compatibility only. New feature work must target the chat/jobs path backed by
 
 ## 2. Active Runtime Contract
 
-- Chat ingress and scheduled jobs are the product execution surfaces.
+- Chat ingress and scheduled jobs (roles) are the product execution surfaces.
 - `internal/runtime` owns mailbox scheduling, queueing, cancellation, and child completion routing.
 - Different session keys execute in parallel.
-- Each session key executes one run at a time.
+- Each session key executes one run at a time (FIFO within a session).
 - Transport layers submit work; they do not execute model logic directly.
+- The runtime broadcasts events (EventQueued, EventActive, EventUpdate, EventDone, EventError, EventChildDone, EventChildFailed) for monitoring.
 
 ## 3. Session Model
 
@@ -28,31 +31,84 @@ Canonical session keys:
 - `agent:<agentId>:telegram:group:<chatId>:thread:<topicId>`
 - `agent:<agentId>:subagent:<runSlug>`
 
-## 4. Adapters and Workers
+Each session key gets its own `SessionWorker` goroutine that processes requests sequentially from a bounded mailbox.
+
+## 4. Chat Routing
+
+Incoming chat turns are classified by `DecideChatRoute()` before execution:
+
+- **reply** -- lightweight turns stay on the inline AI reply path
+- **clarification** -- underspecified work requests get a follow-up question first
+- **background job** -- heavy work (investigate, debug, fix, implement, refactor, review, etc.) is launched as an isolated sub-agent task
+
+Forced job prefixes (`job:`, `task:`, `background:`) bypass classification and route directly to background execution.
+
+**Files:** `internal/runtime/chat_router.go`, `internal/bot/chat_routing.go`
+
+## 5. Adapters and Workers
 
 - Telegram, control/TUI, and jobs are adapters over chat/jobs requests and runtime events.
 - Adapters handle input/output rendering and acknowledgments.
 - Execution, queueing, cancellation, and child completion routing stay in `internal/runtime`.
 
-## 5. Control Plane
+## 6. Roles and Scheduled Jobs
+
+Roles are declarative markdown manifests with YAML frontmatter (worker, tools, schedule, approval, report_template). The role system:
+
+- Loads `.md` files from the configured `roles_path` directory on startup.
+- Registers cron jobs for roles that define a `schedule` (idempotent across restarts).
+- Selects model class via cost tiers: `premium`, `standard`, `cheap`, `local`.
+- Respects per-agent capability policy and estop state.
+- Delivers reports to the admin chat (`auth.admin_id`).
+
+Three prebuilt roles ship as bundled examples: `researcher`, `monitor`, `release-watch`.
+
+**Important:** Roles do not yet enforce hard token/cost budgets. Budget enforcement is the primary gate before scheduled autonomy can be considered production-safe. See [ROADMAP.md](ROADMAP.md).
+
+**Files:** `internal/role/manifest.go`, `internal/role/bundled.go`, `internal/role/prebuilt/`
+
+## 7. Control Plane and Mission Control
 
 The control server provides loopback API/WS access for status, session operations,
 abort, and chat/job control. Legacy sub-agent RPC surfaces remain available only
 as frozen compatibility shims.
 
-## 6. Legacy Freeze Policy
+The Mission Control API extends the control plane with role and job monitoring:
+- `GET /api/mission/roles` -- list configured roles
+- `GET /api/mission/schedules` -- list cron jobs with next-run times
+- `GET /api/mission/runs` -- recent run history
+- `GET /api/mission/stats` -- aggregate statistics
+
+**Files:** `internal/control/mission.go`
+
+## 8. Legacy Freeze Policy
 
 - `internal/agent.RuntimeHub` is legacy compatibility code.
 - `browser_task`, `/task`, and legacy control-server sub-agent helpers may still depend on it today.
 - Keep changes there limited to bug fixes or removal prep; do not add new product surface area.
 
-## 7. Persistence
+## 9. Persistence
 
-SQLite remains the persistence layer for sessions, messages, routes, and runtime metadata.
+SQLite remains the persistence layer for sessions, messages, routes, runtime metadata, skill scores, and evolution metrics/versions.
 
-## 8. Memory
+## 10. Memory
 
 Memory remains markdown-first (`MEMORY.md` + `memory/*.md`) with semantic indexing for retrieval.
+
+## 11. Security Architecture
+
+Security is enforced at multiple layers:
+
+- **Capability policy** (`internal/tools/policy.go`): per-agent tool restrictions (shell, network, cron, memory_write, spawn, filesystem_roots, file_write_scope). Applied as a wrapper around the tool registry.
+- **Emergency stop** (`/estop`): instant kill switch for dangerous tool families.
+- **Exec approval**: dangerous commands require Telegram inline keyboard confirmation.
+- **Auth**: fail-closed default, brute-force lockout for pairing, three access modes.
+- **SSRF protection**: private IP blocking with redirect revalidation in web_fetch.
+- **CORS/Origin**: loopback-only for control and API servers.
+- **Path safety**: symlink escape prevention, filesystem roots enforcement.
+- **Log redaction**: masks API keys and tokens in log output.
+
+See [SECURITY.md](SECURITY.md) for the full security posture and threat model.
 
 ## 9. Configuration Reference (Canonical)
 

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -1,6 +1,6 @@
 # Competitive Landscape: OpenFang, ZeroClaw, OpenClaw, and ok-gobot
 
-Snapshot date: March 12, 2026.
+Original snapshot: March 12, 2026. Updated: April 29, 2026.
 
 This document compares two newer Rust competitors, [OpenFang](https://github.com/RightNow-AI/openfang) and [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw), against [OpenClaw](https://github.com/openclaw/openclaw) and this project, [ok-gobot](../README.md).
 
@@ -79,12 +79,15 @@ Where the challengers differentiate:
 - **Practical coding-agent bridge**: using Claude Code, Codex, Gemini CLI, Droid, or OpenCode as backends is a concrete differentiator.
 - **Markdown-first workspace**: `IDENTITY.md`, `SOUL.md`, `USER.md`, `AGENTS.md`, `TOOLS.md`, `MEMORY.md` is easy to understand and hack.
 - **Faster path from OpenClaw to a personal bot**: the project has a focused migration command and a simpler target runtime.
+- **Declarative roles and scheduled autonomy**: prebuilt roles (researcher, monitor, release-watch) ship as markdown manifests. Operators define custom roles without writing Go code. (Shipped since Phase 3.)
+- **Skills with audit**: CLI-managed skill installation with static safety analysis (symlink, script, pipe-to-shell detection) and utility score tracking.
+- **Self-evolution loop**: A-Evolve-inspired cycle with benchmark gating, version history, and automatic rollback.
 
 ### Where ok-gobot is weaker
 
 - **Channel breadth**: it does not compete with OpenClaw/OpenFang/ZeroClaw on messaging footprint.
-- **Productized autonomy**: it does not yet have the "activate a pre-built autonomous worker" story that OpenFang pushes.
-- **Formal isolation/security**: it has practical safety controls, but not the kind of capability/sandbox architecture marketed by OpenFang and ZeroClaw.
+- **Budget enforcement**: scheduled roles are functional but lack hard token/cost budgets. Production-grade unattended autonomy requires this gate (planned for Mission Control v1).
+- **Formal isolation/security**: it has practical capability policy and estop controls, but not the WASM sandbox or taint-tracking architecture marketed by OpenFang.
 - **Broader app surface**: it does not currently match OpenClaw's device-node, Canvas, and voice ecosystem.
 
 ## Recommended Positioning for ok-gobot
@@ -111,6 +114,16 @@ Instead, lean into:
 - opinionated defaults
 - OpenClaw migration compatibility
 - coding/ops usefulness over platform maximalism
+
+## April 2026 Update
+
+Since the original March 2026 snapshot, ok-gobot has shipped all nine items from the original roadmap backlog. The gap analysis at the time identified three main weaknesses: productized autonomy, formal isolation/security, and broader app surface. Progress:
+
+- **Productized autonomy**: now shipped. Declarative role manifests, prebuilt roles, scheduled execution, chat routing with automatic background job promotion, sub-agent spawning with cost tiers. Missing: hard token/cost budgets for unattended roles.
+- **Formal security**: capability policy system with per-agent tool restrictions, emergency stop, and explicit tool denials with reason. Still lacks WASM sandboxing.
+- **App surface**: unchanged. Telegram remains the only channel. Mission Control API is available for monitoring but has no dedicated UI yet.
+
+The competitive positioning recommendation remains the same: lean into operational simplicity, Telegram-first focus, coding-agent bridge, and low deployment friction. Do not over-claim on channel count or sandbox architecture.
 
 ## Bottom-Line Read
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -8,10 +8,22 @@ Uses the structured `tools` API parameter instead of parsing JSON from text resp
 **Files:** `internal/ai/types.go`, `internal/ai/client.go`, `internal/agent/tool_agent.go`
 
 ### Model Failover
-Automatic fallback chain when the primary model fails. Retryable errors: 429, 500-504, context_length_exceeded. Models go on 60-second cooldown after failure. Thread-safe.
+Automatic fallback chain when the primary model fails. Retryable errors: 429, 500-504, context_length_exceeded, network errors (EOF, connection reset, TLS failures). Models go on 60-second cooldown after failure. Thread-safe.
 
 **Config:** `ai.fallback_models: ["anthropic/claude-3.5-sonnet", "openai/gpt-4o-mini"]`
 **Files:** `internal/ai/failover.go`
+
+### Multi-Model Routing
+Route messages to different models based on task type. Five task types: `vision`, `summarize`, `reasoning`, `coding`, `default`. Detection via explicit `[task:type]` tags in the message body. Resolution order: exact task match in routes config, then "default" route entry, then global default model.
+
+**Config:**
+```yaml
+model_routes:
+  vision: "google/gemini-2.5-pro"
+  coding: "claude-sonnet-4-5-20250929"
+  summarize: "claude-haiku-3-5-20241022"
+```
+**Files:** `internal/ai/router.go`
 
 ### Per-Session Model Override
 Each chat can use a different model. The `/model` command sets, clears, or lists models. Stored in SQLite.
@@ -31,6 +43,10 @@ agents:
     soul_path: "~/ok-gobot-soul-coder"
     model: "anthropic/claude-3.5-sonnet"
     allowed_tools: ["local", "file", "grep", "patch"]
+    capabilities:
+      shell: true
+      network: false
+      file_write_scope: "full"
 ```
 **Files:** `internal/agent/registry.go`, `internal/bot/agent_command.go`, `internal/bot/agent_handler.go`
 
@@ -44,52 +60,222 @@ AI-powered summarization when conversation approaches 80% of model context limit
 
 **Files:** `internal/agent/compactor.go`, `internal/agent/tokens.go`
 
+### Reflection Loop
+Automatic failure tracking per tool. When a tool's failure count exceeds the threshold (default 3), the reflector proposes fixes based on error patterns:
+- "not found" -- verify registration/dependencies
+- "timeout" -- increase timeout or reduce scope
+- "permission denied" -- check runtime permissions
+- "parse/unmarshal/invalid" -- review input schema
+- "connect/dial/network" -- check connectivity
+
+Failure records are persisted to daily memory notes. Non-blocking background processing.
+
+**Files:** `internal/agent/reflection.go`
+
+---
+
+## Roles & Jobs
+
+### Prebuilt Roles
+Three bundled role manifests ship as starting points for scheduled autonomous workflows:
+
+| Role | Default Schedule | Description |
+|------|-----------------|-------------|
+| `researcher` | 09:00 UTC daily | Searches the web and compiles a daily research digest |
+| `monitor` | Every 30 minutes | Checks service/URL health and reports status |
+| `release-watch` | 10:00 UTC every Monday | Tracks software releases for configured projects |
+
+Roles are enabled by setting `roles_path` in config and placing markdown manifests in that directory. No roles run by default.
+
+**Files:** `internal/role/bundled.go`, `internal/role/manifest.go`, `internal/role/prebuilt/`
+
+### Declarative Role Manifests
+Operators define custom roles as markdown files with YAML frontmatter:
+
+```markdown
+---
+worker: standard
+tools: [web_fetch, search]
+schedule: "0 0 9 * * *"
+approval: auto
+report_template: "{{.Result}}"
+---
+# My Researcher
+
+You are a research agent. Search for news about Go releases...
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `worker` | string | Cost tier: `premium`, `standard`, `cheap`, `local` |
+| `tools` | list | Allowed tools. Empty = all tools permitted |
+| `schedule` | string | 6-field cron expression (seconds included). Empty = no schedule |
+| `approval` | string | `auto` (default), `always`, or `never` |
+| `report_template` | string | Go `text/template` for report formatting |
+
+**Files:** `internal/role/manifest.go`
+
+### Rules-First Chat Routing
+Incoming chat turns are classified before execution:
+- **reply** -- lightweight turns stay on the inline AI reply path
+- **clarification** -- underspecified work requests get a short follow-up question first
+- **background job** -- obvious heavy work is launched as an explicit isolated task instead of blocking the main chat session
+
+Forced job prefixes: `job:`, `task:`, `background:` at the start of a message.
+
+**Files:** `internal/runtime/chat_router.go`, `internal/bot/chat_routing.go`
+
+### Sub-Agent Spawning
+Background jobs run as isolated sub-agents with their own session keys (`agent:<agentId>:subagent:<runSlug>`). Parent-child session tracking delivers results back to the originating chat. Cost tier support selects the model class per job.
+
+**Files:** `internal/runtime/subagent.go`, `internal/runtime/runtime.go`
+
+### Mission Control API
+HTTP endpoints for monitoring the runtime:
+- `GET /api/mission/roles` -- list configured roles with metadata
+- `GET /api/mission/schedules` -- list cron jobs with next-run times
+- `GET /api/mission/runs` -- recent job run history
+- `GET /api/mission/stats` -- aggregate statistics
+
+Loopback-only access with CORS.
+
+**Files:** `internal/control/mission.go`
+
+**Important:** Scheduled roles are functional but do not yet enforce hard token/cost budgets. Budget enforcement is planned for Mission Control v1 (see [ROADMAP.md](ROADMAP.md)).
+
+---
+
+## Skills
+
+### Markdown-First Skills
+Skills are markdown-based extensions stored in the workspace `skills/` directory. Each skill has a `SKILL.md` file describing its capabilities.
+
+### CLI Management
+```bash
+ok-gobot skills list       # Show installed skills with utility scores
+ok-gobot skills install <path-or-git-url>  # Install with safety audit
+ok-gobot skills remove <name>              # Remove skill
+ok-gobot skills audit <path>               # Run safety audit only
+ok-gobot skills history                    # Version history
+ok-gobot skills rollback                   # Revert to previous version
+```
+
+### Safety Audit
+Static analysis rejects unsafe skill packages:
+- Symlinks pointing outside the skill root
+- Script files (`.sh`, `.py`, `.js`, `.exe`, etc.)
+- Executable file permission bits
+- Pipe-to-shell patterns (`curl | bash`)
+- Markdown links escaping the skill root (`../` prefixes)
+
+Errors block installation; warnings are reported but allowed.
+
+### Utility Score Tracking
+Each skill tracks uses, successes, and failures in SQLite. The system prompt includes skill descriptions sorted by utility score descending, prioritizing proven-useful skills.
+
+**Files:** `internal/bootstrap/skills.go`, `internal/bootstrap/loader.go`, `internal/cli/skills.go`, `internal/agent/personality.go`
+
+---
+
+## Self-Evolution
+
+### A-Evolve Cycle
+ok-gobot implements a self-evolution loop inspired by the A-Evolve paper:
+
+1. **Solve** -- execute tasks and collect metrics (success rate, tokens, duration, retries, tool calls)
+2. **Observe** -- analyze failure patterns (high failure rate, excessive tokens, slow completions, tool overuse)
+3. **Evolve** -- generate candidate mutations with human-readable notes
+4. **Gate** -- benchmark suite scoring; new version must score strictly higher than current
+5. **Reload** -- promote the new version and reload configuration
+
+Safety guards:
+- Human approval required for large prompt diffs (>20% change)
+- Daily cycle limit (max 1 per 24 hours)
+- Production failure tracking with automatic rollback after 3 failures
+- Versioned snapshots stored in `evolution_dir/v<N>/` with manifest and diff
+
+**CLI:**
+```bash
+ok-gobot evolution status     # Show config and latest version
+ok-gobot evolution history    # List all versions with scores
+ok-gobot evolution rollback <version>  # Roll back to a specific version
+ok-gobot evolution metrics    # Show task metrics
+```
+
+**Files:** `internal/evolution/engine.go`, `internal/cli/evolution.go`
+
 ---
 
 ## Tools
 
 ### Shell & Files
-- **local** — Execute shell commands. Dangerous commands (rm -rf, kill, shutdown, etc.) require inline keyboard approval.
-- **ssh** — Remote execution. Hosts configured in `~/ok-gobot-soul/TOOLS.md`.
-- **file** — Read/write with path traversal protection.
-- **patch** — Apply unified diffs to files.
-- **grep** — Recursive regex search, skips binary files and `.git`/`node_modules`. Max 50 results.
-- **obsidian** — Obsidian vault CRUD with frontmatter timestamps.
+- **local** -- Execute shell commands. Dangerous commands (rm -rf, kill, shutdown, sudo, curl|sh, etc.) require inline keyboard approval.
+- **ssh** -- Remote execution. Hosts configured in `~/ok-gobot-soul/TOOLS.md`. Uses `StrictHostKeyChecking=accept-new` (trust-on-first-use).
+- **file** -- Read/write with path traversal and symlink escape protection.
+- **patch** -- Apply unified diffs to files.
+- **grep** -- Recursive regex search, skips binary files and `.git`/`node_modules`. Max 50 results.
+- **obsidian** -- Obsidian vault CRUD with frontmatter timestamps. Symlink-safe path resolution.
 
 ### Web
-- **search** — Brave Search or Exa API. Returns 5 results with title/URL/snippet.
-- **web_fetch** — Fetch URLs with Mozilla Readability extraction (go-shiori/go-readability). Falls back to basic HTML stripping. SSRF protection blocks private IPs. 12KB content limit.
-- **browser** — Chrome automation via ChromeDP: navigate, click, fill, screenshot, wait, extract text.
+- **search** -- Brave Search or Exa API. Returns 5 results with title/URL/snippet.
+- **web_fetch** -- Fetch URLs with Mozilla Readability extraction (go-shiori/go-readability). Falls back to basic HTML stripping. SSRF protection blocks private IPs and validates redirect targets. 12KB content limit.
+- **browser** -- Chrome automation via ChromeDP: navigate, click, fill, screenshot, wait, extract text. Blocks `file://`, localhost, and `.internal`/`.local` URLs.
 
 ### Media
-- **image_gen** — DALL-E 3. Sizes: 1024x1024, 1792x1024, 1024x1792. Quality: standard/hd.
-- **tts** — Two providers: OpenAI (paid, 6 voices) and Edge TTS (free, Russian/English voices). Provider prefix: `edge:text` or `openai:text`. Auto OGG conversion for Telegram.
+- **image_gen** -- DALL-E 3. Sizes: 1024x1024, 1792x1024, 1024x1792. Quality: standard/hd.
+- **tts** -- Two providers: OpenAI (paid, 6 voices) and Edge TTS (free, Russian/English voices). Provider prefix: `edge:text` or `openai:text`. Auto OGG conversion for Telegram.
 
 ### Memory & Scheduling
-- **memory** — Semantic vector memory. Embeds text via OpenAI embeddings API, stores in SQLite as binary BLOBs, searches with cosine similarity in Go. Commands: save, search, list, forget.
-- **cron** — 5-field cron expressions. Persistent in SQLite. Enable/disable without deletion.
-- **message** — Send to other chats by ID or alias. Allowlist-based security.
+- **memory_search** -- Semantic vector search. Embeds text via OpenAI embeddings API, stores in SQLite as binary BLOBs, searches with cosine similarity in Go.
+- **memory_get** -- Read markdown memory content by source and optional header path.
+- **cron** -- 5-field cron expressions. Persistent in SQLite. Enable/disable without deletion.
+- **message** -- Send to other chats by ID or alias. Allowlist-based security.
 
 ---
 
 ## Security & Control
 
+### Capability Policy
+Per-agent capability restrictions enforced at tool dispatch:
+
+| Capability | Controls | Default |
+|-----------|----------|---------|
+| `shell` | local, ssh execution | allowed |
+| `network` | web_fetch, search, browser | allowed |
+| `network_allowlist` | restrict network to listed hostnames | all allowed |
+| `cron` | scheduling | allowed |
+| `memory_write` | memory capture | allowed |
+| `spawn` | sub-agent/job spawning | allowed |
+| `filesystem_roots` | restrict file access to listed paths | unrestricted |
+| `file_write_scope` | `full` or `read_only` | full |
+
+Denied tool calls return a structured `ToolDenial` with reason and remediation hint.
+
+**Files:** `internal/tools/policy.go`
+
+### Emergency Stop (estop)
+`/estop on` disables dangerous tool families (local, ssh, browser, cron, message) instantly. `/estop off` re-enables. Status visible in `/status`, TUI, and `ok-gobot estop status`.
+
+**Files:** `internal/cli/estop.go`, `internal/tools/tools.go`
+
 ### Exec Approval
-Dangerous commands (`rm -rf`, `kill`, `shutdown`, `DROP TABLE`, etc.) trigger a Telegram inline keyboard with Approve/Deny buttons. Auto-deny after 60 seconds.
+Dangerous commands (`rm -rf`, `kill`, `shutdown`, `DROP TABLE`, `sudo`, `curl|sh`, etc.) trigger a Telegram inline keyboard with Approve/Deny buttons. Auto-deny after 60 seconds.
 
 **Files:** `internal/bot/approval.go`, `internal/bot/bot_approval.go`
 
 ### DM Authorization
 Three modes:
-- **open** — anyone can use the bot (default)
-- **allowlist** — only configured user IDs + DB-authorized users
-- **pairing** — requires pairing code from admin (`/auth pair` generates 6-digit code, `/pair <code>` to activate)
+- **open** -- anyone can use the bot (default)
+- **allowlist** -- only configured user IDs + DB-authorized users
+- **pairing** -- requires pairing code from admin (`/auth pair` generates 6-digit code, `/pair <code>` to activate)
+
+Unknown modes are denied (fail-closed). Brute-force protection: 5 failed pairing attempts triggers 15-minute lockout.
 
 **Files:** `internal/bot/auth.go`
 
 ### Group Activation Modes
-- **active** — bot responds to all messages
-- **standby** — bot responds only to @mentions, replies to its messages, or messages starting with its name
+- **active** -- bot responds to all messages
+- **standby** -- bot responds only to @mentions, replies to its messages, or messages starting with its name
 
 Per-group, stored in DB. Commands: `/activate`, `/standby`.
 
@@ -102,7 +288,7 @@ Per-group, stored in DB. Commands: `/activate`, `/standby`.
 **Files:** `internal/bot/ratelimit.go`, `internal/bot/debounce.go`
 
 ### SSRF Protection
-web_fetch validates URLs before requests: blocks localhost, private IPs (10.x, 172.16-31.x, 192.168.x, fc00::/7), resolves DNS first to prevent rebinding.
+web_fetch validates URLs before requests: blocks localhost, private IPs (10.x, 172.16-31.x, 192.168.x, fc00::/7), resolves DNS first to prevent rebinding. Redirect targets are revalidated.
 
 **Files:** `internal/tools/web_fetch.go`
 
@@ -112,9 +298,9 @@ Masks sensitive patterns in log output: API keys (sk-...), Bearer tokens, bot to
 **Files:** `internal/redact/redact.go`
 
 ### Message Sanitization
-- `SanitizeShellArg` — escapes shell metacharacters
-- `SanitizeTelegramMarkdown` — escapes MarkdownV2 special chars
-- `StripControlChars` — removes non-printable characters
+- `SanitizeShellArg` -- escapes shell metacharacters
+- `SanitizeTelegramMarkdown` -- escapes MarkdownV2 special chars
+- `StripControlChars` -- removes non-printable characters
 
 **Files:** `internal/sanitize/sanitize.go`
 
@@ -124,10 +310,12 @@ Masks sensitive patterns in log output: API keys (sk-...), Bearer tokens, bot to
 
 ### HTTP API
 REST API with API key authentication (`X-API-Key` header or Bearer token). Endpoints:
-- `GET /api/health` — no auth
-- `GET /api/status` — bot status
-- `POST /api/send` — send message to chat
-- `POST /api/webhook` — forward event to configured chat
+- `GET /api/health` -- no auth
+- `GET /api/status` -- bot status
+- `POST /api/send` -- send message to chat
+- `POST /api/webhook` -- forward event to configured chat
+
+CORS restricted to loopback origins.
 
 See [API.md](API.md) for full reference.
 
@@ -151,6 +339,18 @@ Validates config, Telegram token, AI API key, API reachability, storage path. Ch
 ok-gobot doctor
 ```
 
+### Git Worktree Management
+`ok-gobot work <task>` creates a git worktree with a dedicated worker agent for the task. Worktrees provide isolated working copies for parallel development.
+
+```bash
+ok-gobot work <task>            # Spawn worktree + worker
+ok-gobot worktrees list         # Show tracked worktrees
+ok-gobot worktrees cleanup      # Remove merged/stale worktrees
+ok-gobot worktrees rm <id>      # Delete specific worktree
+```
+
+**Files:** `internal/cli/worktrees.go`
+
 ---
 
 ## Message Processing
@@ -166,27 +366,19 @@ Per-chat accumulation of prompt/completion tokens from API responses. Displayed 
 **Files:** `internal/bot/usage.go`, `internal/bot/agent_handler.go`
 
 ### Fragment Buffering
-Reassembles long messages that Telegram splits into multiple fragments. Detects continuation by same user, message ID gap ≤ 1, time gap ≤ 1.5s. Buffers up to 12 parts / 50K chars.
+Reassembles long messages that Telegram splits into multiple fragments. Detects continuation by same user, message ID gap <= 1, time gap <= 1.5s. Buffers up to 12 parts / 50K chars.
 
 **Files:** `internal/bot/fragment_buffer.go`
 
 ### Queue Modes
 Controls how incoming messages are handled during an active AI run:
-- **interrupt** (default) — cancel current run, process new message fresh
-- **collect** — buffer silently, process after run completes
-- **steer** — feed new messages as steering input to the active run
+- **interrupt** (default) -- cancel current run, process new message fresh
+- **collect** -- buffer silently, process after run completes
+- **steer** -- feed new messages as steering input to the active run
 
 Commands: `/queue collect|steer|interrupt [debounce_ms]`
 
 **Files:** `internal/bot/queue.go`
-
-### Rules-First Chat Routing
-Incoming chat turns are classified before execution:
-- **reply** — lightweight turns stay on the inline AI reply path
-- **clarification** — underspecified work requests get a short follow-up question first
-- **background job** — obvious heavy work is launched as an explicit isolated task instead of blocking the main chat session
-
-**Files:** `internal/runtime/chat_router.go`, `internal/bot/chat_routing.go`
 
 ### Usage Footer
 Optional token usage display appended to AI responses. Modes: `off` (default), `tokens`, `full`.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -156,8 +156,8 @@ ok-gobot skills list       # Show installed skills with utility scores
 ok-gobot skills install <path-or-git-url>  # Install with safety audit
 ok-gobot skills remove <name>              # Remove skill
 ok-gobot skills audit <path>               # Run safety audit only
-ok-gobot skills history                    # Version history
-ok-gobot skills rollback                   # Revert to previous version
+ok-gobot skills history <skill-name>       # Version history
+ok-gobot skills rollback <skill-name> <version-filename>  # Revert to previous version
 ```
 
 ### Safety Audit

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -433,7 +433,9 @@ export OKGOBOT_AUTH_MODE="pairing"
 3. If enabling control server, set a strong `control.token`.
 4. Config file permissions should be `0600` (set automatically by `config init`).
 5. OAuth credentials stored in `~/.ok-gobot/oauth/` are automatically set to `0600`.
-6. See `docs/SECURITY-FIXES.md` for full details on security hardening.
+6. Use capability policy to restrict agents running less-trusted models.
+7. Scheduled roles do not yet enforce token/cost budgets. See [SECURITY.md](SECURITY.md) and [ROADMAP.md](ROADMAP.md).
+8. See [SECURITY.md](SECURITY.md) for the full security posture and [SECURITY-FIXES.md](SECURITY-FIXES.md) for the hardening changelog.
 
 ---
 

--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -1,0 +1,96 @@
+# Mission Control v1
+
+Last updated: April 29, 2026.
+
+## Concept
+
+Mission Control is the operator-facing layer that ties together ok-gobot's runtime, roles, jobs, and monitoring into a coherent experience. Instead of managing individual cron jobs, sub-agents, and tool policies separately, Mission Control presents them as a unified operations view.
+
+## Current State
+
+The following pieces are shipped and functional:
+
+### Runtime
+- **Chat/jobs mailbox runtime** (`internal/runtime`): session-keyed workers with bounded queues, parallel execution across sessions, FIFO within each session.
+- **Chat routing**: rules-first classification routes lightweight replies inline, promotes heavy work to background jobs, and asks for clarification on ambiguous requests.
+- **Sub-agent spawning**: background jobs run as isolated sub-agents with parent-child result delivery and cost tier selection.
+
+### Roles
+- **Declarative role manifests**: markdown files with YAML frontmatter define prompt, tools, schedule, approval mode, worker tier, and report template.
+- **Prebuilt roles**: `researcher`, `monitor`, `release-watch` ship as bundled examples.
+- **Cron integration**: roles with a `schedule` field are registered as cron jobs on startup. Reports delivered to the admin chat.
+
+### Monitoring API
+- `GET /api/mission/roles` -- list configured roles with metadata
+- `GET /api/mission/schedules` -- list cron jobs with next-run times
+- `GET /api/mission/runs` -- recent job run history
+- `GET /api/mission/stats` -- aggregate statistics
+
+Loopback-only with CORS restriction.
+
+### Safety Controls
+- **Capability policy**: per-agent tool restrictions (shell, network, cron, memory_write, spawn, filesystem_roots, file_write_scope).
+- **Emergency stop**: `/estop on` instantly kills dangerous tool families.
+- **Reflection loop**: automatic failure tracking with pattern-based fix proposals.
+- **Self-evolution**: A-Evolve cycle with benchmark gating, version history, and rollback.
+
+## What's Missing for v1
+
+### Budget and Policy Enforcement
+Scheduled roles and background jobs need hard limits before operators can trust them unattended:
+- **Token budget**: maximum prompt + completion tokens per role run.
+- **Cost budget**: maximum dollar cost per run (requires provider pricing data).
+- **Wall-clock timeout**: maximum execution duration.
+- **Tool call cap**: maximum number of tool invocations per run.
+
+Without budgets, a runaway role or sub-agent can exhaust API quota silently. The docs intentionally avoid claiming that scheduled autonomy is production-safe until this ships.
+
+### Lifecycle Dashboard
+The monitoring API exists but has no dedicated UI. A TUI or web dashboard would show:
+- Active roles and their run status
+- Run history with success/failure/cost metrics
+- Current estop state and capability policy
+- Evolution version and metrics
+
+### Skill Ecosystem
+Skills can be installed and audited from the CLI, but discovery is manual. A lightweight registry or feed would help operators find useful skills.
+
+## Architecture
+
+```
+Telegram/TUI/API (adapters)
+        |
+        v
+  internal/runtime (mailbox scheduler)
+        |
+    +---+---+
+    |       |
+  chat    jobs/roles
+  routing   |
+    |     cron scheduler
+    v       |
+  session   role manifest
+  worker    loader
+    |       |
+    v       v
+  AI client + tools (with capability policy)
+        |
+        v
+  Mission Control API (monitoring)
+```
+
+All execution flows through `internal/runtime`. Adapters (Telegram, TUI, API) submit work but never execute model logic directly. The Mission Control API reads state from the runtime, storage, and cron scheduler.
+
+## Files
+
+| Component | Location |
+|-----------|----------|
+| Runtime | `internal/runtime/runtime.go` |
+| Chat router | `internal/runtime/chat_router.go` |
+| Sub-agent spawning | `internal/runtime/subagent.go` |
+| Role manifests | `internal/role/manifest.go` |
+| Prebuilt roles | `internal/role/prebuilt/` |
+| Mission Control API | `internal/control/mission.go` |
+| Capability policy | `internal/tools/policy.go` |
+| Evolution engine | `internal/evolution/engine.go` |
+| Reflection | `internal/agent/reflection.go` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,287 +1,88 @@
 # ok-gobot Roadmap
 
-Snapshot date: March 12, 2026.
+Last updated: April 29, 2026.
 
-This roadmap turns the findings from [Competitive Landscape](./COMPETITORS.md) into an implementation backlog for `ok-gobot`.
+This roadmap tracks shipped capabilities and planned work for ok-gobot. The original backlog was derived from the [Competitive Landscape](./COMPETITORS.md) analysis (March 2026). Items are phrased as user outcomes per [PROCESS.md](./PROCESS.md).
 
-The goal is not to copy OpenFang or ZeroClaw wholesale. The goal is to borrow the parts that improve `ok-gobot` without destroying its main advantage: a small, understandable, Telegram-first single-binary operator bot.
+## Shipped
 
-Every backlog item is phrased as a user outcome per [PROCESS.md](./PROCESS.md). Infrastructure sub-tasks may reference internals, but the parent item describes what a user can observe when it ships.
+### Phase 1: Quick Wins (complete)
 
-## Sequencing
+1. **Operator can kill dangerous tools instantly without restarting the bot**
+   `/estop on|off|status` in Telegram and CLI. Blocks shell, SSH, browser, cron, and message tool families. Status visible in `/status` and TUI.
 
-### Phase 1: Quick Wins
+2. **User can list available models and see which providers are healthy**
+   `ok-gobot providers` lists configured providers. `ok-gobot config models` lists available models with aliases. `ok-gobot doctor` distinguishes auth, endpoint, and model errors.
 
-1. Operator can kill dangerous tools instantly without restarting the bot
-2. User can list available models and see which providers are healthy
-3. Operator gets a detailed report after migrating from OpenClaw
+3. **Operator gets a detailed report after migrating from OpenClaw**
+   `ok-gobot migrate` with `--dry-run` support. Reports copied files, skipped sessions, and key mapping.
 
-### Phase 2: Safety and Extensibility Foundation
+### Phase 2: Safety and Extensibility Foundation (complete)
 
-4. Operator can restrict an agent to read-only tools without editing Go code
-5. Denied tool calls show a clear reason in Telegram instead of silently failing
-6. Operator can install and audit third-party skills from the CLI
+4. **Operator can restrict an agent to read-only tools without editing Go code**
+   Per-agent `capabilities` block in config: `shell`, `network`, `network_allowlist`, `cron`, `memory_write`, `spawn`, `filesystem_roots`, `file_write_scope`. Runtime receives a structured policy object. Existing `allowed_tools` configs still load.
 
-### Phase 3: Productized Autonomy
+5. **Denied tool calls show a clear reason in Telegram instead of silently failing**
+   Every denied tool call returns a human-readable reason with remediation hint. Denial messages appear in Telegram, TUI, and API. Policy enforcement covers both agent-mediated and direct tool invocation.
 
-7. Operator can cap a background task's tool calls, duration, and model cost
-8. Operator can enable a prebuilt role that runs on schedule and posts a report
-9. Operator can define new roles declaratively without writing Go code
+6. **Operator can install and audit third-party skills from the CLI**
+   `ok-gobot skills list|install|remove|audit`. Install from local path or git URL. Static safety audit rejects symlinks, scripts, pipe-to-shell patterns, and escaping links. Utility score tracking (uses, successes, failures) with score-sorted skill prompts.
 
-## Backlog
+### Phase 3: Productized Autonomy (complete)
 
-### 1. Operator can kill dangerous tools instantly without restarting the bot
+7. **Operator can cap a background task's tool calls, duration, and model cost**
+   Sub-agent spawning via `SpawnSubagent()` with cost tier support (cheap, standard, premium, local). Chat router automatically promotes heavy work to background jobs. Parent-child session tracking delivers results back.
 
-**User Story**
-As an operator, I want to disable dangerous tool families (shell, SSH, browser,
-cron, message, fetch) with a single command so that I can respond to incidents
-without restarting the process or losing in-flight sessions.
+8. **Operator can enable a prebuilt role that runs on schedule and posts a report**
+   Three prebuilt roles ship: `researcher` (daily), `monitor` (every 30 min), `release-watch` (weekly). Enable by setting `roles_path` in config. Roles run through cron infrastructure and respect capability policy and estop.
 
-**Why:** Highest-ROI safety feature. Gives operators a fast kill switch.
+9. **Operator can define new roles declaratively without writing Go code**
+   Role manifests are markdown files with YAML frontmatter: `worker`, `tools`, `schedule`, `approval`, `report_template`. Stored in the `roles_path` directory. Prebuilt roles use the same format.
 
-**Acceptance Criteria**
-- [ ] `/estop on` disables dangerous tool families; `/estop off` re-enables them.
-- [ ] Blocked tools return a user-visible reason in Telegram, TUI, and API.
-- [ ] `/status` and the TUI show current estop state.
-- [ ] CLI equivalent: `ok-gobot estop on|off|status`.
+### Additional Shipped Features
 
-**Default Behavior**
-Estop is off. All configured tools are available. This is correct because most
-operators run the bot in a trusted environment and should not pay an opt-in cost
-for normal operation.
+10. **Self-evolution loop (A-Evolve inspired)**
+    Solve-Observe-Evolve-Gate-Reload cycle. Failure pattern analysis, candidate mutation, benchmark gating, strict improvement gate, human approval for large diffs, version history with rollback, daily cycle limit. CLI: `ok-gobot evolution status|history|rollback|metrics`.
 
-**Likely files**
-- `internal/cli/estop.go` (new)
-- `internal/control/server.go`
-- `internal/bot/approval.go`
-- `internal/tools/tools.go`
-- `internal/config/config.go`
+11. **Multi-model routing by task type**
+    Route messages to different models by task type (vision, summarize, reasoning, coding). Explicit `[task:type]` tags or config-based routing. Falls back through routing default then global default.
 
-### 2. User can list available models and see which providers are healthy
+12. **Automatic reflection loop after tool failures**
+    Tracks failure counts per tool, proposes fixes based on error patterns (not found, timeout, permission denied, parse error, network). Records failures to daily memory notes.
 
-**User Story**
-As a user, I want to see which models and providers are available so that I can
-pick the right model for my task and diagnose failures without reading config files.
+13. **Rules-first chat routing**
+    Incoming turns classified as reply (fast inline), clarification (follow-up question), or background job (heavy work launched as isolated task). Forced job prefixes: `job:`, `task:`, `background:`.
 
-**Why:** Multi-provider usability. Users currently have no way to discover models
-or understand why a request failed at the provider level.
+14. **Git worktree management for parallel tasks**
+    `ok-gobot work <task>` spawns a git worktree with a dedicated worker agent. `ok-gobot worktrees list|cleanup|rm` manages tracked worktrees.
 
-**Acceptance Criteria**
-- [ ] `ok-gobot providers` lists configured providers with health status.
-- [ ] `ok-gobot models refresh` fetches and caches remote model catalogs.
-- [ ] `ok-gobot doctor` distinguishes auth failure, endpoint failure, and model lookup failure.
-- [ ] Model picker flows use cached catalogs when available.
+15. **Mission Control API**
+    HTTP endpoints for monitoring: `/api/mission/roles`, `/api/mission/schedules`, `/api/mission/runs`, `/api/mission/stats`. Loopback-only access with CORS.
 
-**Default Behavior**
-Provider list shows whatever is configured in `config.yaml`. Model catalog is
-fetched on first `models refresh` and cached locally. No automatic background
-fetching.
+## Planned
 
-**Likely files**
-- `internal/cli/providers.go` (new)
-- `internal/cli/models.go` (new)
-- `internal/cli/doctor.go`
-- `internal/ai/client.go`
+### Mission Control v1
 
-### 3. Operator gets a detailed report after migrating from OpenClaw
+The next milestone consolidates the runtime, roles, jobs, and monitoring API into a coherent operator experience called Mission Control. See [MISSION-CONTROL.md](./MISSION-CONTROL.md) for the concept.
 
-**User Story**
-As an operator migrating from OpenClaw, I want a durable report of what was
-copied, skipped, and deduplicated so that I can trust the migration and debug
-problems without re-running it.
+- **Budget and policy enforcement for scheduled autonomy.** Scheduled roles and background jobs need hard token/cost budgets and wall-clock limits before operators can trust them in unattended production. Without this gate, the docs intentionally avoid claiming that scheduled autonomy is production-safe.
+- **Role and job lifecycle dashboard.** The Mission Control API exists but has no dedicated UI. A TUI or web dashboard showing active roles, run history, failures, and cost would make the operator loop complete.
+- **Skill marketplace and versioning.** Skills can be installed and audited, but there is no discovery or versioning beyond `skills history|rollback`. A lightweight registry or feed would help.
 
-**Why:** Imports without an artifact are harder to trust and harder to debug.
+### Future Considerations
 
-**Acceptance Criteria**
-- [ ] Every migration run emits a report (markdown or JSON) listing copied files, skipped sessions, duplicates, backup path, and key mapping.
-- [ ] `--dry-run` prints the same categories as the real report.
-- [ ] Failed migrations preserve enough detail for rollback and debugging.
+- Multi-channel expansion beyond Telegram (not a current priority)
+- WASM sandboxing for tool isolation
+- Reproducible local benchmarks for evolution gating
+- AI-powered fix generation in the reflection loop (currently heuristic)
 
-**Default Behavior**
-Report is written to `~/.ok-gobot/migration-report-<timestamp>.md` alongside
-the database. `--dry-run` prints to stdout only.
+## Non-Goals
 
-**Likely files**
-- `internal/cli/migrate.go`
-- `internal/migrate/migrate.go`
-
-### 4. Operator can restrict an agent to read-only tools without editing Go code
-
-**User Story**
-As an operator, I want to give an agent narrower permissions (no shell, no
-network, read-only filesystem) through config so that I can run less-trusted
-models safely without changing source code.
-
-**Why:** `AllowedTools` is too coarse once you add more autonomy. Operators need
-declarative, fine-grained capability control.
-
-**Acceptance Criteria**
-- [ ] Agent config accepts explicit permissions: shell, filesystem roots, network allowlists, cron, memory writes, sub-agent spawn.
-- [ ] Existing `allowed_tools` configs still load without breakage.
-- [ ] Runtime receives a structured policy object, not ad-hoc booleans.
-- [ ] A restricted agent cannot escalate to a tool outside its policy.
-
-**Default Behavior**
-If no policy block is set, all tools in the agent's `allowed_tools` list remain
-available (full backward compatibility). An empty `allowed_tools` still means
-"all tools."
-
-**Likely files**
-- `internal/config/config.go`
-- `internal/agent/registry.go`
-- `internal/agent/resolver.go`
-- `docs/ARCHITECTURE.md`
-
-### 5. Denied tool calls show a clear reason in Telegram instead of silently failing
-
-**User Story**
-As a user, I want to see why a tool call was blocked so that I understand the
-bot's limitations and can ask an operator to adjust permissions if needed.
-
-**Why:** Capability policy is useless if denied actions are silent. Users lose
-trust when the bot ignores requests without explanation.
-
-**Acceptance Criteria**
-- [ ] Every denied tool call returns a consistent, human-readable reason.
-- [ ] The denial message appears in Telegram, TUI, and API responses.
-- [ ] Tests cover both allowed and denied flows for `local`, `ssh`, `browser`, `web_fetch`, `search`, `cron`, and `message`.
-- [ ] Policy checks survive direct tool invocation, not only agent-mediated runs.
-
-**Default Behavior**
-No tools are denied unless the operator configures capability policy or activates
-estop. When a tool is denied, the user sees: "Tool [name] blocked: [reason]."
-
-**Likely files**
-- `internal/tools/tools.go`
-- `internal/tools/browser_tool.go`
-- `internal/tools/web_fetch.go`
-- `internal/tools/search.go`
-- `internal/tools/cron.go`
-- `internal/tools/message.go`
-
-### 6. Operator can install and audit third-party skills from the CLI
-
-**User Story**
-As an operator, I want to install, list, and remove skills from the CLI so that
-I can extend the bot's capabilities without editing source code, and audit
-installed skills for safety.
-
-**Why:** `ok-gobot` already has the workspace shape for skills. A safe
-install/audit path makes the extension model usable in practice.
-
-**Acceptance Criteria**
-- [ ] `ok-gobot skills list|install|remove|audit` works from the CLI.
-- [ ] Install accepts a local path or git URL.
-- [ ] Static safety audit rejects symlinks, scripts, pipe-to-shell patterns, and markdown links escaping the skill root.
-- [ ] Installed skills are markdown-first and compatible with the workspace model.
-
-**Default Behavior**
-No skills installed out of the box. `skills list` shows an empty list.
-`skills install` runs the safety audit before accepting; unsafe packages are
-rejected with actionable error messages.
-
-**Likely files**
-- `internal/cli/skills.go` (new)
-- `internal/tools/tools.go`
-- `docs/INSTALL.md`
-
-### 7. Operator can cap a background task's tool calls, duration, and model cost
-
-**User Story**
-As an operator, I want to set limits on background tasks (max tool calls, max
-duration, model override) so that a runaway subagent cannot consume unbounded
-resources or time.
-
-**Why:** Subagents currently have no budget constraints. A stuck or recursive
-subagent can exhaust API quota silently.
-
-**Acceptance Criteria**
-- [ ] Operator can set max tool calls, max duration, and model override per task.
-- [ ] A task that hits its limit stops and returns a structured summary, not raw output.
-- [ ] Failed or timed-out tasks produce understandable feedback in Telegram and TUI.
-- [ ] Memory writes from subagents can be disabled by policy.
-
-**Default Behavior**
-Default budget: 50 tool calls, 5-minute wall-clock timeout. Model inherits from
-the parent agent. Memory writes allowed unless the agent's capability policy
-disables them.
-
-**Likely files**
-- `internal/agent/subagent.go`
-- `internal/bot/task_command.go`
-- `internal/control/server_tui.go`
-- `internal/bot/subagent_notifier.go`
-
-### 8. Operator can enable a prebuilt role that runs on schedule and posts a report
-
-**User Story**
-As an operator, I want to enable a prebuilt role (researcher, monitor,
-release-watch) with minimal config so that useful autonomous workflows run on
-schedule and post bounded, readable reports to Telegram.
-
-**Why:** The value of autonomy features is prebuilt, useful workflows — not
-platform infrastructure.
-
-**Acceptance Criteria**
-- [ ] At least 3 prebuilt roles ship: `researcher`, `monitor`, `release-watch`.
-- [ ] A role can be enabled by adding its name to config — no Go code needed.
-- [ ] Each role runs on schedule via existing cron infrastructure.
-- [ ] Reports are bounded in length and formatted for Telegram readability.
-- [ ] Roles respect capability policy and estop.
-
-**Default Behavior**
-No roles enabled out of the box. Enabling a role requires explicit config. Roles
-run through existing cron + runtime infrastructure, not a second orchestration
-system.
-
-**Likely files**
-- `internal/cron/scheduler.go`
-- `internal/agent/subagent.go`
-- `internal/bot/hub_handler.go`
-- `internal/bot/subagent_notifier.go`
-
-### 9. Operator can define new roles declaratively without writing Go code
-
-**User Story**
-As an operator, I want to define custom autonomous roles using a simple manifest
-format (prompt, tools, schedule, output template) so that I can create new
-workflows without modifying the bot's source.
-
-**Why:** Hardcoded roles do not scale. Operators need a hackable, workspace-local
-format for role definitions.
-
-**Acceptance Criteria**
-- [ ] Role manifests are defined in a lightweight declarative format stored in the workspace.
-- [ ] A manifest specifies: prompt, tools, schedule, output template, and approval mode.
-- [ ] Role outputs have a stable, structured report format.
-- [ ] Memory writes from roles can be disabled by policy.
-
-**Default Behavior**
-No custom roles defined. Prebuilt roles (item 8) use the same manifest format
-internally, serving as examples.
-
-**Likely files**
-- `internal/agent/memory.go`
-- `internal/agent/registry.go`
-- `internal/bot/hub_handler.go`
-- `docs/FEATURES.md`
-
-## Non-Goals for Now
-
-- Multi-channel expansion to match OpenClaw/OpenFang/ZeroClaw
-- Desktop app or giant dashboard work
-- WASM sandboxing
+- Desktop app or large dashboard
 - A generic "swap everything" runtime abstraction
-- Benchmark marketing before reproducible local benchmarks exist
+- Benchmark marketing before reproducible benchmarks exist
+- Competing on channel count with OpenFang/ZeroClaw/OpenClaw
 
 ## Short Version
 
-If only the first five things get done, the order should be:
-
-1. estop — operator can kill dangerous tools instantly
-2. provider/model catalog — user can see what's available and healthy
-3. migration report — operator gets a trustworthy import artifact
-4. capability policy — operator restricts agents through config
-5. tool denial messages — users see why something was blocked
-
-That sequence improves safety, operator UX, and extensibility without pushing `ok-gobot` into platform bloat.
+The original top-5 priority list (estop, provider catalog, migration report, capability policy, tool denial messages) is fully shipped. Current focus is Mission Control v1: budget enforcement, lifecycle dashboard, and skill ecosystem.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,8 +30,8 @@ This roadmap tracks shipped capabilities and planned work for ok-gobot. The orig
 
 ### Phase 3: Productized Autonomy (complete)
 
-7. **Operator can cap a background task's tool calls, duration, and model cost**
-   Sub-agent spawning via `SpawnSubagent()` with cost tier support (cheap, standard, premium, local). Chat router automatically promotes heavy work to background jobs. Parent-child session tracking delivers results back.
+7. **Operator can cap a background task's tool calls and duration, and choose a cost tier**
+   Sub-agent spawning via `SpawnSubagent()` with tool-call and duration limits plus cost tier routing (cheap, standard, premium, local). Chat router automatically promotes heavy work to background jobs. Parent-child session tracking delivers results back. Hard token/cost budget enforcement is still planned for Mission Control v1.
 
 8. **Operator can enable a prebuilt role that runs on schedule and posts a report**
    Three prebuilt roles ship: `researcher` (daily), `monitor` (every 30 min), `release-watch` (weekly). Enable by setting `roles_path` in config. Roles run through cron infrastructure and respect capability policy and estop.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,95 @@
+# ok-gobot Security Posture
+
+Last updated: April 29, 2026.
+
+This document describes the security model, hardening measures, and known limitations of ok-gobot. For the changelog of specific security fixes, see [SECURITY-FIXES.md](SECURITY-FIXES.md).
+
+## Threat Model
+
+ok-gobot is a single-operator Telegram bot that executes AI-directed tool calls (shell commands, file operations, web requests, browser automation) on the host machine. The primary threats are:
+
+1. **Unauthorized access** -- untrusted Telegram users issuing commands.
+2. **AI-directed misuse** -- the AI model requesting dangerous tool calls.
+3. **Injection via external content** -- web pages, documents, or user input containing prompt injection or command injection payloads.
+4. **Network-level attacks** -- SSRF, CSWSH, or redirect-based bypasses.
+5. **Credential leakage** -- API keys or tokens appearing in logs, configs, or responses.
+
+## Defense Layers
+
+### 1. Access Control
+
+| Layer | Mechanism |
+|-------|-----------|
+| DM authorization | Three modes: `open`, `allowlist`, `pairing`. Default can be set to any; unknown modes are **fail-closed**. |
+| Pairing brute-force protection | 5 failed attempts triggers 15-minute lockout per user ID. |
+| Admin-only commands | `/estop`, `/auth`, `/reload`, `/restart` require `auth.admin_id`. |
+| Group activation | Groups default to `standby` (respond only to mentions). |
+
+### 2. Tool Execution Safety
+
+| Layer | Mechanism |
+|-------|-----------|
+| Exec approval | Dangerous shell commands require Telegram inline keyboard confirmation. Auto-deny after 60s. |
+| Dangerous command detection | Patterns: `rm -rf`, `kill`, `shutdown`, `sudo`, `su`, `doas`, `curl\|sh`, `wget\|bash`, `eval`, `exec`, `DROP TABLE`, `DROP DATABASE`, Docker destructive ops, and path-qualified binaries (`/bin/rm`, `/sbin/mkfs`). |
+| Emergency stop (estop) | `/estop on` disables tool families: `local`, `ssh`, `browser`, `cron`, `message`. Immediate effect, no restart needed. |
+| Capability policy | Per-agent structured policy: `shell`, `network`, `network_allowlist`, `cron`, `memory_write`, `spawn`, `filesystem_roots`, `file_write_scope`. Denied tool calls return a reason and remediation hint. |
+
+### 3. Path and Filesystem Safety
+
+| Layer | Mechanism |
+|-------|-----------|
+| Path traversal prevention | All file/patch/grep operations resolve paths against allowed roots. |
+| Symlink escape prevention | `filepath.EvalSymlinks` after prefix check catches symlinks pointing outside workspace. |
+| Obsidian vault isolation | Separate `resolveVaultPath()` with the same symlink resolution. |
+| Filesystem roots | Capability policy can restrict agents to specific directory trees. |
+| Read-only mode | `file_write_scope: "read_only"` blocks all write operations. |
+
+### 4. Network Safety
+
+| Layer | Mechanism |
+|-------|-----------|
+| SSRF protection (web_fetch) | Blocks localhost, private IPs (10.x, 172.16-31.x, 192.168.x, fc00::/7). DNS resolved before request to prevent rebinding. |
+| Redirect revalidation | Each HTTP redirect target is revalidated against the same private-IP/scheme rules. |
+| Browser URL validation | Blocks `file://` scheme, localhost/127.0.0.1/::1, `.internal`/`.local` hostnames. |
+| CORS restriction | API and control server accept only loopback origins (`http://127.0.0.1`, `http://localhost`). |
+| CSWSH protection | WebSocket upgrade validates `Origin` header. Non-browser (empty Origin) allowed; non-loopback browser origins rejected. |
+| SSH host key policy | `StrictHostKeyChecking=accept-new` (trust-on-first-use, reject changes). |
+
+### 5. Credential Safety
+
+| Layer | Mechanism |
+|-------|-----------|
+| Log redaction | Masks API keys (sk-...), Bearer tokens, bot tokens, and long hex/base64 strings in log output. |
+| Config file permissions | `config init` sets 0600 on config.yaml. |
+| OAuth credential storage | Anthropic/ChatGPT OAuth credentials stored in `~/.ok-gobot/oauth/` with 0600 permissions. |
+| Control server default | `control.enabled` defaults to `false`. Must be explicitly enabled. |
+| Token auth | Control server token comparison uses `crypto/subtle.ConstantTimeCompare` (timing-safe). |
+
+### 6. Input Sanitization
+
+| Layer | Mechanism |
+|-------|-----------|
+| Shell argument escaping | `SanitizeShellArg` escapes shell metacharacters. |
+| Telegram markdown escaping | `SanitizeTelegramMarkdown` escapes MarkdownV2 special characters. |
+| Control character stripping | `StripControlChars` removes non-printable characters. |
+| Web UI XSS prevention | DOMPurify sanitizes all `marked.parse()` output before innerHTML insertion. CDN scripts loaded with SRI integrity attributes. |
+
+## Known Limitations
+
+1. **No token/cost budgets for scheduled roles.** Roles running on cron can consume unbounded API tokens. Budget enforcement is planned for Mission Control v1. Until then, scheduled autonomy should not be considered production-safe for unattended operation.
+
+2. **No WASM sandboxing.** Tool execution happens in-process on the host. The capability policy restricts which tools are available, but does not sandbox their execution environment.
+
+3. **No taint tracking.** Content fetched from the web is not tracked through the system. Prompt injection from web content could influence tool calls within the same session.
+
+4. **Single-machine deployment.** Security controls assume a single operator on a single machine. Multi-tenant or multi-machine deployments are not a design target.
+
+## Hardening Recommendations
+
+1. Use `auth.mode: "pairing"` or `"allowlist"` in production. Never `"open"`.
+2. Keep `control.enabled: false` unless actively using TUI/web UI.
+3. If enabling control server, set a strong `control.token`.
+4. Use capability policy to restrict agents that run less-trusted models.
+5. Set `filesystem_roots` for agents that only need access to specific directories.
+6. Monitor `/estop status` and `ok-gobot evolution metrics` for anomalies.
+7. Review `docs/SECURITY-FIXES.md` for the full history of security hardening.

--- a/greptile.json
+++ b/greptile.json
@@ -4,9 +4,6 @@
   "triggerOnUpdates": true,
   "statusCheck": true,
   "fixWithAI": true,
-  "ignorePatterns": "*.lock
-*.sum
-Cargo.lock
-bun.lockb",
+  "ignorePatterns": "*.lock\n*.sum\nCargo.lock\nbun.lockb",
   "excludeAuthors": ["dependabot[bot]", "renovate[bot]"]
 }


### PR DESCRIPTION
Implements #290

## Changes

Refreshes all user-facing docs to match the current codebase after the 2026-04-29 comparison found them partially stale.

**Updated:**
- **README.md** — adds roles/jobs/skills/evolution sections, updates CLI commands list, adds OpenRouter provider, fixes Go version to 1.24+, adds Mission Control API to infrastructure, updates project structure tree
- **docs/ROADMAP.md** — distinguishes shipped features (Phase 1-3 complete + 6 additional shipped items) from planned work (Mission Control v1 budget enforcement, lifecycle dashboard, skill ecosystem)
- **docs/FEATURES.md** — adds sections for roles & jobs, skills, self-evolution, multi-model routing, reflection loop, chat routing, Mission Control API, capability policy, and git worktree management
- **docs/ARCHITECTURE.md** — adds chat routing, roles/scheduled jobs, Mission Control, and security architecture sections; updates runtime contract with event types
- **docs/COMPETITORS.md** — adds April 2026 update noting shipped autonomy, capability policy, and remaining gaps; updates ok-gobot strengths/weaknesses
- **docs/INSTALL.md** — updates security recommendations to reference SECURITY.md and note the budget enforcement caveat for scheduled roles

**New:**
- **docs/SECURITY.md** — security posture, threat model, defense layers, known limitations, hardening recommendations
- **docs/MISSION-CONTROL.md** — concise Mission Control v1 concept page with current state, missing pieces, and architecture

**Safety caveat:** docs consistently note that scheduled autonomy (roles on cron) does not yet enforce hard token/cost budgets and should not be considered production-safe for unattended operation.

## Testing

```
go fmt ./...    # clean
go vet ./...    # clean
go test ./...   # all pass
go build ./cmd/ok-gobot/  # success
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes all user-facing documentation to match the current codebase, adding new docs for Security posture and Mission Control v1, and updating README, ARCHITECTURE, FEATURES, ROADMAP, COMPETITORS, and INSTALL to reflect shipped capabilities (roles, skills, self-evolution, multi-model routing, capability policy, git worktrees).

- `docs/ARCHITECTURE.md` has a duplicate section 9: adding §4 (Chat Routing) and §6 (Roles) shifted Persistence to §9, but the Configuration Reference header was not renumbered — leaving two `## 9.` headings in the document and sub-sections `### 9.1`/`### 9.2` that should be `### 12.1`/`### 12.2`. The README anchor link (`#9-configuration-reference-canonical`) was updated to point to the old number but will resolve correctly only because the anchor text differs from Persistence; however the numbered headings in the rendered document will be visually wrong.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the duplicate section 9 numbering in ARCHITECTURE.md

Single P1 finding: duplicate section heading introduced by the renumbering of intermediate sections without updating the Configuration Reference section. All other changes are accurate documentation refreshes with no code impact.

docs/ARCHITECTURE.md — duplicate §9 heading and sub-section numbers (9.1/9.2) need to be updated to §12/12.1/12.2, and the README anchor updated to match

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/ARCHITECTURE.md | Adds chat routing (§4), roles (§6), Mission Control (§7), and security architecture (§11) sections; renumbers intermediate sections — but leaves a duplicate §9 (Persistence and Configuration Reference both labeled 9) |
| README.md | Adds roles/jobs/skills/evolution sections, OpenRouter provider, Mission Control API, updated CLI commands, Go 1.24+ requirement, and updated project structure tree; cross-reference to ARCHITECTURE.md §9 anchor will resolve to Persistence rather than Configuration Reference once the section numbering is fixed |
| docs/FEATURES.md | Adds multi-model routing, reflection loop, roles & jobs, skills, self-evolution, capability policy, and git worktree management sections; content is internally consistent with other docs |
| docs/SECURITY.md | New file documenting threat model, six defense layers, known limitations (no token budgets, no WASM sandbox, no taint tracking), and hardening recommendations; accurately reflects the caveats noted in other docs |
| docs/MISSION-CONTROL.md | New concept page for Mission Control v1; clearly distinguishes shipped pieces from missing gates (budget enforcement, lifecycle dashboard, skill ecosystem) |
| docs/ROADMAP.md | Rewrites backlog-style roadmap into shipped (Phases 1-3 + 6 additional items) and planned (Mission Control v1) sections; concise and consistent with other docs |
| docs/COMPETITORS.md | Adds April 2026 update section noting shipped autonomy features and remaining gaps; updates strengths/weaknesses table accordingly |
| docs/INSTALL.md | Adds capability policy and budget enforcement caveats to security recommendations; references new SECURITY.md |
| greptile.json | Fixes invalid multi-line JSON string by replacing literal newlines with \n escape sequences; valid correctness fix |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/ARCHITECTURE.md
Line: 113

Comment:
**Duplicate section 9 — Configuration Reference not renumbered**

This PR added two new sections (§4 Chat Routing and §6 Roles), which correctly shifted Persistence to §9 and Memory to §10. However, the Configuration Reference heading was not updated, leaving the document with **two sections numbered 9** (line 90 `## 9. Persistence` and line 113 `## 9. Configuration Reference (Canonical)`). The sub-sections `### 9.1 PRD Extensions` and `### 9.2 Compatibility Notes` are also affected.

The Configuration Reference should be renumbered to §12, and the README anchor (currently `#9-configuration-reference-canonical`) updated to `#12-configuration-reference-canonical` to match.

```suggestion
## 12. Configuration Reference (Canonical)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix review feedback and Greptile c..."](https://github.com/befeast/ok-gobot/commit/8e87c42ac2698398eb0656f8bce3a42771319ee7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30152643)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->