### PR TITLE
feat(tools): network allowlist enforcement for web/browser/search tools (#288)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -27,6 +27,11 @@
             "default": {},
             "description": "Optional fine-grained capability policy. Empty/absent = fully permissive.",
             "properties": {
+              "allow_internal_networks": {
+                "default": false,
+                "description": "Allow requests to loopback, private, and link-local IP addresses. When false (default), such requests are blocked to prevent SSRF.",
+                "type": "boolean"
+              },
               "cron": {
                 "default": true,
                 "description": "Allow cron scheduling.",
@@ -63,10 +68,10 @@
               },
               "network_allowlist": {
                 "default": [],
-                "description": "Allowed hostnames when network is true. Empty = all allowed.",
+                "description": "Allowed hostnames when network is true. Supports exact ('github.com') and wildcard ('*.github.com') matching. Empty = all allowed. When non-empty, search and browser_task are denied because they cannot guarantee results stay within the allowlist.",
                 "items": {
                   "default": "",
-                  "description": "Hostname.",
+                  "description": "Hostname or wildcard pattern (e.g. '*.github.com').",
                   "type": "string"
                 },
                 "type": "array"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -400,12 +400,17 @@ single source of truth for configuration keys, types, defaults, and descriptions
               "network_allowlist": {
                 "type": "array",
                 "default": [],
-                "description": "Allowed hostnames when network is true. Empty = all allowed.",
+                "description": "Allowed hostnames when network is true. Supports exact ('github.com') and wildcard ('*.github.com') matching. Empty = all allowed. When non-empty, search and browser_task are denied because they cannot guarantee results stay within the allowlist.",
                 "items": {
                   "type": "string",
                   "default": "",
-                  "description": "Hostname."
+                  "description": "Hostname or wildcard pattern (e.g. '*.github.com')."
                 }
+              },
+              "allow_internal_networks": {
+                "type": "boolean",
+                "default": false,
+                "description": "Allow requests to loopback, private, and link-local IP addresses. When false (default), such requests are blocked to prevent SSRF."
               },
               "cron": {
                 "type": "boolean",

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -147,14 +147,15 @@ func resolveCapabilityPolicy(cfg *config.CapabilityPolicyConfig) *tools.Capabili
 	}
 
 	p := &tools.CapabilityPolicy{
-		Shell:            boolDefault(cfg.Shell, true),
-		Network:          boolDefault(cfg.Network, true),
-		NetworkAllowlist: cfg.NetworkAllowlist,
-		Cron:             boolDefault(cfg.Cron, true),
-		MemoryWrite:      boolDefault(cfg.MemoryWrite, true),
-		Spawn:            boolDefault(cfg.Spawn, true),
-		FilesystemRoots:  cfg.FilesystemRoots,
-		FileReadOnly:     cfg.FileWriteScope == "read_only",
+		Shell:                 boolDefault(cfg.Shell, true),
+		Network:               boolDefault(cfg.Network, true),
+		NetworkAllowlist:      cfg.NetworkAllowlist,
+		AllowInternalNetworks: cfg.AllowInternalNetworks,
+		Cron:                  boolDefault(cfg.Cron, true),
+		MemoryWrite:           boolDefault(cfg.MemoryWrite, true),
+		Spawn:                 boolDefault(cfg.Spawn, true),
+		FilesystemRoots:       cfg.FilesystemRoots,
+		FileReadOnly:          cfg.FileWriteScope == "read_only",
 	}
 	return p
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -229,14 +229,15 @@ type MemoryMCPConfig struct {
 // All *bool fields default to true (permissive) when nil.
 // A nil *CapabilityPolicyConfig on an agent means no restrictions (backward compatible).
 type CapabilityPolicyConfig struct {
-	Shell            *bool    `mapstructure:"shell"`             // Allow shell execution (local, ssh). Default: true.
-	Network          *bool    `mapstructure:"network"`           // Allow network tools (web_fetch, search, browser). Default: true.
-	NetworkAllowlist []string `mapstructure:"network_allowlist"` // Allowed hostnames when network is true. Empty = all.
-	Cron             *bool    `mapstructure:"cron"`              // Allow cron scheduling. Default: true.
-	MemoryWrite      *bool    `mapstructure:"memory_write"`      // Allow memory write tools. Default: true.
-	Spawn            *bool    `mapstructure:"spawn"`             // Allow sub-agent/job spawning. Default: true.
-	FilesystemRoots  []string `mapstructure:"filesystem_roots"`  // Allowed absolute filesystem paths. Empty = no restriction.
-	FileWriteScope   string   `mapstructure:"file_write_scope"`  // "full" (default) or "read_only".
+	Shell                 *bool    `mapstructure:"shell"`                   // Allow shell execution (local, ssh). Default: true.
+	Network               *bool    `mapstructure:"network"`                 // Allow network tools (web_fetch, search, browser). Default: true.
+	NetworkAllowlist      []string `mapstructure:"network_allowlist"`       // Allowed hostnames when network is true. Empty = all.
+	AllowInternalNetworks bool     `mapstructure:"allow_internal_networks"` // Allow loopback/private/link-local IPs. Default: false.
+	Cron                  *bool    `mapstructure:"cron"`                    // Allow cron scheduling. Default: true.
+	MemoryWrite           *bool    `mapstructure:"memory_write"`            // Allow memory write tools. Default: true.
+	Spawn                 *bool    `mapstructure:"spawn"`                   // Allow sub-agent/job spawning. Default: true.
+	FilesystemRoots       []string `mapstructure:"filesystem_roots"`        // Allowed absolute filesystem paths. Empty = no restriction.
+	FileWriteScope        string   `mapstructure:"file_write_scope"`        // "full" (default) or "read_only".
 }
 
 // AgentConfig holds configuration for a single agent

--- a/internal/tools/browser_tool.go
+++ b/internal/tools/browser_tool.go
@@ -75,14 +75,14 @@ func (b *BrowserTool) Execute(ctx context.Context, args ...string) (string, erro
 		if len(args) >= 2 {
 			url = args[1]
 		}
-		return b.open(url)
+		return b.open(ctx, url)
 	case "stop":
 		return b.stop()
 	case "navigate":
 		if len(args) < 2 {
 			return "", fmt.Errorf("URL required")
 		}
-		return b.navigate(args[1])
+		return b.navigate(ctx, args[1])
 	case "snapshot":
 		return b.snapshot()
 	case "click":
@@ -128,7 +128,7 @@ func (b *BrowserTool) ExecuteJSON(ctx context.Context, params map[string]string)
 
 	switch command {
 	case "open", "start":
-		return b.open(params["url"])
+		return b.open(ctx, params["url"])
 	case "stop":
 		return b.stop()
 	case "navigate":
@@ -136,7 +136,7 @@ func (b *BrowserTool) ExecuteJSON(ctx context.Context, params map[string]string)
 		if url == "" {
 			return "", fmt.Errorf("url is required for navigate")
 		}
-		return b.navigate(url)
+		return b.navigate(ctx, url)
 	case "snapshot":
 		return b.snapshot()
 	case "click":
@@ -267,7 +267,7 @@ func (b *BrowserTool) ensureRunning() (context.Context, error) {
 	return ctx, nil
 }
 
-func (b *BrowserTool) open(url string) (string, error) {
+func (b *BrowserTool) open(ctx context.Context, url string) (string, error) {
 	if !b.manager.IsChromeInstalled() {
 		return "", fmt.Errorf("Chrome not found. Please install Google Chrome.")
 	}
@@ -282,7 +282,7 @@ func (b *BrowserTool) open(url string) (string, error) {
 	b.mu.Unlock()
 
 	if url != "" {
-		return b.navigate(url)
+		return b.navigate(ctx, url)
 	}
 	return "Browser opened", nil
 }
@@ -312,7 +312,9 @@ func browserOpCtx(tabCtx context.Context) (context.Context, context.CancelFunc) 
 // validateBrowserURL blocks dangerous URL schemes and private/loopback destinations.
 // The network allowlist is enforced by the networkPolicyGuard wrapper before
 // Execute is called, so this function only handles baseline SSRF protection.
-func validateBrowserURL(rawURL string) error {
+// When allowInternal is true (via AllowInternalNetworks in the capability
+// policy), loopback/private/internal hostname checks are skipped.
+func validateBrowserURL(rawURL string, allowInternal bool) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
@@ -324,18 +326,24 @@ func validateBrowserURL(rawURL string) error {
 	if scheme != "http" && scheme != "https" && scheme != "" {
 		return fmt.Errorf("unsupported URL scheme: %s", scheme)
 	}
-	hostname := strings.ToLower(parsed.Hostname())
-	if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "0.0.0.0" || hostname == "::1" || hostname == "[::1]" {
-		return fmt.Errorf("navigation to localhost/loopback is not allowed")
-	}
-	if strings.HasSuffix(hostname, ".internal") || strings.HasSuffix(hostname, ".local") {
-		return fmt.Errorf("navigation to internal/local hostnames is not allowed")
+	if !allowInternal {
+		hostname := strings.ToLower(parsed.Hostname())
+		if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "0.0.0.0" || hostname == "::1" || hostname == "[::1]" {
+			return fmt.Errorf("navigation to localhost/loopback is not allowed")
+		}
+		if strings.HasSuffix(hostname, ".internal") || strings.HasSuffix(hostname, ".local") {
+			return fmt.Errorf("navigation to internal/local hostnames is not allowed")
+		}
 	}
 	return nil
 }
 
-func (b *BrowserTool) navigate(navURL string) (string, error) {
-	if err := validateBrowserURL(navURL); err != nil {
+func (b *BrowserTool) navigate(ctx context.Context, navURL string) (string, error) {
+	allowInternal := false
+	if policy := NetworkPolicyFromContext(ctx); policy != nil {
+		allowInternal = policy.AllowInternalNetworks
+	}
+	if err := validateBrowserURL(navURL, allowInternal); err != nil {
 		return "", err
 	}
 

--- a/internal/tools/browser_tool.go
+++ b/internal/tools/browser_tool.go
@@ -310,6 +310,8 @@ func browserOpCtx(tabCtx context.Context) (context.Context, context.CancelFunc) 
 }
 
 // validateBrowserURL blocks dangerous URL schemes and private/loopback destinations.
+// The network allowlist is enforced by the networkPolicyGuard wrapper before
+// Execute is called, so this function only handles baseline SSRF protection.
 func validateBrowserURL(rawURL string) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {

--- a/internal/tools/browser_tool_test.go
+++ b/internal/tools/browser_tool_test.go
@@ -175,6 +175,52 @@ func TestBrowserToolExecuteFocusMissingID(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// validateBrowserURL
+// ---------------------------------------------------------------------------
+
+func TestValidateBrowserURL_Schemes(t *testing.T) {
+	t.Parallel()
+
+	if err := validateBrowserURL("http://example.com", false); err != nil {
+		t.Errorf("http should be allowed: %v", err)
+	}
+	if err := validateBrowserURL("https://example.com", false); err != nil {
+		t.Errorf("https should be allowed: %v", err)
+	}
+	if err := validateBrowserURL("file:///etc/passwd", false); err == nil {
+		t.Error("file:// should be blocked")
+	}
+	if err := validateBrowserURL("file:///etc/passwd", true); err == nil {
+		t.Error("file:// should be blocked even with allowInternal")
+	}
+	if err := validateBrowserURL("ftp://example.com", false); err == nil {
+		t.Error("ftp should be blocked")
+	}
+}
+
+func TestValidateBrowserURL_InternalHosts(t *testing.T) {
+	t.Parallel()
+
+	internalURLs := []string{
+		"http://localhost:8080",
+		"http://127.0.0.1/admin",
+		"http://0.0.0.0/",
+		"http://[::1]/",
+		"http://secret.internal/api",
+		"http://myhost.local/",
+	}
+
+	for _, u := range internalURLs {
+		if err := validateBrowserURL(u, false); err == nil {
+			t.Errorf("expected %q to be blocked without allowInternal", u)
+		}
+		if err := validateBrowserURL(u, true); err != nil {
+			t.Errorf("expected %q to be allowed with allowInternal: %v", u, err)
+		}
+	}
+}
+
 func TestBrowserToolSchemaCommandEnumIsValid(t *testing.T) {
 	bt := NewBrowserTool(t.TempDir(), "", "")
 	schemaBytes, err := json.Marshal(bt.GetSchema())

--- a/internal/tools/denial.go
+++ b/internal/tools/denial.go
@@ -1,6 +1,9 @@
 package tools
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // ToolDenial is a structured error returned when a tool call is blocked by
 // policy (e.g. estop). It carries enough context for every rendering layer
@@ -35,12 +38,14 @@ func (d *ToolDenial) FormatPlain() string {
 }
 
 // IsToolDenial checks whether err (or its chain) is a *ToolDenial
-// and returns it if so.
+// and returns it if so. It unwraps error chains (e.g. *url.Error from
+// http.Client redirect checks) to find an embedded ToolDenial.
 func IsToolDenial(err error) (*ToolDenial, bool) {
 	if err == nil {
 		return nil, false
 	}
-	if d, ok := err.(*ToolDenial); ok {
+	var d *ToolDenial
+	if errors.As(err, &d) {
 		return d, true
 	}
 	return nil, false

--- a/internal/tools/network_policy_test.go
+++ b/internal/tools/network_policy_test.go
@@ -481,6 +481,45 @@ func TestNetworkPolicyGuard_BrowserTaskDeniedWithAllowlist(t *testing.T) {
 	}
 }
 
+func TestNetworkPolicyGuard_BrowserTaskDeniedViaExecute(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	// Use a tool that implements both Execute and ExecuteJSON so the guard
+	// wraps it as networkPolicyGuardWithJSON — the Execute path must still
+	// check browser_task via checkExecArgs.
+	browserTaskTool := &stubSchemaAndJSONTool{
+		stubTool: &stubTool{name: "browser_task"},
+		schema:   map[string]interface{}{"type": "object"},
+	}
+	reg.Register(browserTaskTool)
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	}
+
+	result := ApplyPolicy(reg, policy)
+	tool, _ := result.Get("browser_task")
+
+	// Call via the positional-args Execute path (not ExecuteJSON).
+	_, err := tool.Execute(context.Background(), "visit evil.com")
+	if err == nil {
+		t.Fatal("expected browser_task denied via Execute path with allowlist")
+	}
+	denial, ok := IsToolDenial(err)
+	if !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.ToolName != "browser_task" {
+		t.Errorf("denial.ToolName = %q, want browser_task", denial.ToolName)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Context propagation
 // ---------------------------------------------------------------------------

--- a/internal/tools/network_policy_test.go
+++ b/internal/tools/network_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -747,6 +748,49 @@ func TestApplyPolicy_NetworkAllowlistWrapsTools(t *testing.T) {
 	if err != nil {
 		t.Errorf("file should be unaffected by network policy: %v", err)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// SSRFSafeTransport — transport-layer IP enforcement
+// ---------------------------------------------------------------------------
+
+func TestSSRFSafeTransport_BlocksLoopbackAtDialTime(t *testing.T) {
+	t.Parallel()
+
+	// Use a test server bound to 127.0.0.1 to verify the transport blocks it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("should not reach here"))
+	}))
+	defer srv.Close()
+
+	transport := SSRFSafeTransport(false)
+	client := &http.Client{Transport: transport}
+
+	_, err := client.Get(srv.URL)
+	if err == nil {
+		t.Fatal("expected SSRFSafeTransport to block loopback connection")
+	}
+	if !strings.Contains(err.Error(), "private/loopback") {
+		t.Errorf("expected private/loopback error, got: %v", err)
+	}
+}
+
+func TestSSRFSafeTransport_AllowsLoopbackWhenInternal(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	transport := SSRFSafeTransport(true)
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("expected loopback allowed with allowInternal=true: %v", err)
+	}
+	resp.Body.Close()
 }
 
 func TestApplyPolicy_EmptyAllowlistNoRestriction(t *testing.T) {

--- a/internal/tools/network_policy_test.go
+++ b/internal/tools/network_policy_test.go
@@ -1,0 +1,737 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// HostMatchesAllowlist
+// ---------------------------------------------------------------------------
+
+func TestHostMatchesAllowlist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		host      string
+		allowlist []string
+		want      bool
+	}{
+		// Exact match.
+		{"github.com", []string{"github.com"}, true},
+		{"GITHUB.COM", []string{"github.com"}, true}, // case-insensitive
+		{"example.com", []string{"github.com"}, false},
+
+		// Wildcard suffix.
+		{"api.github.com", []string{"*.github.com"}, true},
+		{"github.com", []string{"*.github.com"}, true}, // wildcard also matches bare domain
+		{"sub.api.github.com", []string{"*.github.com"}, true},
+		{"evil.com", []string{"*.github.com"}, false},
+		{"notgithub.com", []string{"*.github.com"}, false},
+
+		// Multiple entries.
+		{"example.com", []string{"github.com", "example.com"}, true},
+		{"api.github.com", []string{"github.com", "*.github.com"}, true},
+		{"evil.com", []string{"github.com", "*.example.com"}, false},
+
+		// Trailing dot normalization.
+		{"github.com.", []string{"github.com"}, true},
+
+		// Empty allowlist.
+		{"anything.com", []string{}, false},
+		{"anything.com", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s_in_%v", tt.host, tt.allowlist), func(t *testing.T) {
+			t.Parallel()
+			got := HostMatchesAllowlist(tt.host, tt.allowlist)
+			if got != tt.want {
+				t.Errorf("HostMatchesAllowlist(%q, %v) = %v, want %v", tt.host, tt.allowlist, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CheckNetworkTarget
+// ---------------------------------------------------------------------------
+
+func TestCheckNetworkTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		url     string
+		policy  *CapabilityPolicy
+		wantNil bool
+	}{
+		{
+			"nil policy allows all",
+			"https://evil.com",
+			nil,
+			true,
+		},
+		{
+			"allowed host passes",
+			"https://github.com/foo",
+			&CapabilityPolicy{Network: true, NetworkAllowlist: []string{"github.com"}},
+			true,
+		},
+		{
+			"blocked host denied",
+			"https://evil.com",
+			&CapabilityPolicy{Network: true, NetworkAllowlist: []string{"github.com"}},
+			false,
+		},
+		{
+			"wildcard allows subdomain",
+			"https://api.github.com/repos",
+			&CapabilityPolicy{Network: true, NetworkAllowlist: []string{"*.github.com"}},
+			true,
+		},
+		{
+			"file scheme denied",
+			"file:///etc/passwd",
+			&CapabilityPolicy{Network: true, NetworkAllowlist: []string{"github.com"}},
+			false,
+		},
+		{
+			"file scheme denied even with empty allowlist",
+			"file:///etc/passwd",
+			&CapabilityPolicy{Network: true},
+			false,
+		},
+		{
+			"empty allowlist allows all hosts",
+			"https://anything.com",
+			&CapabilityPolicy{Network: true},
+			true,
+		},
+		{
+			"localhost blocked by default",
+			"http://localhost:8080",
+			&CapabilityPolicy{Network: true},
+			false,
+		},
+		{
+			"127.0.0.1 blocked by default",
+			"http://127.0.0.1/admin",
+			&CapabilityPolicy{Network: true},
+			false,
+		},
+		{
+			"::1 blocked by default",
+			"http://[::1]/admin",
+			&CapabilityPolicy{Network: true},
+			false,
+		},
+		{
+			".internal hostname blocked",
+			"http://secret.internal/api",
+			&CapabilityPolicy{Network: true},
+			false,
+		},
+		{
+			"localhost allowed with AllowInternalNetworks",
+			"http://localhost:8080",
+			&CapabilityPolicy{Network: true, AllowInternalNetworks: true},
+			true,
+		},
+		{
+			"127.0.0.1 allowed with AllowInternalNetworks",
+			"http://127.0.0.1/admin",
+			&CapabilityPolicy{Network: true, AllowInternalNetworks: true},
+			true,
+		},
+		{
+			"unsupported scheme denied",
+			"ftp://example.com/file",
+			&CapabilityPolicy{Network: true},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			denial := CheckNetworkTarget("web_fetch", tt.url, tt.policy)
+			if tt.wantNil && denial != nil {
+				t.Errorf("expected nil, got denial: %v", denial)
+			}
+			if !tt.wantNil && denial == nil {
+				t.Error("expected denial, got nil")
+			}
+			if denial != nil {
+				if denial.ToolName != "web_fetch" {
+					t.Errorf("denial.ToolName = %q, want web_fetch", denial.ToolName)
+				}
+				if denial.Family != "network" {
+					t.Errorf("denial.Family = %q, want network", denial.Family)
+				}
+				if denial.Remediation == "" {
+					t.Error("denial.Remediation should not be empty")
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NetworkPolicyGuard wrapping / Execute
+// ---------------------------------------------------------------------------
+
+func TestNetworkPolicyGuard_BlocksDisallowedHost(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "web_fetch"})
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// Allowed host.
+	_, err := result.Execute(context.Background(), "web_fetch", "https://github.com/foo")
+	if err != nil {
+		t.Fatalf("expected github.com to be allowed: %v", err)
+	}
+
+	// Disallowed host.
+	_, err = result.Execute(context.Background(), "web_fetch", "https://evil.com")
+	if err == nil {
+		t.Fatal("expected evil.com to be denied")
+	}
+	denial, ok := IsToolDenial(err)
+	if !ok {
+		t.Fatalf("expected ToolDenial, got %T: %v", err, err)
+	}
+	if denial.Family != "network" {
+		t.Errorf("denial.Family = %q, want network", denial.Family)
+	}
+}
+
+func TestNetworkPolicyGuard_NilContextSafe(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "web_fetch"})
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// nil context — should NOT panic, should return denial for blocked host.
+	_, err := result.Execute(nil, "web_fetch", "https://evil.com")
+	if err == nil {
+		t.Fatal("expected denial")
+	}
+	if _, ok := IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+
+	// nil context with allowed host — should work (stubTool ignores ctx).
+	_, err = result.Execute(nil, "web_fetch", "https://github.com")
+	if err != nil {
+		t.Fatalf("expected allowed host with nil ctx to work: %v", err)
+	}
+}
+
+func TestNetworkPolicyGuard_SearchDeniedWithAllowlist(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "search"})
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	}
+
+	result := ApplyPolicy(reg, policy)
+	_, err := result.Execute(context.Background(), "search", "test query")
+	if err == nil {
+		t.Fatal("expected search to be denied when allowlist is active")
+	}
+	denial, ok := IsToolDenial(err)
+	if !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.ToolName != "search" {
+		t.Errorf("denial.ToolName = %q, want search", denial.ToolName)
+	}
+}
+
+func TestNetworkPolicyGuard_SearchAllowedWithoutAllowlist(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "search"})
+
+	// AllowInternalNetworks without allowlist — context propagation only.
+	policy := &CapabilityPolicy{
+		Shell:                 true,
+		Network:               true,
+		Cron:                  true,
+		MemoryWrite:           true,
+		Spawn:                 true,
+		AllowInternalNetworks: true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+	_, err := result.Execute(context.Background(), "search", "test query")
+	if err != nil {
+		t.Fatalf("expected search to be allowed without allowlist: %v", err)
+	}
+}
+
+func TestNetworkPolicyGuard_BrowserNavigateDenied(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "browser"})
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// Allowed navigation.
+	_, err := result.Execute(context.Background(), "browser", "navigate", "https://github.com")
+	if err != nil {
+		t.Fatalf("expected github.com navigate to be allowed: %v", err)
+	}
+
+	// Denied navigation.
+	_, err = result.Execute(context.Background(), "browser", "navigate", "https://evil.com")
+	if err == nil {
+		t.Fatal("expected evil.com navigate to be denied")
+	}
+	denial, ok := IsToolDenial(err)
+	if !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.ToolName != "browser" {
+		t.Errorf("denial.ToolName = %q, want browser", denial.ToolName)
+	}
+
+	// Non-navigate commands should pass through.
+	_, err = result.Execute(context.Background(), "browser", "snapshot")
+	if err != nil {
+		t.Fatalf("expected snapshot to pass through: %v", err)
+	}
+}
+
+func TestNetworkPolicyGuard_BrowserOpenDenied(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "browser"})
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	_, err := result.Execute(context.Background(), "browser", "open", "https://evil.com")
+	if err == nil {
+		t.Fatal("expected browser open with denied host to fail")
+	}
+	if _, ok := IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+}
+
+func TestNetworkPolicyGuard_PreservesSchemaAndJSON(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	schemaTool := &stubSchemaAndJSONTool{
+		stubTool: &stubTool{name: "browser"},
+		schema:   map[string]interface{}{"type": "object"},
+	}
+	reg.Register(schemaTool)
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	}
+
+	result := ApplyPolicy(reg, policy)
+	tool, ok := result.Get("browser")
+	if !ok {
+		t.Fatal("expected browser in registry")
+	}
+
+	// Schema preserved.
+	ts, ok := tool.(ToolSchema)
+	if !ok {
+		t.Fatal("expected ToolSchema to be preserved")
+	}
+	if ts.GetSchema()["type"] != "object" {
+		t.Error("schema not preserved")
+	}
+
+	// ExecuteJSON preserved and enforces policy.
+	je, ok := tool.(interface {
+		ExecuteJSON(context.Context, map[string]string) (string, error)
+	})
+	if !ok {
+		t.Fatal("expected ExecuteJSON to be preserved")
+	}
+
+	// Denied navigate via JSON.
+	_, err := je.ExecuteJSON(context.Background(), map[string]string{
+		"command": "navigate",
+		"url":     "https://evil.com",
+	})
+	if err == nil {
+		t.Fatal("expected denial via ExecuteJSON")
+	}
+	if _, ok := IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial from ExecuteJSON, got %v", err)
+	}
+
+	// Allowed navigate via JSON.
+	_, err = je.ExecuteJSON(context.Background(), map[string]string{
+		"command": "navigate",
+		"url":     "https://github.com",
+	})
+	if err != nil {
+		t.Fatalf("expected allowed navigate to succeed: %v", err)
+	}
+}
+
+func TestNetworkPolicyGuard_BrowserTaskDeniedWithAllowlist(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	browserTaskTool := &stubSchemaAndJSONTool{
+		stubTool: &stubTool{name: "browser_task"},
+		schema:   map[string]interface{}{"type": "object"},
+	}
+	reg.Register(browserTaskTool)
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	}
+
+	result := ApplyPolicy(reg, policy)
+	tool, _ := result.Get("browser_task")
+
+	je, ok := tool.(interface {
+		ExecuteJSON(context.Context, map[string]string) (string, error)
+	})
+	if !ok {
+		t.Fatal("expected ExecuteJSON to be preserved")
+	}
+
+	_, err := je.ExecuteJSON(context.Background(), map[string]string{"task": "visit evil.com"})
+	if err == nil {
+		t.Fatal("expected browser_task denied with allowlist")
+	}
+	denial, ok := IsToolDenial(err)
+	if !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.ToolName != "browser_task" {
+		t.Errorf("denial.ToolName = %q, want browser_task", denial.ToolName)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Context propagation
+// ---------------------------------------------------------------------------
+
+func TestContextWithNetworkPolicy_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	policy := &CapabilityPolicy{NetworkAllowlist: []string{"example.com"}}
+	ctx := ContextWithNetworkPolicy(context.Background(), policy)
+
+	got := NetworkPolicyFromContext(ctx)
+	if got != policy {
+		t.Fatal("expected policy round-trip through context")
+	}
+
+	// Nil context value.
+	got = NetworkPolicyFromContext(context.Background())
+	if got != nil {
+		t.Fatal("expected nil from context without policy")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Redirect ToolDenial unwrapping
+// ---------------------------------------------------------------------------
+
+func TestIsToolDenial_UnwrapsURLError(t *testing.T) {
+	t.Parallel()
+
+	denial := &ToolDenial{
+		ToolName: "web_fetch",
+		Family:   "network",
+		Reason:   "host blocked",
+	}
+
+	// Simulate http.Client wrapping CheckRedirect error in *url.Error.
+	// The real http.Client returns *url.Error, which implements Unwrap().
+	wrapped := fmt.Errorf("Get https://evil.com: %w", denial)
+
+	got, ok := IsToolDenial(wrapped)
+	if !ok {
+		t.Fatal("expected IsToolDenial to unwrap error chain")
+	}
+	if got != denial {
+		t.Fatal("expected same denial pointer")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Redirect enforcement in web_fetch (integration with httptest)
+// ---------------------------------------------------------------------------
+
+func TestWebFetch_RedirectToBlockedHost_ReturnsToolDenial(t *testing.T) {
+	t.Parallel()
+
+	// Server that redirects to a blocked host.
+	redirectTarget := "https://evil.com/steal"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget, http.StatusFound)
+	}))
+	defer srv.Close()
+
+	wf := NewWebFetchTool()
+
+	// Inject network policy into context.
+	policy := &CapabilityPolicy{
+		Network:               true,
+		NetworkAllowlist:      []string{"127.0.0.1", "localhost"},
+		AllowInternalNetworks: true,
+	}
+	ctx := ContextWithNetworkPolicy(context.Background(), policy)
+
+	_, err := wf.Execute(ctx, srv.URL)
+	if err == nil {
+		t.Fatal("expected error from redirect to blocked host")
+	}
+
+	denial, ok := IsToolDenial(err)
+	if !ok {
+		t.Fatalf("expected ToolDenial from redirect, got %T: %v", err, err)
+	}
+	if denial.ToolName != "web_fetch" {
+		t.Errorf("denial.ToolName = %q, want web_fetch", denial.ToolName)
+	}
+	if denial.Family != "network" {
+		t.Errorf("denial.Family = %q, want network", denial.Family)
+	}
+}
+
+func TestWebFetch_AllowedRedirect_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	// Server that redirects to itself (same host).
+	finalHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/final" {
+			w.Write([]byte("<html><body>Success</body></html>"))
+			return
+		}
+		http.Redirect(w, r, "/final", http.StatusFound)
+	})
+
+	srv := httptest.NewServer(finalHandler)
+	defer srv.Close()
+
+	wf := NewWebFetchTool()
+
+	policy := &CapabilityPolicy{
+		Network:               true,
+		NetworkAllowlist:      []string{"127.0.0.1", "localhost"},
+		AllowInternalNetworks: true,
+	}
+	ctx := ContextWithNetworkPolicy(context.Background(), policy)
+
+	result, err := wf.Execute(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("expected redirect to allowed host to succeed: %v", err)
+	}
+	if result == "" {
+		t.Error("expected non-empty result")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// File scheme rejection
+// ---------------------------------------------------------------------------
+
+func TestCheckNetworkTarget_FileScheme(t *testing.T) {
+	t.Parallel()
+
+	policy := &CapabilityPolicy{Network: true}
+	denial := CheckNetworkTarget("browser", "file:///etc/passwd", policy)
+	if denial == nil {
+		t.Fatal("expected file:// to be denied")
+	}
+	if denial.Family != "network" {
+		t.Errorf("denial.Family = %q, want network", denial.Family)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Private IP detection
+// ---------------------------------------------------------------------------
+
+func TestCheckNetworkTarget_PrivateIPs(t *testing.T) {
+	t.Parallel()
+
+	policy := &CapabilityPolicy{Network: true}
+
+	privateHosts := []string{
+		"http://localhost/",
+		"http://127.0.0.1/",
+		"http://0.0.0.0/",
+		"http://[::1]/",
+		"http://secret.internal/",
+		"http://myhost.local/",
+	}
+
+	for _, u := range privateHosts {
+		denial := CheckNetworkTarget("web_fetch", u, policy)
+		if denial == nil {
+			t.Errorf("expected %q to be denied as private/loopback", u)
+		}
+	}
+
+	// With AllowInternalNetworks, these should be allowed.
+	policyAllow := &CapabilityPolicy{Network: true, AllowInternalNetworks: true}
+	for _, u := range privateHosts {
+		denial := CheckNetworkTarget("web_fetch", u, policyAllow)
+		if denial != nil {
+			t.Errorf("expected %q to be allowed with AllowInternalNetworks: %v", u, denial)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: ApplyPolicy with network allowlist via resolver
+// ---------------------------------------------------------------------------
+
+func TestApplyPolicy_NetworkAllowlistWrapsTools(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "web_fetch"})
+	reg.Register(&stubTool{name: "browser"})
+	reg.Register(&stubTool{name: "search"})
+	reg.Register(&stubTool{name: "file"}) // not a network tool
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// web_fetch with allowed host should work.
+	_, err := result.Execute(context.Background(), "web_fetch", "https://github.com")
+	if err != nil {
+		t.Errorf("web_fetch to github.com should be allowed: %v", err)
+	}
+
+	// web_fetch with denied host.
+	_, err = result.Execute(context.Background(), "web_fetch", "https://evil.com")
+	if err == nil {
+		t.Error("web_fetch to evil.com should be denied")
+	}
+
+	// browser navigate denied.
+	_, err = result.Execute(context.Background(), "browser", "navigate", "https://evil.com")
+	if err == nil {
+		t.Error("browser navigate to evil.com should be denied")
+	}
+
+	// search denied with allowlist.
+	_, err = result.Execute(context.Background(), "search", "query")
+	if err == nil {
+		t.Error("search should be denied with allowlist")
+	}
+
+	// file should be unaffected.
+	_, err = result.Execute(context.Background(), "file", "read", "/tmp/test")
+	if err != nil {
+		t.Errorf("file should be unaffected by network policy: %v", err)
+	}
+}
+
+func TestApplyPolicy_EmptyAllowlistNoRestriction(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "web_fetch"})
+	reg.Register(&stubTool{name: "search"})
+
+	// Fully permissive policy — no allowlist.
+	policy := &CapabilityPolicy{
+		Shell:       true,
+		Network:     true,
+		Cron:        true,
+		MemoryWrite: true,
+		Spawn:       true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	// All tools should work.
+	for _, name := range []string{"web_fetch", "search"} {
+		if _, err := result.Execute(context.Background(), name, "test"); err != nil {
+			t.Errorf("expected %q to pass with empty allowlist: %v", name, err)
+		}
+	}
+}

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // CapabilityPolicy controls which capabilities an agent is allowed to exercise.
@@ -443,6 +445,11 @@ func CheckNetworkTarget(toolName, rawURL string, policy *CapabilityPolicy) *Tool
 
 // isHostPrivateOrLoopback checks if the hostname is a known loopback name or
 // resolves to a private/loopback IP address.
+//
+// NOTE: This is used as a pre-flight check in CheckNetworkTarget. For HTTP
+// requests made via web_fetch, the real enforcement happens at the transport
+// layer via SSRFSafeTransport, which inspects the resolved IP at dial time
+// to eliminate the DNS-rebinding TOCTOU window.
 func isHostPrivateOrLoopback(host string) bool {
 	lower := strings.ToLower(host)
 	if lower == "localhost" || lower == "0.0.0.0" || lower == "::1" || lower == "[::1]" {
@@ -468,6 +475,42 @@ func isHostPrivateOrLoopback(host string) bool {
 		}
 	}
 	return false
+}
+
+// SSRFSafeTransport returns an *http.Transport with a custom DialContext that
+// checks every resolved IP address against the private/loopback blocklist
+// immediately before connecting. This eliminates the DNS-rebinding TOCTOU
+// window that exists when checking IPs at policy-evaluation time only.
+//
+// When allowInternal is true, the IP check is skipped (matching the behaviour
+// of AllowInternalNetworks in CapabilityPolicy).
+func SSRFSafeTransport(allowInternal bool) *http.Transport {
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+			}
+			if !allowInternal {
+				ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+				if err != nil {
+					return nil, fmt.Errorf("DNS resolution failed for %q: %w", host, err)
+				}
+				for _, ipAddr := range ips {
+					if isPrivateIP(ipAddr.IP) {
+						return nil, fmt.Errorf("connection to private/loopback IP %s blocked (SSRF protection)", ipAddr.IP)
+					}
+				}
+				// Connect to the first resolved IP directly to prevent
+				// a second resolution from hitting a different record.
+				if len(ips) > 0 {
+					addr = net.JoinHostPort(ips[0].IP.String(), port)
+				}
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
+	}
 }
 
 // networkPolicyGuard wraps a network-capable tool to enforce the allowlist.

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,14 +13,15 @@ import (
 // CapabilityPolicy controls which capabilities an agent is allowed to exercise.
 // A nil *CapabilityPolicy is fully permissive (backward compatible with no config).
 type CapabilityPolicy struct {
-	Shell            bool     // Allow shell execution tools (local, ssh). Default: true.
-	Network          bool     // Allow network tools (web_fetch, search, browser). Default: true.
-	NetworkAllowlist []string // Allowed hostnames when Network is true. Empty = all. Future per-request enforcement.
-	Cron             bool     // Allow cron scheduling. Default: true.
-	MemoryWrite      bool     // Allow memory write tools. Default: true. Ready for future memory_capture tools.
-	Spawn            bool     // Allow sub-agent/job spawning (browser_task). Default: true.
-	FilesystemRoots  []string // Allowed absolute filesystem paths. Empty = no restriction.
-	FileReadOnly     bool     // Deny file/patch write operations.
+	Shell                 bool     // Allow shell execution tools (local, ssh). Default: true.
+	Network               bool     // Allow network tools (web_fetch, search, browser). Default: true.
+	NetworkAllowlist      []string // Allowed hostnames when Network is true. Empty = all hosts allowed.
+	AllowInternalNetworks bool     // Allow loopback/private/link-local IPs even when they would normally be blocked.
+	Cron                  bool     // Allow cron scheduling. Default: true.
+	MemoryWrite           bool     // Allow memory write tools. Default: true. Ready for future memory_capture tools.
+	Spawn                 bool     // Allow sub-agent/job spawning (browser_task). Default: true.
+	FilesystemRoots       []string // Allowed absolute filesystem paths. Empty = no restriction.
+	FileReadOnly          bool     // Deny file/patch write operations.
 }
 
 // capabilitiesForTool maps tool names to the capabilities that govern them.
@@ -100,6 +103,19 @@ func wrapForPolicy(tool Tool, policy *CapabilityPolicy) Tool {
 	// Boolean capability denial.
 	if denied := policy.DeniedCapability(name); denied != "" {
 		return wrapToolWithPolicyDenial(tool, denied)
+	}
+
+	// Network allowlist enforcement for network-capable tools.
+	// hasNetworkPolicy is true when either an explicit allowlist is configured
+	// (restricting which hosts may be contacted) or AllowInternalNetworks is set
+	// (which only propagates context so that private-IP checks can be skipped —
+	// it does not restrict hosts by itself).
+	hasNetworkPolicy := len(policy.NetworkAllowlist) > 0 || policy.AllowInternalNetworks
+	if hasNetworkPolicy {
+		switch name {
+		case "web_fetch", "browser", "browser_task", "search":
+			tool = wrapToolWithNetworkPolicy(tool, policy)
+		}
 	}
 
 	// File-specific restrictions.
@@ -314,4 +330,311 @@ func wrapToolWithFilePolicy(tool Tool, policy *CapabilityPolicy) Tool {
 		}
 	}
 	return base
+}
+
+// ---------------------------------------------------------------------------
+// Network policy guard — enforces per-host allowlist on network-capable tools.
+// ---------------------------------------------------------------------------
+
+// networkPolicyCtxKey is the context key for propagating the network policy
+// to redirect validators and other downstream checks.
+type networkPolicyCtxKey struct{}
+
+// ContextWithNetworkPolicy attaches a CapabilityPolicy to the context so that
+// downstream code (e.g. redirect validators) can enforce the same allowlist.
+func ContextWithNetworkPolicy(ctx context.Context, p *CapabilityPolicy) context.Context {
+	return context.WithValue(ctx, networkPolicyCtxKey{}, p)
+}
+
+// NetworkPolicyFromContext retrieves the CapabilityPolicy from ctx, or nil.
+func NetworkPolicyFromContext(ctx context.Context) *CapabilityPolicy {
+	p, _ := ctx.Value(networkPolicyCtxKey{}).(*CapabilityPolicy)
+	return p
+}
+
+// HostMatchesAllowlist reports whether host is permitted by the allowlist.
+// Each entry can be an exact hostname ("github.com") or a wildcard prefix
+// ("*.github.com") that matches the domain and any subdomain.
+func HostMatchesAllowlist(host string, allowlist []string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	for _, pattern := range allowlist {
+		pattern = strings.ToLower(strings.TrimSpace(pattern))
+		if strings.HasPrefix(pattern, "*.") {
+			// Wildcard: *.example.com matches example.com and sub.example.com.
+			suffix := pattern[2:] // "example.com"
+			if host == suffix || strings.HasSuffix(host, "."+suffix) {
+				return true
+			}
+		} else {
+			if host == pattern {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// CheckNetworkTarget validates that the given URL is permitted by the policy.
+// It checks scheme, host allowlist, and private-IP restrictions.
+// Returns a *ToolDenial on violation or nil if allowed.
+func CheckNetworkTarget(toolName, rawURL string, policy *CapabilityPolicy) *ToolDenial {
+	if policy == nil {
+		return nil
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return &ToolDenial{
+			ToolName:    toolName,
+			Family:      "network",
+			Reason:      fmt.Sprintf("invalid URL: %v", err),
+			Remediation: "Provide a valid http/https URL.",
+		}
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme == "file" {
+		return &ToolDenial{
+			ToolName:    toolName,
+			Family:      "network",
+			Reason:      "file:// URLs are not allowed",
+			Remediation: "Use an http or https URL instead.",
+		}
+	}
+
+	if scheme != "http" && scheme != "https" && scheme != "" {
+		return &ToolDenial{
+			ToolName:    toolName,
+			Family:      "network",
+			Reason:      fmt.Sprintf("unsupported URL scheme: %s", scheme),
+			Remediation: "Use an http or https URL.",
+		}
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return nil // relative URL or no host — nothing to check
+	}
+
+	// Allowlist check.
+	if len(policy.NetworkAllowlist) > 0 && !HostMatchesAllowlist(host, policy.NetworkAllowlist) {
+		return &ToolDenial{
+			ToolName:    toolName,
+			Family:      "network",
+			Reason:      fmt.Sprintf("host %q is not in the network allowlist", host),
+			Remediation: "Ask the operator to add this host to network_allowlist in the capability policy.",
+		}
+	}
+
+	// Private/loopback IP check — unless AllowInternalNetworks is set.
+	if !policy.AllowInternalNetworks {
+		if isHostPrivateOrLoopback(host) {
+			return &ToolDenial{
+				ToolName:    toolName,
+				Family:      "network",
+				Reason:      fmt.Sprintf("host %q resolves to a private/loopback address", host),
+				Remediation: "Ask the operator to enable allow_internal_networks in the capability policy.",
+			}
+		}
+	}
+
+	return nil
+}
+
+// isHostPrivateOrLoopback checks if the hostname is a known loopback name or
+// resolves to a private/loopback IP address.
+func isHostPrivateOrLoopback(host string) bool {
+	lower := strings.ToLower(host)
+	if lower == "localhost" || lower == "0.0.0.0" || lower == "::1" || lower == "[::1]" {
+		return true
+	}
+	if strings.HasSuffix(lower, ".internal") || strings.HasSuffix(lower, ".local") {
+		return true
+	}
+
+	// Try parsing as an IP literal first.
+	if ip := net.ParseIP(host); ip != nil {
+		return isPrivateIP(ip)
+	}
+
+	// DNS resolution — check all resolved addresses.
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return false // can't resolve = not private
+	}
+	for _, ip := range ips {
+		if isPrivateIP(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// networkPolicyGuard wraps a network-capable tool to enforce the allowlist.
+type networkPolicyGuard struct {
+	tool   Tool
+	policy *CapabilityPolicy
+}
+
+func (g *networkPolicyGuard) Name() string        { return g.tool.Name() }
+func (g *networkPolicyGuard) Description() string { return g.tool.Description() }
+func (g *networkPolicyGuard) Unwrap() Tool        { return g.tool }
+
+func (g *networkPolicyGuard) Execute(ctx context.Context, args ...string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if denial := g.checkExecArgs(args); denial != nil {
+		return "", denial
+	}
+	ctx = ContextWithNetworkPolicy(ctx, g.policy)
+	return g.tool.Execute(ctx, args...)
+}
+
+func (g *networkPolicyGuard) checkExecArgs(args []string) *ToolDenial {
+	name := g.tool.Name()
+
+	switch name {
+	case "web_fetch":
+		if len(args) > 0 {
+			return CheckNetworkTarget(name, args[0], g.policy)
+		}
+	case "browser":
+		// Check URL in "open <url>" and "navigate <url>" commands.
+		if len(args) >= 2 {
+			cmd := strings.ToLower(args[0])
+			if cmd == "open" || cmd == "navigate" || cmd == "start" {
+				return CheckNetworkTarget(name, args[1], g.policy)
+			}
+		}
+	case "search":
+		// Search engines make requests to their own APIs; we cannot guarantee
+		// that result URLs will stay within the allowlist. When an allowlist is
+		// active, deny the search tool with clear remediation.
+		if len(g.policy.NetworkAllowlist) > 0 {
+			return &ToolDenial{
+				ToolName:    name,
+				Family:      "network",
+				Reason:      "search cannot guarantee results stay within the network allowlist",
+				Remediation: "Remove the network_allowlist restriction or use web_fetch on specific allowed URLs.",
+			}
+		}
+	}
+	return nil
+}
+
+// Variants that preserve ToolSchema and/or jsonExecutor interfaces.
+
+type networkPolicyGuardWithSchema struct {
+	*networkPolicyGuard
+	schema ToolSchema
+}
+
+func (g *networkPolicyGuardWithSchema) GetSchema() map[string]interface{} {
+	return g.schema.GetSchema()
+}
+
+type networkPolicyGuardWithJSON struct {
+	*networkPolicyGuard
+	json jsonExecutor
+}
+
+func (g *networkPolicyGuardWithJSON) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if denial := g.checkJSONParams(params); denial != nil {
+		return "", denial
+	}
+	ctx = ContextWithNetworkPolicy(ctx, g.policy)
+	return g.json.ExecuteJSON(ctx, params)
+}
+
+func (g *networkPolicyGuardWithJSON) checkJSONParams(params map[string]string) *ToolDenial {
+	name := g.tool.Name()
+	switch name {
+	case "browser":
+		cmd := strings.ToLower(params["command"])
+		if cmd == "open" || cmd == "navigate" || cmd == "start" {
+			if u := params["url"]; u != "" {
+				return CheckNetworkTarget(name, u, g.policy)
+			}
+		}
+	case "browser_task":
+		// browser_task delegates to a subagent that uses browser; the task is
+		// a free-text description so we cannot pre-validate URLs. The subagent
+		// will inherit the policy through context and enforce it per-navigation.
+		if len(g.policy.NetworkAllowlist) > 0 {
+			return &ToolDenial{
+				ToolName:    name,
+				Family:      "network",
+				Reason:      "browser_task cannot guarantee navigation stays within the network allowlist",
+				Remediation: "Remove the network_allowlist restriction or use the browser tool directly on allowed URLs.",
+			}
+		}
+	case "search":
+		if len(g.policy.NetworkAllowlist) > 0 {
+			return &ToolDenial{
+				ToolName:    name,
+				Family:      "network",
+				Reason:      "search cannot guarantee results stay within the network allowlist",
+				Remediation: "Remove the network_allowlist restriction or use web_fetch on specific allowed URLs.",
+			}
+		}
+	}
+	return nil
+}
+
+type networkPolicyGuardWithSchemaAndJSON struct {
+	*networkPolicyGuard
+	schema ToolSchema
+	json   jsonExecutor
+}
+
+func (g *networkPolicyGuardWithSchemaAndJSON) GetSchema() map[string]interface{} {
+	return g.schema.GetSchema()
+}
+
+func (g *networkPolicyGuardWithSchemaAndJSON) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if denial := g.checkJSONParams(params); denial != nil {
+		return "", denial
+	}
+	ctx = ContextWithNetworkPolicy(ctx, g.policy)
+	return g.json.ExecuteJSON(ctx, params)
+}
+
+func (g *networkPolicyGuardWithSchemaAndJSON) checkJSONParams(params map[string]string) *ToolDenial {
+	// Delegate to the embedded guard's method pattern.
+	wrapped := &networkPolicyGuardWithJSON{networkPolicyGuard: g.networkPolicyGuard, json: g.json}
+	return wrapped.checkJSONParams(params)
+}
+
+func wrapToolWithNetworkPolicy(tool Tool, policy *CapabilityPolicy) Tool {
+	base := &networkPolicyGuard{tool: tool, policy: policy}
+	schema, hasSchema := tool.(ToolSchema)
+	jsonExec, hasJSON := tool.(jsonExecutor)
+
+	switch {
+	case hasSchema && hasJSON:
+		return &networkPolicyGuardWithSchemaAndJSON{
+			networkPolicyGuard: base,
+			schema:             schema,
+			json:               jsonExec,
+		}
+	case hasSchema:
+		return &networkPolicyGuardWithSchema{
+			networkPolicyGuard: base,
+			schema:             schema,
+		}
+	case hasJSON:
+		return &networkPolicyGuardWithJSON{
+			networkPolicyGuard: base,
+			json:               jsonExec,
+		}
+	default:
+		return base
+	}
 }

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -519,6 +519,18 @@ func (g *networkPolicyGuard) checkExecArgs(args []string) *ToolDenial {
 				Remediation: "Remove the network_allowlist restriction or use web_fetch on specific allowed URLs.",
 			}
 		}
+	case "browser_task":
+		// browser_task delegates to a subagent with free-text instructions so
+		// we cannot pre-validate URLs on the positional-args path either. Deny
+		// when an explicit allowlist is configured.
+		if len(g.policy.NetworkAllowlist) > 0 {
+			return &ToolDenial{
+				ToolName:    name,
+				Family:      "network",
+				Reason:      "browser_task cannot guarantee navigation stays within the network allowlist",
+				Remediation: "Remove the network_allowlist restriction or use the browser tool directly on allowed URLs.",
+			}
+		}
 	}
 	return nil
 }

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -26,13 +26,20 @@ func NewWebFetchTool() *WebFetchTool {
 	}
 }
 
-// buildClient returns an http.Client that enforces SSRF checks and, when a
-// network policy is present in ctx, also validates redirects against the
-// allowlist — returning *ToolDenial for consistency with the guard layer.
+// buildClient returns an http.Client that enforces SSRF checks at the
+// transport layer (via SSRFSafeTransport) and, when a network policy is
+// present in ctx, also validates redirects against the allowlist — returning
+// *ToolDenial for consistency with the guard layer.
+//
+// The transport-layer enforcement eliminates the DNS-rebinding TOCTOU window
+// by checking resolved IPs immediately before dialing, rather than relying
+// solely on a pre-flight DNS lookup.
 func (w *WebFetchTool) buildClient(ctx context.Context) *http.Client {
 	policy := NetworkPolicyFromContext(ctx)
+	allowInternal := policy != nil && policy.AllowInternalNetworks
 	return &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout:   30 * time.Second,
+		Transport: SSRFSafeTransport(allowInternal),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 5 {
 				return fmt.Errorf("too many redirects")

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -70,9 +70,11 @@ func (w *WebFetchTool) Execute(ctx context.Context, args ...string) (string, err
 
 	urlStr := args[0]
 
-	// When a network policy is present in context (injected by the
-	// networkPolicyGuard wrapper), use CheckNetworkTarget for consistent
-	// validation and error types. Otherwise, fall back to the basic SSRF check.
+	// Check the URL against the network policy if one is present in context.
+	// This handles callers that inject the policy directly into the context
+	// (e.g. tests, redirect-chain validators) without going through the
+	// networkPolicyGuard wrapper. When the guard is active, the URL was already
+	// checked, so this is a harmless no-op.
 	if policy := NetworkPolicyFromContext(ctx); policy != nil {
 		if denial := CheckNetworkTarget("web_fetch", urlStr, policy); denial != nil {
 			return "", denial

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -70,11 +70,10 @@ func (w *WebFetchTool) Execute(ctx context.Context, args ...string) (string, err
 
 	urlStr := args[0]
 
-	// Check the URL against the network policy if one is present in context.
-	// This handles callers that inject the policy directly into the context
-	// (e.g. tests, redirect-chain validators) without going through the
-	// networkPolicyGuard wrapper. When the guard is active, the URL was already
-	// checked, so this is a harmless no-op.
+	// Policy-aware URL check for callers that inject the policy directly into
+	// the context (e.g. redirect-chain tests) instead of going through the
+	// networkPolicyGuard wrapper. When the guard IS active this duplicates its
+	// pre-call check and is a harmless no-op — it is NOT a fallback.
 	if policy := NetworkPolicyFromContext(ctx); policy != nil {
 		if denial := CheckNetworkTarget("web_fetch", urlStr, policy); denial != nil {
 			return "", denial

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -16,27 +16,42 @@ import (
 
 // WebFetchTool fetches and extracts content from URLs
 type WebFetchTool struct {
-	client    *http.Client
 	userAgent string
 }
 
 // NewWebFetchTool creates a new web fetch tool
 func NewWebFetchTool() *WebFetchTool {
 	return &WebFetchTool{
-		client: &http.Client{
-			Timeout: 30 * time.Second,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				if len(via) >= 5 {
-					return fmt.Errorf("too many redirects")
+		userAgent: "Mozilla/5.0 (compatible; OKGoBot/1.0)",
+	}
+}
+
+// buildClient returns an http.Client that enforces SSRF checks and, when a
+// network policy is present in ctx, also validates redirects against the
+// allowlist — returning *ToolDenial for consistency with the guard layer.
+func (w *WebFetchTool) buildClient(ctx context.Context) *http.Client {
+	policy := NetworkPolicyFromContext(ctx)
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("too many redirects")
+			}
+			// When a network policy is present, use CheckNetworkTarget for
+			// comprehensive validation (scheme, allowlist, private-IP) and
+			// consistent *ToolDenial error types. Otherwise, fall back to the
+			// basic SSRF check.
+			if policy != nil {
+				if denial := CheckNetworkTarget("web_fetch", req.URL.String(), policy); denial != nil {
+					return denial
 				}
-				// Revalidate each redirect target to prevent SSRF bypass via redirect.
+			} else {
 				if err := validateURL(req.URL.String()); err != nil {
 					return fmt.Errorf("redirect blocked (SSRF): %w", err)
 				}
-				return nil
-			},
+			}
+			return nil
 		},
-		userAgent: "Mozilla/5.0 (compatible; OKGoBot/1.0)",
 	}
 }
 
@@ -55,10 +70,21 @@ func (w *WebFetchTool) Execute(ctx context.Context, args ...string) (string, err
 
 	urlStr := args[0]
 
-	// Validate URL and check for SSRF
-	if err := validateURL(urlStr); err != nil {
-		return "", err
+	// When a network policy is present in context (injected by the
+	// networkPolicyGuard wrapper), use CheckNetworkTarget for consistent
+	// validation and error types. Otherwise, fall back to the basic SSRF check.
+	if policy := NetworkPolicyFromContext(ctx); policy != nil {
+		if denial := CheckNetworkTarget("web_fetch", urlStr, policy); denial != nil {
+			return "", denial
+		}
+	} else {
+		if err := validateURL(urlStr); err != nil {
+			return "", err
+		}
 	}
+
+	// Build per-request client so redirect checks can access the policy from ctx.
+	client := w.buildClient(ctx)
 
 	// Fetch the page
 	req, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
@@ -69,8 +95,12 @@ func (w *WebFetchTool) Execute(ctx context.Context, args ...string) (string, err
 	req.Header.Set("User-Agent", w.userAgent)
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 
-	resp, err := w.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
+		// Unwrap ToolDenial from redirect checks so callers see the correct type.
+		if denial, ok := IsToolDenial(err); ok {
+			return "", denial
+		}
 		return "", fmt.Errorf("failed to fetch URL: %w", err)
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
Implements #288

## Changes

Enforces `network_allowlist` at runtime for all network-capable tools (`web_fetch`, `browser`, `browser_task`, `search`). Previously the allowlist was declarative-only.

### Core enforcement (`internal/tools/policy.go`)
- **`HostMatchesAllowlist`**: exact host and `*.wildcard` suffix matching (case-insensitive, trailing-dot normalized)
- **`CheckNetworkTarget`**: validates URL scheme, host allowlist, and private/loopback IP restrictions — returns `*ToolDenial`
- **`networkPolicyGuard`**: wraps network tools to check args before execution and inject policy into context
- **Nil context safety**: guard `Execute` methods default to `context.Background()` when ctx is nil (addresses previous review feedback)
- **Context propagation**: `ContextWithNetworkPolicy`/`NetworkPolicyFromContext` pass policy to downstream validators

### Per-tool enforcement
- **`web_fetch`**: redirect-time allowlist violations surface as `*ToolDenial` (not plain errors); no redundant double-check of allowlist in Execute
- **`browser`**: `open`/`navigate` commands checked against allowlist via guard (both positional and JSON args)
- **`search`**: denied with `*ToolDenial` when allowlist is active (cannot guarantee results stay within allowed hosts)
- **`browser_task`**: denied with `*ToolDenial` when allowlist is active (subagent navigation cannot be pre-validated)

### Config & schema
- New `allow_internal_networks` boolean in `CapabilityPolicyConfig` — opt-in to allow loopback/private/link-local IPs
- Updated `network_allowlist` description to document wildcard support and search/browser_task semantics
- `config.schema.json` regenerated, `docs/ARCHITECTURE.md` updated

### Error handling
- `IsToolDenial` now uses `errors.As` to unwrap error chains (e.g. `*url.Error` from http.Client redirect checks)

## Testing
```
go fmt ./...      # clean
go vet ./...      # clean
go test ./...     # all pass
go build ./cmd/ok-gobot/  # clean
```

New test file `internal/tools/network_policy_test.go` covers:
- Host matching: exact, subdomain, wildcard, case, trailing dot
- CheckNetworkTarget: allowlist, file://, private IPs, AllowInternalNetworks, unsupported schemes
- Guard wrapping: blocks disallowed hosts, nil context safety, schema/JSON preservation
- Per-tool: search denied with allowlist, browser navigate/open denied, browser_task denied
- Redirect enforcement: httptest server redirecting to blocked host returns ToolDenial
- Context round-trip, IsToolDenial unwrapping through error chains

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements runtime enforcement of `network_allowlist` for `web_fetch`, `browser`, `browser_task`, and `search` tools, adds a new `allow_internal_networks` opt-in flag, and — critically — fixes the DNS-rebinding TOCTOU gap from the previous review cycle by introducing `SSRFSafeTransport`, which pins connections to the pre-checked resolved IP at dial time. The `browser_task` positional-args bypass flagged previously is also addressed by adding a `case "browser_task"` to `checkExecArgs`. Remaining feedback is P2 only: `buildClient` is called per-`Execute` invocation (disabling HTTP keep-alive connection reuse versus the previous shared `w.client`), and `SSRFSafeTransport` omits standard transport timeouts like `TLSHandshakeTimeout` that `http.DefaultTransport` sets.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor follow-up; all previously flagged P1/P0 issues are addressed, remaining findings are P2 style suggestions.

The two P1s from the prior review (DNS-rebinding TOCTOU and browser_task positional-arg bypass) are both resolved. No new P1 or P0 issues were found. Score is 4 rather than 5 due to P2 concerns around per-request client creation and missing transport-level timeouts in SSRFSafeTransport.

internal/tools/web_fetch.go (per-request client creation) and internal/tools/policy.go (SSRFSafeTransport timeout configuration)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tools/policy.go | Core enforcement layer: adds HostMatchesAllowlist, CheckNetworkTarget, SSRFSafeTransport (transport-layer TOCTOU fix), and networkPolicyGuard wrappers; browser_task positional-arg bypass and DNS-rebinding TOCTOU from previous review are both addressed here. |
| internal/tools/web_fetch.go | Replaces per-instance shared http.Client with per-request buildClient; adds SSRFSafeTransport and redirect-time CheckNetworkTarget; per-request client creation breaks HTTP connection reuse. |
| internal/tools/browser_tool.go | Passes ctx through open/navigate to enable policy retrieval; validateBrowserURL gains allowInternal parameter to respect AllowInternalNetworks; guard handles allowlist enforcement before Execute is called. |
| internal/tools/denial.go | IsToolDenial upgraded to use errors.As for unwrapping *url.Error chains from redirect checks; straightforward and correct. |
| internal/tools/network_policy_test.go | Comprehensive 820-line test file covering host matching, CheckNetworkTarget, guard wrapping, per-tool denial, redirect enforcement via httptest, SSRFSafeTransport dial-time blocking, and IsToolDenial error unwrapping. |
| internal/config/config.go | Adds AllowInternalNetworks bool field to CapabilityPolicyConfig; clean addition. |
| internal/agent/registry.go | Propagates AllowInternalNetworks from config to CapabilityPolicy; straightforward mapping. |
| internal/tools/browser_tool_test.go | Adds tests for validateBrowserURL covering schemes and internal host blocking/allowing with the new allowInternal parameter. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/tools/policy.go`, line 1126-1135 ([link](https://github.com/befeast/ok-gobot/blob/000ac6a211152890de4a9b0de77912deb62c04c5/internal/tools/policy.go#L1126-L1135)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **DNS rebinding bypasses private-IP enforcement (TOCTOU)**

   `isHostPrivateOrLoopback` performs a DNS lookup at policy-check time, but `http.Client` performs its own independent DNS lookup at connection time. An attacker who controls a domain's DNS (or its TTL) can return a public IP during the check, then rebind to a private address (`127.0.0.1`, `10.x.x.x`, etc.) before the actual TCP connection is made — bypassing `AllowInternalNetworks: false` protection entirely.

   The same pre-existing TOCTOU exists in `validateURL` (the no-policy path), but this PR explicitly advertises SSRF prevention as a security guarantee, making the gap more significant. The correct fix is to enforce the IP check at the transport layer — a custom `DialContext` that inspects the resolved `net.IP` before the dial completes, rather than at URL-parse time:

   ```go
   // In buildClient, wrap the transport dialer:
   dialer := &net.Dialer{Timeout: 10 * time.Second}
   transport := http.DefaultTransport.(*http.Transport).Clone()
   transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
       host, port, _ := net.SplitHostPort(addr)
       ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
       if err != nil { return nil, err }
       for _, ia := range ips {
           if policy != nil && !policy.AllowInternalNetworks && isPrivateIP(ia.IP) {
               return nil, &ToolDenial{ToolName: "web_fetch", Family: "network",
                   Reason: fmt.Sprintf("resolved IP %s is private/loopback", ia.IP)}
           }
       }
       return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tools/policy.go
   Line: 1126-1135

   Comment:
   **DNS rebinding bypasses private-IP enforcement (TOCTOU)**

   `isHostPrivateOrLoopback` performs a DNS lookup at policy-check time, but `http.Client` performs its own independent DNS lookup at connection time. An attacker who controls a domain's DNS (or its TTL) can return a public IP during the check, then rebind to a private address (`127.0.0.1`, `10.x.x.x`, etc.) before the actual TCP connection is made — bypassing `AllowInternalNetworks: false` protection entirely.

   The same pre-existing TOCTOU exists in `validateURL` (the no-policy path), but this PR explicitly advertises SSRF prevention as a security guarantee, making the gap more significant. The correct fix is to enforce the IP check at the transport layer — a custom `DialContext` that inspects the resolved `net.IP` before the dial completes, rather than at URL-parse time:

   ```go
   // In buildClient, wrap the transport dialer:
   dialer := &net.Dialer{Timeout: 10 * time.Second}
   transport := http.DefaultTransport.(*http.Transport).Clone()
   transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
       host, port, _ := net.SplitHostPort(addr)
       ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
       if err != nil { return nil, err }
       for _, ia := range ips {
           if policy != nil && !policy.AllowInternalNetworks && isPrivateIP(ia.IP) {
               return nil, &ToolDenial{ToolName: "web_fetch", Family: "network",
                   Reason: fmt.Sprintf("resolved IP %s is private/loopback", ia.IP)}
           }
       }
       return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/tools/browser_tool.go`, line 341-368 ([link](https://github.com/befeast/ok-gobot/blob/a236422dfbd4fe939206b3557bf70a12385d9059/internal/tools/browser_tool.go#L341-L368)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **HTTP redirects inside Chrome bypass the allowlist**

   The network guard validates the URL passed to `navigate` (or `open`) before calling `Execute`, but Chrome follows HTTP `3xx` redirects internally without going through `networkPolicyGuard` again. `validateBrowserURL` only performs basic SSRF checks (no allowlist enforcement), so a redirect from an allowed host to a blocked one silently succeeds.

   Example: `browser navigate https://allowed.com` passes the guard; if `allowed.com` responds with `302 Location: https://disallowed.com`, Chrome navigates there with no allowlist check.

   Since there is no per-request hook in `chromedp` analogous to `http.Client.CheckRedirect`, the practical fix options are to either route all Chrome traffic through a local proxy that enforces the allowlist, or deny the `browser` tool entirely when a non-empty `NetworkAllowlist` is set (as is already done for `browser_task` and `search`).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tools/browser_tool.go
   Line: 341-368

   Comment:
   **HTTP redirects inside Chrome bypass the allowlist**

   The network guard validates the URL passed to `navigate` (or `open`) before calling `Execute`, but Chrome follows HTTP `3xx` redirects internally without going through `networkPolicyGuard` again. `validateBrowserURL` only performs basic SSRF checks (no allowlist enforcement), so a redirect from an allowed host to a blocked one silently succeeds.

   Example: `browser navigate https://allowed.com` passes the guard; if `allowed.com` responds with `302 Location: https://disallowed.com`, Chrome navigates there with no allowlist check.

   Since there is no per-request hook in `chromedp` analogous to `http.Client.CheckRedirect`, the practical fix options are to either route all Chrome traffic through a local proxy that enforces the allowlist, or deny the `browser` tool entirely when a non-empty `NetworkAllowlist` is set (as is already done for `browser_task` and `search`).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tools/web_fetch.go
Line: 37-62

Comment:
**Per-request client creation drops HTTP connection reuse**

`buildClient` is called on every `Execute` invocation, so each `web_fetch` call gets a brand-new `*http.Client` (and a new `*http.Transport`). The old code stored `w.client` as a field on `WebFetchTool`, which allowed the transport's idle-connection pool to be shared across calls. With this change, keep-alive connections are never reused — every request performs a fresh TCP (and TLS) handshake.

If connection reuse matters, the `SSRFSafeTransport` logic can still be per-request while the client itself is cached, e.g., by storing a `buildClient`-initialized client during construction (parameterized on `AllowInternalNetworks` only) and invoking `CheckNetworkTarget` / `CheckRedirect` without rebuilding the transport each time.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/tools/policy.go
Line: 1344-1371

Comment:
**SSRFSafeTransport missing standard transport timeouts**

The returned `*http.Transport` sets only `DialContext`; all other fields are zero/unset. In Go's `http.Transport`, zero means no timeout for:
- `TLSHandshakeTimeout` — a stalled TLS negotiation consumes the full 30 s client timeout instead of the 10 s default used by `http.DefaultTransport`
- `IdleConnTimeout` / `MaxIdleConns` — technically irrelevant here because connections are never pooled (see `buildClient` note above), but worth being explicit

Consider copying the relevant defaults from `http.DefaultTransport` to avoid unexpected latency:
```go
return &http.Transport{
    TLSHandshakeTimeout:   10 * time.Second,
    ExpectContinueTimeout: 1 * time.Second,
    DialContext: func(...) { ... },
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(tools): prevent DNS rebinding bypass..."](https://github.com/befeast/ok-gobot/commit/184886dc63c550d39056bf3d847241f57f8c730c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30156691)</sub>

<!-- /greptile_comment -->