### PR TITLE
feat(tools): network allowlist enforcement for web/browser/search tools (#288)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -27,6 +27,11 @@
             "default": {},
             "description": "Optional fine-grained capability policy. Empty/absent = fully permissive.",
             "properties": {
+              "allow_internal_networks": {
+                "default": false,
+                "description": "Allow requests to loopback, private, and link-local addresses.",
+                "type": "boolean"
+              },
               "cron": {
                 "default": true,
                 "description": "Allow cron scheduling.",
@@ -63,7 +68,7 @@
               },
               "network_allowlist": {
                 "default": [],
-                "description": "Allowed hostnames when network is true. Empty = all allowed.",
+                "description": "Allowed hostnames when network is true. Empty = all allowed. Supports wildcards: *.example.com. Enforced per-request for web_fetch, browser navigate, and redirect targets. Search is denied when an allowlist is set.",
                 "items": {
                   "default": "",
                   "description": "Hostname.",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -386,12 +386,17 @@ single source of truth for configuration keys, types, defaults, and descriptions
               "network_allowlist": {
                 "type": "array",
                 "default": [],
-                "description": "Allowed hostnames when network is true. Empty = all allowed.",
+                "description": "Allowed hostnames when network is true. Empty = all allowed. Supports wildcards: *.example.com. Enforced per-request for web_fetch, browser navigate, and redirect targets. Search is denied when an allowlist is set.",
                 "items": {
                   "type": "string",
                   "default": "",
                   "description": "Hostname."
                 }
+              },
+              "allow_internal_networks": {
+                "type": "boolean",
+                "default": false,
+                "description": "Allow requests to loopback, private, and link-local addresses."
               },
               "cron": {
                 "type": "boolean",

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -147,14 +147,15 @@ func resolveCapabilityPolicy(cfg *config.CapabilityPolicyConfig) *tools.Capabili
 	}
 
 	p := &tools.CapabilityPolicy{
-		Shell:            boolDefault(cfg.Shell, true),
-		Network:          boolDefault(cfg.Network, true),
-		NetworkAllowlist: cfg.NetworkAllowlist,
-		Cron:             boolDefault(cfg.Cron, true),
-		MemoryWrite:      boolDefault(cfg.MemoryWrite, true),
-		Spawn:            boolDefault(cfg.Spawn, true),
-		FilesystemRoots:  cfg.FilesystemRoots,
-		FileReadOnly:     cfg.FileWriteScope == "read_only",
+		Shell:                 boolDefault(cfg.Shell, true),
+		Network:               boolDefault(cfg.Network, true),
+		NetworkAllowlist:      cfg.NetworkAllowlist,
+		AllowInternalNetworks: boolDefault(cfg.AllowInternalNetworks, false),
+		Cron:                  boolDefault(cfg.Cron, true),
+		MemoryWrite:           boolDefault(cfg.MemoryWrite, true),
+		Spawn:                 boolDefault(cfg.Spawn, true),
+		FilesystemRoots:       cfg.FilesystemRoots,
+		FileReadOnly:          cfg.FileWriteScope == "read_only",
 	}
 	return p
 }

--- a/internal/agent/resolver_policy_test.go
+++ b/internal/agent/resolver_policy_test.go
@@ -252,3 +252,83 @@ func TestBuildToolRegistry_FileReadOnlyViaBuildToolRegistry(t *testing.T) {
 		t.Fatalf("expected ToolDenial, got %v", err)
 	}
 }
+
+func TestBuildToolRegistry_NetworkAllowlistBlocksWebFetch(t *testing.T) {
+	t.Parallel()
+
+	base := tools.NewRegistry()
+	base.Register(&resolverDangerousTool{name: "web_fetch"})
+	base.Register(&resolverDangerousTool{name: "file"})
+
+	resolver := &RunResolver{ToolRegistry: base}
+	profile := &AgentProfile{
+		Policy: &tools.CapabilityPolicy{
+			Shell:            true,
+			Network:          true,
+			NetworkAllowlist: []string{"github.com"},
+			Cron:             true,
+			MemoryWrite:      true,
+			Spawn:            true,
+		},
+	}
+
+	reg := resolver.buildToolRegistry(0, profile, false, nil)
+
+	// web_fetch to non-allowlisted host should be denied.
+	_, err := reg.Execute(context.Background(), "web_fetch", "https://evil.com")
+	if err == nil {
+		t.Fatal("expected web_fetch denied for non-allowlisted host")
+	}
+	denial, isDenial := tools.IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.Family != "network_allowlist" {
+		t.Errorf("denial.Family = %q, want network_allowlist", denial.Family)
+	}
+
+	// web_fetch to allowlisted host should work.
+	_, err = reg.Execute(context.Background(), "web_fetch", "https://github.com/foo")
+	if err != nil {
+		t.Fatalf("expected github.com to be allowed: %v", err)
+	}
+
+	// file tool should not be affected.
+	_, err = reg.Execute(context.Background(), "file", "read")
+	if err != nil {
+		t.Fatalf("expected file to be allowed: %v", err)
+	}
+}
+
+func TestBuildToolRegistry_NetworkAllowlistDeniesSearch(t *testing.T) {
+	t.Parallel()
+
+	base := tools.NewRegistry()
+	base.Register(&resolverDangerousTool{name: "search"})
+
+	resolver := &RunResolver{ToolRegistry: base}
+	profile := &AgentProfile{
+		Policy: &tools.CapabilityPolicy{
+			Shell:            true,
+			Network:          true,
+			NetworkAllowlist: []string{"github.com"},
+			Cron:             true,
+			MemoryWrite:      true,
+			Spawn:            true,
+		},
+	}
+
+	reg := resolver.buildToolRegistry(0, profile, false, nil)
+
+	_, err := reg.Execute(context.Background(), "search", "golang testing")
+	if err == nil {
+		t.Fatal("expected search denied when allowlist is set")
+	}
+	denial, isDenial := tools.IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.Family != "network_allowlist" {
+		t.Errorf("denial.Family = %q, want network_allowlist", denial.Family)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -229,14 +229,15 @@ type MemoryMCPConfig struct {
 // All *bool fields default to true (permissive) when nil.
 // A nil *CapabilityPolicyConfig on an agent means no restrictions (backward compatible).
 type CapabilityPolicyConfig struct {
-	Shell            *bool    `mapstructure:"shell"`             // Allow shell execution (local, ssh). Default: true.
-	Network          *bool    `mapstructure:"network"`           // Allow network tools (web_fetch, search, browser). Default: true.
-	NetworkAllowlist []string `mapstructure:"network_allowlist"` // Allowed hostnames when network is true. Empty = all.
-	Cron             *bool    `mapstructure:"cron"`              // Allow cron scheduling. Default: true.
-	MemoryWrite      *bool    `mapstructure:"memory_write"`      // Allow memory write tools. Default: true.
-	Spawn            *bool    `mapstructure:"spawn"`             // Allow sub-agent/job spawning. Default: true.
-	FilesystemRoots  []string `mapstructure:"filesystem_roots"`  // Allowed absolute filesystem paths. Empty = no restriction.
-	FileWriteScope   string   `mapstructure:"file_write_scope"`  // "full" (default) or "read_only".
+	Shell                 *bool    `mapstructure:"shell"`                   // Allow shell execution (local, ssh). Default: true.
+	Network               *bool    `mapstructure:"network"`                 // Allow network tools (web_fetch, search, browser). Default: true.
+	NetworkAllowlist      []string `mapstructure:"network_allowlist"`       // Allowed hostnames when network is true. Empty = all.
+	Cron                  *bool    `mapstructure:"cron"`                    // Allow cron scheduling. Default: true.
+	MemoryWrite           *bool    `mapstructure:"memory_write"`            // Allow memory write tools. Default: true.
+	Spawn                 *bool    `mapstructure:"spawn"`                   // Allow sub-agent/job spawning. Default: true.
+	AllowInternalNetworks *bool    `mapstructure:"allow_internal_networks"` // Allow loopback/private/link-local access. Default: false.
+	FilesystemRoots       []string `mapstructure:"filesystem_roots"`        // Allowed absolute filesystem paths. Empty = no restriction.
+	FileWriteScope        string   `mapstructure:"file_write_scope"`        // "full" (default) or "read_only".
 }
 
 // AgentConfig holds configuration for a single agent

--- a/internal/tools/browser_tool.go
+++ b/internal/tools/browser_tool.go
@@ -75,14 +75,14 @@ func (b *BrowserTool) Execute(ctx context.Context, args ...string) (string, erro
 		if len(args) >= 2 {
 			url = args[1]
 		}
-		return b.open(url)
+		return b.open(ctx, url)
 	case "stop":
 		return b.stop()
 	case "navigate":
 		if len(args) < 2 {
 			return "", fmt.Errorf("URL required")
 		}
-		return b.navigate(args[1])
+		return b.navigate(ctx, args[1])
 	case "snapshot":
 		return b.snapshot()
 	case "click":
@@ -128,7 +128,7 @@ func (b *BrowserTool) ExecuteJSON(ctx context.Context, params map[string]string)
 
 	switch command {
 	case "open", "start":
-		return b.open(params["url"])
+		return b.open(ctx, params["url"])
 	case "stop":
 		return b.stop()
 	case "navigate":
@@ -136,7 +136,7 @@ func (b *BrowserTool) ExecuteJSON(ctx context.Context, params map[string]string)
 		if url == "" {
 			return "", fmt.Errorf("url is required for navigate")
 		}
-		return b.navigate(url)
+		return b.navigate(ctx, url)
 	case "snapshot":
 		return b.snapshot()
 	case "click":
@@ -267,7 +267,7 @@ func (b *BrowserTool) ensureRunning() (context.Context, error) {
 	return ctx, nil
 }
 
-func (b *BrowserTool) open(url string) (string, error) {
+func (b *BrowserTool) open(ctx context.Context, url string) (string, error) {
 	if !b.manager.IsChromeInstalled() {
 		return "", fmt.Errorf("Chrome not found. Please install Google Chrome.")
 	}
@@ -282,7 +282,7 @@ func (b *BrowserTool) open(url string) (string, error) {
 	b.mu.Unlock()
 
 	if url != "" {
-		return b.navigate(url)
+		return b.navigate(ctx, url)
 	}
 	return "Browser opened", nil
 }
@@ -311,6 +311,11 @@ func browserOpCtx(tabCtx context.Context) (context.Context, context.CancelFunc) 
 
 // validateBrowserURL blocks dangerous URL schemes and private/loopback destinations.
 func validateBrowserURL(rawURL string) error {
+	return validateBrowserURLWithOpts(rawURL, false)
+}
+
+// validateBrowserURLWithOpts validates a browser URL, optionally allowing internal access.
+func validateBrowserURLWithOpts(rawURL string, allowInternal bool) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
@@ -322,18 +327,22 @@ func validateBrowserURL(rawURL string) error {
 	if scheme != "http" && scheme != "https" && scheme != "" {
 		return fmt.Errorf("unsupported URL scheme: %s", scheme)
 	}
-	hostname := strings.ToLower(parsed.Hostname())
-	if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "0.0.0.0" || hostname == "::1" || hostname == "[::1]" {
-		return fmt.Errorf("navigation to localhost/loopback is not allowed")
-	}
-	if strings.HasSuffix(hostname, ".internal") || strings.HasSuffix(hostname, ".local") {
-		return fmt.Errorf("navigation to internal/local hostnames is not allowed")
+	if !allowInternal {
+		hostname := strings.ToLower(parsed.Hostname())
+		if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "0.0.0.0" || hostname == "::1" || hostname == "[::1]" {
+			return fmt.Errorf("navigation to localhost/loopback is not allowed")
+		}
+		if strings.HasSuffix(hostname, ".internal") || strings.HasSuffix(hostname, ".local") {
+			return fmt.Errorf("navigation to internal/local hostnames is not allowed")
+		}
 	}
 	return nil
 }
 
-func (b *BrowserTool) navigate(navURL string) (string, error) {
-	if err := validateBrowserURL(navURL); err != nil {
+func (b *BrowserTool) navigate(parentCtx context.Context, navURL string) (string, error) {
+	policy := NetworkPolicyFromContext(parentCtx)
+	allowInternal := policy != nil && policy.AllowInternalNetworks
+	if err := validateBrowserURLWithOpts(navURL, allowInternal); err != nil {
 		return "", err
 	}
 

--- a/internal/tools/network_policy_test.go
+++ b/internal/tools/network_policy_test.go
@@ -1,0 +1,210 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func TestValidateURLWithOpts_BlocksPrivateIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		url           string
+		allowInternal bool
+		wantErr       bool
+	}{
+		{"localhost blocked", "http://localhost/test", false, true},
+		{"0.0.0.0 blocked", "http://0.0.0.0/test", false, true},
+		{"localhost allowed when internal", "http://localhost/test", true, false},
+		{"0.0.0.0 allowed when internal", "http://0.0.0.0/test", true, false},
+		{"file scheme blocked", "file:///etc/passwd", false, true},
+		{"ftp scheme blocked", "ftp://example.com", false, true},
+		{"https allowed", "https://example.com", false, false},
+		{"http allowed", "http://example.com", false, false},
+		{"missing hostname blocked", "https://", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateURLWithOpts(tt.url, tt.allowInternal)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %q", tt.url)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tt.url, err)
+			}
+		})
+	}
+}
+
+func TestValidateURLForContext_AllowlistEnforcement(t *testing.T) {
+	t.Parallel()
+
+	// Use real resolvable hostnames to avoid DNS failures.
+	policy := &CapabilityPolicy{
+		Network:          true,
+		NetworkAllowlist: []string{"github.com", "*.google.com"},
+	}
+	ctx := ContextWithNetworkPolicy(context.Background(), policy)
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"allowed exact host", "https://github.com/foo", false},
+		{"allowed wildcard", "https://www.google.com/search", false},
+		{"blocked host", "https://example.com/nope", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateURLForContext(ctx, tt.url)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %q", tt.url)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tt.url, err)
+			}
+		})
+	}
+}
+
+func TestValidateURLForContext_NoPolicy(t *testing.T) {
+	t.Parallel()
+
+	// Without policy in context, validateURLForContext should behave like validateURL.
+	err := validateURLForContext(context.Background(), "https://anything.com")
+	if err != nil {
+		t.Fatalf("no policy should allow any valid URL: %v", err)
+	}
+}
+
+func TestValidateURLForContext_AllowInternalWithAllowlist(t *testing.T) {
+	t.Parallel()
+
+	policy := &CapabilityPolicy{
+		Network:               true,
+		NetworkAllowlist:      []string{"localhost"},
+		AllowInternalNetworks: true,
+	}
+	ctx := ContextWithNetworkPolicy(context.Background(), policy)
+
+	// localhost is in the allowlist and AllowInternalNetworks=true, so this should pass.
+	err := validateURLForContext(ctx, "http://localhost:8080/api")
+	if err != nil {
+		t.Fatalf("expected localhost to be allowed with AllowInternalNetworks: %v", err)
+	}
+
+	// Evil host is not in the allowlist.
+	err = validateURLForContext(ctx, "https://evil.com")
+	if err == nil {
+		t.Fatal("expected non-allowlisted host to be blocked")
+	}
+}
+
+func TestValidateBrowserURLWithOpts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		url           string
+		allowInternal bool
+		wantErr       bool
+	}{
+		{"file scheme always blocked", "file:///etc/passwd", false, true},
+		{"file scheme blocked even when internal", "file:///etc/passwd", true, true},
+		{"localhost blocked", "http://localhost:3000", false, true},
+		{"localhost allowed when internal", "http://localhost:3000", true, false},
+		{"loopback blocked", "http://127.0.0.1:8080", false, true},
+		{"loopback allowed when internal", "http://127.0.0.1:8080", true, false},
+		{"ipv6 loopback blocked", "http://[::1]:8080", false, true},
+		{"ipv6 loopback allowed when internal", "http://[::1]:8080", true, false},
+		{".internal blocked", "http://app.internal", false, true},
+		{".internal allowed when internal", "http://app.internal", true, false},
+		{".local blocked", "http://printer.local", false, true},
+		{".local allowed when internal", "http://printer.local", true, false},
+		{"https allowed", "https://example.com", false, false},
+		{"ftp blocked", "ftp://example.com", false, true},
+		{"javascript blocked", "javascript:alert(1)", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateBrowserURLWithOpts(tt.url, tt.allowInternal)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %q (allowInternal=%v)", tt.url, tt.allowInternal)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for %q (allowInternal=%v): %v", tt.url, tt.allowInternal, err)
+			}
+		})
+	}
+}
+
+func TestNetworkPolicyGuard_FileSchemeBlocked(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "web_fetch"})
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		NetworkAllowlist: []string{"example.com"},
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	_, err := result.Execute(context.Background(), "web_fetch", "file:///etc/passwd")
+	if err == nil {
+		t.Fatal("expected file:// URL to be blocked")
+	}
+	denial, isDenial := IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.Family != "network_allowlist" {
+		t.Errorf("denial.Family = %q, want network_allowlist", denial.Family)
+	}
+}
+
+func TestNetworkPolicyGuard_BrowserOpenBlocked(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "browser"})
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		NetworkAllowlist: []string{"github.com"},
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// open with blocked URL.
+	_, err := result.Execute(context.Background(), "browser", "open", "https://evil.com")
+	if err == nil {
+		t.Fatal("expected browser open to be denied for non-allowlisted host")
+	}
+	if _, ok := IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+
+	// open with allowed URL.
+	_, err = result.Execute(context.Background(), "browser", "open", "https://github.com")
+	if err != nil {
+		t.Fatalf("expected github.com open to be allowed: %v", err)
+	}
+}

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,14 +12,15 @@ import (
 // CapabilityPolicy controls which capabilities an agent is allowed to exercise.
 // A nil *CapabilityPolicy is fully permissive (backward compatible with no config).
 type CapabilityPolicy struct {
-	Shell            bool     // Allow shell execution tools (local, ssh). Default: true.
-	Network          bool     // Allow network tools (web_fetch, search, browser). Default: true.
-	NetworkAllowlist []string // Allowed hostnames when Network is true. Empty = all. Future per-request enforcement.
-	Cron             bool     // Allow cron scheduling. Default: true.
-	MemoryWrite      bool     // Allow memory write tools. Default: true. Ready for future memory_capture tools.
-	Spawn            bool     // Allow sub-agent/job spawning (browser_task). Default: true.
-	FilesystemRoots  []string // Allowed absolute filesystem paths. Empty = no restriction.
-	FileReadOnly     bool     // Deny file/patch write operations.
+	Shell                 bool     // Allow shell execution tools (local, ssh). Default: true.
+	Network               bool     // Allow network tools (web_fetch, search, browser). Default: true.
+	NetworkAllowlist      []string // Allowed hostnames when Network is true. Empty = all. Supports wildcards: "*.example.com".
+	AllowInternalNetworks bool     // Allow loopback/private/link-local network access. Default: false.
+	Cron                  bool     // Allow cron scheduling. Default: true.
+	MemoryWrite           bool     // Allow memory write tools. Default: true. Ready for future memory_capture tools.
+	Spawn                 bool     // Allow sub-agent/job spawning (browser_task). Default: true.
+	FilesystemRoots       []string // Allowed absolute filesystem paths. Empty = no restriction.
+	FileReadOnly          bool     // Deny file/patch write operations.
 }
 
 // capabilitiesForTool maps tool names to the capabilities that govern them.
@@ -102,6 +104,24 @@ func wrapForPolicy(tool Tool, policy *CapabilityPolicy) Tool {
 		return wrapToolWithPolicyDenial(tool, denied)
 	}
 
+	// Network policy enforcement (allowlist and/or AllowInternalNetworks).
+	hasNetworkPolicy := len(policy.NetworkAllowlist) > 0 || policy.AllowInternalNetworks
+	if hasNetworkPolicy {
+		switch name {
+		case "web_fetch", "browser":
+			return wrapToolWithNetworkPolicy(tool, policy)
+		case "search":
+			if len(policy.NetworkAllowlist) > 0 {
+				return wrapToolWithCustomDenial(tool, &ToolDenial{
+					ToolName:    tool.Name(),
+					Family:      "network_allowlist",
+					Reason:      "search cannot guarantee results are limited to the network allowlist",
+					Remediation: "Remove network_allowlist to use search, or use web_fetch to access specific allowed URLs.",
+				})
+			}
+		}
+	}
+
 	// File-specific restrictions.
 	needsWriteGuard := (name == "file" || name == "patch") && policy.FileReadOnly
 	needsRootsGuard := (name == "file" || name == "patch" || name == "grep") && len(policy.FilesystemRoots) > 0
@@ -119,6 +139,7 @@ func wrapForPolicy(tool Tool, policy *CapabilityPolicy) Tool {
 type policyDenialGuard struct {
 	tool       Tool
 	capability string
+	customDeny *ToolDenial // optional: returned instead of default denial
 }
 
 func (g *policyDenialGuard) Name() string        { return g.tool.Name() }
@@ -130,6 +151,9 @@ func (g *policyDenialGuard) Execute(_ context.Context, _ ...string) (string, err
 }
 
 func (g *policyDenialGuard) denial() *ToolDenial {
+	if g.customDeny != nil {
+		return g.customDeny
+	}
 	return &ToolDenial{
 		ToolName:    g.tool.Name(),
 		Family:      g.capability,
@@ -174,6 +198,15 @@ func (g *policyDenialGuardWithSchemaAndJSON) ExecuteJSON(_ context.Context, _ ma
 
 func wrapToolWithPolicyDenial(tool Tool, capability string) Tool {
 	base := &policyDenialGuard{tool: tool, capability: capability}
+	return finishPolicyDenialGuard(base, tool)
+}
+
+func wrapToolWithCustomDenial(tool Tool, deny *ToolDenial) Tool {
+	base := &policyDenialGuard{tool: tool, capability: deny.Family, customDeny: deny}
+	return finishPolicyDenialGuard(base, tool)
+}
+
+func finishPolicyDenialGuard(base *policyDenialGuard, tool Tool) Tool {
 	schema, hasSchema := tool.(ToolSchema)
 	jsonExec, hasJSON := tool.(jsonExecutor)
 
@@ -314,4 +347,218 @@ func wrapToolWithFilePolicy(tool Tool, policy *CapabilityPolicy) Tool {
 		}
 	}
 	return base
+}
+
+// ---------------------------------------------------------------------------
+// Network allowlist enforcement
+// ---------------------------------------------------------------------------
+
+// HostMatchesAllowlist reports whether host matches any entry in the allowlist.
+// Supports exact matching (e.g. "github.com") and wildcard prefix matching
+// (e.g. "*.github.com" matches "api.github.com" but not "github.com" itself).
+func HostMatchesAllowlist(host string, allowlist []string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	for _, entry := range allowlist {
+		entry = strings.ToLower(strings.TrimSuffix(entry, "."))
+		if entry == host {
+			return true
+		}
+		if strings.HasPrefix(entry, "*.") {
+			suffix := entry[1:] // e.g. ".github.com"
+			if strings.HasSuffix(host, suffix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// CheckNetworkTarget validates a URL against the network allowlist.
+// Returns nil if allowed, *ToolDenial if blocked.
+// A nil policy or empty allowlist always allows.
+func (p *CapabilityPolicy) CheckNetworkTarget(toolName, rawURL string) *ToolDenial {
+	if p == nil || len(p.NetworkAllowlist) == 0 {
+		return nil
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return &ToolDenial{
+			ToolName:    toolName,
+			Family:      "network_allowlist",
+			Reason:      fmt.Sprintf("invalid URL: %v", err),
+			Remediation: "Provide a valid http:// or https:// URL.",
+		}
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme == "file" {
+		return &ToolDenial{
+			ToolName:    toolName,
+			Family:      "network_allowlist",
+			Reason:      "file:// URLs are not allowed",
+			Remediation: "Use http:// or https:// URLs only.",
+		}
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return &ToolDenial{
+			ToolName:    toolName,
+			Family:      "network_allowlist",
+			Reason:      "URL has no hostname",
+			Remediation: "Provide a URL with a valid hostname.",
+		}
+	}
+
+	if !HostMatchesAllowlist(host, p.NetworkAllowlist) {
+		return &ToolDenial{
+			ToolName:    toolName,
+			Family:      "network_allowlist",
+			Reason:      fmt.Sprintf("host %q is not in the network allowlist", host),
+			Remediation: fmt.Sprintf("Ask the operator to add %q to network_allowlist.", host),
+		}
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Context-based network policy propagation
+// ---------------------------------------------------------------------------
+
+type networkPolicyContextKey struct{}
+
+// ContextWithNetworkPolicy returns a context carrying the given network policy.
+func ContextWithNetworkPolicy(ctx context.Context, p *CapabilityPolicy) context.Context {
+	return context.WithValue(ctx, networkPolicyContextKey{}, p)
+}
+
+// NetworkPolicyFromContext returns the network policy from the context, or nil.
+func NetworkPolicyFromContext(ctx context.Context) *CapabilityPolicy {
+	p, _ := ctx.Value(networkPolicyContextKey{}).(*CapabilityPolicy)
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// Network policy guard — per-request URL validation for network tools.
+// ---------------------------------------------------------------------------
+
+type networkPolicyGuard struct {
+	tool   Tool
+	policy *CapabilityPolicy
+}
+
+func (g *networkPolicyGuard) Name() string        { return g.tool.Name() }
+func (g *networkPolicyGuard) Description() string { return g.tool.Description() }
+func (g *networkPolicyGuard) Unwrap() Tool        { return g.tool }
+
+func (g *networkPolicyGuard) Execute(ctx context.Context, args ...string) (string, error) {
+	if denial := g.checkExecArgs(args); denial != nil {
+		return "", denial
+	}
+	ctx = ContextWithNetworkPolicy(ctx, g.policy)
+	return g.tool.Execute(ctx, args...)
+}
+
+func (g *networkPolicyGuard) checkExecArgs(args []string) *ToolDenial {
+	name := g.tool.Name()
+	switch name {
+	case "web_fetch":
+		if len(args) > 0 {
+			return g.policy.CheckNetworkTarget(name, args[0])
+		}
+	case "browser":
+		if len(args) >= 2 {
+			switch args[0] {
+			case "navigate":
+				return g.policy.CheckNetworkTarget(name, args[1])
+			case "open", "start":
+				return g.policy.CheckNetworkTarget(name, args[1])
+			}
+		}
+	}
+	return nil
+}
+
+func (g *networkPolicyGuard) checkJSONParams(params map[string]string) *ToolDenial {
+	name := g.tool.Name()
+	switch name {
+	case "browser":
+		cmd := params["command"]
+		u := params["url"]
+		if (cmd == "navigate" || cmd == "open" || cmd == "start") && u != "" {
+			return g.policy.CheckNetworkTarget(name, u)
+		}
+	}
+	return nil
+}
+
+// Variants that preserve ToolSchema and/or jsonExecutor interfaces.
+
+type networkPolicyGuardWithSchema struct {
+	*networkPolicyGuard
+	schema ToolSchema
+}
+
+func (g *networkPolicyGuardWithSchema) GetSchema() map[string]interface{} {
+	return g.schema.GetSchema()
+}
+
+type networkPolicyGuardWithJSON struct {
+	*networkPolicyGuard
+	json jsonExecutor
+}
+
+func (g *networkPolicyGuardWithJSON) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
+	if denial := g.checkJSONParams(params); denial != nil {
+		return "", denial
+	}
+	ctx = ContextWithNetworkPolicy(ctx, g.policy)
+	return g.json.ExecuteJSON(ctx, params)
+}
+
+type networkPolicyGuardWithSchemaAndJSON struct {
+	*networkPolicyGuard
+	schema ToolSchema
+	json   jsonExecutor
+}
+
+func (g *networkPolicyGuardWithSchemaAndJSON) GetSchema() map[string]interface{} {
+	return g.schema.GetSchema()
+}
+
+func (g *networkPolicyGuardWithSchemaAndJSON) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
+	if denial := g.checkJSONParams(params); denial != nil {
+		return "", denial
+	}
+	ctx = ContextWithNetworkPolicy(ctx, g.policy)
+	return g.json.ExecuteJSON(ctx, params)
+}
+
+func wrapToolWithNetworkPolicy(tool Tool, policy *CapabilityPolicy) Tool {
+	base := &networkPolicyGuard{tool: tool, policy: policy}
+	schema, hasSchema := tool.(ToolSchema)
+	jsonExec, hasJSON := tool.(jsonExecutor)
+
+	switch {
+	case hasSchema && hasJSON:
+		return &networkPolicyGuardWithSchemaAndJSON{
+			networkPolicyGuard: base,
+			schema:             schema,
+			json:               jsonExec,
+		}
+	case hasSchema:
+		return &networkPolicyGuardWithSchema{
+			networkPolicyGuard: base,
+			schema:             schema,
+		}
+	case hasJSON:
+		return &networkPolicyGuardWithJSON{
+			networkPolicyGuard: base,
+			json:               jsonExec,
+		}
+	default:
+		return base
+	}
 }

--- a/internal/tools/policy_test.go
+++ b/internal/tools/policy_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"testing"
 )
 
@@ -329,6 +330,400 @@ func TestIsPathInRoots(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Network allowlist tests
+// ---------------------------------------------------------------------------
+
+func TestHostMatchesAllowlist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		host      string
+		allowlist []string
+		want      bool
+	}{
+		// Exact match.
+		{"github.com", []string{"github.com"}, true},
+		{"GITHUB.COM", []string{"github.com"}, true},
+		{"github.com.", []string{"github.com"}, true},
+		// Non-match.
+		{"evil.com", []string{"github.com"}, false},
+		{"notgithub.com", []string{"github.com"}, false},
+		// Wildcard match.
+		{"api.github.com", []string{"*.github.com"}, true},
+		{"deep.api.github.com", []string{"*.github.com"}, true},
+		// Wildcard does NOT match the base domain itself.
+		{"github.com", []string{"*.github.com"}, false},
+		// Multiple entries.
+		{"api.github.com", []string{"example.com", "*.github.com"}, true},
+		{"example.com", []string{"example.com", "*.github.com"}, true},
+		{"evil.com", []string{"example.com", "*.github.com"}, false},
+		// Empty allowlist.
+		{"anything.com", nil, false},
+		{"anything.com", []string{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host+"_"+fmt.Sprint(tt.allowlist), func(t *testing.T) {
+			t.Parallel()
+			got := HostMatchesAllowlist(tt.host, tt.allowlist)
+			if got != tt.want {
+				t.Errorf("HostMatchesAllowlist(%q, %v) = %v, want %v", tt.host, tt.allowlist, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckNetworkTarget(t *testing.T) {
+	t.Parallel()
+
+	policy := &CapabilityPolicy{
+		Network:          true,
+		NetworkAllowlist: []string{"github.com", "*.example.com"},
+	}
+
+	tests := []struct {
+		name       string
+		url        string
+		wantDenied bool
+		wantFamily string
+	}{
+		{"allowed exact host", "https://github.com/foo", false, ""},
+		{"allowed wildcard host", "https://api.example.com/bar", false, ""},
+		{"blocked host", "https://evil.com/hack", true, "network_allowlist"},
+		{"blocked file scheme", "file:///etc/passwd", true, "network_allowlist"},
+		{"blocked no hostname", "https://", true, "network_allowlist"},
+		{"allowed subdomain", "https://sub.deep.example.com", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			denial := policy.CheckNetworkTarget("web_fetch", tt.url)
+			if tt.wantDenied {
+				if denial == nil {
+					t.Fatal("expected denial, got nil")
+				}
+				if denial.Family != tt.wantFamily {
+					t.Errorf("denial.Family = %q, want %q", denial.Family, tt.wantFamily)
+				}
+			} else {
+				if denial != nil {
+					t.Fatalf("expected no denial, got %v", denial)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckNetworkTarget_NilPolicy(t *testing.T) {
+	t.Parallel()
+	var p *CapabilityPolicy
+	if denial := p.CheckNetworkTarget("web_fetch", "https://evil.com"); denial != nil {
+		t.Fatalf("nil policy should allow everything, got %v", denial)
+	}
+}
+
+func TestCheckNetworkTarget_EmptyAllowlist(t *testing.T) {
+	t.Parallel()
+	p := &CapabilityPolicy{Network: true}
+	if denial := p.CheckNetworkTarget("web_fetch", "https://anything.com"); denial != nil {
+		t.Fatalf("empty allowlist should allow everything, got %v", denial)
+	}
+}
+
+func TestApplyPolicy_NetworkAllowlistBlocksWebFetch(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "web_fetch"})
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		NetworkAllowlist: []string{"github.com"},
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// Blocked host.
+	_, err := result.Execute(context.Background(), "web_fetch", "https://evil.com")
+	if err == nil {
+		t.Fatal("expected web_fetch to be denied for non-allowlisted host")
+	}
+	denial, isDenial := IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.Family != "network_allowlist" {
+		t.Errorf("denial.Family = %q, want network_allowlist", denial.Family)
+	}
+
+	// Allowed host — passes through to underlying stub.
+	got, err := result.Execute(context.Background(), "web_fetch", "https://github.com/foo")
+	if err != nil {
+		t.Fatalf("expected github.com to be allowed: %v", err)
+	}
+	if got != "ok" {
+		t.Errorf("got %q, want ok", got)
+	}
+}
+
+func TestApplyPolicy_NetworkAllowlistDeniesSearch(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "search"})
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		NetworkAllowlist: []string{"github.com"},
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	_, err := result.Execute(context.Background(), "search", "golang")
+	if err == nil {
+		t.Fatal("expected search to be denied when allowlist is set")
+	}
+	denial, isDenial := IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.Family != "network_allowlist" {
+		t.Errorf("denial.Family = %q, want network_allowlist", denial.Family)
+	}
+}
+
+func TestApplyPolicy_NetworkAllowlistBlocksBrowserNavigate(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	schemaTool := &stubSchemaAndJSONTool{
+		stubTool: &stubTool{name: "browser"},
+		schema:   map[string]interface{}{"type": "object"},
+	}
+	reg.Register(schemaTool)
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		NetworkAllowlist: []string{"github.com"},
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// Navigate to blocked host.
+	_, err := result.Execute(context.Background(), "browser", "navigate", "https://evil.com")
+	if err == nil {
+		t.Fatal("expected browser navigate to be denied for non-allowlisted host")
+	}
+	denial, isDenial := IsToolDenial(err)
+	if !isDenial {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.Family != "network_allowlist" {
+		t.Errorf("denial.Family = %q, want network_allowlist", denial.Family)
+	}
+
+	// Navigate to allowed host.
+	got, err := result.Execute(context.Background(), "browser", "navigate", "https://github.com/foo")
+	if err != nil {
+		t.Fatalf("expected github.com to be allowed: %v", err)
+	}
+	if got != "ok" {
+		t.Errorf("got %q, want ok", got)
+	}
+
+	// Non-navigate commands (snapshot, tabs) should pass through.
+	got, err = result.Execute(context.Background(), "browser", "snapshot")
+	if err != nil {
+		t.Fatalf("expected snapshot to be allowed: %v", err)
+	}
+	if got != "ok" {
+		t.Errorf("got %q, want ok", got)
+	}
+}
+
+func TestApplyPolicy_NetworkAllowlistBrowserJSON(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	schemaTool := &stubSchemaAndJSONTool{
+		stubTool: &stubTool{name: "browser"},
+		schema:   map[string]interface{}{"type": "object"},
+	}
+	reg.Register(schemaTool)
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		NetworkAllowlist: []string{"github.com"},
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+	tool, _ := result.Get("browser")
+	je, ok := tool.(interface {
+		ExecuteJSON(context.Context, map[string]string) (string, error)
+	})
+	if !ok {
+		t.Fatal("expected wrapped browser to preserve ExecuteJSON")
+	}
+
+	// Blocked via JSON.
+	_, err := je.ExecuteJSON(context.Background(), map[string]string{
+		"command": "navigate",
+		"url":     "https://evil.com",
+	})
+	if err == nil {
+		t.Fatal("expected browser JSON navigate to be denied for non-allowlisted host")
+	}
+	if _, ok := IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+
+	// Allowed via JSON.
+	_, err = je.ExecuteJSON(context.Background(), map[string]string{
+		"command": "navigate",
+		"url":     "https://github.com",
+	})
+	if err != nil {
+		t.Fatalf("expected github.com JSON navigate to be allowed: %v", err)
+	}
+}
+
+func TestApplyPolicy_NetworkAllowlistPreservesSchema(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	schemaTool := &stubSchemaAndJSONTool{
+		stubTool: &stubTool{name: "browser"},
+		schema:   map[string]interface{}{"type": "object"},
+	}
+	reg.Register(schemaTool)
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		NetworkAllowlist: []string{"github.com"},
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+	tool, ok := result.Get("browser")
+	if !ok {
+		t.Fatal("expected browser to be in registry")
+	}
+	ts, ok := tool.(ToolSchema)
+	if !ok {
+		t.Fatal("expected wrapped tool to preserve ToolSchema")
+	}
+	schema := ts.GetSchema()
+	if schema["type"] != "object" {
+		t.Errorf("schema type = %v, want object", schema["type"])
+	}
+}
+
+func TestApplyPolicy_AllowInternalNetworksPropagatesContext(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	// Use a tool that captures the context to verify policy propagation.
+	captureTool := &contextCaptureTool{stubTool: &stubTool{name: "web_fetch"}}
+	reg.Register(captureTool)
+
+	policy := &CapabilityPolicy{
+		Shell:                 true,
+		Network:               true,
+		AllowInternalNetworks: true,
+		Cron:                  true,
+		MemoryWrite:           true,
+		Spawn:                 true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	_, err := result.Execute(context.Background(), "web_fetch", "https://example.com")
+	if err != nil {
+		t.Fatalf("expected tool to be allowed: %v", err)
+	}
+
+	// Verify the context carried the policy.
+	if captureTool.lastCtx == nil {
+		t.Fatal("expected context to be captured")
+	}
+	ctxPolicy := NetworkPolicyFromContext(captureTool.lastCtx)
+	if ctxPolicy == nil {
+		t.Fatal("expected network policy in context")
+	}
+	if !ctxPolicy.AllowInternalNetworks {
+		t.Error("expected AllowInternalNetworks=true in context policy")
+	}
+}
+
+func TestContextWithNetworkPolicy_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	policy := &CapabilityPolicy{
+		Network:          true,
+		NetworkAllowlist: []string{"example.com"},
+	}
+
+	ctx := ContextWithNetworkPolicy(context.Background(), policy)
+	got := NetworkPolicyFromContext(ctx)
+	if got != policy {
+		t.Errorf("round-trip failed: got %v, want %v", got, policy)
+	}
+
+	// No policy in plain context.
+	got = NetworkPolicyFromContext(context.Background())
+	if got != nil {
+		t.Errorf("expected nil policy from plain context, got %v", got)
+	}
+}
+
+func TestApplyPolicy_BrowserTaskNotBlockedByAllowlist(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "browser_task"})
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		NetworkAllowlist: []string{"github.com"},
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// browser_task should pass through — URL enforcement is in the subagent's browser.
+	got, err := result.Execute(context.Background(), "browser_task", "visit github.com")
+	if err != nil {
+		t.Fatalf("expected browser_task to be allowed: %v", err)
+	}
+	if got != "ok" {
+		t.Errorf("got %q, want ok", got)
+	}
+}
+
 // Test helpers.
 
 type stubSchemaAndJSONTool struct {
@@ -343,5 +738,15 @@ func (s *stubSchemaAndJSONTool) GetSchema() map[string]interface{} {
 
 func (s *stubSchemaAndJSONTool) ExecuteJSON(_ context.Context, _ map[string]string) (string, error) {
 	s.jsonCalled++
+	return "ok", nil
+}
+
+type contextCaptureTool struct {
+	*stubTool
+	lastCtx context.Context
+}
+
+func (c *contextCaptureTool) Execute(ctx context.Context, args ...string) (string, error) {
+	c.lastCtx = ctx
 	return "ok", nil
 }

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -29,9 +29,10 @@ func NewWebFetchTool() *WebFetchTool {
 				if len(via) >= 5 {
 					return fmt.Errorf("too many redirects")
 				}
-				// Revalidate each redirect target to prevent SSRF bypass via redirect.
-				if err := validateURL(req.URL.String()); err != nil {
-					return fmt.Errorf("redirect blocked (SSRF): %w", err)
+				// Revalidate each redirect target using context-aware validation.
+				// This enforces SSRF checks and network allowlist for redirects.
+				if err := validateURLForContext(req.Context(), req.URL.String()); err != nil {
+					return fmt.Errorf("redirect blocked: %w", err)
 				}
 				return nil
 			},
@@ -55,8 +56,8 @@ func (w *WebFetchTool) Execute(ctx context.Context, args ...string) (string, err
 
 	urlStr := args[0]
 
-	// Validate URL and check for SSRF
-	if err := validateURL(urlStr); err != nil {
+	// Validate URL with context-aware checks (SSRF + network allowlist).
+	if err := validateURLForContext(ctx, urlStr); err != nil {
 		return "", err
 	}
 
@@ -175,40 +176,65 @@ func isPrivateIP(ip net.IP) bool {
 	return false
 }
 
-// validateURL validates a URL and checks for SSRF vulnerabilities
+// validateURL validates a URL and checks for SSRF vulnerabilities.
 func validateURL(rawURL string) error {
-	// Parse URL
+	return validateURLWithOpts(rawURL, false)
+}
+
+// validateURLWithOpts validates a URL with optional internal-access override.
+func validateURLWithOpts(rawURL string, allowInternal bool) error {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
 	}
 
-	// Only allow http/https
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
 		return fmt.Errorf("only http/https URLs are supported")
 	}
 
-	// Extract hostname
 	hostname := parsedURL.Hostname()
 	if hostname == "" {
 		return fmt.Errorf("invalid URL: missing hostname")
 	}
 
-	// Block localhost variations
-	if hostname == "localhost" || hostname == "0.0.0.0" {
-		return fmt.Errorf("requests to localhost are not allowed")
+	if !allowInternal {
+		if hostname == "localhost" || hostname == "0.0.0.0" {
+			return fmt.Errorf("requests to localhost are not allowed")
+		}
+
+		ips, err := net.LookupIP(hostname)
+		if err != nil {
+			return fmt.Errorf("failed to resolve hostname: %w", err)
+		}
+
+		for _, ip := range ips {
+			if isPrivateIP(ip) {
+				return fmt.Errorf("requests to private IP addresses are not allowed: %s", ip.String())
+			}
+		}
 	}
 
-	// Resolve hostname to IP addresses
-	ips, err := net.LookupIP(hostname)
-	if err != nil {
-		return fmt.Errorf("failed to resolve hostname: %w", err)
+	return nil
+}
+
+// validateURLForContext validates a URL using the network policy from context.
+// Enforces SSRF checks (with AllowInternalNetworks support) and network allowlist.
+func validateURLForContext(ctx context.Context, rawURL string) error {
+	policy := NetworkPolicyFromContext(ctx)
+	allowInternal := policy != nil && policy.AllowInternalNetworks
+
+	if err := validateURLWithOpts(rawURL, allowInternal); err != nil {
+		return err
 	}
 
-	// Check each resolved IP
-	for _, ip := range ips {
-		if isPrivateIP(ip) {
-			return fmt.Errorf("requests to private IP addresses are not allowed: %s", ip.String())
+	if policy != nil && len(policy.NetworkAllowlist) > 0 {
+		parsedURL, err := url.Parse(rawURL)
+		if err != nil {
+			return fmt.Errorf("invalid URL: %w", err)
+		}
+		host := parsedURL.Hostname()
+		if !HostMatchesAllowlist(host, policy.NetworkAllowlist) {
+			return fmt.Errorf("host %q is not in the network allowlist", host)
 		}
 	}
 


### PR DESCRIPTION
Implements #288

## Changes

Enforces `network_allowlist` at the tool execution layer for all network-capable tools. Previously the allowlist was declarative only; now every network request is validated against it.

### Network policy enforcement (`internal/tools/policy.go`)
- `HostMatchesAllowlist` — exact host and wildcard suffix matching (e.g. `github.com`, `*.github.com`)
- `CheckNetworkTarget` — validates URL scheme, hostname, and allowlist membership; returns structured `ToolDenial`
- `networkPolicyGuard` wrapper — intercepts `Execute`/`ExecuteJSON` to validate URLs before delegation
- Context-based policy propagation (`ContextWithNetworkPolicy` / `NetworkPolicyFromContext`) for redirect revalidation

### Per-tool enforcement
- **web_fetch**: initial URL validated by guard; redirect targets revalidated via context-aware `validateURLForContext`
- **browser**: `navigate`/`open` commands validated by guard (both positional args and JSON params)
- **search**: denied entirely when allowlist is set (search providers can't guarantee result restriction)
- **browser_task**: inherits policy through resolver — subagent's browser tool gets the same guard

### SSRF hardening
- `validateURLWithOpts` / `validateBrowserURLWithOpts` — refactored to support `AllowInternalNetworks`
- `file://` and unsafe schemes rejected at both guard and tool level
- Private/loopback/link-local IPs blocked unless `allow_internal_networks: true`

### Config
- Added `allow_internal_networks` (`*bool`, default `false`) to `CapabilityPolicyConfig`
- Updated `config.schema.json` and `docs/ARCHITECTURE.md` canonical config block
- Updated `network_allowlist` description to document wildcard support and enforcement scope

## Testing

```
go fmt ./...    # clean
go vet ./...    # clean
go test ./...   # all pass
go build ./cmd/ok-gobot/  # clean
```

### New tests (44 cases)
- `TestHostMatchesAllowlist` — exact, wildcard, subdomain, case-insensitive, trailing dot, empty
- `TestCheckNetworkTarget` — allowed/blocked hosts, file scheme, empty hostname
- `TestApplyPolicy_NetworkAllowlist*` — web_fetch blocked/allowed, search denied, browser navigate/open/JSON, schema preservation, browser_task pass-through
- `TestAllowInternalNetworksPropagatesContext` — verifies policy reaches tools via context
- `TestValidateURLWithOpts_BlocksPrivateIP` — localhost, 0.0.0.0, scheme validation
- `TestValidateURLForContext_AllowlistEnforcement` — end-to-end context-based validation
- `TestValidateBrowserURLWithOpts` — file://, loopback, .internal, .local, AllowInternalNetworks
- `TestBuildToolRegistry_NetworkAllowlist*` — resolver integration tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes `network_allowlist` from a declarative config field to an actively enforced per-request policy, adds a new `allow_internal_networks` flag to relax SSRF blocks, and wires both through a `networkPolicyGuard` wrapper and context propagation so redirect targets are also validated.

- **P1 — redirect allowlist violations don't produce `*ToolDenial`**: when an initial URL passes the guard but a server redirect lands on a blocked host, `CheckRedirect` → `validateURLForContext` returns a plain `fmt.Errorf`; callers using `IsToolDenial` will misclassify this as a transient network error rather than a policy denial.
- `browser`'s `navigate` function has no internal allowlist fallback; allowlist enforcement there relies entirely on the guard with no defence-in-depth.

<h3>Confidence Score: 3/5</h3>

Enforcement is functionally correct (requests are blocked), but the P1 error-type inconsistency for redirects should be addressed before merge.

One P1 finding: redirect-time allowlist violations surface as plain errors rather than ToolDenial, causing incorrect error classification by callers. Enforcement itself is not bypassed, but the semantic inconsistency is a real defect in the changed path. Two P2 findings are quality concerns that don't affect security correctness.

internal/tools/web_fetch.go (redirect check error type) and internal/tools/browser_tool.go (no internal allowlist fallback in navigate).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tools/policy.go | Core of the PR: adds HostMatchesAllowlist, CheckNetworkTarget, networkPolicyGuard, and context helpers. Logic is sound; minor clarity concern around the hasNetworkPolicy trigger for AllowInternalNetworks-only case. |
| internal/tools/web_fetch.go | Redirect enforcement upgraded to context-aware validation, but redirect-time allowlist violations return plain error rather than *ToolDenial, and the initial-URL allowlist check is redundantly duplicated with a different error type from the guard. |
| internal/tools/browser_tool.go | open/navigate now propagate context; validateBrowserURLWithOpts correctly gates on AllowInternalNetworks. Allowlist enforcement is entirely delegated to the guard with no internal fallback. |
| internal/agent/registry.go | Simple field addition mapping AllowInternalNetworks from config to policy struct; no issues. |
| internal/config/config.go | Adds AllowInternalNetworks *bool field with correct mapstructure tag and comment; no issues. |
| internal/tools/policy_test.go | Comprehensive tests for allowlist matching, CheckNetworkTarget, ApplyPolicy variants, browser JSON, schema preservation, and context round-trip. Missing a test for redirect-to-blocked-host scenario. |
| internal/tools/network_policy_test.go | Good coverage of validateURLWithOpts, validateBrowserURLWithOpts, and validateURLForContext; file-scheme and browser-open blocked cases verified. |
| internal/agent/resolver_policy_test.go | Integration tests confirming buildToolRegistry applies allowlist guard to web_fetch and search denial at the resolver level; no issues. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/tools/browser_tool.go`, line 288-292 ([link](https://github.com/befeast/ok-gobot/blob/171118253ad0cd21d83ea2ff6f62424fdcdfcae9/internal/tools/browser_tool.go#L288-L292)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`navigate` has no allowlist check — browser is entirely dependent on the guard**

   `validateBrowserURLWithOpts` only checks scheme and SSRF-class addresses (loopback, `.internal`, `.local`). It does NOT check the network allowlist. Allowlist enforcement for the browser is 100% delegated to `networkPolicyGuard.checkExecArgs`. For `web_fetch`, `validateURLForContext` inside `Execute` provides a second allowlist check as defence-in-depth; `navigate` has no equivalent fallback. If the guard is ever bypassed (e.g. through a future code path that calls `navigate` directly, or a test that reaches the tool without wrapping), allowlisted hosts would still be blocked by SSRF checks, but non-SSRF blocked hosts on the allowlist would be unchecked.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tools/browser_tool.go
   Line: 288-292

   Comment:
   **`navigate` has no allowlist check — browser is entirely dependent on the guard**

   `validateBrowserURLWithOpts` only checks scheme and SSRF-class addresses (loopback, `.internal`, `.local`). It does NOT check the network allowlist. Allowlist enforcement for the browser is 100% delegated to `networkPolicyGuard.checkExecArgs`. For `web_fetch`, `validateURLForContext` inside `Execute` provides a second allowlist check as defence-in-depth; `navigate` has no equivalent fallback. If the guard is ever bypassed (e.g. through a future code path that calls `navigate` directly, or a test that reaches the tool without wrapping), allowlisted hosts would still be blocked by SSRF checks, but non-SSRF blocked hosts on the allowlist would be unchecked.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tools/web_fetch.go
Line: 33-36

Comment:
**Redirect-time allowlist violations don't surface as `ToolDenial`**

When the initial URL passes the guard (e.g. `https://github.com` is allowlisted), but a server-side redirect leads to `https://evil.com`, `CheckRedirect` calls `validateURLForContext` which returns a plain `fmt.Errorf("host %q is not in the network allowlist", host)`. This gets wrapped as `"redirect blocked: ..."` and then `"failed to fetch URL: ..."` — none of which is a `*ToolDenial`. Any caller using `IsToolDenial(err)` to distinguish a policy denial from a transient network error will silently mis-classify this as a network failure rather than an allowlist violation, potentially triggering retry logic or showing a less precise error to the user.

The guard's `checkExecArgs` path (initial URL) returns `*ToolDenial`; the redirect path does not — so enforcement is correct, but error semantics are inconsistent.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tools/browser_tool.go
Line: 288-292

Comment:
**`navigate` has no allowlist check — browser is entirely dependent on the guard**

`validateBrowserURLWithOpts` only checks scheme and SSRF-class addresses (loopback, `.internal`, `.local`). It does NOT check the network allowlist. Allowlist enforcement for the browser is 100% delegated to `networkPolicyGuard.checkExecArgs`. For `web_fetch`, `validateURLForContext` inside `Execute` provides a second allowlist check as defence-in-depth; `navigate` has no equivalent fallback. If the guard is ever bypassed (e.g. through a future code path that calls `navigate` directly, or a test that reaches the tool without wrapping), allowlisted hosts would still be blocked by SSRF checks, but non-SSRF blocked hosts on the allowlist would be unchecked.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tools/policy.go
Line: 108-123

Comment:
**`hasNetworkPolicy` triggers guard wrapping when only `AllowInternalNetworks` is set**

When `AllowInternalNetworks=true` and `NetworkAllowlist` is empty, `hasNetworkPolicy` is `true`, so `web_fetch` and `browser` are wrapped by `networkPolicyGuard`. Inside `checkExecArgs`, `CheckNetworkTarget` is called but immediately returns `nil` (empty allowlist ⇒ all hosts allowed). The guard's only effect in this case is to inject the policy into the context so that `validateURLForContext` later skips the private-IP check. This is correct, but the condition name (`hasNetworkPolicy`) and comment don't make it obvious that `AllowInternalNetworks=true` alone is purely a context-propagation concern, not a restriction. A brief comment clarifying this intent would help future maintainers.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tools/web_fetch.go
Line: 59-62

Comment:
**Redundant allowlist check with inconsistent error type**

When the `networkPolicyGuard` is active (allowlist is non-empty), the guard's `checkExecArgs` already validates the initial URL against the allowlist (returning `*ToolDenial` on failure). Then `web_fetch.Execute` re-validates the same URL through `validateURLForContext`, which checks the allowlist again but returns a plain `fmt.Errorf` for violations — a different error type than the guard. In practice this double-check is harmless (the guard always runs first), but any future code path that calls `Execute` after bypassing the guard would produce a plain error instead of `*ToolDenial`, silently breaking callers that rely on `IsToolDenial` for policy-violation detection.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tools): enforce network allowlist f..."](https://github.com/befeast/ok-gobot/commit/171118253ad0cd21d83ea2ff6f62424fdcdfcae9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30154674)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->