### PR TITLE
docs: refresh all docs after current-state comparison (#290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ok-gobot
 
-A fast, single-binary Telegram bot with AI agent capabilities. Ground-up Go rewrite of [OpenClaw](https://github.com/openclaw/openclaw) with opinionated defaults for personal use.
+A fast, single-binary Telegram bot and mission-control agent. Ground-up Go rewrite of [OpenClaw](https://github.com/openclaw/openclaw) with opinionated defaults for personal operator workflows.
+
+ok-gobot combines chat-driven AI with scheduled autonomous roles, a durable jobs runtime, installable skills, and a self-evolution loop -- all in a single Go binary.
 
 Competitive landscape: [docs/COMPETITORS.md](docs/COMPETITORS.md).
 
@@ -41,7 +43,7 @@ ok-gobot doctor
 ok-gobot start
 ```
 
-**Requirements:** Go 1.23+, C compiler (for SQLite CGO).
+**Requirements:** Go 1.24+, C compiler (for SQLite CGO).
 
 ## AI Providers
 
@@ -58,14 +60,24 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 ## Features
 
 ### AI & LLM
-- **Multi-provider** -- Anthropic, ChatGPT, OpenAI, Gemini, Droid, any OpenAI-compatible endpoint
+- **Multi-provider** -- Anthropic, ChatGPT, OpenAI, OpenRouter, Gemini, Droid, any OpenAI-compatible endpoint
 - **Native tool calling** -- structured `tools` API, not text parsing
+- **Multi-model routing** -- route vision, coding, reasoning, and summarization tasks to different models
 - **Model failover** -- automatic fallback chain with cooldown (`ai.fallback_models`)
 - **Per-session model override** -- `/model claude-sonnet-4-5` per chat
 - **Multi-agent system** -- multiple personalities, models, tool sets per agent (`/agent`)
 - **Context compaction** -- AI-powered summarization when approaching token limits
 - **Streaming responses** -- live message editing with rate limiting
 - **CLI agent transport** -- use Factory Droid, Claude Code, Codex, Gemini CLI, or OpenCode as backends
+
+### Roles, Skills & Autonomy
+- **Scheduled roles** -- markdown-first role manifests with cron scheduling, prebuilt researcher/monitor/release-watch roles
+- **Skills** -- install, audit, and manage third-party skills from the CLI (`ok-gobot skills`)
+- **Utility scoring** -- tracks skill usage, success, and failure rates for routing
+- **Jobs runtime** -- durable background jobs with retry, cancellation, timeout, and artifact support
+- **Chat routing** -- classifies incoming turns as reply, clarification, or background job
+- **Self-evolution** -- A-Evolve-inspired loop: observe task metrics, propose mutations, gate via benchmarks, promote or rollback
+- **Reflection loop** -- automatic failure analysis with suggested fixes after tool errors
 
 ### Tools
 | Tool | Description |
@@ -149,7 +161,7 @@ All commands are auto-registered with BotFather for slash autocomplete.
 ## Configuration
 
 Config file: `~/.ok-gobot/config.yaml` (see [config.example.yaml](config.example.yaml))
-Canonical key reference: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#8-configuration-reference-canonical)
+Canonical key reference: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#12-configuration-reference-canonical)
 
 ```yaml
 telegram:
@@ -205,6 +217,13 @@ ok-gobot status                   # Show status
 ok-gobot estop on|off|status      # Toggle emergency stop for dangerous tools
 ok-gobot doctor                   # Check config and dependencies
 ok-gobot daemon install|start|stop|status|logs|uninstall
+ok-gobot skills list|install|remove|audit|history|rollback
+ok-gobot jobs                     # View background jobs
+ok-gobot providers                # List AI providers
+ok-gobot models                   # List available models
+ok-gobot evolution                # Inspect self-evolution state
+ok-gobot sessions                 # Manage sessions
+ok-gobot export                   # Export data
 ok-gobot version
 ```
 
@@ -228,24 +247,26 @@ ok-gobot loads personality files from a configurable directory (default `~/ok-go
 ok-gobot/
 ├── cmd/ok-gobot/         # Entry point
 ├── internal/
-│   ├── agent/            # Personality, memory, safety, compactor, registry
-│   ├── ai/               # AI client, failover, types
+│   ├── agent/            # Personality, memory, safety, compactor, registry, reflection
+│   ├── ai/              # AI client, failover, multi-model router, types
 │   ├── api/              # HTTP API server
 │   ├── app/              # Application orchestrator
-│   ├── bootstrap/        # First-run onboarding
+│   ├── bootstrap/        # Skills loader, audit, utility scoring
 │   ├── bot/              # Telegram bot, commands, media, queue, status, usage
 │   ├── browser/          # Chrome automation
-│   ├── cli/              # Cobra CLI (start, config, doctor, daemon, auth)
+│   ├── cli/              # Cobra CLI (25 subcommands)
 │   ├── config/           # YAML config, watcher
 │   ├── configschema/     # Schema generation
-│   ├── control/          # WebSocket control server, hub, TUI protocol
+│   ├── control/          # WebSocket control server, hub, mission control API
 │   ├── cron/             # Job scheduler
 │   ├── errorx/           # Error handling
+│   ├── evolution/        # Self-evolution engine (A-Evolve loop)
 │   ├── logger/           # Level-aware debug logging
 │   ├── memory/           # Markdown-backed memory index (embeddings, store)
 │   ├── memorymcp/        # Memory MCP server
 │   ├── migrate/          # Database migrations
 │   ├── redact/           # Log redaction
+│   ├── role/             # Markdown-first role manifests, prebuilt roles
 │   ├── runtime/          # Chat/jobs mailbox runtime, session scheduling
 │   ├── sanitize/         # Input sanitization
 │   ├── session/          # Context monitoring
@@ -259,14 +280,16 @@ ok-gobot/
 
 ## Documentation
 
+- [Mission Control](docs/MISSION-CONTROL.md) -- Concept and API for the roles/jobs/schedules runtime
 - [Competitive Landscape](docs/COMPETITORS.md) -- OpenFang, ZeroClaw, OpenClaw, and ok-gobot comparison
-- [Roadmap](docs/ROADMAP.md) -- Implementation backlog derived from the competitor analysis
+- [Roadmap](docs/ROADMAP.md) -- Shipped and planned features
 - [Installation Guide](docs/INSTALL.md) -- Setup, configuration, providers, deployment
 - [API Reference](docs/API.md) -- HTTP REST API and WebSocket control protocol
 - [Architecture](docs/ARCHITECTURE.md) -- Chat/jobs architecture contract, legacy-runtime freeze, and canonical config reference
 - [Features](docs/FEATURES.md) -- Detailed feature descriptions
 - [Tools Reference](docs/TOOLS.md) -- All tools with usage examples
 - [Memory](docs/MEMORY.md) -- Semantic memory system
+- [Security Policy](SECURITY.md) -- Security posture and reporting
 - [Security Fixes](docs/SECURITY-FIXES.md) -- Security hardening changelog
 - [TTS](docs/TTS_USAGE.md) / [TTS (RU)](docs/TTS_USAGE_RU.md) -- Text-to-speech setup
 - [Changelog](docs/CHANGELOG.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability in ok-gobot, please report it responsibly by opening a private security advisory on GitHub:
+
+**GitHub Security Advisories:** [BeFeast/ok-gobot Security](https://github.com/BeFeast/ok-gobot/security/advisories)
+
+Do not open a public issue for security vulnerabilities.
+
+## Security Posture
+
+ok-gobot is a single-operator Telegram bot that executes shell commands, accesses the filesystem, and makes network requests on the operator's behalf. The security model is designed for a trusted-operator deployment, not a multi-tenant service.
+
+### Implemented Controls
+
+**Authentication & Authorization**
+- DM authorization: open, allowlist, or pairing code modes
+- Pairing code brute-force protection (lockout after 5 failed attempts)
+- Auth fail-closed by default (unknown modes deny access)
+- Admin-only commands for sensitive operations
+
+**Execution Safety**
+- Dangerous command approval via Telegram inline keyboard
+- Emergency stop (`/estop`) to disable dangerous tool families without restart
+- Capability policies per agent: shell, filesystem, network, cron, memory, spawn
+- Symlink escape prevention with `filepath.EvalSymlinks`
+
+**Network Safety**
+- SSRF protection: blocks private IPs, validates redirect targets
+- Browser tool blocks `file://`, localhost, `.internal`/`.local`
+- CORS restriction: loopback-only origins for API and control server
+- Control server disabled by default, loopback-only binding
+
+**Data Protection**
+- Log redaction for API keys, Bearer tokens, bot tokens
+- OAuth credentials stored with 0600 permissions
+- Config file permissions set to 0600 by `config init`
+- WebSocket origin validation (CSWSH protection)
+- Constant-time token comparison
+
+**Skill Safety**
+- Security audit on skill install: rejects symlinks, scripts, pipe-to-shell, path escaping
+- Markdown-only enforcement for skill content
+
+### Known Limitations
+
+- **No budget enforcement for autonomous runs.** Scheduled roles execute tool calls without per-role cost caps. Operators should restrict tool access via capability policies until budget controls ship.
+- **No WASM sandboxing.** Tool execution happens in the host process. Capability policies restrict which tools are available but do not sandbox execution.
+- **Single-operator model.** ok-gobot is not designed for multi-tenant deployments. All authorized users share the same execution context.
+
+### Security Hardening History
+
+See [docs/SECURITY-FIXES.md](docs/SECURITY-FIXES.md) for the detailed security hardening changelog.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,33 +28,75 @@ Canonical session keys:
 - `agent:<agentId>:telegram:group:<chatId>:thread:<topicId>`
 - `agent:<agentId>:subagent:<runSlug>`
 
-## 4. Adapters and Workers
+## 4. Chat Routing
+
+Incoming chat turns are classified before execution:
+
+- **reply** -- lightweight turns stay on the inline AI reply path.
+- **clarification** -- underspecified work requests get a short follow-up question first.
+- **background job** -- obvious heavy work is launched as an isolated durable job instead of blocking the main chat session.
+
+**Files:** `internal/runtime/chat_router.go`, `internal/bot/chat_routing.go`
+
+## 5. Adapters and Workers
 
 - Telegram, control/TUI, and jobs are adapters over chat/jobs requests and runtime events.
 - Adapters handle input/output rendering and acknowledgments.
 - Execution, queueing, cancellation, and child completion routing stay in `internal/runtime`.
 
-## 5. Control Plane
+## 6. Roles
+
+Roles are markdown-first autonomous worker definitions. Each role is a `.md` file
+with optional YAML frontmatter specifying worker tier, tools, schedule, approval
+mode, and report template.
+
+- Prebuilt roles ship embedded in the binary (`internal/role/prebuilt/`).
+- Operators place custom roles in the `roles_path` directory.
+- Scheduled roles register as cron jobs on startup.
+- Role execution respects capability policy and estop state.
+
+**Files:** `internal/role/manifest.go`, `internal/role/loader.go`
+
+## 7. Skills
+
+Skills are installable markdown-first extensions managed via the CLI.
+
+- Each skill is a directory with a `SKILL.md` manifest.
+- `ok-gobot skills install` runs a security audit before accepting: rejects symlinks, scripts, pipe-to-shell patterns, and path-escaping links.
+- Utility scores (uses, successes, failures) are tracked in SQLite and used for routing.
+
+**Files:** `internal/bootstrap/skills.go`, `internal/bootstrap/loader.go`
+
+## 8. Control Plane
 
 The control server provides loopback API/WS access for status, session operations,
-abort, and chat/job control. Legacy sub-agent RPC surfaces remain available only
-as frozen compatibility shims.
+abort, and chat/job control. Mission Control endpoints (`/api/mission/*`) expose
+role, schedule, run, and stats data.
 
-## 6. Legacy Freeze Policy
+Legacy sub-agent RPC surfaces remain available only as frozen compatibility shims.
+
+## 9. Evolution
+
+The self-evolution engine (`internal/evolution/engine.go`) runs an A-Evolve-inspired
+loop: observe task metrics, analyze failure patterns, propose prompt mutations,
+gate candidates via benchmarks, and promote or rollback.
+
+- Max 1 cycle per 24 hours.
+- Human approval required when diff exceeds the configured threshold (default 20%).
+- Rollback triggers automatically after 3 production failures on a promoted version.
+- Disabled by default (`evolution.enabled: false`).
+
+## 10. Legacy Freeze Policy
 
 - `internal/agent.RuntimeHub` is legacy compatibility code.
 - `browser_task`, `/task`, and legacy control-server sub-agent helpers may still depend on it today.
 - Keep changes there limited to bug fixes or removal prep; do not add new product surface area.
 
-## 7. Persistence
+## 11. Persistence
 
-SQLite remains the persistence layer for sessions, messages, routes, and runtime metadata.
+SQLite remains the persistence layer for sessions, messages, routes, job records, skill scores, and evolution snapshots.
 
-## 8. Memory
-
-Memory remains markdown-first (`MEMORY.md` + `memory/*.md`) with semantic indexing for retrieval.
-
-## 9. Configuration Reference (Canonical)
+## 12. Configuration Reference (Canonical)
 
 `config.schema.json` is generated from the canonical JSON block below. This section is the
 single source of truth for configuration keys, types, defaults, and descriptions.
@@ -465,7 +507,7 @@ single source of truth for configuration keys, types, defaults, and descriptions
 ```
 <!-- CONFIG_CANONICAL:END -->
 
-### 9.1 PRD Extensions
+### 12.1 PRD Extensions
 
 PRD adds rollout-specific configuration extensions to the canonical reference:
 
@@ -474,7 +516,7 @@ PRD adds rollout-specific configuration extensions to the canonical reference:
 
 These keys remain part of the canonical schema above and must stay synchronized with PRD language.
 
-### 9.2 Compatibility Notes
+### 12.2 Compatibility Notes
 
 Legacy `runtime.mode` values (`hub`, `legacy`) are still accepted on load as
 ignored compatibility aliases for older config files, but they are not canonical
@@ -482,3 +524,7 @@ keys and are intentionally excluded from the schema.
 
 Legacy `openai.api_key` and `openai.model` are still accepted as migration aliases,
 but they are not canonical keys and are intentionally excluded from the schema.
+
+## 13. Memory
+
+Memory remains markdown-first (`MEMORY.md` + `memory/*.md`) with semantic indexing for retrieval.

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -1,6 +1,7 @@
 # Competitive Landscape: OpenFang, ZeroClaw, OpenClaw, and ok-gobot
 
-Snapshot date: March 12, 2026.
+Original snapshot: March 12, 2026.
+Updated: April 29, 2026 (ok-gobot column refreshed after current-state comparison).
 
 This document compares two newer Rust competitors, [OpenFang](https://github.com/RightNow-AI/openfang) and [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw), against [OpenClaw](https://github.com/openclaw/openclaw) and this project, [ok-gobot](../README.md).
 
@@ -20,22 +21,22 @@ Important caveat: external benchmark, security-layer, and channel-count claims a
 | **OpenFang** | Rust | Autonomous agent OS with bundled "Hands" and dashboard | Created February 24, 2026. 13.8k stars / 1.6k forks. Dual-license in Cargo manifest (`MIT OR Apache-2.0`); GitHub metadata reports Apache-2.0. |
 | **ZeroClaw** | Rust | Fast, small, fully swappable assistant infrastructure | Created February 13, 2026. 26.2k stars / 3.4k forks. Dual-license in Cargo manifest (`MIT OR Apache-2.0`); GitHub metadata reports Apache-2.0. |
 | **OpenClaw** | TypeScript | Personal AI assistant across channels, apps, and devices | Created November 24, 2025. 303.7k stars / 57.4k forks. MIT. |
-| **ok-gobot** | Go | Fast single-binary Telegram bot and OpenClaw rewrite with opinionated defaults | Local project. README positions it as a Go rewrite of OpenClaw. |
+| **ok-gobot** | Go | Telegram-first mission-control agent with scheduled roles, skills, and self-evolution | Local project. Go rewrite of OpenClaw, now a standalone operator bot with autonomous capabilities. |
 
 ## Comparison Matrix
 
 | Dimension | OpenFang | ZeroClaw | OpenClaw | ok-gobot |
 |-----------|----------|----------|----------|----------|
-| **Primary product idea** | Agent OS with built-in autonomous workloads | Runtime OS for agent workflows | Personal assistant control plane | Telegram-first personal/operator bot |
+| **Primary product idea** | Agent OS with built-in autonomous workloads | Runtime OS for agent workflows | Personal assistant control plane | Telegram-first mission-control agent with scheduled roles and self-evolution |
 | **Runtime / packaging** | Rust workspace, one binary, desktop app, Docker | Rust single binary, size-first build profile, optional feature flags | Node 22+, pnpm workspace, UI + apps + extensions | Go single binary, simple build/install, launchd/systemd |
-| **Default interaction model** | Activate prebuilt "Hands" that run for you | Run agent/gateway/daemon/channels as composable infra | Talk to one assistant over many channels/devices | Talk to one or more agents through Telegram, TUI, or API |
-| **Autonomy** | Strongest. Built around scheduled, continuous, proactive agents | Moderate. Has daemon, cron, channels, estop, but less productized autonomy | Moderate. Strong automation/webhooks/cron, but framed as assistant surfaces | Moderate. Has cron, sub-agents, queue modes, compaction, but not an autonomous OS |
+| **Default interaction model** | Activate prebuilt "Hands" that run for you | Run agent/gateway/daemon/channels as composable infra | Talk to one assistant over many channels/devices | Talk to one or more agents through Telegram, TUI, or API; enable scheduled roles for autonomous workflows |
+| **Autonomy** | Strongest. Built around scheduled, continuous, proactive agents | Moderate. Has daemon, cron, channels, estop, but less productized autonomy | Moderate. Strong automation/webhooks/cron, but framed as assistant surfaces | Strong. Scheduled markdown roles, durable jobs runtime, self-evolution loop, reflection; budget enforcement pending |
 | **Channels** | Claims ~40 adapters across chat/social/enterprise platforms | Broad multi-channel matrix with compile-time toggles | Very broad messaging + device node footprint | Telegram only |
-| **Apps / UI surfaces** | Dashboard, TUI, desktop app | Gateway/daemon/web assets, more infra-oriented | Control UI, WebChat, macOS app, iOS node, Android node, Canvas, voice | Telegram UI, TUI, WebSocket control protocol, REST API, simple web UI |
-| **Multi-agent model** | First-class manifests, capabilities, agent spawn | Agent runtime plus provider/model switching and integrations | Multi-agent routing per channel/account/peer | Multi-agent profiles plus isolated sub-agent runs |
+| **Apps / UI surfaces** | Dashboard, TUI, desktop app | Gateway/daemon/web assets, more infra-oriented | Control UI, WebChat, macOS app, iOS node, Android node, Canvas, voice | Telegram UI, TUI, WebSocket control protocol, REST API, Mission Control API, simple web UI |
+| **Multi-agent model** | First-class manifests, capabilities, agent spawn | Agent runtime plus provider/model switching and integrations | Multi-agent routing per channel/account/peer | Multi-agent profiles, capability policies, multi-model routing, isolated sub-agent runs |
 | **Memory model** | SQLite + vector memory with confidence decay | Configurable storage/memory posture, SQLite/Postgres options, multiple memory modes | Session-centric assistant runtime with skills/extensions ecosystem | Markdown-first memory plus SQLite semantic index and optional memory MCP |
-| **Tool / extension story** | 53 tools, MCP, A2A, WASM modules, FangHub | Skills, integrations, provider/channel/tool swapping, security audit on install | Skills platform, plugin SDKs, browser/canvas/node tooling | Built-in local/ssh/file/patch/search/browser/media/memory tools; CLI-agent transports; skill-like workspace files |
-| **Security posture** | Most explicit and systematized: capabilities, WASM sandbox, audit chain, taint tracking, manifest signing | Strong infra controls: allowlists, pairing, workspace scoping, estop, sandbox feature flags, skill audit | Sensible assistant safety defaults, DM pairing, remote access controls, but heavier and less isolation-centric | Practical controls: approvals, DM auth modes, SSRF protection, rate limiting, redaction; less formal sandboxing |
+| **Tool / extension story** | 53 tools, MCP, A2A, WASM modules, FangHub | Skills, integrations, provider/channel/tool swapping, security audit on install | Skills platform, plugin SDKs, browser/canvas/node tooling | Built-in tools (local/ssh/file/patch/search/browser/media/memory); installable skills with audit and utility scoring; CLI-agent transports |
+| **Security posture** | Most explicit and systematized: capabilities, WASM sandbox, audit chain, taint tracking, manifest signing | Strong infra controls: allowlists, pairing, workspace scoping, estop, sandbox feature flags, skill audit | Sensible assistant safety defaults, DM pairing, remote access controls, but heavier and less isolation-centric | Capability policies, estop, approvals, DM auth modes, SSRF protection, rate limiting, redaction, skill audit; budget enforcement pending |
 | **Operational posture** | Broadest promise, highest complexity | Leanest runtime and strongest low-resource story | Broadest ecosystem and surface area, highest Node complexity | Simplest scope and lowest cognitive overhead for one operator |
 | **Migration stance** | Explicitly migrates from OpenClaw | Explicitly migrates from OpenClaw | Ecosystem source project others migrate away from | Explicitly migrates from OpenClaw DB/workspace |
 
@@ -79,12 +80,14 @@ Where the challengers differentiate:
 - **Practical coding-agent bridge**: using Claude Code, Codex, Gemini CLI, Droid, or OpenCode as backends is a concrete differentiator.
 - **Markdown-first workspace**: `IDENTITY.md`, `SOUL.md`, `USER.md`, `AGENTS.md`, `TOOLS.md`, `MEMORY.md` is easy to understand and hack.
 - **Faster path from OpenClaw to a personal bot**: the project has a focused migration command and a simpler target runtime.
+- **Scheduled roles and skills**: markdown role manifests, prebuilt roles, installable skills with security audit and utility scoring now ship out of the box.
+- **Self-evolution**: A-Evolve-inspired loop for automatic prompt improvement is a unique differentiator.
 
 ### Where ok-gobot is weaker
 
 - **Channel breadth**: it does not compete with OpenClaw/OpenFang/ZeroClaw on messaging footprint.
-- **Productized autonomy**: it does not yet have the "activate a pre-built autonomous worker" story that OpenFang pushes.
-- **Formal isolation/security**: it has practical safety controls, but not the kind of capability/sandbox architecture marketed by OpenFang and ZeroClaw.
+- **Budget enforcement**: scheduled roles run autonomously but per-role cost caps and token budgets are not yet enforced. Operators must use capability policies and manual review until budget controls ship.
+- **Formal isolation/security**: it has capability policies and practical safety controls, but not the kind of WASM sandbox architecture marketed by OpenFang and ZeroClaw.
 - **Broader app surface**: it does not currently match OpenClaw's device-node, Canvas, and voice ecosystem.
 
 ## Recommended Positioning for ok-gobot
@@ -117,7 +120,7 @@ Instead, lean into:
 - Pick **OpenFang** if you want the most ambitious all-in autonomous-agent product story.
 - Pick **ZeroClaw** if you want the leanest and most swappable Rust runtime substrate.
 - Pick **OpenClaw** if you want the richest assistant surface across channels, devices, and UX layers.
-- Pick **ok-gobot** if you want the most direct, small, Telegram-centric operator assistant with a clean path to external coding-agent backends.
+- Pick **ok-gobot** if you want a direct, small, Telegram-centric operator agent with scheduled roles, installable skills, self-evolution, and a clean path to external coding-agent backends.
 
 ## Sources
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -270,3 +270,135 @@ Vector embeddings stored in SQLite. Cosine similarity search in Go. OpenAI-compa
 Periodic background checks: context usage warnings, email monitoring (IMAP). Custom checker registration.
 
 **Files:** `internal/agent/heartbeat.go`
+
+---
+
+## Roles & Scheduled Autonomy
+
+### Markdown-First Role Manifests
+Roles are autonomous worker definitions stored as `.md` files with optional YAML frontmatter. Operators drop role files into the `roles_path` directory; the bot loads them on startup and registers cron schedules automatically.
+
+Frontmatter fields: `worker` (cost tier), `tools` (allowed tools), `schedule` (6-field cron), `approval` (auto/always/never), `report_template` (Go text/template).
+
+**Files:** `internal/role/manifest.go`, `internal/role/loader.go`
+
+### Prebuilt Roles
+Three prebuilt roles ship embedded in the binary as starting points:
+
+| Role | Schedule | Description |
+|------|----------|-------------|
+| `researcher` | 09:00 UTC daily | Web search and daily research digest |
+| `monitor` | Every 30 minutes | Service/URL health checking |
+| `release-watch` | 10:00 UTC Mondays | Software release tracking |
+
+No roles run by default. Operators must set `roles_path` and place or copy role files to enable them.
+
+**Files:** `internal/role/prebuilt/`
+
+### Safety caveat
+Scheduled roles execute tool calls autonomously. Budget and policy enforcement for autonomous runs is not yet shipped. Operators should review role manifests carefully and use capability policies to restrict tool access until budget controls land.
+
+---
+
+## Skills
+
+### Skill Installation & Audit
+Skills are installable markdown-first extensions. Each skill is a directory with a `SKILL.md` manifest. Install from a local path or git URL via the CLI.
+
+The audit system rejects unsafe packages: symlinks, executable scripts, pipe-to-shell patterns, and markdown links that escape the skill root.
+
+**Commands:** `ok-gobot skills list|install|remove|audit|history|rollback`
+
+**Files:** `internal/bootstrap/skills.go`
+
+### Utility Score Tracking
+The skill loader tracks usage metrics per skill (uses, successes, failures) in SQLite. Scores are displayed in `skills list` and available for routing decisions.
+
+**Files:** `internal/bootstrap/loader.go`
+
+---
+
+## Multi-Model Routing
+
+### Task-Type Router
+Routes requests to different models based on task type: vision, summarize, reasoning, coding, or default. Task types are detected from explicit `[task:TYPE]` tags in messages.
+
+**Config:**
+```yaml
+ai:
+  routing:
+    vision: "gpt-4-vision"
+    reasoning: "claude-opus"
+    coding: "claude-sonnet"
+    default: "gpt-4o"
+```
+
+**Files:** `internal/ai/router.go`
+
+---
+
+## Reflection Loop
+
+### Automatic Failure Analysis
+The reflector tracks tool failures asynchronously. When a tool fails repeatedly (default threshold: 3), it generates suggested fixes based on error patterns:
+
+- "not found" errors suggest checking registration and dependencies
+- "timeout" errors suggest increasing timeouts or reducing scope
+- "permission" errors suggest checking runtime permissions
+- "parse" errors suggest reviewing input schema
+- "network" errors suggest checking connectivity
+
+Failure records are optionally persisted to memory for cross-session learning.
+
+**Files:** `internal/agent/reflection.go`
+
+---
+
+## Self-Evolution
+
+### A-Evolve Loop
+The self-evolution engine runs a cyclic pipeline: observe task metrics, analyze failure patterns, propose prompt mutations, gate candidates via benchmarks, and promote or rollback.
+
+- Triggers after a configurable number of completed tasks (default 50).
+- Max 1 cycle per 24 hours.
+- Candidates are gated by benchmark evaluation before promotion.
+- Human approval required when prompt diff exceeds threshold (default 20%).
+- Automatic rollback after 3 production failures on a promoted version.
+- Version snapshots stored in `evolution_dir`.
+
+Disabled by default (`evolution.enabled: false`).
+
+**Files:** `internal/evolution/engine.go`
+
+---
+
+## Jobs Runtime
+
+### Durable Background Jobs
+The jobs runtime provides durable background execution with retry, cancellation, timeout, and artifact support.
+
+- **States:** pending, running, succeeded, failed, cancelled, timed_out
+- **Events:** full lifecycle tracking persisted to SQLite
+- **Artifacts:** structured outputs returned with metadata
+- **Retry:** configurable max attempts with automatic re-enqueue
+- **Timeout:** per-job wall-clock limits with context cancellation
+
+**Commands:** `ok-gobot jobs`
+
+**Files:** `internal/runtime/jobs.go`
+
+---
+
+## Mission Control
+
+### Mission Control API
+The control server exposes Mission Control endpoints for inspecting roles, schedules, run history, and aggregate stats:
+
+- `GET /api/mission/roles` -- list roles with metadata
+- `GET /api/mission/schedules` -- cron job schedules
+- `GET /api/mission/runs` -- execution history
+- `GET /api/mission/stats` -- aggregate metrics
+
+See [Mission Control](MISSION-CONTROL.md) for the full concept page.
+
+**Files:** `internal/control/mission.go`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -6,9 +6,11 @@
 - **Telegram bot token** from [@BotFather](https://t.me/BotFather)
 - **AI provider access** — one or more of:
   - **Anthropic** (OAuth via Claude MAX subscription, or API key)
-  - **ChatGPT** (OAuth via ChatGPT Pro/Plus — uses `chatgpt.com/backend-api` codex endpoint)
+  - **ChatGPT** (OAuth via ChatGPT Pro/Plus -- uses `chatgpt.com/backend-api` codex endpoint)
+  - **OpenRouter** (API key -- default provider)
   - **Google Gemini** (API key from Google AI Studio)
   - **OpenAI** (API key from platform.openai.com)
+  - **Droid** (CLI agent transport -- Claude Code, Codex, Gemini CLI, etc.)
   - Any **OpenAI-compatible** API with a custom base URL
 
 ### Platform-Specific Dependencies
@@ -441,7 +443,12 @@ export OKGOBOT_AUTH_MODE="pairing"
 
 ok-gobot ships three prebuilt role manifests that operators can use as starting
 points for scheduled autonomous workflows. They are embedded in the binary and
-serve as **examples** — no roles run by default.
+serve as **examples** -- no roles run by default.
+
+**Safety note:** Scheduled roles execute tool calls autonomously. Per-role budget
+and token caps are not yet enforced. Operators should review role manifests
+carefully and use capability policies to restrict tool access until budget
+controls land.
 
 ### Available prebuilt roles
 

--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -1,0 +1,90 @@
+# Mission Control v1
+
+## Concept
+
+Mission Control is ok-gobot's operator visibility layer for roles, jobs, and schedules. It exposes the autonomous runtime state through a set of REST API endpoints served by the control server.
+
+The goal is to give operators a single place to understand what ok-gobot is doing autonomously: which roles are loaded, what schedules are active, which jobs have run, and aggregate execution stats.
+
+## Current State
+
+Mission Control v1 ships as HTTP API endpoints on the control server (default port 8787, disabled by default). A web-based operator dashboard is planned but not yet built.
+
+### Prerequisites
+
+Enable the control server in config:
+
+```yaml
+control:
+  enabled: true
+  port: 8787
+```
+
+The control server binds to `127.0.0.1` only. External access requires a reverse proxy.
+
+## API Endpoints
+
+### GET /api/mission/roles
+
+Lists all loaded roles with metadata.
+
+Response:
+```json
+[
+  {
+    "name": "researcher",
+    "display_name": "Researcher",
+    "emoji": "",
+    "model": "",
+    "allowed_tools": ["web_fetch", "search"]
+  }
+]
+```
+
+### GET /api/mission/schedules
+
+Lists active cron schedules registered by roles.
+
+### GET /api/mission/runs
+
+Lists recent job execution history with status and timing.
+
+Query parameters:
+- `status` -- filter by job status (pending, running, succeeded, failed, cancelled, timed_out)
+- `limit` -- max results (default 50)
+
+### GET /api/mission/stats
+
+Returns aggregate execution metrics.
+
+## Architecture
+
+Mission Control is implemented in `internal/control/mission.go`. It bridges the agent registry, cron scheduler, and storage layer through a `MissionProvider` interface:
+
+```
+Telegram/TUI/API  -->  Control Server  -->  Mission Control endpoints
+                                              |
+                                              +-- AgentRegistry (roles)
+                                              +-- Scheduler (cron jobs)
+                                              +-- Store (job records, events)
+```
+
+Roles are loaded from `roles_path` by `internal/role/loader.go`. Each role with a `schedule` field registers a cron job on startup. Job execution records and events are persisted to SQLite.
+
+## Safety
+
+Mission Control exposes read-only data. It does not allow starting, stopping, or modifying roles or jobs through the API (those operations go through Telegram commands or direct config changes).
+
+Scheduled roles execute tool calls autonomously. Per-role budget caps (tool calls, duration, tokens) are not yet enforced. Until budget enforcement ships, operators should:
+
+- Review role manifests before enabling them.
+- Use capability policies to restrict tool access per agent.
+- Monitor execution via `/api/mission/runs` and `/api/mission/stats`.
+- Use `/estop on` to kill dangerous tools if needed.
+
+## Roadmap
+
+- Operator web dashboard for role/job/schedule visibility
+- Per-role and per-job cost caps (tool calls, duration, tokens)
+- Role enable/disable via API (currently config-only)
+- Alerting on job failures or budget threshold breaches

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,7 @@
 # ok-gobot Roadmap
 
-Snapshot date: March 12, 2026.
+Last updated: April 29, 2026.
+Previous snapshot: March 12, 2026.
 
 This roadmap turns the findings from [Competitive Landscape](./COMPETITORS.md) into an implementation backlog for `ok-gobot`.
 
@@ -10,261 +11,120 @@ Every backlog item is phrased as a user outcome per [PROCESS.md](./PROCESS.md). 
 
 ## Sequencing
 
-### Phase 1: Quick Wins
+### Phase 1: Quick Wins -- SHIPPED
 
-1. Operator can kill dangerous tools instantly without restarting the bot
-2. User can list available models and see which providers are healthy
-3. Operator gets a detailed report after migrating from OpenClaw
+1. ~~Operator can kill dangerous tools instantly without restarting the bot~~ (shipped: `/estop`)
+2. ~~User can list available models and see which providers are healthy~~ (shipped: `ok-gobot providers`, `ok-gobot models`)
+3. ~~Operator gets a detailed report after migrating from OpenClaw~~ (shipped: migration report)
 
-### Phase 2: Safety and Extensibility Foundation
+### Phase 2: Safety and Extensibility Foundation -- SHIPPED
 
-4. Operator can restrict an agent to read-only tools without editing Go code
-5. Denied tool calls show a clear reason in Telegram instead of silently failing
-6. Operator can install and audit third-party skills from the CLI
+4. ~~Operator can restrict an agent to read-only tools without editing Go code~~ (shipped: capability policy)
+5. ~~Denied tool calls show a clear reason in Telegram instead of silently failing~~ (shipped: tool denial messages)
+6. ~~Operator can install and audit third-party skills from the CLI~~ (shipped: `ok-gobot skills`)
 
-### Phase 3: Productized Autonomy
+### Phase 3: Productized Autonomy -- SHIPPED
 
-7. Operator can cap a background task's tool calls, duration, and model cost
-8. Operator can enable a prebuilt role that runs on schedule and posts a report
-9. Operator can define new roles declaratively without writing Go code
+7. ~~Operator can enable a prebuilt role that runs on schedule and posts a report~~ (shipped: prebuilt roles)
+8. ~~Operator can define new roles declaratively without writing Go code~~ (shipped: markdown role manifests)
 
-## Backlog
+### Phase 4: Intelligence & Observability -- SHIPPED
+
+9. ~~Multi-model routing by task type~~ (shipped: `ai.routing` config)
+10. ~~Automatic reflection loop after tool failures~~ (shipped: reflector)
+11. ~~Self-evolution loop~~ (shipped: A-Evolve-inspired engine)
+12. ~~Utility score tracking and skill router~~ (shipped: skill scores)
+
+### Phase 5: Mission Control v1 -- IN PROGRESS
+
+13. Budget and policy enforcement for autonomous runs
+14. Per-role and per-job cost caps (tool calls, duration, tokens)
+15. Operator dashboard for role/job/schedule visibility (Mission Control API shipped; UI pending)
+
+### Phase 6: Hardening
+
+16. SECURITY.md with formal vulnerability reporting process
+17. Reproducible local benchmarks for evolution gate
+18. Full live agent benchmarking (currently heuristic-based)
+
+## Shipped Backlog (Detail)
+
+The items below were the original Phase 1-3 backlog entries. They are retained for historical context. All are now implemented.
 
 ### 1. Operator can kill dangerous tools instantly without restarting the bot
 
-**User Story**
-As an operator, I want to disable dangerous tool families (shell, SSH, browser,
-cron, message, fetch) with a single command so that I can respond to incidents
-without restarting the process or losing in-flight sessions.
+**Status: SHIPPED**
 
-**Why:** Highest-ROI safety feature. Gives operators a fast kill switch.
-
-**Acceptance Criteria**
-- [ ] `/estop on` disables dangerous tool families; `/estop off` re-enables them.
-- [ ] Blocked tools return a user-visible reason in Telegram, TUI, and API.
-- [ ] `/status` and the TUI show current estop state.
-- [ ] CLI equivalent: `ok-gobot estop on|off|status`.
-
-**Default Behavior**
-Estop is off. All configured tools are available. This is correct because most
-operators run the bot in a trusted environment and should not pay an opt-in cost
-for normal operation.
-
-**Likely files**
-- `internal/cli/estop.go` (new)
-- `internal/control/server.go`
-- `internal/bot/approval.go`
-- `internal/tools/tools.go`
-- `internal/config/config.go`
+`/estop on` disables dangerous tool families (shell, SSH, browser, cron, message, fetch).
+`/estop off` re-enables them. Blocked tools return a user-visible reason. `/status` shows estop state.
+CLI: `ok-gobot estop on|off|status`.
 
 ### 2. User can list available models and see which providers are healthy
 
-**User Story**
-As a user, I want to see which models and providers are available so that I can
-pick the right model for my task and diagnose failures without reading config files.
+**Status: SHIPPED**
 
-**Why:** Multi-provider usability. Users currently have no way to discover models
-or understand why a request failed at the provider level.
-
-**Acceptance Criteria**
-- [ ] `ok-gobot providers` lists configured providers with health status.
-- [ ] `ok-gobot models refresh` fetches and caches remote model catalogs.
-- [ ] `ok-gobot doctor` distinguishes auth failure, endpoint failure, and model lookup failure.
-- [ ] Model picker flows use cached catalogs when available.
-
-**Default Behavior**
-Provider list shows whatever is configured in `config.yaml`. Model catalog is
-fetched on first `models refresh` and cached locally. No automatic background
-fetching.
-
-**Likely files**
-- `internal/cli/providers.go` (new)
-- `internal/cli/models.go` (new)
-- `internal/cli/doctor.go`
-- `internal/ai/client.go`
+`ok-gobot providers` lists configured providers with health status.
+`ok-gobot models` lists available models. `ok-gobot doctor` distinguishes auth, endpoint, and model lookup failures.
 
 ### 3. Operator gets a detailed report after migrating from OpenClaw
 
-**User Story**
-As an operator migrating from OpenClaw, I want a durable report of what was
-copied, skipped, and deduplicated so that I can trust the migration and debug
-problems without re-running it.
+**Status: SHIPPED**
 
-**Why:** Imports without an artifact are harder to trust and harder to debug.
-
-**Acceptance Criteria**
-- [ ] Every migration run emits a report (markdown or JSON) listing copied files, skipped sessions, duplicates, backup path, and key mapping.
-- [ ] `--dry-run` prints the same categories as the real report.
-- [ ] Failed migrations preserve enough detail for rollback and debugging.
-
-**Default Behavior**
-Report is written to `~/.ok-gobot/migration-report-<timestamp>.md` alongside
-the database. `--dry-run` prints to stdout only.
-
-**Likely files**
-- `internal/cli/migrate.go`
-- `internal/migrate/migrate.go`
+Migration runs emit a report listing copied files, skipped sessions, duplicates, backup path, and key mapping.
 
 ### 4. Operator can restrict an agent to read-only tools without editing Go code
 
-**User Story**
-As an operator, I want to give an agent narrower permissions (no shell, no
-network, read-only filesystem) through config so that I can run less-trusted
-models safely without changing source code.
+**Status: SHIPPED**
 
-**Why:** `AllowedTools` is too coarse once you add more autonomy. Operators need
-declarative, fine-grained capability control.
-
-**Acceptance Criteria**
-- [ ] Agent config accepts explicit permissions: shell, filesystem roots, network allowlists, cron, memory writes, sub-agent spawn.
-- [ ] Existing `allowed_tools` configs still load without breakage.
-- [ ] Runtime receives a structured policy object, not ad-hoc booleans.
-- [ ] A restricted agent cannot escalate to a tool outside its policy.
-
-**Default Behavior**
-If no policy block is set, all tools in the agent's `allowed_tools` list remain
-available (full backward compatibility). An empty `allowed_tools` still means
-"all tools."
-
-**Likely files**
-- `internal/config/config.go`
-- `internal/agent/registry.go`
-- `internal/agent/resolver.go`
-- `docs/ARCHITECTURE.md`
+Agent config accepts `capabilities` block: shell, filesystem_roots, network/network_allowlist, cron, memory_write, spawn, file_write_scope. Existing `allowed_tools` configs still load without breakage.
 
 ### 5. Denied tool calls show a clear reason in Telegram instead of silently failing
 
-**User Story**
-As a user, I want to see why a tool call was blocked so that I understand the
-bot's limitations and can ask an operator to adjust permissions if needed.
+**Status: SHIPPED**
 
-**Why:** Capability policy is useless if denied actions are silent. Users lose
-trust when the bot ignores requests without explanation.
-
-**Acceptance Criteria**
-- [ ] Every denied tool call returns a consistent, human-readable reason.
-- [ ] The denial message appears in Telegram, TUI, and API responses.
-- [ ] Tests cover both allowed and denied flows for `local`, `ssh`, `browser`, `web_fetch`, `search`, `cron`, and `message`.
-- [ ] Policy checks survive direct tool invocation, not only agent-mediated runs.
-
-**Default Behavior**
-No tools are denied unless the operator configures capability policy or activates
-estop. When a tool is denied, the user sees: "Tool [name] blocked: [reason]."
-
-**Likely files**
-- `internal/tools/tools.go`
-- `internal/tools/browser_tool.go`
-- `internal/tools/web_fetch.go`
-- `internal/tools/search.go`
-- `internal/tools/cron.go`
-- `internal/tools/message.go`
+Every denied tool call returns "Tool [name] blocked: [reason]" in Telegram, TUI, and API.
 
 ### 6. Operator can install and audit third-party skills from the CLI
 
-**User Story**
-As an operator, I want to install, list, and remove skills from the CLI so that
-I can extend the bot's capabilities without editing source code, and audit
-installed skills for safety.
+**Status: SHIPPED**
 
-**Why:** `ok-gobot` already has the workspace shape for skills. A safe
-install/audit path makes the extension model usable in practice.
-
-**Acceptance Criteria**
-- [ ] `ok-gobot skills list|install|remove|audit` works from the CLI.
-- [ ] Install accepts a local path or git URL.
-- [ ] Static safety audit rejects symlinks, scripts, pipe-to-shell patterns, and markdown links escaping the skill root.
-- [ ] Installed skills are markdown-first and compatible with the workspace model.
-
-**Default Behavior**
-No skills installed out of the box. `skills list` shows an empty list.
-`skills install` runs the safety audit before accepting; unsafe packages are
-rejected with actionable error messages.
-
-**Likely files**
-- `internal/cli/skills.go` (new)
-- `internal/tools/tools.go`
-- `docs/INSTALL.md`
+`ok-gobot skills list|install|remove|audit|history|rollback`. Install accepts local path or git URL. Security audit rejects symlinks, scripts, pipe-to-shell patterns, and path-escaping links.
 
 ### 7. Operator can cap a background task's tool calls, duration, and model cost
 
-**User Story**
-As an operator, I want to set limits on background tasks (max tool calls, max
-duration, model override) so that a runaway subagent cannot consume unbounded
-resources or time.
+**Status: PARTIALLY SHIPPED**
 
-**Why:** Subagents currently have no budget constraints. A stuck or recursive
-subagent can exhaust API quota silently.
-
-**Acceptance Criteria**
-- [ ] Operator can set max tool calls, max duration, and model override per task.
-- [ ] A task that hits its limit stops and returns a structured summary, not raw output.
-- [ ] Failed or timed-out tasks produce understandable feedback in Telegram and TUI.
-- [ ] Memory writes from subagents can be disabled by policy.
-
-**Default Behavior**
-Default budget: 50 tool calls, 5-minute wall-clock timeout. Model inherits from
-the parent agent. Memory writes allowed unless the agent's capability policy
-disables them.
-
-**Likely files**
-- `internal/agent/subagent.go`
-- `internal/bot/task_command.go`
-- `internal/control/server_tui.go`
-- `internal/bot/subagent_notifier.go`
+Jobs runtime supports timeout and cancellation. Full per-task budget caps (max tool calls, token limits) are not yet enforced. This is a Phase 5 priority.
 
 ### 8. Operator can enable a prebuilt role that runs on schedule and posts a report
 
-**User Story**
-As an operator, I want to enable a prebuilt role (researcher, monitor,
-release-watch) with minimal config so that useful autonomous workflows run on
-schedule and post bounded, readable reports to Telegram.
+**Status: SHIPPED**
 
-**Why:** The value of autonomy features is prebuilt, useful workflows — not
-platform infrastructure.
-
-**Acceptance Criteria**
-- [ ] At least 3 prebuilt roles ship: `researcher`, `monitor`, `release-watch`.
-- [ ] A role can be enabled by adding its name to config — no Go code needed.
-- [ ] Each role runs on schedule via existing cron infrastructure.
-- [ ] Reports are bounded in length and formatted for Telegram readability.
-- [ ] Roles respect capability policy and estop.
-
-**Default Behavior**
-No roles enabled out of the box. Enabling a role requires explicit config. Roles
-run through existing cron + runtime infrastructure, not a second orchestration
-system.
-
-**Likely files**
-- `internal/cron/scheduler.go`
-- `internal/agent/subagent.go`
-- `internal/bot/hub_handler.go`
-- `internal/bot/subagent_notifier.go`
+Three prebuilt roles: `researcher`, `monitor`, `release-watch`. Enabled by setting `roles_path` and placing role files. Reports delivered to `auth.admin_id`.
 
 ### 9. Operator can define new roles declaratively without writing Go code
 
-**User Story**
-As an operator, I want to define custom autonomous roles using a simple manifest
-format (prompt, tools, schedule, output template) so that I can create new
-workflows without modifying the bot's source.
+**Status: SHIPPED**
 
-**Why:** Hardcoded roles do not scale. Operators need a hackable, workspace-local
-format for role definitions.
+Markdown role manifests with YAML frontmatter. Fields: worker, tools, schedule, approval, report_template. Placed in `roles_path` directory.
 
-**Acceptance Criteria**
-- [ ] Role manifests are defined in a lightweight declarative format stored in the workspace.
-- [ ] A manifest specifies: prompt, tools, schedule, output template, and approval mode.
-- [ ] Role outputs have a stable, structured report format.
-- [ ] Memory writes from roles can be disabled by policy.
+## Future Work
 
-**Default Behavior**
-No custom roles defined. Prebuilt roles (item 8) use the same manifest format
-internally, serving as examples.
+### Budget and Policy Enforcement
 
-**Likely files**
-- `internal/agent/memory.go`
-- `internal/agent/registry.go`
-- `internal/bot/hub_handler.go`
-- `docs/FEATURES.md`
+Operators need per-role and per-job budget caps before autonomous scheduled runs can be considered safe for production use. Until this ships:
+
+- Operators should review role manifests carefully.
+- Use capability policies to restrict tool access.
+- Monitor job execution via Mission Control API.
+
+### Evolution Benchmarks
+
+The self-evolution gate currently uses heuristic scoring. Full live agent benchmarking with reproducible test suites is planned.
+
+### Mission Control UI
+
+The Mission Control API endpoints are shipped (`/api/mission/*`). A web-based operator dashboard for role/job/schedule visibility is planned but not yet built.
 
 ## Non-Goals for Now
 
@@ -276,12 +136,8 @@ internally, serving as examples.
 
 ## Short Version
 
-If only the first five things get done, the order should be:
+Phase 1-4 are shipped. The next priorities are:
 
-1. estop — operator can kill dangerous tools instantly
-2. provider/model catalog — user can see what's available and healthy
-3. migration report — operator gets a trustworthy import artifact
-4. capability policy — operator restricts agents through config
-5. tool denial messages — users see why something was blocked
-
-That sequence improves safety, operator UX, and extensibility without pushing `ok-gobot` into platform bloat.
+1. **Budget enforcement** -- per-role and per-job cost caps for safe autonomous operation
+2. **Mission Control UI** -- operator dashboard for roles, jobs, schedules
+3. **Evolution benchmarks** -- reproducible live agent testing for the evolution gate


### PR DESCRIPTION
Implements #290

## Changes

Refreshes all documentation to match the current codebase after the 2026-04-29 comparison found partially stale docs.

**README.md:**
- Updated positioning to reflect mission-control agent direction
- Fixed Go version requirement (1.24+, not 1.23+)
- Added roles, skills, evolution, jobs, multi-model routing to feature list
- Updated CLI commands section with new commands (skills, jobs, evolution, providers, models, sessions, export)
- Updated project structure with new packages (evolution, role, bootstrap)
- Updated config reference anchor to match renumbered architecture doc

**docs/ARCHITECTURE.md:**
- Fixed duplicate section 9 numbering (review feedback from previous PR)
- Added sections: Chat Routing (4), Roles (6), Skills (7), Evolution (9)
- Renumbered all sections correctly through 13
- Updated PRD extension and compatibility note section numbers to 12.1/12.2

**docs/FEATURES.md:**
- Added sections for: roles & scheduled autonomy, skills, multi-model routing, reflection loop, self-evolution, jobs runtime, Mission Control
- Added safety caveat about budget enforcement for scheduled roles

**docs/ROADMAP.md:**
- Marked Phase 1-4 items as shipped (estop, providers, migration, capability policy, tool denial, skills, roles, multi-model routing, reflection, evolution, utility scoring)
- Added Phase 5 (Mission Control v1 / budget enforcement) and Phase 6 (hardening) as future work
- Distinguished shipped detail from future work clearly

**docs/COMPETITORS.md:**
- Updated snapshot date to April 29, 2026
- Refreshed ok-gobot column in comparison matrix for shipped autonomy features
- Updated strengths/weaknesses to reflect roles, skills, self-evolution, capability policies

**docs/INSTALL.md:**
- Added OpenRouter and Droid to provider prerequisites
- Added safety note about budget enforcement for scheduled roles

**docs/MISSION-CONTROL.md (new):**
- Concept page for the roles/jobs/schedules runtime
- Documents API endpoints, architecture, safety caveats, and roadmap

**SECURITY.md (new):**
- Security policy with vulnerability reporting instructions
- Summary of implemented controls and known limitations
- Links to SECURITY-FIXES.md for detailed hardening history

## Review feedback addressed

- Fixed duplicate section 9 in ARCHITECTURE.md (renumbered Configuration Reference to section 12)
- Updated README anchor from `#8-configuration-reference-canonical` to `#12-configuration-reference-canonical`

## Testing

```
go fmt ./...   # pass
go vet ./...   # pass
go test ./...  # all pass
go build ./cmd/ok-gobot/  # pass
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documentation-only refresh syncing all docs to the current codebase state. New files (`SECURITY.md`, `docs/MISSION-CONTROL.md`) are added and existing docs are updated for roles, skills, multi-model routing, reflection, self-evolution, and the jobs runtime.

- `docs/ROADMAP.md` Phase 6 item 16 lists \"SECURITY.md with formal vulnerability reporting process\" as future work, but `SECURITY.md` is created in this same PR — item 16 should be marked shipped or removed from the future-work list.
- `docs/ROADMAP.md` Phase 3 is headed \"SHIPPED\" but the original item 7 (per-task budget caps) is only partially shipped; the heading should read \"MOSTLY SHIPPED\" or similar to avoid misleading readers.

<h3>Confidence Score: 4/5</h3>

Safe to merge after resolving the two roadmap status inconsistencies.

Two P1 logic issues exist in docs/ROADMAP.md: SECURITY.md is listed as future work while being added in this PR, and Phase 3 is marked fully shipped when one item is only partially complete. All other changed files are consistent and accurate.

docs/ROADMAP.md requires fixes to Phase 3 heading and Phase 6 item 16.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Positioning, feature list, CLI commands, and project structure updated to reflect current codebase; Go version bump to 1.24+ and anchor fix look correct. |
| SECURITY.md | New security policy document; content is accurate but its own roadmap entry (Phase 6 item 16) still marks it as future work. |
| docs/ARCHITECTURE.md | Added Chat Routing (4), Roles (6), Skills (7), Evolution (9) sections; renumbered all sections correctly through 13; Memory moved to end as section 13. |
| docs/COMPETITORS.md | ok-gobot column refreshed with shipped autonomy features; strengths/weaknesses updated; budget enforcement limitation consistently noted. |
| docs/FEATURES.md | Added Roles, Skills, Multi-Model Routing, Reflection, Self-Evolution, Jobs, and Mission Control sections; relative link to MISSION-CONTROL.md is correct. |
| docs/INSTALL.md | OpenRouter and Droid added to provider prerequisites; safety note added for scheduled roles; minor dash normalization. |
| docs/MISSION-CONTROL.md | New concept page for Mission Control; API endpoints, architecture diagram, safety caveats, and roadmap are all consistent with other docs. |
| docs/ROADMAP.md | Phase 3 heading says SHIPPED but original budget-caps item is only partially shipped; Phase 6 item 16 lists SECURITY.md as future work but it is added in this PR. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/ROADMAP.md
Line: 50-52

Comment:
**SECURITY.md listed as future work but added in this PR**

Phase 6, item 16 says "SECURITY.md with formal vulnerability reporting process" is planned future work, but `SECURITY.md` is actually being created by this very PR. This will immediately mislead readers into thinking security policy documentation is still outstanding when it has already shipped.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/ROADMAP.md
Line: 30-34

Comment:
**Phase 3 marked SHIPPED but original budget-caps item is only PARTIALLY SHIPPED**

The `### Phase 3: Productized Autonomy -- SHIPPED` heading implies the entire phase is done, but the original Phase 3 item 7 ("Operator can cap a background task's tool calls, duration, and model cost") is listed in the Shipped Backlog section as **PARTIALLY SHIPPED** — timeout/cancellation only, with full per-task budget caps deferred to Phase 5. A reader scanning the phase headers will get incorrect signal about Phase 3's completion status.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: refresh all docs after current-sta..."](https://github.com/befeast/ok-gobot/commit/e091cb3b38961f12c7a1e2f57fc57f70059c875e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30154466)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->