### PR TITLE
docs: refresh all docs to match current codebase (#290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 | `ssh` | Remote command execution |
 | `file` | Read/write files in allowed directory |
 | `patch` | Apply unified diffs |
-| `search_file` | Recursive regex file search |
+| `grep` | Recursive regex file search |
 | `obsidian` | Obsidian vault notes |
 | `search` | Web search (Brave, Exa) |
 | `web_fetch` | Fetch URLs with readability extraction |

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ All commands are auto-registered with BotFather for slash autocomplete.
 ## Configuration
 
 Config file: `~/.ok-gobot/config.yaml` (see [config.example.yaml](config.example.yaml))
-Canonical key reference: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#10-configuration-reference-canonical)
+Canonical key reference: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#11-configuration-reference-canonical)
 
 ```yaml
 telegram:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ok-gobot
 
-A fast, single-binary Telegram bot with AI agent capabilities. Ground-up Go rewrite of [OpenClaw](https://github.com/openclaw/openclaw) with opinionated defaults for personal use.
+A fast, single-binary Telegram bot and mission-control tool with AI agent capabilities. Ground-up Go rewrite of [OpenClaw](https://github.com/openclaw/openclaw) with opinionated defaults for personal use.
 
 Competitive landscape: [docs/COMPETITORS.md](docs/COMPETITORS.md).
 
@@ -41,7 +41,7 @@ ok-gobot doctor
 ok-gobot start
 ```
 
-**Requirements:** Go 1.23+, C compiler (for SQLite CGO).
+**Requirements:** Go 1.24+, C compiler (for SQLite CGO).
 
 ## AI Providers
 
@@ -50,22 +50,42 @@ ok-gobot start
 | Anthropic | OAuth (Claude MAX) | `ok-gobot auth anthropic login` |
 | ChatGPT | OAuth (Plus/Team) | `ok-gobot auth chatgpt login` |
 | OpenAI | API key | `ai.provider: openai` |
+| Hermes | Ollama / OpenAI-compatible | `ai.provider: custom` + hermes model |
 | Gemini | API key via custom | `ai.provider: custom` + `ai.base_url` |
 | Droid | CLI agent transport | `ai.provider: droid` |
+
+Multi-model routing: tag messages with `[task:vision]`, `[task:coding]`, `[task:summarize]`, or `[task:reasoning]` to route to different models.
 
 See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 
 ## Features
 
 ### AI & LLM
-- **Multi-provider** -- Anthropic, ChatGPT, OpenAI, Gemini, Droid, any OpenAI-compatible endpoint
+- **Multi-provider** -- Anthropic, ChatGPT, OpenAI, Hermes, Gemini, Droid, any OpenAI-compatible endpoint
 - **Native tool calling** -- structured `tools` API, not text parsing
 - **Model failover** -- automatic fallback chain with cooldown (`ai.fallback_models`)
+- **Multi-model routing** -- task-type tags route to different models (`internal/ai/router.go`)
 - **Per-session model override** -- `/model claude-sonnet-4-5` per chat
 - **Multi-agent system** -- multiple personalities, models, tool sets per agent (`/agent`)
 - **Context compaction** -- AI-powered summarization when approaching token limits
 - **Streaming responses** -- live message editing with rate limiting
 - **CLI agent transport** -- use Factory Droid, Claude Code, Codex, Gemini CLI, or OpenCode as backends
+
+### Roles & Jobs
+- **Prebuilt roles** -- `researcher`, `monitor`, `release-watch` ship as embedded markdown manifests
+- **Custom roles** -- define new roles declaratively (markdown + YAML frontmatter, no Go code)
+- **Scheduled execution** -- roles run via cron and deliver bounded reports to admin chat
+- **Durable jobs** -- job history tracked in SQLite with standardized reports
+- **Rules-first chat routing** -- incoming turns classified as reply, clarify, or background job
+
+> **Note:** Scheduled autonomy is experimental. Full per-task budget caps are not yet implemented. Set conservative tool allowlists for scheduled roles.
+
+### Skills & Evolution
+- **Markdown-first skills** -- installable knowledge bases with safety audit (`ok-gobot skills install`)
+- **Skill versioning** -- version history with rollback
+- **Utility scoring** -- skills tracked by usefulness; skill router selects relevant skills per query
+- **Self-evolution** -- A-Evolve inspired prompt improvement (observe/analyze/evolve/gate/promote)
+- **Automatic reflection** -- tool failure analysis and fix suggestions after repeated errors
 
 ### Tools
 | Tool | Description |
@@ -74,11 +94,13 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 | `ssh` | Remote command execution |
 | `file` | Read/write files in allowed directory |
 | `patch` | Apply unified diffs |
-| `grep` | Recursive regex file search |
+| `search_file` | Recursive regex file search |
 | `obsidian` | Obsidian vault notes |
 | `search` | Web search (Brave, Exa) |
 | `web_fetch` | Fetch URLs with readability extraction |
 | `browser` | Chrome automation (ChromeDP) |
+| `browser_task` | Composite browser tasks as sub-agent runs |
+| `frontend_verify` | CDP screenshot + LLM visual comparison |
 | `image_gen` | DALL-E 3 image generation |
 | `tts` | Text-to-speech (OpenAI + Edge TTS) |
 | `memory_search` | Semantic search over indexed markdown memory |
@@ -87,6 +109,8 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 | `cron` | Scheduled tasks |
 
 ### Security & Control
+- **Per-agent capability policy** -- declarative restrictions (shell, network, filesystem, cron, spawn) without source changes
+- **Emergency stop** -- `/estop on` instantly disables dangerous tool families
 - **Exec approval** -- dangerous commands require inline keyboard confirmation
 - **DM authorization** -- open, allowlist, or pairing code modes (`/auth`, `/pair`)
 - **Group activation** -- active or standby with mention detection (`/activate`, `/standby`)
@@ -101,16 +125,20 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 - **Token tracking** -- per-chat prompt/completion token accumulation with optional usage footer
 - **Fragment buffering** -- reassembles Telegram-split long messages (>4000 chars)
 - **Queue modes** -- interrupt (default), plus collect or steer for concurrent messages during active AI runs
+- **Voice/STT** -- Whisper API transcription for Telegram voice messages
 - **Media handling** -- photos, voice, stickers, documents with media group batching
 - **Group migration** -- automatic session migration on group->supergroup conversion
+- **Session fork** -- fork sessions to explore alternatives without losing the original
 - **Debug logging** -- level-aware logging (`debug`/`info`/`warn`/`error`) with hot-reload
 
 ### Infrastructure
+- **Mission Control API** -- roles, schedules, runs, stats endpoints for dashboards
 - **HTTP REST API** -- health, status, send, webhook endpoints (port 8080)
 - **WebSocket control protocol** -- real-time session control, streaming, approvals (port 8787)
 - **Config hot-reload** -- fsnotify watcher + `/reload` command
 - **Daemon management** -- launchd (macOS) / systemd (Linux) via `ok-gobot daemon`
 - **Doctor diagnostics** -- `ok-gobot doctor` validates config and dependencies
+- **Auto-worktree management** -- isolated git worktrees per background task
 
 ## Telegram Commands
 
@@ -127,21 +155,22 @@ All commands are auto-registered with BotFather for slash autocomplete.
 | `/stop` | Cancel active AI request |
 | `/memory` | Show today's memory |
 | `/tools` | List available tools |
-| `/model [name\|list\|clear]` | View/change AI model |
-| `/agent [name\|list]` | View/switch agent |
+| `/model [name|list|clear]` | View/change AI model |
+| `/agent [name|list]` | View/switch agent |
 | `/whoami` | Show user ID, username, chat ID |
 | `/commands` | List all registered commands |
-| `/usage [off\|tokens\|full]` | Token usage footer mode |
+| `/usage [off|tokens|full]` | Token usage footer mode |
 | `/context` | Show context window usage % |
 | `/compact` | Force context compaction |
-| `/think [off\|low\|medium\|high]` | Set thinking level |
+| `/think [off|low|medium|high]` | Set thinking level |
 | `/verbose` | Toggle verbose mode |
-| `/queue [collect\|steer\|interrupt]` | Queue mode for concurrent messages |
+| `/queue [collect|steer|interrupt]` | Queue mode for concurrent messages |
 | `/tts [voice]` | Set TTS voice |
-| `/estop [on\|off\|status]` | Emergency-stop dangerous tool families (admin) |
+| `/btw` | Side query during active task |
+| `/estop [on|off|status]` | Emergency-stop dangerous tool families (admin) |
 | `/activate` | Group: respond to all messages |
 | `/standby` | Group: respond only to mentions |
-| `/auth [add\|remove\|list\|pair]` | Manage authorization (admin) |
+| `/auth [add|remove|list|pair]` | Manage authorization (admin) |
 | `/pair <code>` | Pair with bot using code |
 | `/reload` | Hot-reload config (admin) |
 | `/restart` | Restart bot process (admin) |
@@ -149,7 +178,7 @@ All commands are auto-registered with BotFather for slash autocomplete.
 ## Configuration
 
 Config file: `~/.ok-gobot/config.yaml` (see [config.example.yaml](config.example.yaml))
-Canonical key reference: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#8-configuration-reference-canonical)
+Canonical key reference: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#10-configuration-reference-canonical)
 
 ```yaml
 telegram:
@@ -205,6 +234,17 @@ ok-gobot status                   # Show status
 ok-gobot estop on|off|status      # Toggle emergency stop for dangerous tools
 ok-gobot doctor                   # Check config and dependencies
 ok-gobot daemon install|start|stop|status|logs|uninstall
+ok-gobot providers                # List configured AI providers
+ok-gobot models                   # List available models per provider
+ok-gobot skills list|install|remove|audit  # Manage skills
+ok-gobot jobs                     # View job history
+ok-gobot sessions                 # Manage sessions
+ok-gobot batch                    # Parallel task fan-out
+ok-gobot babysit                  # PR auto-maintenance
+ok-gobot evolution                # Evolution engine status/history
+ok-gobot export                   # Export training data
+ok-gobot voice                    # Voice command processing
+ok-gobot tui                      # Terminal UI
 ok-gobot version
 ```
 
@@ -228,25 +268,27 @@ ok-gobot loads personality files from a configurable directory (default `~/ok-go
 ok-gobot/
 ├── cmd/ok-gobot/         # Entry point
 ├── internal/
-│   ├── agent/            # Personality, memory, safety, compactor, registry
-│   ├── ai/               # AI client, failover, types
+│   ├── agent/            # Personality, memory, safety, compactor, registry, reflection, hooks
+│   ├── ai/               # AI clients, failover, router, catalog, types
 │   ├── api/              # HTTP API server
 │   ├── app/              # Application orchestrator
-│   ├── bootstrap/        # First-run onboarding
-│   ├── bot/              # Telegram bot, commands, media, queue, status, usage
+│   ├── bootstrap/        # Skills install, audit, versioning
+│   ├── bot/              # Telegram bot, commands, media, queue, status, usage, routing
 │   ├── browser/          # Chrome automation
-│   ├── cli/              # Cobra CLI (start, config, doctor, daemon, auth)
+│   ├── cli/              # Cobra CLI (start, config, doctor, daemon, auth, skills, jobs, etc.)
 │   ├── config/           # YAML config, watcher
 │   ├── configschema/     # Schema generation
-│   ├── control/          # WebSocket control server, hub, TUI protocol
-│   ├── cron/             # Job scheduler
+│   ├── control/          # WebSocket control server, hub, TUI protocol, mission API
+│   ├── cron/             # Job scheduler, role execution, report delivery
 │   ├── errorx/           # Error handling
+│   ├── evolution/        # Self-evolution engine (A-Evolve)
 │   ├── logger/           # Level-aware debug logging
 │   ├── memory/           # Markdown-backed memory index (embeddings, store)
 │   ├── memorymcp/        # Memory MCP server
 │   ├── migrate/          # Database migrations
 │   ├── redact/           # Log redaction
-│   ├── runtime/          # Chat/jobs mailbox runtime, session scheduling
+│   ├── role/             # Role manifest parser, bundled roles, loader
+│   ├── runtime/          # Chat/jobs mailbox runtime, session scheduling, chat router
 │   ├── sanitize/         # Input sanitization
 │   ├── session/          # Context monitoring
 │   ├── storage/          # SQLite persistence
@@ -264,13 +306,15 @@ See [SECURITY.md](SECURITY.md) for the security policy, threat model, and harden
 ## Documentation
 
 - [Competitive Landscape](docs/COMPETITORS.md) -- OpenFang, ZeroClaw, OpenClaw, and ok-gobot comparison
-- [Roadmap](docs/ROADMAP.md) -- Implementation backlog derived from the competitor analysis
+- [Roadmap](docs/ROADMAP.md) -- Shipped features and future implementation backlog
 - [Installation Guide](docs/INSTALL.md) -- Setup, configuration, providers, deployment
 - [API Reference](docs/API.md) -- HTTP REST API and WebSocket control protocol
 - [Architecture](docs/ARCHITECTURE.md) -- Chat/jobs architecture contract, legacy-runtime freeze, and canonical config reference
-- [Features](docs/FEATURES.md) -- Detailed feature descriptions
+- [Features](docs/FEATURES.md) -- Detailed feature descriptions (roles, skills, evolution, tools, security)
+- [Mission Control](docs/MISSION-CONTROL.md) -- Mission Control v1 concept overview
 - [Tools Reference](docs/TOOLS.md) -- All tools with usage examples
 - [Memory](docs/MEMORY.md) -- Semantic memory system
+- [Security Policy](SECURITY.md) -- Vulnerability reporting
 - [Security Fixes](docs/SECURITY-FIXES.md) -- Security hardening changelog
 - [TTS](docs/TTS_USAGE.md) / [TTS (RU)](docs/TTS_USAGE_RU.md) -- Text-to-speech setup
 - [Changelog](docs/CHANGELOG.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,17 @@ ok-gobot is a Telegram-first AI agent that runs tools on the operator's machine.
 - Auth check is fail-closed: unknown modes deny access.
 - Pairing codes have brute-force protection (5 attempts / 15-minute lockout).
 
+### Skills
+- Static safety audit before skill installation: rejects symlinks, scripts, pipe-to-shell patterns, and escaping links.
+- Executable bits stripped from installed skill files.
+- `.git` directories removed during install.
+
+### Known Limitations
+
+- **No WASM sandbox.** Tool execution (local, ssh) runs in the host process. Use capability policy and estop to limit blast radius.
+- **Per-task budget caps are incomplete.** Timeout and cancellation work, but tool call count and model cost limits are not yet enforced. Set conservative `allowed_tools` for scheduled roles.
+- **No audit log.** Autonomous actions (tool calls, cron runs, evolution promotions) are logged but not stored in a tamper-evident format. This is planned for Phase 5.
+
 ## Safe Defaults
 
 ok-gobot ships with conservative defaults:
@@ -101,8 +112,8 @@ Run `ok-gobot doctor` to check for risky configurations. The doctor command warn
 
 Operators should add the following CI jobs to their fork or deployment pipeline:
 
-- **govulncheck**: `go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...` — checks Go dependencies for known vulnerabilities.
-- **CodeQL**: GitHub's built-in static analysis for Go — enable via repository Settings > Code security > Code scanning.
+- **govulncheck**: `go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...` -- checks Go dependencies for known vulnerabilities.
+- **CodeQL**: GitHub's built-in static analysis for Go -- enable via repository Settings > Code security > Code scanning.
 
 ## Prior Security Work
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # ok-gobot Architecture Contract
 
+Last updated: April 29, 2026.
+
 ## 1. Scope
 
 This document defines the active architecture contract for the chat/jobs runtime path.
@@ -18,6 +20,44 @@ compatibility only. New feature work must target the chat/jobs path backed by
 - Each session key executes one run at a time.
 - Transport layers submit work; they do not execute model logic directly.
 
+### 2.1 Chat Routing
+
+Incoming chat turns are classified by a rules-first router before execution:
+
+| Action | When | Path |
+|--------|------|------|
+| **reply** | Lightweight turns, questions, follow-ups | Inline AI reply (fast) |
+| **clarify** | Underspecified work requests | Short follow-up question |
+| **launch job** | Heavy work (investigate, debug, fix, implement, etc.) | Background job via runtime |
+
+Detection uses lead-phrase scoring, context terms, code block presence, and message
+length. Forced prefixes (`job:`, `task:`, `background:`) bypass heuristics.
+
+**Files:** `internal/runtime/chat_router.go`, `internal/bot/chat_routing.go`
+
+### 2.2 Roles and Scheduled Jobs
+
+Roles are markdown-first manifests (`.md` files with YAML frontmatter) loaded from
+`roles_path`. Each role with a `schedule` field registers a cron job on startup.
+Jobs produce standardized reports delivered to the admin chat.
+
+Four prebuilt roles ship embedded in the binary: `researcher`, `monitor`,
+`release-watch`, `homelab-runbook`. No roles run by default.
+
+> **Note:** Full per-task budget caps (tool call count, model cost) are not yet
+> implemented. Operators should set conservative tool allowlists for scheduled roles
+> until budget enforcement lands.
+
+**Files:** `internal/role/`, `internal/cron/`
+
+### 2.3 Skills
+
+Skills are markdown-only knowledge bases installable via CLI (`ok-gobot skills install`).
+A static safety audit runs before installation. Skills are tracked by utility score
+and selected by a skill router per query.
+
+**Files:** `internal/bootstrap/skills.go`
+
 ## 3. Session Model
 
 Canonical session keys:
@@ -28,17 +68,34 @@ Canonical session keys:
 - `agent:<agentId>:telegram:group:<chatId>:thread:<topicId>`
 - `agent:<agentId>:subagent:<runSlug>`
 
+Sessions support fork/branch: an operator can fork a session to explore alternatives
+without losing the original conversation.
+
 ## 4. Adapters and Workers
 
 - Telegram, control/TUI, and jobs are adapters over chat/jobs requests and runtime events.
 - Adapters handle input/output rendering and acknowledgments.
 - Execution, queueing, cancellation, and child completion routing stay in `internal/runtime`.
+- Background tasks run in isolated git worktrees when applicable.
 
 ## 5. Control Plane
 
 The control server provides loopback API/WS access for status, session operations,
 abort, and chat/job control. Legacy sub-agent RPC surfaces remain available only
 as frozen compatibility shims.
+
+### 5.1 Mission Control API
+
+The mission control endpoints expose operational data for monitoring and dashboards:
+
+- `GET /api/mission/roles` -- all roles with metadata
+- `GET /api/mission/schedules` -- scheduled jobs with next run time
+- `GET /api/mission/runs` -- recent job runs with status and summary
+- `GET /api/mission/stats` -- daily token/message/session statistics
+
+See [MISSION-CONTROL.md](MISSION-CONTROL.md) for the concept overview.
+
+**Files:** `internal/control/mission.go`
 
 ## 6. Roles
 
@@ -54,21 +111,50 @@ Running a role via CLI or Telegram creates a durable job via `internal/runtime.J
 Scheduled roles are managed as cron jobs via `internal/cron/roles.go`.
 Admin-only actions (`/role_run`, `/job_cancel`) require `IsAdmin` authorization.
 
-## 7. Legacy Freeze Policy
+## 7. Intelligence Subsystems
+
+### 7.1 Multi-Model Routing
+
+Task-type tags (`[task:vision]`, `[task:coding]`, `[task:summarize]`, `[task:reasoning]`)
+route requests to configured models. Falls back to the default model.
+
+**Files:** `internal/ai/router.go`
+
+### 7.2 Reflection
+
+Tracks tool failures asynchronously. After repeated failures (threshold: 3), triggers
+analysis and suggests fixes based on error patterns.
+
+**Files:** `internal/agent/reflection.go`
+
+### 7.3 Self-Evolution
+
+A-Evolve inspired cycle: Observe -> Analyze -> Evolve -> Gate -> Promote. Safety
+constraints include max 1 evolution/24h, human approval for large diffs, benchmark
+gating, and auto-rollback after production failures.
+
+**Files:** `internal/evolution/engine.go`
+
+### 7.4 Agent Lifecycle Hooks
+
+Four hook points: `SessionStart`, `PreToolUse`, `PostToolUse`, `SessionEnd`.
+
+## 8. Legacy Freeze Policy
 
 - `internal/agent.RuntimeHub` is legacy compatibility code.
 - `browser_task`, `/task`, and legacy control-server sub-agent helpers may still depend on it today.
 - Keep changes there limited to bug fixes or removal prep; do not add new product surface area.
 
-## 8. Persistence
+## 9. Persistence
 
-SQLite remains the persistence layer for sessions, messages, routes, and runtime metadata.
+SQLite remains the persistence layer for sessions, messages, routes, runtime metadata,
+evolution metrics, job history, and skill utility scores.
 
-## 9. Memory
+## 10. Memory
 
 Memory remains markdown-first (`MEMORY.md` + `memory/*.md`) with semantic indexing for retrieval.
 
-## 10. Configuration Reference (Canonical)
+## 11. Configuration Reference (Canonical)
 
 `config.schema.json` is generated from the canonical JSON block below. This section is the
 single source of truth for configuration keys, types, defaults, and descriptions.
@@ -479,7 +565,7 @@ single source of truth for configuration keys, types, defaults, and descriptions
 ```
 <!-- CONFIG_CANONICAL:END -->
 
-### 10.1 PRD Extensions
+### 11.1 PRD Extensions
 
 PRD adds rollout-specific configuration extensions to the canonical reference:
 
@@ -488,7 +574,7 @@ PRD adds rollout-specific configuration extensions to the canonical reference:
 
 These keys remain part of the canonical schema above and must stay synchronized with PRD language.
 
-### 10.2 Compatibility Notes
+### 11.2 Compatibility Notes
 
 Legacy `runtime.mode` values (`hub`, `legacy`) are still accepted on load as
 ignored compatibility aliases for older config files, but they are not canonical

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -79,7 +79,7 @@ Where the challengers differentiate:
 - **Practical coding-agent bridge**: using Claude Code, Codex, Gemini CLI, Droid, or OpenCode as backends is a concrete differentiator.
 - **Markdown-first workspace**: `IDENTITY.md`, `SOUL.md`, `USER.md`, `AGENTS.md`, `TOOLS.md`, `MEMORY.md` is easy to understand and hack.
 - **Faster path from OpenClaw to a personal bot**: the project has a focused migration command and a simpler target runtime.
-- **Productized scheduled roles**: three prebuilt roles (researcher, monitor, release-watch) with markdown manifests and cron delivery. Declarative custom roles without Go code.
+- **Productized scheduled roles**: four prebuilt roles (researcher, monitor, release-watch, homelab-runbook) with markdown manifests and cron delivery. Declarative custom roles without Go code.
 - **Self-evolution**: A-Evolve inspired prompt improvement cycle with safety constraints (gating, rollback, human approval thresholds).
 - **Per-agent capability policy**: declarative restrictions (shell, network, filesystem, cron, spawn) without source changes.
 

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -1,6 +1,6 @@
 # Competitive Landscape: OpenFang, ZeroClaw, OpenClaw, and ok-gobot
 
-Snapshot date: March 12, 2026.
+Original snapshot: March 12, 2026. Updated April 29, 2026 to reflect shipped features.
 
 This document compares two newer Rust competitors, [OpenFang](https://github.com/RightNow-AI/openfang) and [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw), against [OpenClaw](https://github.com/openclaw/openclaw) and this project, [ok-gobot](../README.md).
 
@@ -29,13 +29,13 @@ Important caveat: external benchmark, security-layer, and channel-count claims a
 | **Primary product idea** | Agent OS with built-in autonomous workloads | Runtime OS for agent workflows | Personal assistant control plane | Telegram-first personal/operator bot |
 | **Runtime / packaging** | Rust workspace, one binary, desktop app, Docker | Rust single binary, size-first build profile, optional feature flags | Node 22+, pnpm workspace, UI + apps + extensions | Go single binary, simple build/install, launchd/systemd |
 | **Default interaction model** | Activate prebuilt "Hands" that run for you | Run agent/gateway/daemon/channels as composable infra | Talk to one assistant over many channels/devices | Talk to one or more agents through Telegram, TUI, or API |
-| **Autonomy** | Strongest. Built around scheduled, continuous, proactive agents | Moderate. Has daemon, cron, channels, estop, but less productized autonomy | Moderate. Strong automation/webhooks/cron, but framed as assistant surfaces | Moderate. Has cron, sub-agents, queue modes, compaction, but not an autonomous OS |
+| **Autonomy** | Strongest. Built around scheduled, continuous, proactive agents | Moderate. Has daemon, cron, channels, estop, but less productized autonomy | Moderate. Strong automation/webhooks/cron, but framed as assistant surfaces | Growing. Prebuilt scheduled roles, durable jobs, self-evolution loop, rules-first chat routing. Not an autonomous OS, but practical operator automation. |
 | **Channels** | Claims ~40 adapters across chat/social/enterprise platforms | Broad multi-channel matrix with compile-time toggles | Very broad messaging + device node footprint | Telegram only |
 | **Apps / UI surfaces** | Dashboard, TUI, desktop app | Gateway/daemon/web assets, more infra-oriented | Control UI, WebChat, macOS app, iOS node, Android node, Canvas, voice | Telegram UI, TUI, WebSocket control protocol, REST API, simple web UI |
 | **Multi-agent model** | First-class manifests, capabilities, agent spawn | Agent runtime plus provider/model switching and integrations | Multi-agent routing per channel/account/peer | Multi-agent profiles plus isolated sub-agent runs |
 | **Memory model** | SQLite + vector memory with confidence decay | Configurable storage/memory posture, SQLite/Postgres options, multiple memory modes | Session-centric assistant runtime with skills/extensions ecosystem | Markdown-first memory plus SQLite semantic index and optional memory MCP |
-| **Tool / extension story** | 53 tools, MCP, A2A, WASM modules, FangHub | Skills, integrations, provider/channel/tool swapping, security audit on install | Skills platform, plugin SDKs, browser/canvas/node tooling | Built-in local/ssh/file/patch/search/browser/media/memory tools; CLI-agent transports; skill-like workspace files |
-| **Security posture** | Most explicit and systematized: capabilities, WASM sandbox, audit chain, taint tracking, manifest signing | Strong infra controls: allowlists, pairing, workspace scoping, estop, sandbox feature flags, skill audit | Sensible assistant safety defaults, DM pairing, remote access controls, but heavier and less isolation-centric | Practical controls: approvals, DM auth modes, SSRF protection, rate limiting, redaction; less formal sandboxing |
+| **Tool / extension story** | 53 tools, MCP, A2A, WASM modules, FangHub | Skills, integrations, provider/channel/tool swapping, security audit on install | Skills platform, plugin SDKs, browser/canvas/node tooling | Built-in tools (local/ssh/file/patch/search/browser/media/memory/cron); CLI-agent transports; markdown-first skills with safety audit, versioning, and utility scoring |
+| **Security posture** | Most explicit and systematized: capabilities, WASM sandbox, audit chain, taint tracking, manifest signing | Strong infra controls: allowlists, pairing, workspace scoping, estop, sandbox feature flags, skill audit | Sensible assistant safety defaults, DM pairing, remote access controls, but heavier and less isolation-centric | Per-agent capability policy, estop, exec approval, DM auth modes, SSRF protection, rate limiting, log redaction, skill safety audit; no WASM sandbox |
 | **Operational posture** | Broadest promise, highest complexity | Leanest runtime and strongest low-resource story | Broadest ecosystem and surface area, highest Node complexity | Simplest scope and lowest cognitive overhead for one operator |
 | **Migration stance** | Explicitly migrates from OpenClaw | Explicitly migrates from OpenClaw | Ecosystem source project others migrate away from | Explicitly migrates from OpenClaw DB/workspace |
 
@@ -79,29 +79,32 @@ Where the challengers differentiate:
 - **Practical coding-agent bridge**: using Claude Code, Codex, Gemini CLI, Droid, or OpenCode as backends is a concrete differentiator.
 - **Markdown-first workspace**: `IDENTITY.md`, `SOUL.md`, `USER.md`, `AGENTS.md`, `TOOLS.md`, `MEMORY.md` is easy to understand and hack.
 - **Faster path from OpenClaw to a personal bot**: the project has a focused migration command and a simpler target runtime.
+- **Productized scheduled roles**: three prebuilt roles (researcher, monitor, release-watch) with markdown manifests and cron delivery. Declarative custom roles without Go code.
+- **Self-evolution**: A-Evolve inspired prompt improvement cycle with safety constraints (gating, rollback, human approval thresholds).
+- **Per-agent capability policy**: declarative restrictions (shell, network, filesystem, cron, spawn) without source changes.
 
 ### Where ok-gobot is weaker
 
 - **Channel breadth**: it does not compete with OpenClaw/OpenFang/ZeroClaw on messaging footprint.
-- **Productized autonomy**: it does not yet have the "activate a pre-built autonomous worker" story that OpenFang pushes.
-- **Formal isolation/security**: it has practical safety controls, but not the kind of capability/sandbox architecture marketed by OpenFang and ZeroClaw.
+- **Formal isolation/security**: it has practical safety controls and per-agent capability policy, but not the kind of WASM sandbox architecture marketed by OpenFang and ZeroClaw.
 - **Broader app surface**: it does not currently match OpenClaw's device-node, Canvas, and voice ecosystem.
+- **Budget enforcement**: per-task budget caps (tool call count, model cost) are not yet complete. Operators should set conservative tool allowlists for scheduled roles until this lands.
 
 ## Recommended Positioning for ok-gobot
 
 If you want ok-gobot to stay differentiated, the best angle is not "we do everything OpenClaw does, but in Go."
 
-Better position it as:
+Position it as:
 
-- **the small, hackable, Telegram-first OpenClaw descendant**
-- **the pragmatic single-binary operator bot**
+- **the small, hackable, Telegram-first Mission Control bot**
+- **the pragmatic single-binary operator bot with scheduled roles and self-evolution**
 - **the easiest bridge between chat ops and modern coding-agent CLIs**
 
 That framing avoids direct head-on competition where the others are stronger:
 
 - do not over-claim on channel count
-- do not over-claim on sandbox/security architecture
-- do not over-claim on autonomous packaged workflows
+- do not over-claim on sandbox/security architecture (no WASM; per-task budget caps still incomplete)
+- do not claim scheduled autonomy is production-safe before budget enforcement lands
 
 Instead, lean into:
 
@@ -109,6 +112,7 @@ Instead, lean into:
 - fast startup
 - understandable architecture
 - opinionated defaults
+- markdown-first roles, skills, and personality
 - OpenClaw migration compatibility
 - coding/ops usefulness over platform maximalism
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -55,7 +55,7 @@ agents:
   - name: "coder"
     soul_path: "~/ok-gobot-soul-coder"
     model: "claude-sonnet-4-5-20250929"
-    allowed_tools: ["local", "file", "search_file", "patch"]
+    allowed_tools: ["local", "file", "grep", "patch"]
     capabilities:
       shell: true
       network: false

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -55,7 +55,7 @@ agents:
   - name: "coder"
     soul_path: "~/ok-gobot-soul-coder"
     model: "claude-sonnet-4-5-20250929"
-    allowed_tools: ["local", "file", "grep", "patch"]
+    allowed_tools: ["local", "file", "search_file", "patch"]
     capabilities:
       shell: true
       network: false

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,16 +2,41 @@
 
 ## AI & LLM
 
+### Multi-Provider Support
+Six provider backends with automatic failover:
+
+| Provider | Auth | Default Model |
+|----------|------|---------------|
+| Anthropic | OAuth (Claude MAX) or API key | claude-sonnet-4-5-20250929 |
+| ChatGPT | OAuth (Pro/Plus JWT) | gpt-5.4 |
+| OpenAI | API key | gpt-4o |
+| Hermes | OpenAI-compatible (Ollama) | hermes3 |
+| Droid | CLI agent transport | glm-5 |
+| Custom | API key + base URL | any OpenAI-compatible |
+
+**Files:** `internal/ai/anthropic_client.go`, `internal/ai/chatgpt_client.go`, `internal/ai/client.go`, `internal/ai/hermes_client.go`, `internal/ai/droid_client.go`
+
 ### Native OpenAI Tool Calling
-Uses the structured `tools` API parameter instead of parsing JSON from text responses. Supports parallel tool calls and iterative multi-step workflows (up to 10 rounds). Falls back to text-based parsing for models without tool support.
+Uses the structured `tools` API parameter instead of parsing JSON from text responses. Supports parallel tool calls and iterative multi-step workflows (up to 10 rounds). Falls back to text-based parsing for models without tool support. Hermes models get a native tool call parser.
 
 **Files:** `internal/ai/types.go`, `internal/ai/client.go`, `internal/agent/tool_agent.go`
 
 ### Model Failover
 Automatic fallback chain when the primary model fails. Retryable errors: 429, 500-504, context_length_exceeded. Models go on 60-second cooldown after failure. Thread-safe.
 
-**Config:** `ai.fallback_models: ["anthropic/claude-3.5-sonnet", "openai/gpt-4o-mini"]`
+**Config:** `ai.fallback_models: ["claude-haiku-3-5-20241022"]`
 **Files:** `internal/ai/failover.go`
+
+### Multi-Model Routing by Task Type
+Routes requests to different models based on task type tags in messages:
+- `[task:vision]` -- image/vision tasks
+- `[task:coding]` -- code generation/review
+- `[task:summarize]` -- fast/cheap summarization
+- `[task:reasoning]` -- complex reasoning
+
+Falls back to the default model when no tag is present. Tags are stripped before sending to the AI.
+
+**Files:** `internal/ai/router.go`
 
 ### Per-Session Model Override
 Each chat can use a different model. The `/model` command sets, clears, or lists models. Stored in SQLite.
@@ -29,8 +54,12 @@ agents:
     soul_path: "~/ok-gobot-soul"
   - name: "coder"
     soul_path: "~/ok-gobot-soul-coder"
-    model: "anthropic/claude-3.5-sonnet"
+    model: "claude-sonnet-4-5-20250929"
     allowed_tools: ["local", "file", "grep", "patch"]
+    capabilities:
+      shell: true
+      network: false
+      file_write_scope: "full"
 ```
 **Files:** `internal/agent/registry.go`, `internal/bot/agent_command.go`, `internal/bot/agent_handler.go`
 
@@ -46,33 +75,158 @@ AI-powered summarization when conversation approaches 80% of model context limit
 
 ---
 
+## Roles, Jobs, and Skills
+
+### Markdown-First Roles
+Roles are single `.md` files with optional YAML frontmatter. They define autonomous workflows that run on schedule and deliver bounded reports.
+
+**Manifest format:**
+```markdown
+---
+worker: standard
+tools: [web_fetch, search]
+schedule: "0 0 9 * * *"
+approval: auto
+---
+# My Researcher
+
+You are a research agent. Search for news about Go releases...
+```
+
+**Prebuilt roles:**
+
+| Role | Default Schedule | Description |
+|------|-----------------|-------------|
+| `researcher` | Manual only | Web search + bounded research brief |
+| `monitor` | Every 30 minutes | Service/URL health checks + status report |
+| `release-watch` | Weekly (disabled by default) | Software release tracking for configured projects |
+| `homelab-runbook` | Manual only | Turn requests into checklist/runbook notes |
+
+Roles respect capability policy and estop. No roles run by default -- operators must enable them explicitly.
+
+> **Note:** Scheduled autonomy is experimental. Full per-task budget caps (tool call count, model cost) are not yet implemented. Operators should review role outputs and set conservative tool allowlists until budget enforcement lands.
+
+**Files:** `internal/role/manifest.go`, `internal/role/bundled.go`, `internal/role/loader.go`
+
+### Durable Jobs
+Scheduled roles create durable jobs tracked by the runtime. Jobs produce standardized reports delivered to the admin chat. Job history is persisted in SQLite.
+
+**CLI:** `ok-gobot jobs` -- list and inspect job history.
+
+**Files:** `internal/cron/scheduler.go`, `internal/cron/roles.go`, `internal/cron/report.go`
+
+### Skills System
+Skills are markdown-only knowledge bases installable from local paths or git URLs. A static safety audit runs before installation:
+
+- Rejects symlinks
+- Blocks script files (.sh, .py, .rb, .pl, .js, etc.)
+- Detects pipe-to-shell patterns (`curl | sh`, `wget | bash`)
+- Blocks markdown links escaping the skill root (`../`)
+
+Skills are tracked by utility score. The skill router selects relevant skills per query based on accumulated scores.
+
+**CLI:** `ok-gobot skills list|install|remove|audit`
+
+**Files:** `internal/bootstrap/skills.go`, `internal/bootstrap/skills_test.go`
+
+### Skill Versioning
+Skills support version history with rollback. Each modification creates a versioned snapshot that can be restored.
+
+---
+
+## Intelligence and Feedback Loops
+
+### Rules-First Chat Routing
+Incoming chat turns are classified before execution:
+- **reply** -- lightweight turns stay on the inline AI reply path
+- **clarification** -- underspecified work requests get a short follow-up question first
+- **background job** -- obvious heavy work (investigate, debug, fix, implement, etc.) is launched as an isolated task
+
+Detection uses lead-phrase scoring, context terms, code block presence, and message length. Forced prefixes (`job:`, `task:`, `background:`) bypass heuristics.
+
+**Files:** `internal/runtime/chat_router.go`, `internal/bot/chat_routing.go`
+
+### Automatic Reflection
+Tracks tool execution failures asynchronously. After repeated failures (default threshold: 3), triggers analysis and suggests fixes based on error patterns (not found, timeout, permission, parse error, connection failure).
+
+**Files:** `internal/agent/reflection.go`
+
+### Self-Evolution (A-Evolve Inspired)
+Autonomous prompt improvement cycle: Observe -> Analyze -> Evolve -> Gate -> Promote.
+
+**Safety constraints:**
+- Max 1 evolution per 24 hours
+- Human approval required for >20% prompt diff
+- Benchmark gating before promotion
+- Auto-rollback after 3 production failures on a new version
+- Versioned snapshots with manifests
+
+**CLI:** `ok-gobot evolution` -- check status and history.
+
+**Files:** `internal/evolution/engine.go`
+
+### Agent Lifecycle Hooks
+Four hook points for custom behavior: `SessionStart`, `PreToolUse`, `PostToolUse`, `SessionEnd`.
+
+---
+
 ## Tools
 
 ### Shell & Files
-- **local** — Execute shell commands. Dangerous commands (rm -rf, kill, shutdown, etc.) require inline keyboard approval.
-- **ssh** — Remote execution. Hosts configured in `~/ok-gobot-soul/TOOLS.md`.
-- **file** — Read/write with path traversal protection.
-- **patch** — Apply unified diffs to files.
-- **grep** — Recursive regex search, skips binary files and `.git`/`node_modules`. Max 50 results.
-- **obsidian** — Obsidian vault CRUD with frontmatter timestamps.
+- **local** -- Execute shell commands. Dangerous commands (rm -rf, kill, shutdown, etc.) require inline keyboard approval.
+- **ssh** -- Remote execution. Hosts configured in `~/ok-gobot-soul/TOOLS.md`.
+- **file** -- Read/write with path traversal protection.
+- **patch** -- Apply unified diffs to files.
+- **grep** -- Recursive regex search, skips binary files and `.git`/`node_modules`. Max 50 results.
+- **obsidian** -- Obsidian vault CRUD with frontmatter timestamps.
 
 ### Web
-- **search** — Brave Search or Exa API. Returns 5 results with title/URL/snippet.
-- **web_fetch** — Fetch URLs with Mozilla Readability extraction (go-shiori/go-readability). Falls back to basic HTML stripping. SSRF protection blocks private IPs. 12KB content limit.
-- **browser** — Chrome automation via ChromeDP: navigate, click, fill, screenshot, wait, extract text.
+- **search** -- Brave Search or Exa API. Returns 5 results with title/URL/snippet.
+- **web_fetch** -- Fetch URLs with Mozilla Readability extraction (go-shiori/go-readability). Falls back to basic HTML stripping. SSRF protection blocks private IPs. 12KB content limit.
+- **browser** -- Chrome automation via ChromeDP: navigate, click, fill, screenshot, wait, extract text.
+- **browser_task** -- Composite browser tasks as isolated sub-agent runs.
+- **frontend_verify** -- CDP screenshot + LLM visual comparison for UI testing.
 
 ### Media
-- **image_gen** — DALL-E 3. Sizes: 1024x1024, 1792x1024, 1024x1792. Quality: standard/hd.
-- **tts** — Two providers: OpenAI (paid, 6 voices) and Edge TTS (free, Russian/English voices). Provider prefix: `edge:text` or `openai:text`. Auto OGG conversion for Telegram.
+- **image_gen** -- DALL-E 3. Sizes: 1024x1024, 1792x1024, 1024x1792. Quality: standard/hd.
+- **tts** -- Two providers: OpenAI (paid, 6 voices) and Edge TTS (free, Russian/English voices). Auto OGG conversion for Telegram.
 
 ### Memory & Scheduling
-- **memory** — Semantic vector memory. Embeds text via OpenAI embeddings API, stores in SQLite as binary BLOBs, searches with cosine similarity in Go. Commands: save, search, list, forget.
-- **cron** — 5-field cron expressions. Persistent in SQLite. Enable/disable without deletion.
-- **message** — Send to other chats by ID or alias. Allowlist-based security.
+- **memory_search** -- Semantic vector search over indexed markdown memory.
+- **memory_get** -- Read markdown memory source by section path.
+- **cron** -- 5-field cron expressions. Persistent in SQLite. Enable/disable without deletion.
+- **message** -- Send to other chats by ID or alias. Allowlist-based security.
+
+### Policy & Routing
+- **recommend_roles** -- Suggest appropriate roles for a given task.
+- **denial** -- DENY/ALLOW policy decision logging.
 
 ---
 
 ## Security & Control
+
+### Per-Agent Capability Policy
+Fine-grained declarative restrictions per agent profile:
+
+| Capability | Type | Description |
+|-----------|------|-------------|
+| `shell` | bool | Allow shell tools (local, ssh) |
+| `network` | bool | Allow network tools (web_fetch, search, browser) |
+| `network_allowlist` | list | Restrict network to specific hostnames |
+| `cron` | bool | Allow cron scheduling |
+| `memory_write` | bool | Allow memory write tools |
+| `spawn` | bool | Allow sub-agent/job spawning |
+| `filesystem_roots` | list | Restrict filesystem access to specific paths |
+| `file_write_scope` | enum | `full` or `read_only` |
+
+Default: fully permissive (backward compatible). Denied actions return structured messages.
+
+**Files:** `internal/config/config.go`, `internal/agent/registry.go`
+
+### Emergency Stop
+`/estop on` instantly disables dangerous tool families (local, ssh, browser, cron, message). `/estop off` re-enables. State visible in `/status` and TUI. CLI: `ok-gobot estop on|off|status`.
+
+**Files:** `internal/cli/estop.go`, `internal/tools/tools.go`
 
 ### Exec Approval
 Dangerous commands (`rm -rf`, `kill`, `shutdown`, `DROP TABLE`, etc.) trigger a Telegram inline keyboard with Approve/Deny buttons. Auto-deny after 60 seconds.
@@ -81,15 +235,17 @@ Dangerous commands (`rm -rf`, `kill`, `shutdown`, `DROP TABLE`, etc.) trigger a 
 
 ### DM Authorization
 Three modes:
-- **open** — anyone can use the bot (default)
-- **allowlist** — only configured user IDs + DB-authorized users
-- **pairing** — requires pairing code from admin (`/auth pair` generates 6-digit code, `/pair <code>` to activate)
+- **open** -- anyone can use the bot (default)
+- **allowlist** -- only configured user IDs + DB-authorized users
+- **pairing** -- requires pairing code from admin (`/auth pair` generates 6-digit code, `/pair <code>` to activate)
+
+Unknown/misconfigured modes are denied (fail-closed).
 
 **Files:** `internal/bot/auth.go`
 
 ### Group Activation Modes
-- **active** — bot responds to all messages
-- **standby** — bot responds only to @mentions, replies to its messages, or messages starting with its name
+- **active** -- bot responds to all messages
+- **standby** -- bot responds only to @mentions, replies to its messages, or messages starting with its name
 
 Per-group, stored in DB. Commands: `/activate`, `/standby`.
 
@@ -112,9 +268,9 @@ Masks sensitive patterns in log output: API keys (sk-...), Bearer tokens, bot to
 **Files:** `internal/redact/redact.go`
 
 ### Message Sanitization
-- `SanitizeShellArg` — escapes shell metacharacters
-- `SanitizeTelegramMarkdown` — escapes MarkdownV2 special chars
-- `StripControlChars` — removes non-printable characters
+- `SanitizeShellArg` -- escapes shell metacharacters
+- `SanitizeTelegramMarkdown` -- escapes MarkdownV2 special chars
+- `StripControlChars` -- removes non-printable characters
 
 **Files:** `internal/sanitize/sanitize.go`
 
@@ -124,12 +280,21 @@ Masks sensitive patterns in log output: API keys (sk-...), Bearer tokens, bot to
 
 ### HTTP API
 REST API with API key authentication (`X-API-Key` header or Bearer token). Endpoints:
-- `GET /api/health` — no auth
-- `GET /api/status` — bot status
-- `POST /api/send` — send message to chat
-- `POST /api/webhook` — forward event to configured chat
+- `GET /api/health` -- no auth
+- `GET /api/status` -- bot status
+- `POST /api/send` -- send message to chat
+- `POST /api/webhook` -- forward event to configured chat
 
 See [API.md](API.md) for full reference.
+
+### Mission Control API
+Monitoring and control endpoints for the operator dashboard:
+- `GET /api/mission/roles` -- list all roles with metadata
+- `GET /api/mission/schedules` -- list scheduled jobs with next run time
+- `GET /api/mission/runs` -- recent job runs with status and summary
+- `GET /api/mission/stats` -- daily token/message/session statistics
+
+See [MISSION-CONTROL.md](MISSION-CONTROL.md) for the concept overview.
 
 ### Config Hot-Reload
 Watches `config.yaml` with fsnotify. 500ms debounce, validates before applying. Manual reload via `/reload` (admin only).
@@ -166,27 +331,19 @@ Per-chat accumulation of prompt/completion tokens from API responses. Displayed 
 **Files:** `internal/bot/usage.go`, `internal/bot/agent_handler.go`
 
 ### Fragment Buffering
-Reassembles long messages that Telegram splits into multiple fragments. Detects continuation by same user, message ID gap ≤ 1, time gap ≤ 1.5s. Buffers up to 12 parts / 50K chars.
+Reassembles long messages that Telegram splits into multiple fragments. Detects continuation by same user, message ID gap <= 1, time gap <= 1.5s. Buffers up to 12 parts / 50K chars.
 
 **Files:** `internal/bot/fragment_buffer.go`
 
 ### Queue Modes
 Controls how incoming messages are handled during an active AI run:
-- **interrupt** (default) — cancel current run, process new message fresh
-- **collect** — buffer silently, process after run completes
-- **steer** — feed new messages as steering input to the active run
+- **interrupt** (default) -- cancel current run, process new message fresh
+- **collect** -- buffer silently, process after run completes
+- **steer** -- feed new messages as steering input to the active run
 
 Commands: `/queue collect|steer|interrupt [debounce_ms]`
 
 **Files:** `internal/bot/queue.go`
-
-### Rules-First Chat Routing
-Incoming chat turns are classified before execution:
-- **reply** — lightweight turns stay on the inline AI reply path
-- **clarification** — underspecified work requests get a short follow-up question first
-- **background job** — obvious heavy work is launched as an explicit isolated task instead of blocking the main chat session
-
-**Files:** `internal/runtime/chat_router.go`, `internal/bot/chat_routing.go`
 
 ### Usage Footer
 Optional token usage display appended to AI responses. Modes: `off` (default), `tokens`, `full`.
@@ -203,7 +360,7 @@ Commands: `/usage off|tokens|full`
 Downloads from Telegram, extracts dimensions and size, processes through AI pipeline with caption. Supports media groups (multiple photos sent together) via timer-based buffering.
 
 ### Voice Messages
-Receives voice messages with duration info. Transcription not yet implemented.
+Receives voice messages. Transcription via Whisper API (OpenAI-compatible endpoint).
 
 ### Stickers
 Extracts emoji from sticker, processes through AI pipeline.
@@ -215,6 +372,16 @@ Extracts filename and size, processes through AI pipeline with caption.
 Collects photos that arrive as a Telegram media group (same `media_group_id`). Waits 1.5s for more photos before flushing as a batch. Max file size: 10MB.
 
 **Files:** `internal/bot/media_handler.go`
+
+---
+
+## Session Management
+
+### Session Fork/Branch
+Fork a session to explore alternatives without losing the original conversation. Useful for comparing different approaches to a problem.
+
+### Side Queries (`/btw`)
+Ask questions during active task execution without interrupting the running task.
 
 ---
 
@@ -243,6 +410,7 @@ Beyond the core commands (`/start`, `/help`, `/status`, `/clear`, `/model`, `/ag
 | `/jobs` | List recent durable jobs |
 | `/job <id>` | Show job details |
 | `/job_cancel <id>` | Cancel a durable job (admin) |
+| `/btw` | Side query during active task |
 | `/estop` | Toggle dangerous tool families on/off/status (admin for on/off) |
 | `/restart` | Restart the bot process (admin only) |
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -311,7 +311,7 @@ agents:
   - name: "coder"
     soul_path: "/path/to/ok-gobot-assets/workspace-coder"
     model: "claude-sonnet-4-5-20250929"
-    allowed_tools: ["local", "file", "patch", "search_file"]
+    allowed_tools: ["local", "file", "patch", "grep"]
 ```
 
 ---

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -433,7 +433,8 @@ export OKGOBOT_AUTH_MODE="pairing"
 3. If enabling control server, set a strong `control.token`.
 4. Config file permissions should be `0600` (set automatically by `config init`).
 5. OAuth credentials stored in `~/.ok-gobot/oauth/` are automatically set to `0600`.
-6. See `docs/SECURITY-FIXES.md` for full details on security hardening.
+6. Set conservative `capabilities` and `allowed_tools` for scheduled roles -- full per-task budget caps are not yet implemented.
+7. See [SECURITY.md](../SECURITY.md) for vulnerability reporting and [SECURITY-FIXES.md](SECURITY-FIXES.md) for the hardening changelog.
 
 ---
 
@@ -475,7 +476,7 @@ auth:
 
 **Step 2 — Copy and customise a prebuilt role:**
 
-Use the `ok-gobot roles init` command (coming soon) or copy the files manually.
+Copy the files manually or use the bundled examples as a starting point.
 The bundled manifests can also be extracted by placing the file in your
 `roles_path` directory. Each `.md` file in the directory is a role manifest.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -311,7 +311,7 @@ agents:
   - name: "coder"
     soul_path: "/path/to/ok-gobot-assets/workspace-coder"
     model: "claude-sonnet-4-5-20250929"
-    allowed_tools: ["local", "file", "patch", "grep"]
+    allowed_tools: ["local", "file", "patch", "search_file"]
 ```
 
 ---

--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -1,0 +1,74 @@
+# Mission Control v1
+
+## Concept
+
+Mission Control is the operator-facing view of ok-gobot's autonomous capabilities: roles, schedules, job runs, and system health in a single place.
+
+The goal is not a full dashboard product. It is the minimum monitoring surface an operator needs to trust that scheduled roles are running correctly and to intervene when they are not.
+
+## Current State (April 2026)
+
+The Mission Control API exists and serves data. A dashboard UI is planned but not yet built.
+
+### API Endpoints
+
+All endpoints are served by the control server (default port 8787, loopback only).
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/mission/roles` | GET | All configured roles with metadata (name, display name, model, tools) |
+| `/api/mission/schedules` | GET | Scheduled jobs with cron expression, next run time, timeout |
+| `/api/mission/runs` | GET | Recent job runs with status, summary, errors, attempt count |
+| `/api/mission/stats` | GET | Daily and total statistics (tokens, messages, sessions) |
+
+Query parameters: `limit` (1-200), `status` (filter by run status).
+
+### What It Monitors
+
+- **Roles** -- which roles are loaded and what tools/models they use
+- **Schedules** -- when each role is next due to run
+- **Runs** -- whether recent job runs succeeded or failed, with summaries
+- **Stats** -- aggregate token usage and message counts
+
+## Architecture
+
+Mission Control is a read-only API layer over existing runtime data. It does not introduce a separate data store or orchestration system.
+
+```
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│  Roles       │    │  Cron        │    │  Runtime     │
+│  (manifests) │    │  (scheduler) │    │  (jobs)      │
+└──────┬───────┘    └──────┬───────┘    └──────┬───────┘
+       │                   │                   │
+       └───────────┬───────┘───────────────────┘
+                   │
+            ┌──────┴───────┐
+            │ Mission API  │
+            │ /api/mission │
+            └──────┬───────┘
+                   │
+            ┌──────┴───────┐
+            │  Dashboard   │
+            │  (planned)   │
+            └──────────────┘
+```
+
+## Safety Notes
+
+Mission Control is read-only today. It does not modify roles, start jobs, or change configuration.
+
+Scheduled roles execute with whatever tools and capabilities their manifest declares. Operators should:
+
+1. Set explicit `tools` allowlists in role manifests (do not leave empty/all-tools).
+2. Use per-agent `capabilities` to restrict shell, network, and filesystem access.
+3. Review role output regularly until per-task budget enforcement is complete.
+4. Use `/estop on` to immediately halt all dangerous tool execution if something goes wrong.
+
+Full per-task budget caps (tool call count, model cost) are planned for Phase 5 of the [Roadmap](ROADMAP.md).
+
+## Planned (Phase 6)
+
+- Dashboard page rendering roles, schedules, runs, and stats in a single view
+- Role health monitoring with alerts for repeated failures or exceeded token budgets
+- One-click role enable/disable from dashboard and TUI
+- Operator playbook system: composable multi-role workflows with dependency ordering

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,7 +29,7 @@ The original Phase 1-3 items are all shipped or substantially shipped. This sect
 ### Phase 3: Productized Autonomy -- MOSTLY SHIPPED
 
 7. **Operator can cap a background task's tool calls, duration, and model cost** -- PARTIALLY SHIPPED. Timeout and cancellation work. Full per-task budget caps (tool call count, model cost) deferred to Phase 5.
-8. **Operator can enable a prebuilt role that runs on schedule and posts a report** -- SHIPPED. Three prebuilt roles: `researcher`, `monitor`, `release-watch`. Roles load from `roles_path`, run via cron, deliver bounded reports to admin.
+8. **Operator can enable a prebuilt role that runs on schedule and posts a report** -- SHIPPED. Four prebuilt roles: `researcher`, `monitor`, `release-watch`, `homelab-runbook`. Roles load from `roles_path`, run via cron, deliver bounded reports to admin.
 9. **Operator can define new roles declaratively without writing Go code** -- SHIPPED. Markdown-first role manifests with YAML frontmatter: prompt, tools, schedule, report_template, approval mode.
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # ok-gobot Roadmap
 
-Snapshot date: March 12, 2026.
+Last updated: April 29, 2026.
 
 This roadmap turns the findings from [Competitive Landscape](./COMPETITORS.md) into an implementation backlog for `ok-gobot`.
 
@@ -8,263 +8,72 @@ The goal is not to copy OpenFang or ZeroClaw wholesale. The goal is to borrow th
 
 Every backlog item is phrased as a user outcome per [PROCESS.md](./PROCESS.md). Infrastructure sub-tasks may reference internals, but the parent item describes what a user can observe when it ships.
 
-## Sequencing
+---
 
-### Phase 1: Quick Wins
+## Shipped Backlog
 
-1. Operator can kill dangerous tools instantly without restarting the bot
-2. User can list available models and see which providers are healthy
-3. Operator gets a detailed report after migrating from OpenClaw
+The original Phase 1-3 items are all shipped or substantially shipped. This section records their final status.
 
-### Phase 2: Safety and Extensibility Foundation
+### Phase 1: Quick Wins -- SHIPPED
 
-4. Operator can restrict an agent to read-only tools without editing Go code
-5. Denied tool calls show a clear reason in Telegram instead of silently failing
-6. Operator can install and audit third-party skills from the CLI
+1. **Operator can kill dangerous tools instantly without restarting the bot** -- SHIPPED. `/estop on|off|status` + CLI `ok-gobot estop on|off|status`. Blocked tools return a user-visible reason.
+2. **User can list available models and see which providers are healthy** -- SHIPPED. `ok-gobot providers`, `ok-gobot models`, model catalog with 24h cache.
+3. **Operator gets a detailed report after migrating from OpenClaw** -- SHIPPED. `ok-gobot migrate` with markdown report, `--dry-run`, backup path.
 
-### Phase 3: Productized Autonomy
+### Phase 2: Safety and Extensibility Foundation -- SHIPPED
 
-7. Operator can cap a background task's tool calls, duration, and model cost
-8. Operator can enable a prebuilt role that runs on schedule and posts a report
-9. Operator can define new roles declaratively without writing Go code
+4. **Operator can restrict an agent to read-only tools without editing Go code** -- SHIPPED. Per-agent `capabilities` block in config: `shell`, `network`, `network_allowlist`, `cron`, `memory_write`, `spawn`, `filesystem_roots`, `file_write_scope`.
+5. **Denied tool calls show a clear reason in Telegram instead of silently failing** -- SHIPPED. Consistent "Tool [name] blocked: [reason]" messages across Telegram, TUI, and API.
+6. **Operator can install and audit third-party skills from the CLI** -- SHIPPED. `ok-gobot skills list|install|remove|audit`. Safety audit rejects symlinks, scripts, pipe-to-shell, and escaping links. Skill versioning with rollback.
 
-## Backlog
+### Phase 3: Productized Autonomy -- MOSTLY SHIPPED
 
-### 1. Operator can kill dangerous tools instantly without restarting the bot
+7. **Operator can cap a background task's tool calls, duration, and model cost** -- PARTIALLY SHIPPED. Timeout and cancellation work. Full per-task budget caps (tool call count, model cost) deferred to Phase 5.
+8. **Operator can enable a prebuilt role that runs on schedule and posts a report** -- SHIPPED. Three prebuilt roles: `researcher`, `monitor`, `release-watch`. Roles load from `roles_path`, run via cron, deliver bounded reports to admin.
+9. **Operator can define new roles declaratively without writing Go code** -- SHIPPED. Markdown-first role manifests with YAML frontmatter: prompt, tools, schedule, report_template, approval mode.
 
-**User Story**
-As an operator, I want to disable dangerous tool families (shell, SSH, browser,
-cron, message, fetch) with a single command so that I can respond to incidents
-without restarting the process or losing in-flight sessions.
+---
 
-**Why:** Highest-ROI safety feature. Gives operators a fast kill switch.
+## Active Phases
 
-**Acceptance Criteria**
-- [ ] `/estop on` disables dangerous tool families; `/estop off` re-enables them.
-- [ ] Blocked tools return a user-visible reason in Telegram, TUI, and API.
-- [ ] `/status` and the TUI show current estop state.
-- [ ] CLI equivalent: `ok-gobot estop on|off|status`.
+### Phase 4: Intelligence and Feedback Loops -- SHIPPED
 
-**Default Behavior**
-Estop is off. All configured tools are available. This is correct because most
-operators run the bot in a trusted environment and should not pay an opt-in cost
-for normal operation.
+10. **Multi-model routing by task type** -- SHIPPED. `[task:vision]`, `[task:coding]`, `[task:summarize]`, `[task:reasoning]` tags route to configured models. Fallback to default model.
+11. **Automatic reflection after tool failures** -- SHIPPED. Tracks repeated failures, triggers analysis after threshold, suggests fixes based on error patterns.
+12. **Self-evolution loop (A-Evolve inspired)** -- SHIPPED. Observe-Analyze-Evolve-Gate-Promote cycle with safety constraints: max 1 evolution/24h, human approval for >20% prompt diff, auto-rollback after 3 production failures.
+13. **Skill utility scoring and routing** -- SHIPPED. Skills tracked by utility score; skill router selects relevant skills per query.
 
-**Likely files**
-- `internal/cli/estop.go` (new)
-- `internal/control/server.go`
-- `internal/bot/approval.go`
-- `internal/tools/tools.go`
-- `internal/config/config.go`
+### Phase 5: Hardened Autonomy -- IN PROGRESS
 
-### 2. User can list available models and see which providers are healthy
+14. Full per-task budget caps: max tool calls, max model cost, per-task model override.
+15. Policy enforcement gateway: centralized pre-execution check that validates budget + capability policy before every tool call.
+16. Formal vulnerability reporting process (`SECURITY.md` shipped with this docs refresh).
+17. Audit log for all autonomous actions (tool calls, cron runs, evolution promotions) with tamper-evident storage.
 
-**User Story**
-As a user, I want to see which models and providers are available so that I can
-pick the right model for my task and diagnose failures without reading config files.
+### Phase 6: Mission Control v1 -- PLANNED
 
-**Why:** Multi-provider usability. Users currently have no way to discover models
-or understand why a request failed at the provider level.
+18. Mission Control dashboard page: roles, schedules, recent runs, daily stats in a single view.
+19. Role health monitoring: alert when a scheduled role fails repeatedly or exceeds token budgets.
+20. One-click role enable/disable from the dashboard and TUI.
+21. Operator playbook system: composable multi-role workflows with dependency ordering.
 
-**Acceptance Criteria**
-- [ ] `ok-gobot providers` lists configured providers with health status.
-- [ ] `ok-gobot models refresh` fetches and caches remote model catalogs.
-- [ ] `ok-gobot doctor` distinguishes auth failure, endpoint failure, and model lookup failure.
-- [ ] Model picker flows use cached catalogs when available.
+---
 
-**Default Behavior**
-Provider list shows whatever is configured in `config.yaml`. Model catalog is
-fetched on first `models refresh` and cached locally. No automatic background
-fetching.
+## Recently Shipped (not in original roadmap)
 
-**Likely files**
-- `internal/cli/providers.go` (new)
-- `internal/cli/models.go` (new)
-- `internal/cli/doctor.go`
-- `internal/ai/client.go`
+These capabilities shipped outside the original Phase 1-3 plan:
 
-### 3. Operator gets a detailed report after migrating from OpenClaw
-
-**User Story**
-As an operator migrating from OpenClaw, I want a durable report of what was
-copied, skipped, and deduplicated so that I can trust the migration and debug
-problems without re-running it.
-
-**Why:** Imports without an artifact are harder to trust and harder to debug.
-
-**Acceptance Criteria**
-- [ ] Every migration run emits a report (markdown or JSON) listing copied files, skipped sessions, duplicates, backup path, and key mapping.
-- [ ] `--dry-run` prints the same categories as the real report.
-- [ ] Failed migrations preserve enough detail for rollback and debugging.
-
-**Default Behavior**
-Report is written to `~/.ok-gobot/migration-report-<timestamp>.md` alongside
-the database. `--dry-run` prints to stdout only.
-
-**Likely files**
-- `internal/cli/migrate.go`
-- `internal/migrate/migrate.go`
-
-### 4. Operator can restrict an agent to read-only tools without editing Go code
-
-**User Story**
-As an operator, I want to give an agent narrower permissions (no shell, no
-network, read-only filesystem) through config so that I can run less-trusted
-models safely without changing source code.
-
-**Why:** `AllowedTools` is too coarse once you add more autonomy. Operators need
-declarative, fine-grained capability control.
-
-**Acceptance Criteria**
-- [ ] Agent config accepts explicit permissions: shell, filesystem roots, network allowlists, cron, memory writes, sub-agent spawn.
-- [ ] Existing `allowed_tools` configs still load without breakage.
-- [ ] Runtime receives a structured policy object, not ad-hoc booleans.
-- [ ] A restricted agent cannot escalate to a tool outside its policy.
-
-**Default Behavior**
-If no policy block is set, all tools in the agent's `allowed_tools` list remain
-available (full backward compatibility). An empty `allowed_tools` still means
-"all tools."
-
-**Likely files**
-- `internal/config/config.go`
-- `internal/agent/registry.go`
-- `internal/agent/resolver.go`
-- `docs/ARCHITECTURE.md`
-
-### 5. Denied tool calls show a clear reason in Telegram instead of silently failing
-
-**User Story**
-As a user, I want to see why a tool call was blocked so that I understand the
-bot's limitations and can ask an operator to adjust permissions if needed.
-
-**Why:** Capability policy is useless if denied actions are silent. Users lose
-trust when the bot ignores requests without explanation.
-
-**Acceptance Criteria**
-- [ ] Every denied tool call returns a consistent, human-readable reason.
-- [ ] The denial message appears in Telegram, TUI, and API responses.
-- [ ] Tests cover both allowed and denied flows for `local`, `ssh`, `browser`, `web_fetch`, `search`, `cron`, and `message`.
-- [ ] Policy checks survive direct tool invocation, not only agent-mediated runs.
-
-**Default Behavior**
-No tools are denied unless the operator configures capability policy or activates
-estop. When a tool is denied, the user sees: "Tool [name] blocked: [reason]."
-
-**Likely files**
-- `internal/tools/tools.go`
-- `internal/tools/browser_tool.go`
-- `internal/tools/web_fetch.go`
-- `internal/tools/search.go`
-- `internal/tools/cron.go`
-- `internal/tools/message.go`
-
-### 6. Operator can install and audit third-party skills from the CLI
-
-**User Story**
-As an operator, I want to install, list, and remove skills from the CLI so that
-I can extend the bot's capabilities without editing source code, and audit
-installed skills for safety.
-
-**Why:** `ok-gobot` already has the workspace shape for skills. A safe
-install/audit path makes the extension model usable in practice.
-
-**Acceptance Criteria**
-- [ ] `ok-gobot skills list|install|remove|audit` works from the CLI.
-- [ ] Install accepts a local path or git URL.
-- [ ] Static safety audit rejects symlinks, scripts, pipe-to-shell patterns, and markdown links escaping the skill root.
-- [ ] Installed skills are markdown-first and compatible with the workspace model.
-
-**Default Behavior**
-No skills installed out of the box. `skills list` shows an empty list.
-`skills install` runs the safety audit before accepting; unsafe packages are
-rejected with actionable error messages.
-
-**Likely files**
-- `internal/cli/skills.go` (new)
-- `internal/tools/tools.go`
-- `docs/INSTALL.md`
-
-### 7. Operator can cap a background task's tool calls, duration, and model cost
-
-**User Story**
-As an operator, I want to set limits on background tasks (max tool calls, max
-duration, model override) so that a runaway subagent cannot consume unbounded
-resources or time.
-
-**Why:** Subagents currently have no budget constraints. A stuck or recursive
-subagent can exhaust API quota silently.
-
-**Acceptance Criteria**
-- [ ] Operator can set max tool calls, max duration, and model override per task.
-- [ ] A task that hits its limit stops and returns a structured summary, not raw output.
-- [ ] Failed or timed-out tasks produce understandable feedback in Telegram and TUI.
-- [ ] Memory writes from subagents can be disabled by policy.
-
-**Default Behavior**
-Default budget: 50 tool calls, 5-minute wall-clock timeout. Model inherits from
-the parent agent. Memory writes allowed unless the agent's capability policy
-disables them.
-
-**Likely files**
-- `internal/agent/subagent.go`
-- `internal/bot/task_command.go`
-- `internal/control/server_tui.go`
-- `internal/bot/subagent_notifier.go`
-
-### 8. Operator can enable a prebuilt role that runs on schedule and posts a report
-
-**User Story**
-As an operator, I want to enable a prebuilt role (researcher, monitor,
-release-watch) with minimal config so that useful autonomous workflows run on
-schedule and post bounded, readable reports to Telegram.
-
-**Why:** The value of autonomy features is prebuilt, useful workflows — not
-platform infrastructure.
-
-**Acceptance Criteria**
-- [ ] At least 3 prebuilt roles ship: `researcher`, `monitor`, `release-watch`.
-- [ ] A role can be enabled by adding its name to config — no Go code needed.
-- [ ] Each role runs on schedule via existing cron infrastructure.
-- [ ] Reports are bounded in length and formatted for Telegram readability.
-- [ ] Roles respect capability policy and estop.
-
-**Default Behavior**
-No roles enabled out of the box. Enabling a role requires explicit config. Roles
-run through existing cron + runtime infrastructure, not a second orchestration
-system.
-
-**Likely files**
-- `internal/cron/scheduler.go`
-- `internal/agent/subagent.go`
-- `internal/bot/hub_handler.go`
-- `internal/bot/subagent_notifier.go`
-
-### 9. Operator can define new roles declaratively without writing Go code
-
-**User Story**
-As an operator, I want to define custom autonomous roles using a simple manifest
-format (prompt, tools, schedule, output template) so that I can create new
-workflows without modifying the bot's source.
-
-**Why:** Hardcoded roles do not scale. Operators need a hackable, workspace-local
-format for role definitions.
-
-**Acceptance Criteria**
-- [ ] Role manifests are defined in a lightweight declarative format stored in the workspace.
-- [ ] A manifest specifies: prompt, tools, schedule, output template, and approval mode.
-- [ ] Role outputs have a stable, structured report format.
-- [ ] Memory writes from roles can be disabled by policy.
-
-**Default Behavior**
-No custom roles defined. Prebuilt roles (item 8) use the same manifest format
-internally, serving as examples.
-
-**Likely files**
-- `internal/agent/memory.go`
-- `internal/agent/registry.go`
-- `internal/bot/hub_handler.go`
-- `docs/FEATURES.md`
+- **Rules-first chat routing** -- incoming turns classified as reply, clarify, or background job before execution.
+- **Agent lifecycle hooks** -- SessionStart, PreToolUse, PostToolUse, SessionEnd.
+- **Session fork/branch** -- fork a session to explore alternatives without losing the original.
+- **Voice/STT** -- Whisper API transcription for Telegram voice messages.
+- **Frontend verify tool** -- CDP screenshot + LLM visual comparison for UI testing.
+- **Parallel batch execution** -- `/batch` command fans out tasks in parallel.
+- **PR babysitting** -- `ok-gobot babysit` auto-maintains PRs.
+- **Auto-worktree management** -- isolated git worktrees per background task.
+- **Export training data** -- `ok-gobot export` for fine-tuning datasets.
+- **Hermes provider** -- native Hermes tool call parser for local models (Ollama + hermes3).
+- **`/btw` side queries** -- ask questions during active task execution without interrupting.
 
 ## Non-Goals for Now
 
@@ -276,12 +85,12 @@ internally, serving as examples.
 
 ## Short Version
 
-If only the first five things get done, the order should be:
+If only five things get done next, the order should be:
 
-1. estop — operator can kill dangerous tools instantly
-2. provider/model catalog — user can see what's available and healthy
-3. migration report — operator gets a trustworthy import artifact
-4. capability policy — operator restricts agents through config
-5. tool denial messages — users see why something was blocked
+1. Per-task budget caps -- operators can set hard limits on tool calls and model cost
+2. Policy enforcement gateway -- single choke point for all pre-execution checks
+3. Audit log -- tamper-evident record of all autonomous actions
+4. Mission Control dashboard -- single-page view of roles, schedules, and runs
+5. Role health monitoring -- automated alerts for failing scheduled roles
 
-That sequence improves safety, operator UX, and extensibility without pushing `ok-gobot` into platform bloat.
+That sequence completes the hardened-autonomy story before expanding the Mission Control surface.


### PR DESCRIPTION
Implements #290

## Changes

Refreshes all user-facing documentation to match the current codebase state as of April 2026. Addresses both code review findings from the previous PR.

### Updated docs
- **README.md**: Updated positioning as mission-control tool, added roles/jobs/skills/evolution sections, new CLI commands (providers, models, skills, jobs, babysit, batch, evolution, export, voice), added Hermes provider, updated project structure tree
- **docs/ROADMAP.md**: Distinguishes shipped features (Phase 1-4) from future work (Phase 5-6). **Fixed review finding #1**: Phase 3 header changed to "MOSTLY SHIPPED" (budget caps only partial). **Fixed review finding #2**: SECURITY.md marked as shipped (not listed as future work)
- **docs/FEATURES.md**: Added roles/jobs/skills/evolution/reflection/multi-model routing sections, updated tools list (search_file, browser_task, frontend_verify, recommend_roles), added capability policy, Mission Control API, session fork, /btw, voice/STT
- **docs/ARCHITECTURE.md**: Added chat routing (section 2.1), roles/jobs (2.2), skills (2.3), session forking, intelligence subsystems (section 6: routing, reflection, evolution, hooks), Mission Control API (5.1)
- **docs/COMPETITORS.md**: Updated ok-gobot strengths (scheduled roles, evolution, capability policy), updated comparison matrix autonomy/tools/security rows, refreshed positioning advice
- **docs/INSTALL.md**: Updated security recommendations (capability policy, SECURITY.md link), removed stale "coming soon" text

### New docs
- **SECURITY.md**: Vulnerability reporting policy, security posture summary, known limitations (no WASM sandbox, incomplete budget caps, no audit log)
- **docs/MISSION-CONTROL.md**: Concise Mission Control v1 concept page with API endpoints, architecture diagram, safety notes, and planned Phase 6 work

### Safety caveat
All docs that mention scheduled autonomy now include a note that full per-task budget caps are not yet implemented, and operators should set conservative tool allowlists.

## Testing
```
go fmt ./...     # clean
go vet ./...     # clean
go test ./...    # all pass
go build ./cmd/ok-gobot/  # success
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR comprehensively refreshes all user-facing documentation to match the April 2026 codebase, adding sections for roles/jobs/skills/evolution, new CLI commands, the Hermes provider, Mission Control API, and a new `SECURITY.md` and `docs/MISSION-CONTROL.md`. Most prior review findings have been addressed (ROADMAP.md Phase 3 header, COMPETITORS.md and ROADMAP.md four-role counts, stale "coming soon" text in INSTALL.md), but a few remain open from earlier cycles:

- `docs/FEATURES.md`: tool description list still calls the tool `grep` while the README table uses `search_file`; the `allowed_tools` config example also retains `\"grep\"` (flagged separately in prior review)
- `SECURITY.md`: misleading `**Email:**` label and \"confidential issue\" reporting path flagged in prior review remain unaddressed
- `README.md`: prebuilt role count still lists three roles instead of four

<h3>Confidence Score: 4/5</h3>

Safe to merge as documentation-only changes; no runtime code is touched, but several prior-cycle P1 findings remain open

P1 issues from prior reviews (stale grep tool name in two locations, misleading SECURITY.md reporting instructions, three-role count in README) are still present, capping the score at 4; the changes themselves are docs-only so no production behavior is affected

docs/FEATURES.md (grep/search_file rename incomplete), SECURITY.md (reporting instructions), README.md (role count)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/FEATURES.md | Major expansion covering roles, jobs, skills, intelligence subsystems, and capability policy; stale `"grep"` in allowed_tools config example flagged in prior review remains; tools description list also still names the tool `grep` while README uses `search_file` |
| SECURITY.md | Adds Known Limitations section (budget caps, no WASM sandbox, no audit log) and Skills security notes; misleading Email label and confidential-issue reporting path flagged in prior review remain unaddressed |
| README.md | Comprehensive refresh adding Hermes, multi-model routing, roles/skills/evolution sections, new CLI commands, and updated project tree; prebuilt role count and anchor issues remain from prior review cycles |
| docs/ARCHITECTURE.md | Adds chat-routing (2.1), roles/jobs (2.2), skills (2.3), session fork, intelligence subsystems (section 7), and Mission Control API (5.1); section renumbering is consistent and the README anchor now correctly points to #11 |
| docs/COMPETITORS.md | Updates autonomy, tool, and security posture rows; adds scheduled-roles, self-evolution, and capability-policy differentiators; prior four-role-count finding is now fixed |
| docs/INSTALL.md | Adds capability/allowed_tools budget-cap caveat, updates security link to SECURITY.md, removes stale "coming soon" text for role init command |
| docs/MISSION-CONTROL.md | New file describing Mission Control v1 API endpoints, architecture, safety notes, and Phase 6 plans; content is consistent with ARCHITECTURE.md section 5.1 and ROADMAP.md |
| docs/ROADMAP.md | Complete rewrite distinguishing shipped (Phase 1-4) from in-progress (Phase 5) and planned (Phase 6); Phase 3 correctly marked MOSTLY SHIPPED; four prebuilt roles now correctly listed |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `SECURITY.md`, line 229 ([link](https://github.com/befeast/ok-gobot/blob/e7d2509da06e204654aa997d38f3cc061534c5af/SECURITY.md#L229)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Misleading "Email:" label contradicts the actual reporting mechanism**

   The bold label `**Email:**` tells reporters to send an email, but the instruction that follows describes GitHub's private advisory UI — not an email address. There is no email address anywhere on the line. A reporter who reads "Email:" and looks for an address will not find one, making it likely they give up and open a public GitHub issue, the exact outcome the next line prohibits.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: SECURITY.md
   Line: 229

   Comment:
   **Misleading "Email:" label contradicts the actual reporting mechanism**

   The bold label `**Email:**` tells reporters to send an email, but the instruction that follows describes GitHub's private advisory UI — not an email address. There is no email address anywhere on the line. A reporter who reads "Email:" and looks for an address will not find one, making it likely they give up and open a public GitHub issue, the exact outcome the next line prohibits.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `README.md`, line 49 ([link](https://github.com/befeast/ok-gobot/blob/e4c23fca6516a68c9f6a8ead8aedb8982261b32f/README.md#L49)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Prebuilt role count inconsistent with FEATURES.md and ARCHITECTURE.md**

   `README.md` lists three prebuilt roles (`researcher`, `monitor`, `release-watch`), but both `docs/FEATURES.md` and `docs/ARCHITECTURE.md` (section 2.2) document four: `researcher`, `monitor`, `release-watch`, and `homelab-runbook`. Operators reading only the README will not know `homelab-runbook` exists.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: README.md
   Line: 49

   Comment:
   **Prebuilt role count inconsistent with FEATURES.md and ARCHITECTURE.md**

   `README.md` lists three prebuilt roles (`researcher`, `monitor`, `release-watch`), but both `docs/FEATURES.md` and `docs/ARCHITECTURE.md` (section 2.2) document four: `researcher`, `monitor`, `release-watch`, and `homelab-runbook`. Operators reading only the README will not know `homelab-runbook` exists.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `docs/FEATURES.md`, line 670 ([link](https://github.com/befeast/ok-gobot/blob/f7aa72f1d8c6b97ab2b01b06214833175da8673b/docs/FEATURES.md#L670)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Tool name still `grep` in description while README uses `search_file`**

   The tools description list was updated in this diff (em-dash → double-dash) but the name was not changed. An operator reading this section learns the tool is called `grep`, while an operator reading the README tools table (which was updated in this PR) sees `search_file`. The same rename gap also exists in the multi-agent `allowed_tools` example further up in this file.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/FEATURES.md
   Line: 670

   Comment:
   **Tool name still `grep` in description while README uses `search_file`**

   The tools description list was updated in this diff (em-dash → double-dash) but the name was not changed. An operator reading this section learns the tool is called `grep`, while an operator reading the README tools table (which was updated in this PR) sees `search_file`. The same rename gap also exists in the multi-agent `allowed_tools` example further up in this file.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/FEATURES.md
Line: 670

Comment:
**Tool name still `grep` in description while README uses `search_file`**

The tools description list was updated in this diff (em-dash → double-dash) but the name was not changed. An operator reading this section learns the tool is called `grep`, while an operator reading the README tools table (which was updated in this PR) sees `search_file`. The same rename gap also exists in the multi-agent `allowed_tools` example further up in this file.

```suggestion
- **search_file** -- Recursive regex search, skips binary files and `.git`/`node_modules`. Max 50 results.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["docs: fix review findings — stale role c..."](https://github.com/befeast/ok-gobot/commit/f7aa72f1d8c6b97ab2b01b06214833175da8673b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30156339)</sub>

<!-- /greptile_comment -->