### PR TITLE
feat(budget): runtime budgets for role and subagent jobs (#287)

### DIFF
--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -267,7 +267,8 @@ iterationLoop:
 					continue
 				}
 				if maxToolCalls > 0 && toolCallsUsed >= maxToolCalls {
-					finalResponse = fmt.Sprintf("⚠️ Reached tool-call budget (%d). Task not finished.", maxToolCalls)
+					finalResponse = fmt.Sprintf("⚠️ Reached tool-call budget (%d/%d). Task not finished.", toolCallsUsed, maxToolCalls)
+					completed = false
 					break iterationLoop
 				}
 
@@ -352,8 +353,12 @@ iterationLoop:
 		break
 	}
 
+	budgetHit := maxToolCalls > 0 && toolCallsUsed >= maxToolCalls
+
 	if finalResponse == "" {
 		switch {
+		case budgetHit:
+			finalResponse = fmt.Sprintf("⚠️ Reached tool-call budget (%d/%d). Task not finished.", toolCallsUsed, maxToolCalls)
 		case len(toolResults) > 0 && !completed:
 			finalResponse = fmt.Sprintf("⚠️ Reached iteration limit (%d). Task not finished — send \"continue\" to keep going.\n\nLast tools used: %s", maxIterations, strings.Join(usedTools, ", "))
 		case len(toolResults) > 0:
@@ -370,6 +375,8 @@ iterationLoop:
 			CompletionTokens: totalCompletionTokens,
 			TotalTokens:      lastTotalTokens,
 			IsFallback:       true,
+			BudgetExceeded:   budgetHit,
+			ToolCallsUsed:    toolCallsUsed,
 		}, nil
 	}
 
@@ -381,6 +388,8 @@ iterationLoop:
 		PromptTokens:     lastPromptTokens,
 		CompletionTokens: totalCompletionTokens,
 		TotalTokens:      lastTotalTokens,
+		BudgetExceeded:   budgetHit,
+		ToolCallsUsed:    toolCallsUsed,
 	}, nil
 }
 
@@ -551,6 +560,8 @@ type AgentResponse struct {
 	CompletionTokens int
 	TotalTokens      int
 	IsFallback       bool // true when the response is a synthetic fallback, not model-generated
+	BudgetExceeded   bool // true when the run was stopped because a budget limit was hit
+	ToolCallsUsed    int  // number of tool calls consumed during this run
 }
 
 // ToolCall represents a tool invocation (legacy format)

--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -10,6 +10,7 @@ import (
 
 	"ok-gobot/internal/ai"
 	"ok-gobot/internal/bootstrap"
+	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/logger"
 	"ok-gobot/internal/tools"
 )
@@ -353,7 +354,28 @@ iterationLoop:
 		break
 	}
 
-	budgetHit := maxToolCalls > 0 && toolCallsUsed >= maxToolCalls
+	// Only flag budget_exceeded when the limit actually interrupted execution.
+	// If the model used exactly maxToolCalls tools and then gave a normal final
+	// response (completed == true), the run succeeded — it was not stopped by
+	// the budget.
+	budgetHit := maxToolCalls > 0 && toolCallsUsed >= maxToolCalls && !completed
+
+	// Build a BudgetExceededError when the tool-call limit was reached so that
+	// callers (especially the durable job runner) can distinguish budget stops
+	// from normal completions.
+	var budgetErr error
+	if budgetHit {
+		budgetErr = &delegation.BudgetExceededError{
+			Reason: delegation.LimitToolCalls,
+			Report: delegation.RunReport{
+				Status:        "budget_exceeded",
+				LimitReason:   delegation.LimitToolCalls,
+				ToolCallsUsed: toolCallsUsed,
+				ToolCallMax:   maxToolCalls,
+				Summary:       fmt.Sprintf("Reached tool-call budget (%d/%d)", toolCallsUsed, maxToolCalls),
+			},
+		}
+	}
 
 	if finalResponse == "" {
 		switch {
@@ -377,7 +399,7 @@ iterationLoop:
 			IsFallback:       true,
 			BudgetExceeded:   budgetHit,
 			ToolCallsUsed:    toolCallsUsed,
-		}, nil
+		}, budgetErr
 	}
 
 	return &AgentResponse{
@@ -390,7 +412,7 @@ iterationLoop:
 		TotalTokens:      lastTotalTokens,
 		BudgetExceeded:   budgetHit,
 		ToolCallsUsed:    toolCallsUsed,
-	}, nil
+	}, budgetErr
 }
 
 // processWithStreamingClient executes one AI round-trip using the streaming API.

--- a/internal/agent/tool_agent_test.go
+++ b/internal/agent/tool_agent_test.go
@@ -310,8 +310,14 @@ func TestToolCallingAgent_MaxToolCallsStopsFurtherExecution(t *testing.T) {
 		t.Fatalf("ProcessRequest failed: %v", err)
 	}
 
-	if !strings.Contains(resp.Message, "Reached tool-call budget (1)") {
+	if !strings.Contains(resp.Message, "Reached tool-call budget") {
 		t.Fatalf("expected tool budget warning, got %q", resp.Message)
+	}
+	if !resp.BudgetExceeded {
+		t.Fatal("expected BudgetExceeded = true")
+	}
+	if resp.ToolCallsUsed != 1 {
+		t.Fatalf("expected ToolCallsUsed = 1, got %d", resp.ToolCallsUsed)
 	}
 	if len(first.allArgs) == 0 {
 		t.Fatal("expected first tool to execute")

--- a/internal/agent/tool_agent_test.go
+++ b/internal/agent/tool_agent_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"ok-gobot/internal/ai"
+	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/tools"
 )
 
@@ -306,8 +307,14 @@ func TestToolCallingAgent_MaxToolCallsStopsFurtherExecution(t *testing.T) {
 	agent.SetMaxToolCalls(1)
 
 	resp, err := agent.ProcessRequest(context.Background(), "use both tools", "")
-	if err != nil {
-		t.Fatalf("ProcessRequest failed: %v", err)
+
+	// ProcessRequest must return a BudgetExceededError when the budget stops the run.
+	var budgetErr *delegation.BudgetExceededError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("expected BudgetExceededError, got %v", err)
+	}
+	if budgetErr.Reason != delegation.LimitToolCalls {
+		t.Fatalf("expected LimitToolCalls reason, got %q", budgetErr.Reason)
 	}
 
 	if !strings.Contains(resp.Message, "Reached tool-call budget") {
@@ -324,6 +331,39 @@ func TestToolCallingAgent_MaxToolCallsStopsFurtherExecution(t *testing.T) {
 	}
 	if len(second.allArgs) != 0 {
 		t.Fatalf("expected second tool to be skipped, got args %v", second.allArgs)
+	}
+}
+
+func TestToolCallingAgent_ExactLimitCompletionIsNotBudgetExceeded(t *testing.T) {
+	// When the model uses exactly maxToolCalls tools and then gives a normal
+	// final text response, the run completed successfully — BudgetExceeded
+	// should be false and no error should be returned.
+	registry := tools.NewRegistry()
+	registry.Register(&mockTool{name: "browser", desc: "browser"})
+
+	mockAI := &mockAIClient{
+		toolCallName: "browser",
+		toolCallArgs: `{"command":"navigate"}`,
+		finalText:    "All done!",
+	}
+
+	agent := NewToolCallingAgent(mockAI, registry, &Personality{
+		Files: map[string]string{"IDENTITY.md": "Test Bot"},
+	})
+	agent.SetMaxToolCalls(1) // exactly 1 tool call allowed
+
+	resp, err := agent.ProcessRequest(context.Background(), "navigate", "")
+	if err != nil {
+		t.Fatalf("exact-limit completion should not return error, got %v", err)
+	}
+	if resp.BudgetExceeded {
+		t.Fatal("exact-limit completion should not set BudgetExceeded")
+	}
+	if resp.Message != "All done!" {
+		t.Fatalf("unexpected message: %q", resp.Message)
+	}
+	if resp.ToolCallsUsed != 1 {
+		t.Fatalf("expected ToolCallsUsed = 1, got %d", resp.ToolCallsUsed)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,6 +15,7 @@ import (
 	"ok-gobot/internal/config"
 	"ok-gobot/internal/control"
 	"ok-gobot/internal/cron"
+	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/evolution"
 	"ok-gobot/internal/logger"
 	"ok-gobot/internal/memory"
@@ -217,12 +218,12 @@ func (a *App) Start(ctx context.Context) error {
 	jobService := runtime.NewJobService(a.store)
 
 	// Initialize cron scheduler
-	a.scheduler = cron.NewScheduler(a.store, func(ctx context.Context, job storage.CronJob) error {
+	a.scheduler = cron.NewScheduler(a.store, func(ctx context.Context, job storage.CronJob, budget *delegation.Job) error {
 		log.Printf("📅 Executing cron job #%d: %s", job.ID, job.Task)
 		if a.bot == nil {
 			return fmt.Errorf("bot not initialized")
 		}
-		return a.bot.RunCronTask(ctx, job.ChatID, job.Task)
+		return a.bot.RunCronTask(ctx, job.ChatID, job.Task, budget)
 	})
 	a.scheduler.SetNotifier(func(chatID int64, message string) {
 		if a.bot != nil {

--- a/internal/bot/tui_runtime.go
+++ b/internal/bot/tui_runtime.go
@@ -8,6 +8,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/control"
+	"ok-gobot/internal/delegation"
 )
 
 // SubmitTUIRun submits an isolated TUI run through the bot's legacy RuntimeHub
@@ -63,7 +64,9 @@ func (b *Bot) GetStatusText(sessionID string) string {
 
 // RunCronTask processes a cron job's task description through the agent.
 // The result is sent to the job's associated chat.
-func (b *Bot) RunCronTask(ctx context.Context, chatID int64, task string) error {
+// budget is optional; when non-nil it carries role/subagent budget constraints
+// (max tool calls, duration, memory policy, etc.) that the agent runtime enforces.
+func (b *Bot) RunCronTask(ctx context.Context, chatID int64, task string, budget *delegation.Job) error {
 	subKey := agent.SessionKey(fmt.Sprintf("cron:%d:%d", chatID, time.Now().UnixNano()))
 
 	events := b.hub.Submit(agent.RunRequest{
@@ -71,6 +74,7 @@ func (b *Bot) RunCronTask(ctx context.Context, chatID int64, task string) error 
 		ChatID:     chatID,
 		Content:    task,
 		Context:    ctx,
+		Job:        budget,
 	})
 
 	for ev := range events {

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -1098,6 +1098,8 @@ func jobToInfo(j storage.Job) JobInfo {
 		Attempt:            j.Attempt,
 		MaxAttempts:        j.MaxAttempts,
 		TimeoutSeconds:     j.TimeoutSeconds,
+		MaxToolCalls:       j.MaxToolCalls,
+		LimitReason:        j.LimitReason,
 		Summary:            j.Summary,
 		Error:              j.Error,
 		RoleName:           j.RoleName,

--- a/internal/control/tui_types.go
+++ b/internal/control/tui_types.go
@@ -97,6 +97,8 @@ type JobInfo struct {
 	Attempt            int    `json:"attempt"`
 	MaxAttempts        int    `json:"max_attempts"`
 	TimeoutSeconds     int    `json:"timeout_seconds,omitempty"`
+	MaxToolCalls       int    `json:"max_tool_calls,omitempty"`
+	LimitReason        string `json:"limit_reason,omitempty"`
 	Summary            string `json:"summary,omitempty"`
 	Error              string `json:"error,omitempty"`
 	RoleName           string `json:"role_name,omitempty"`

--- a/internal/cron/report.go
+++ b/internal/cron/report.go
@@ -10,15 +10,16 @@ const telegramMaxLen = 4000
 
 // JobReport is a standardized report emitted after every cron-triggered job.
 type JobReport struct {
-	CronJobID  int64
-	Expression string
-	Task       string
-	JobType    string // "llm" or "exec"
-	Status     string // "succeeded", "failed", "timed_out"
-	Summary    string // human-readable output or result
-	Error      string
-	Duration   time.Duration
-	JobID      string // durable job ID (empty when running in legacy mode)
+	CronJobID   int64
+	Expression  string
+	Task        string
+	JobType     string // "llm" or "exec"
+	Status      string // "succeeded", "failed", "timed_out", "budget_exceeded", "cancelled"
+	LimitReason string // non-empty when Status is "budget_exceeded"
+	Summary     string // human-readable output or result
+	Error       string
+	Duration    time.Duration
+	JobID       string // durable job ID (empty when running in legacy mode)
 }
 
 // FormatTelegram renders a Markdown report suitable for Telegram delivery.
@@ -30,6 +31,13 @@ func (r JobReport) FormatTelegram() string {
 		fmt.Fprintf(&b, "✅ *Schedule #%d completed*", r.CronJobID)
 	case "timed_out":
 		fmt.Fprintf(&b, "⏰ *Schedule #%d timed out*", r.CronJobID)
+	case "budget_exceeded":
+		fmt.Fprintf(&b, "🛑 *Schedule #%d budget exceeded*", r.CronJobID)
+		if r.LimitReason != "" {
+			fmt.Fprintf(&b, " (%s)", r.LimitReason)
+		}
+	case "cancelled":
+		fmt.Fprintf(&b, "🚫 *Schedule #%d cancelled*", r.CronJobID)
 	default:
 		fmt.Fprintf(&b, "❌ *Schedule #%d failed*", r.CronJobID)
 	}

--- a/internal/cron/report_test.go
+++ b/internal/cron/report_test.go
@@ -107,6 +107,60 @@ func TestJobReportFormatTelegramTruncation(t *testing.T) {
 	}
 }
 
+func TestJobReportFormatTelegramBudgetExceeded(t *testing.T) {
+	t.Parallel()
+
+	report := JobReport{
+		CronJobID:   8,
+		Expression:  "0 0 * * * *",
+		Task:        "research task",
+		JobType:     "llm",
+		Status:      "budget_exceeded",
+		LimitReason: "tool_call_limit",
+		Summary:     "Completed 50/50 tool calls",
+		Duration:    5 * time.Minute,
+		JobID:       "job-xyz789",
+	}
+
+	msg := report.FormatTelegram()
+
+	if !strings.Contains(msg, "🛑") {
+		t.Error("expected budget exceeded emoji")
+	}
+	if !strings.Contains(msg, "budget exceeded") {
+		t.Error("expected 'budget exceeded' in message")
+	}
+	if !strings.Contains(msg, "tool_call_limit") {
+		t.Error("expected limit reason in message")
+	}
+	if !strings.Contains(msg, "Completed 50/50 tool calls") {
+		t.Error("expected summary in output")
+	}
+}
+
+func TestJobReportFormatTelegramCancelled(t *testing.T) {
+	t.Parallel()
+
+	report := JobReport{
+		CronJobID:  9,
+		Expression: "0 0 * * * *",
+		Task:       "some task",
+		JobType:    "llm",
+		Status:     "cancelled",
+		Error:      "user cancelled",
+		Duration:   1 * time.Minute,
+	}
+
+	msg := report.FormatTelegram()
+
+	if !strings.Contains(msg, "🚫") {
+		t.Error("expected cancelled emoji")
+	}
+	if !strings.Contains(msg, "cancelled") {
+		t.Error("expected 'cancelled' in message")
+	}
+}
+
 func TestJobReportFormatTelegramNoJobID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cron/roles.go
+++ b/internal/cron/roles.go
@@ -63,6 +63,15 @@ func (s *Scheduler) RegisterRoleJobs(manifests []*role.Manifest, chatID int64) e
 	}
 
 	for _, m := range manifests {
+		// Always store the manifest for budget lookup at fire time,
+		// even if the role has no schedule (it may be called by name).
+		s.mu.Lock()
+		if s.manifests == nil {
+			s.manifests = make(map[string]*role.Manifest)
+		}
+		s.manifests[m.Name] = m
+		s.mu.Unlock()
+
 		if !m.HasSchedule() {
 			continue
 		}

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -211,15 +211,16 @@ func (s *Scheduler) waitAndDeliver(cronJob storage.CronJob, jobID string, start 
 	}
 
 	report := JobReport{
-		CronJobID:  cronJob.ID,
-		Expression: cronJob.Expression,
-		Task:       cronJob.Task,
-		JobType:    cronJob.Type,
-		Status:     finished.Status,
-		Summary:    finished.Summary,
-		Error:      finished.Error,
-		Duration:   time.Since(start),
-		JobID:      finished.JobID,
+		CronJobID:   cronJob.ID,
+		Expression:  cronJob.Expression,
+		Task:        cronJob.Task,
+		JobType:     cronJob.Type,
+		Status:      finished.Status,
+		LimitReason: finished.LimitReason,
+		Summary:     finished.Summary,
+		Error:       finished.Error,
+		Duration:    time.Since(start),
+		JobID:       finished.JobID,
 	}
 
 	if cronJob.Type == "" {
@@ -458,7 +459,7 @@ func (s *Scheduler) GetNextRun(jobID int64) (time.Time, error) {
 
 func isTerminal(status string) bool {
 	switch status {
-	case "succeeded", "failed", "cancelled", "timed_out":
+	case "succeeded", "failed", "cancelled", "timed_out", "budget_exceeded":
 		return true
 	}
 	return false

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/robfig/cron/v3"
 
+	"ok-gobot/internal/delegation"
+	"ok-gobot/internal/role"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -18,7 +20,9 @@ import (
 const defaultJobTimeout = 15 * time.Minute
 
 // JobExecutor is called when an LLM-type cron job fires.
-type JobExecutor func(ctx context.Context, job storage.CronJob) error
+// budget is non-nil when the cron job originates from a role manifest with
+// budget fields; the executor should pass it through to the agent runtime.
+type JobExecutor func(ctx context.Context, job storage.CronJob, budget *delegation.Job) error
 
 // ExecResultNotifier is called after an exec-type job finishes to deliver results.
 // Retained for legacy mode when no JobService is configured.
@@ -35,6 +39,7 @@ type Scheduler struct {
 	notifier   ExecResultNotifier
 	deliverer  ReportDeliverer
 	jobService *runtime.JobService
+	manifests  map[string]*role.Manifest // role name → manifest (budget lookup)
 	jobs       map[int64]cron.EntryID
 	mu         sync.RWMutex
 	running    bool
@@ -168,6 +173,22 @@ func (s *Scheduler) fireDurable(cronJob storage.CronJob, timeout time.Duration) 
 		kind = "cron_llm"
 	}
 
+	// Look up manifest to populate budget fields for role jobs.
+	var maxToolCalls int
+	var roleName string
+	if name := roleNameFromTask(cronJob.Task); name != "" {
+		roleName = name
+		s.mu.RLock()
+		m := s.manifests[name]
+		s.mu.RUnlock()
+		if m != nil {
+			maxToolCalls = m.MaxToolCalls
+			if m.MaxDuration > 0 {
+				timeout = m.MaxDuration
+			}
+		}
+	}
+
 	runner := func(ctx context.Context, job *storage.Job, svc *runtime.JobService) (runtime.JobRunResult, error) {
 		if cronJob.Type == "exec" {
 			return s.runExec(ctx, cronJob)
@@ -177,10 +198,12 @@ func (s *Scheduler) fireDurable(cronJob storage.CronJob, timeout time.Duration) 
 
 	start := time.Now()
 	job, err := s.jobService.StartDetached(context.Background(), runtime.JobSpec{
-		Kind:        kind,
-		Worker:      "cron_scheduler",
-		Description: fmt.Sprintf("schedule #%d: %s", cronJob.ID, cronJob.Task),
-		Timeout:     timeout,
+		Kind:         kind,
+		Worker:       "cron_scheduler",
+		Description:  fmt.Sprintf("schedule #%d: %s", cronJob.ID, cronJob.Task),
+		Timeout:      timeout,
+		MaxToolCalls: maxToolCalls,
+		RoleName:     roleName,
 	}, runner)
 
 	if err != nil {
@@ -239,7 +262,7 @@ func (s *Scheduler) fireLegacy(cronJob storage.CronJob, timeout time.Duration) {
 		s.executeExecJob(ctx, cronJob)
 	} else {
 		if s.executor != nil {
-			if err := s.executor(ctx, cronJob); err != nil {
+			if err := s.executor(ctx, cronJob, nil); err != nil {
 				log.Printf("Cron job %d failed: %v", cronJob.ID, err)
 			}
 		}
@@ -278,7 +301,19 @@ func (s *Scheduler) runLLM(ctx context.Context, cronJob storage.CronJob) (runtim
 		return runtime.JobRunResult{}, fmt.Errorf("no LLM executor configured")
 	}
 
-	if err := s.executor(ctx, cronJob); err != nil {
+	// Look up manifest budget for role-originated tasks.
+	var budget *delegation.Job
+	if name := roleNameFromTask(cronJob.Task); name != "" {
+		s.mu.RLock()
+		m := s.manifests[name]
+		s.mu.RUnlock()
+		if m != nil {
+			j := m.ToDelegationJob()
+			budget = &j
+		}
+	}
+
+	if err := s.executor(ctx, cronJob, budget); err != nil {
 		return runtime.JobRunResult{}, err
 	}
 

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"ok-gobot/internal/delegation"
+	"ok-gobot/internal/role"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -117,7 +119,7 @@ func TestSchedulerDurableLLMJob(t *testing.T) {
 	var reportMu sync.Mutex
 	var delivered []JobReport
 
-	executor := func(ctx context.Context, job storage.CronJob) error {
+	executor := func(ctx context.Context, job storage.CronJob, _ *delegation.Job) error {
 		executedMu.Lock()
 		executedTasks = append(executedTasks, job.Task)
 		executedMu.Unlock()
@@ -194,6 +196,93 @@ func TestSchedulerDurableLLMJob(t *testing.T) {
 	}
 	if j.Kind != "cron_llm" {
 		t.Errorf("job kind = %q, want cron_llm", j.Kind)
+	}
+}
+
+func TestSchedulerRoleBudgetPassthrough(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	jobService := runtime.NewJobService(store)
+
+	var budgetMu sync.Mutex
+	var receivedBudget *delegation.Job
+
+	executor := func(ctx context.Context, job storage.CronJob, budget *delegation.Job) error {
+		budgetMu.Lock()
+		receivedBudget = budget
+		budgetMu.Unlock()
+		return nil
+	}
+
+	sched := NewScheduler(store, executor)
+	sched.SetJobService(jobService)
+	sched.SetReportDeliverer(func(chatID int64, report JobReport) {})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := sched.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer sched.Stop()
+
+	// Register a role manifest with budget fields and a 1s schedule.
+	manifests := []*role.Manifest{
+		{
+			Name:         "budget-test",
+			Schedule:     "* * * * * *",
+			Prompt:       "test prompt",
+			Approval:     role.ApprovalAuto,
+			MaxToolCalls: 10,
+			MaxDuration:  2 * time.Minute,
+			MaxTokens:    5000,
+			MaxCostUSD:   0.50,
+			MemoryPolicy: "read_only",
+			Model:        "gpt-4",
+		},
+	}
+	if err := sched.RegisterRoleJobs(manifests, 42); err != nil {
+		t.Fatalf("RegisterRoleJobs failed: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		budgetMu.Lock()
+		got := receivedBudget
+		budgetMu.Unlock()
+		if got != nil {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	budgetMu.Lock()
+	budget := receivedBudget
+	budgetMu.Unlock()
+
+	if budget == nil {
+		t.Fatal("expected executor to receive a non-nil budget for role job")
+	}
+	if budget.MaxToolCalls != 10 {
+		t.Errorf("MaxToolCalls = %d, want 10", budget.MaxToolCalls)
+	}
+	if budget.MaxDuration != 2*time.Minute {
+		t.Errorf("MaxDuration = %v, want 2m", budget.MaxDuration)
+	}
+	if budget.MaxTokens != 5000 {
+		t.Errorf("MaxTokens = %d, want 5000", budget.MaxTokens)
+	}
+	if budget.MaxCostUSD != 0.50 {
+		t.Errorf("MaxCostUSD = %f, want 0.50", budget.MaxCostUSD)
+	}
+	if budget.MemoryPolicy != "read_only" {
+		t.Errorf("MemoryPolicy = %q, want read_only", budget.MemoryPolicy)
+	}
+	if budget.Model != "gpt-4" {
+		t.Errorf("Model = %q, want gpt-4", budget.Model)
 	}
 }
 

--- a/internal/delegation/job.go
+++ b/internal/delegation/job.go
@@ -9,6 +9,8 @@ import (
 const (
 	DefaultMaxToolCalls = 50
 	DefaultMaxDuration  = 10 * time.Minute
+	DefaultMaxTokens    = 0 // 0 = unlimited
+	DefaultMaxCostUSD   = 0 // 0 = unlimited
 
 	OutputFormatText     = "text"
 	OutputFormatMarkdown = "markdown"
@@ -27,9 +29,80 @@ type Job struct {
 	WorkspaceRoot string
 	MaxToolCalls  int
 	MaxDuration   time.Duration
+	MaxTokens     int     // max total tokens (prompt + completion); 0 = unlimited
+	MaxCostUSD    float64 // max estimated cost in USD; 0 = unlimited
 	OutputFormat  string
 	OutputSchema  string
 	MemoryPolicy  string
+}
+
+// LimitReason describes why a run was stopped.
+type LimitReason string
+
+const (
+	LimitNone         LimitReason = ""
+	LimitToolCalls    LimitReason = "tool_call_limit"
+	LimitDuration     LimitReason = "duration_limit"
+	LimitTokens       LimitReason = "token_limit"
+	LimitCost         LimitReason = "cost_limit"
+	LimitCancelled    LimitReason = "cancelled"
+	LimitUnknownError LimitReason = "error"
+)
+
+// RunReport is a structured summary of a delegated run's outcome.
+type RunReport struct {
+	Status        string      `json:"status"`       // "completed", "budget_exceeded", "timed_out", "cancelled", "failed"
+	LimitReason   LimitReason `json:"limit_reason"` // why the run stopped (empty if completed normally)
+	ToolCallsUsed int         `json:"tool_calls_used"`
+	ToolCallMax   int         `json:"tool_call_max"`
+	Duration      string      `json:"duration"`
+	DurationMax   string      `json:"duration_max"`
+	Summary       string      `json:"summary"`
+}
+
+// FormatTelegram returns a Telegram-safe Markdown summary of the run.
+func (r RunReport) FormatTelegram() string {
+	var b strings.Builder
+	switch r.Status {
+	case "completed":
+		b.WriteString("*Run completed*\n")
+	case "budget_exceeded":
+		fmt.Fprintf(&b, "*Run stopped* (%s)\n", r.LimitReason)
+	case "timed_out":
+		b.WriteString("*Run timed out*\n")
+	case "cancelled":
+		b.WriteString("*Run cancelled*\n")
+	default:
+		fmt.Fprintf(&b, "*Run %s*\n", r.Status)
+	}
+	fmt.Fprintf(&b, "Tools: %d/%d", r.ToolCallsUsed, r.ToolCallMax)
+	if r.Duration != "" {
+		fmt.Fprintf(&b, "  Duration: %s/%s", r.Duration, r.DurationMax)
+	}
+	if r.Summary != "" {
+		summary := r.Summary
+		if len(summary) > 1200 {
+			summary = summary[:1200] + "..."
+		}
+		fmt.Fprintf(&b, "\n\n%s", summary)
+	}
+	return b.String()
+}
+
+// BudgetExceededError indicates a run was stopped because a budget limit was hit.
+type BudgetExceededError struct {
+	Reason LimitReason
+	Report RunReport
+}
+
+func (e *BudgetExceededError) Error() string {
+	return fmt.Sprintf("budget exceeded: %s", e.Reason)
+}
+
+// MemoryWriteAllowed returns whether memory writes are permitted under this job's policy.
+// "read_only" → false, everything else → true.
+func (j Job) MemoryWriteAllowed() bool {
+	return NormalizeMemoryPolicy(j.MemoryPolicy) != MemoryPolicyReadOnly
 }
 
 // WithDefaults returns a normalized copy with stable defaults.
@@ -64,6 +137,8 @@ func (j Job) ContractPrompt(task string) string {
 		"EXECUTION CONTRACT:",
 		fmt.Sprintf("- max_tool_calls: %d", j.MaxToolCalls),
 		fmt.Sprintf("- max_duration: %s", j.MaxDuration),
+		fmt.Sprintf("- max_tokens: %s", budgetOrUnlimited(j.MaxTokens)),
+		fmt.Sprintf("- max_cost_usd: %s", costOrUnlimited(j.MaxCostUSD)),
 		fmt.Sprintf("- model_override: %s", valueOrInherit(j.Model)),
 		fmt.Sprintf("- thinking_level: %s", valueOrInherit(j.Thinking)),
 		fmt.Sprintf("- output_format: %s", j.OutputFormat),
@@ -116,9 +191,16 @@ func (j Job) CompletionSummary(result string) string {
 	}
 	result = trimForSummary(result, 1500)
 
+	budgetParts := fmt.Sprintf("%d tool calls / %s", j.MaxToolCalls, j.MaxDuration)
+	if j.MaxTokens > 0 {
+		budgetParts += fmt.Sprintf(" / %d tokens", j.MaxTokens)
+	}
+	if j.MaxCostUSD > 0 {
+		budgetParts += fmt.Sprintf(" / $%.4f", j.MaxCostUSD)
+	}
 	lines := []string{
 		"Run contract:",
-		fmt.Sprintf("- Budget: %d tool calls / %s", j.MaxToolCalls, j.MaxDuration),
+		fmt.Sprintf("- Budget: %s", budgetParts),
 		fmt.Sprintf("- Output: %s", outputSummary(j.OutputFormat, j.OutputSchema)),
 		fmt.Sprintf("- Memory: %s", j.MemoryPolicy),
 	}
@@ -213,6 +295,20 @@ func valueOrInherit(s string) string {
 		return "inherit"
 	}
 	return s
+}
+
+func budgetOrUnlimited(v int) string {
+	if v <= 0 {
+		return "unlimited"
+	}
+	return fmt.Sprintf("%d", v)
+}
+
+func costOrUnlimited(v float64) string {
+	if v <= 0 {
+		return "unlimited"
+	}
+	return fmt.Sprintf("$%.4f", v)
 }
 
 func trimForSummary(s string, limit int) string {

--- a/internal/delegation/job_test.go
+++ b/internal/delegation/job_test.go
@@ -1,0 +1,242 @@
+package delegation
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWithDefaults(t *testing.T) {
+	t.Parallel()
+
+	j := Job{}.WithDefaults()
+	if j.MaxToolCalls != DefaultMaxToolCalls {
+		t.Errorf("MaxToolCalls = %d, want %d", j.MaxToolCalls, DefaultMaxToolCalls)
+	}
+	if j.MaxDuration != DefaultMaxDuration {
+		t.Errorf("MaxDuration = %v, want %v", j.MaxDuration, DefaultMaxDuration)
+	}
+	if j.OutputFormat != OutputFormatMarkdown {
+		t.Errorf("OutputFormat = %q, want %q", j.OutputFormat, OutputFormatMarkdown)
+	}
+	if j.MemoryPolicy != MemoryPolicyReadOnly {
+		t.Errorf("MemoryPolicy = %q, want %q", j.MemoryPolicy, MemoryPolicyReadOnly)
+	}
+}
+
+func TestWithDefaultsPreservesExplicitValues(t *testing.T) {
+	t.Parallel()
+
+	j := Job{
+		MaxToolCalls: 10,
+		MaxDuration:  5 * time.Minute,
+		MaxTokens:    1000,
+		MaxCostUSD:   0.50,
+		OutputFormat: "json",
+		MemoryPolicy: "allow_writes",
+		Model:        "gpt-4",
+	}.WithDefaults()
+
+	if j.MaxToolCalls != 10 {
+		t.Errorf("MaxToolCalls = %d, want 10", j.MaxToolCalls)
+	}
+	if j.MaxDuration != 5*time.Minute {
+		t.Errorf("MaxDuration = %v, want 5m", j.MaxDuration)
+	}
+	if j.MaxTokens != 1000 {
+		t.Errorf("MaxTokens = %d, want 1000", j.MaxTokens)
+	}
+	if j.MaxCostUSD != 0.50 {
+		t.Errorf("MaxCostUSD = %f, want 0.50", j.MaxCostUSD)
+	}
+}
+
+func TestContractPromptIncludesTokensAndCost(t *testing.T) {
+	t.Parallel()
+
+	j := Job{
+		MaxTokens:  5000,
+		MaxCostUSD: 1.25,
+	}
+	prompt := j.ContractPrompt("do something")
+
+	if !strings.Contains(prompt, "max_tokens: 5000") {
+		t.Error("expected max_tokens in contract prompt")
+	}
+	if !strings.Contains(prompt, "max_cost_usd: $1.2500") {
+		t.Error("expected max_cost_usd in contract prompt")
+	}
+}
+
+func TestContractPromptUnlimitedDefaults(t *testing.T) {
+	t.Parallel()
+
+	j := Job{}
+	prompt := j.ContractPrompt("do something")
+
+	if !strings.Contains(prompt, "max_tokens: unlimited") {
+		t.Error("expected unlimited tokens in contract prompt")
+	}
+	if !strings.Contains(prompt, "max_cost_usd: unlimited") {
+		t.Error("expected unlimited cost in contract prompt")
+	}
+}
+
+func TestCompletionSummaryIncludesBudgets(t *testing.T) {
+	t.Parallel()
+
+	j := Job{MaxTokens: 2000, MaxCostUSD: 0.10}
+	summary := j.CompletionSummary("result text")
+
+	if !strings.Contains(summary, "2000 tokens") {
+		t.Error("expected token budget in completion summary")
+	}
+	if !strings.Contains(summary, "$0.1000") {
+		t.Error("expected cost budget in completion summary")
+	}
+	if !strings.Contains(summary, "result text") {
+		t.Error("expected result in completion summary")
+	}
+}
+
+func TestMemoryWriteAllowed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		policy string
+		want   bool
+	}{
+		{"", false}, // default normalizes to read_only
+		{"read_only", false},
+		{"inherit", true},
+		{"allow_writes", true},
+	}
+
+	for _, tc := range cases {
+		j := Job{MemoryPolicy: tc.policy}
+		if got := j.MemoryWriteAllowed(); got != tc.want {
+			t.Errorf("MemoryWriteAllowed(%q) = %v, want %v", tc.policy, got, tc.want)
+		}
+	}
+}
+
+func TestBudgetExceededError(t *testing.T) {
+	t.Parallel()
+
+	err := &BudgetExceededError{
+		Reason: LimitToolCalls,
+		Report: RunReport{
+			Status:        "budget_exceeded",
+			LimitReason:   LimitToolCalls,
+			ToolCallsUsed: 50,
+			ToolCallMax:   50,
+		},
+	}
+
+	if !strings.Contains(err.Error(), "tool_call_limit") {
+		t.Errorf("error message = %q, want to contain tool_call_limit", err.Error())
+	}
+
+	var target *BudgetExceededError
+	if !errors.As(err, &target) {
+		t.Error("errors.As should match *BudgetExceededError")
+	}
+}
+
+func TestRunReportFormatTelegram(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		report RunReport
+		want   string
+	}{
+		{
+			name: "completed",
+			report: RunReport{
+				Status:        "completed",
+				ToolCallsUsed: 5,
+				ToolCallMax:   50,
+				Summary:       "All done",
+			},
+			want: "completed",
+		},
+		{
+			name: "budget_exceeded",
+			report: RunReport{
+				Status:        "budget_exceeded",
+				LimitReason:   LimitToolCalls,
+				ToolCallsUsed: 50,
+				ToolCallMax:   50,
+				Summary:       "Hit limit",
+			},
+			want: "tool_call_limit",
+		},
+		{
+			name: "timed_out",
+			report: RunReport{
+				Status:        "timed_out",
+				ToolCallsUsed: 10,
+				ToolCallMax:   50,
+			},
+			want: "timed out",
+		},
+		{
+			name: "cancelled",
+			report: RunReport{
+				Status:        "cancelled",
+				ToolCallsUsed: 3,
+				ToolCallMax:   50,
+			},
+			want: "cancelled",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := tc.report.FormatTelegram()
+			if !strings.Contains(msg, tc.want) {
+				t.Errorf("FormatTelegram() = %q, want to contain %q", msg, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunReportFormatTelegramTruncation(t *testing.T) {
+	t.Parallel()
+
+	report := RunReport{
+		Status:        "completed",
+		ToolCallsUsed: 1,
+		ToolCallMax:   50,
+		Summary:       strings.Repeat("x", 2000),
+	}
+
+	msg := report.FormatTelegram()
+	if !strings.Contains(msg, "...") {
+		t.Error("expected truncation marker")
+	}
+}
+
+func TestNormalizeMemoryPolicy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"", MemoryPolicyReadOnly},
+		{"  READ_ONLY ", MemoryPolicyReadOnly},
+		{"inherit", MemoryPolicyInherit},
+		{"allow_writes", MemoryPolicyAllowWrites},
+		{"invalid", MemoryPolicyReadOnly},
+	}
+
+	for _, tc := range cases {
+		got := NormalizeMemoryPolicy(tc.input)
+		if got != tc.want {
+			t.Errorf("NormalizeMemoryPolicy(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/role/bundled_test.go
+++ b/internal/role/bundled_test.go
@@ -91,8 +91,8 @@ func TestLoadBundled_AllHaveBudget(t *testing.T) {
 		t.Fatalf("LoadBundled() failed: %v", err)
 	}
 	for _, m := range manifests {
-		if m.Budget <= 0 {
-			t.Errorf("bundled role %q has no budget (got %d)", m.Name, m.Budget)
+		if m.MaxToolCalls <= 0 {
+			t.Errorf("bundled role %q has no max_tool_calls (got %d)", m.Name, m.MaxToolCalls)
 		}
 	}
 }

--- a/internal/role/manifest.go
+++ b/internal/role/manifest.go
@@ -195,6 +195,9 @@ func (m *Manifest) Validate() error {
 	if m.MaxToolCalls < 0 {
 		return fmt.Errorf("role %q: max_tool_calls must be >= 0, got %d", m.Name, m.MaxToolCalls)
 	}
+	if m.MaxDuration < 0 {
+		return fmt.Errorf("role %q: max_duration must be >= 0, got %s", m.Name, m.MaxDuration)
+	}
 	if m.MaxTokens < 0 {
 		return fmt.Errorf("role %q: max_tokens must be >= 0, got %d", m.Name, m.MaxTokens)
 	}

--- a/internal/role/manifest.go
+++ b/internal/role/manifest.go
@@ -24,6 +24,9 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
+	"time"
+
+	"ok-gobot/internal/delegation"
 
 	"gopkg.in/yaml.v3"
 )
@@ -60,7 +63,12 @@ type frontmatter struct {
 	Schedule       string   `yaml:"schedule"`
 	ReportTemplate string   `yaml:"report_template"`
 	Approval       string   `yaml:"approval"`
-	Budget         int      `yaml:"budget"`
+	MaxToolCalls   int      `yaml:"max_tool_calls"`
+	MaxDuration    string   `yaml:"max_duration"`
+	MaxTokens      int      `yaml:"max_tokens"`
+	MaxCostUSD     float64  `yaml:"max_cost_usd"`
+	MemoryPolicy   string   `yaml:"memory_policy"`
+	Model          string   `yaml:"model"`
 }
 
 // Manifest is a parsed role definition loaded from a markdown file.
@@ -92,12 +100,35 @@ type Manifest struct {
 	// Defaults to ApprovalAuto when not specified.
 	Approval ApprovalMode
 
-	// Budget is the maximum number of tool calls allowed per execution.
-	// Zero means no explicit limit (caller decides).
-	Budget int
-
 	// SourcePath is the absolute path to the source .md file.
 	SourcePath string
+
+	// Budget fields for runtime enforcement.
+
+	// MaxToolCalls limits the number of tool executions per run.
+	// 0 means use the delegation default.
+	MaxToolCalls int
+
+	// MaxDuration limits wall-clock time per run.
+	// 0 means use the delegation default.
+	MaxDuration time.Duration
+
+	// MaxTokens limits total tokens (prompt + completion) per run.
+	// 0 means unlimited.
+	MaxTokens int
+
+	// MaxCostUSD limits estimated cost in USD per run.
+	// 0 means unlimited.
+	MaxCostUSD float64
+
+	// MemoryPolicy controls memory write access.
+	// Valid values: "inherit", "read_only", "allow_writes".
+	// Empty means use the delegation default.
+	MemoryPolicy string
+
+	// Model overrides the AI model for this role.
+	// Empty means the caller should use its default.
+	Model string
 }
 
 // Parse reads a role manifest from raw markdown bytes.
@@ -116,6 +147,22 @@ func Parse(name string, data []byte) (*Manifest, error) {
 		}
 	}
 
+	var maxDuration time.Duration
+	if raw := strings.TrimSpace(fm.MaxDuration); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("role %q: invalid max_duration %q: %w", name, raw, err)
+		}
+		maxDuration = d
+	}
+
+	memoryPolicy := strings.TrimSpace(fm.MemoryPolicy)
+	if memoryPolicy != "" {
+		if _, ok := delegation.ParseMemoryPolicy(memoryPolicy); !ok {
+			return nil, fmt.Errorf("role %q: invalid memory_policy %q (want inherit, read_only, or allow_writes)", name, memoryPolicy)
+		}
+	}
+
 	m := &Manifest{
 		Name:           name,
 		Prompt:         strings.TrimSpace(body),
@@ -124,7 +171,12 @@ func Parse(name string, data []byte) (*Manifest, error) {
 		Schedule:       strings.TrimSpace(fm.Schedule),
 		ReportTemplate: fm.ReportTemplate,
 		Approval:       approval,
-		Budget:         fm.Budget,
+		MaxToolCalls:   fm.MaxToolCalls,
+		MaxDuration:    maxDuration,
+		MaxTokens:      fm.MaxTokens,
+		MaxCostUSD:     fm.MaxCostUSD,
+		MemoryPolicy:   memoryPolicy,
+		Model:          strings.TrimSpace(fm.Model),
 	}
 
 	if err := m.Validate(); err != nil {
@@ -140,8 +192,14 @@ func (m *Manifest) Validate() error {
 		return fmt.Errorf("role manifest: name is required")
 	}
 
-	if m.Budget < 0 {
-		return fmt.Errorf("role %q: budget must be non-negative, got %d", m.Name, m.Budget)
+	if m.MaxToolCalls < 0 {
+		return fmt.Errorf("role %q: max_tool_calls must be >= 0, got %d", m.Name, m.MaxToolCalls)
+	}
+	if m.MaxTokens < 0 {
+		return fmt.Errorf("role %q: max_tokens must be >= 0, got %d", m.Name, m.MaxTokens)
+	}
+	if m.MaxCostUSD < 0 {
+		return fmt.Errorf("role %q: max_cost_usd must be >= 0, got %f", m.Name, m.MaxCostUSD)
 	}
 
 	if m.ReportTemplate != "" {
@@ -195,6 +253,20 @@ func (m *Manifest) RenderReport(data any) (string, error) {
 	}
 
 	return buf.String(), nil
+}
+
+// ToDelegationJob builds a delegation.Job from the manifest's budget fields.
+// Fields left at zero/empty use the delegation package defaults.
+func (m *Manifest) ToDelegationJob() delegation.Job {
+	return delegation.Job{
+		Model:         m.Model,
+		ToolAllowlist: m.Tools,
+		MaxToolCalls:  m.MaxToolCalls,
+		MaxDuration:   m.MaxDuration,
+		MaxTokens:     m.MaxTokens,
+		MaxCostUSD:    m.MaxCostUSD,
+		MemoryPolicy:  m.MemoryPolicy,
+	}
 }
 
 // splitFrontmatter separates YAML frontmatter from the markdown body.

--- a/internal/role/manifest_test.go
+++ b/internal/role/manifest_test.go
@@ -530,6 +530,42 @@ Some prompt.
 	}
 }
 
+func TestParse_NegativeMaxToolCalls(t *testing.T) {
+	data := []byte(`---
+max_tool_calls: -1
+---
+Some prompt.
+`)
+	_, err := Parse("neg-calls", data)
+	if err == nil {
+		t.Fatal("Parse should fail for negative max_tool_calls")
+	}
+}
+
+func TestParse_NegativeMaxTokens(t *testing.T) {
+	data := []byte(`---
+max_tokens: -5
+---
+Some prompt.
+`)
+	_, err := Parse("neg-tokens", data)
+	if err == nil {
+		t.Fatal("Parse should fail for negative max_tokens")
+	}
+}
+
+func TestParse_NegativeMaxCostUSD(t *testing.T) {
+	data := []byte(`---
+max_cost_usd: -0.50
+---
+Some prompt.
+`)
+	_, err := Parse("neg-cost", data)
+	if err == nil {
+		t.Fatal("Parse should fail for negative max_cost_usd")
+	}
+}
+
 func TestManifest_ToDelegationJob(t *testing.T) {
 	t.Parallel()
 

--- a/internal/role/manifest_test.go
+++ b/internal/role/manifest_test.go
@@ -566,6 +566,18 @@ Some prompt.
 	}
 }
 
+func TestParse_NegativeMaxDuration(t *testing.T) {
+	data := []byte(`---
+max_duration: "-5m"
+---
+Some prompt.
+`)
+	_, err := Parse("neg-dur", data)
+	if err == nil {
+		t.Fatal("Parse should fail for negative max_duration")
+	}
+}
+
 func TestManifest_ToDelegationJob(t *testing.T) {
 	t.Parallel()
 

--- a/internal/role/manifest_test.go
+++ b/internal/role/manifest_test.go
@@ -11,7 +11,7 @@ func TestParse_FullManifest(t *testing.T) {
 worker: premium
 tools: [web_fetch, search, memory_search]
 schedule: "0 9 * * *"
-budget: 20
+max_tool_calls: 20
 report_template: |
   ## {{.Title}}
   {{.Body}}
@@ -45,8 +45,8 @@ You are a research agent. Your job is to gather information and compile reports.
 	if m.Approval != ApprovalAlways {
 		t.Errorf("Approval = %q, want %q", m.Approval, ApprovalAlways)
 	}
-	if m.Budget != 20 {
-		t.Errorf("Budget = %d, want 20", m.Budget)
+	if m.MaxToolCalls != 20 {
+		t.Errorf("MaxToolCalls = %d, want 20", m.MaxToolCalls)
 	}
 	if m.ReportTemplate == "" {
 		t.Error("ReportTemplate is empty, want non-empty")
@@ -72,14 +72,14 @@ You are a research agent. Your job is to gather information and compile reports.
 
 func TestParse_NegativeBudget(t *testing.T) {
 	data := []byte(`---
-budget: -5
+max_tool_calls: -5
 ---
 Some prompt.
 `)
 
 	_, err := Parse("bad-budget", data)
 	if err == nil {
-		t.Fatal("Parse should fail for negative budget")
+		t.Fatal("Parse should fail for negative max_tool_calls")
 	}
 }
 
@@ -427,6 +427,142 @@ Run locally.
 	}
 	if m.Prompt != "Run locally." {
 		t.Errorf("Prompt = %q, want %q", m.Prompt, "Run locally.")
+	}
+}
+
+func TestParse_BudgetFields(t *testing.T) {
+	data := []byte(`---
+worker: standard
+max_tool_calls: 25
+max_duration: "5m"
+max_tokens: 10000
+max_cost_usd: 0.50
+memory_policy: read_only
+model: gpt-4
+---
+# Budget Role
+
+A role with budget constraints.
+`)
+
+	m, err := Parse("budget", data)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if m.MaxToolCalls != 25 {
+		t.Errorf("MaxToolCalls = %d, want 25", m.MaxToolCalls)
+	}
+	if m.MaxDuration.Minutes() != 5 {
+		t.Errorf("MaxDuration = %v, want 5m", m.MaxDuration)
+	}
+	if m.MaxTokens != 10000 {
+		t.Errorf("MaxTokens = %d, want 10000", m.MaxTokens)
+	}
+	if m.MaxCostUSD != 0.50 {
+		t.Errorf("MaxCostUSD = %f, want 0.50", m.MaxCostUSD)
+	}
+	if m.MemoryPolicy != "read_only" {
+		t.Errorf("MemoryPolicy = %q, want %q", m.MemoryPolicy, "read_only")
+	}
+	if m.Model != "gpt-4" {
+		t.Errorf("Model = %q, want %q", m.Model, "gpt-4")
+	}
+}
+
+func TestParse_BudgetFieldsDefault(t *testing.T) {
+	data := []byte(`---
+worker: cheap
+---
+# No budgets
+
+No budget constraints set.
+`)
+
+	m, err := Parse("no-budget", data)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if m.MaxToolCalls != 0 {
+		t.Errorf("MaxToolCalls = %d, want 0", m.MaxToolCalls)
+	}
+	if m.MaxDuration != 0 {
+		t.Errorf("MaxDuration = %v, want 0", m.MaxDuration)
+	}
+	if m.MaxTokens != 0 {
+		t.Errorf("MaxTokens = %d, want 0", m.MaxTokens)
+	}
+	if m.MaxCostUSD != 0 {
+		t.Errorf("MaxCostUSD = %f, want 0", m.MaxCostUSD)
+	}
+	if m.MemoryPolicy != "" {
+		t.Errorf("MemoryPolicy = %q, want empty", m.MemoryPolicy)
+	}
+	if m.Model != "" {
+		t.Errorf("Model = %q, want empty", m.Model)
+	}
+}
+
+func TestParse_InvalidMaxDuration(t *testing.T) {
+	data := []byte(`---
+max_duration: "not-a-duration"
+---
+Some prompt.
+`)
+
+	_, err := Parse("bad-duration", data)
+	if err == nil {
+		t.Fatal("Parse should fail for invalid max_duration")
+	}
+}
+
+func TestParse_InvalidMemoryPolicy(t *testing.T) {
+	data := []byte(`---
+memory_policy: "yolo"
+---
+Some prompt.
+`)
+
+	_, err := Parse("bad-policy", data)
+	if err == nil {
+		t.Fatal("Parse should fail for invalid memory_policy")
+	}
+}
+
+func TestManifest_ToDelegationJob(t *testing.T) {
+	t.Parallel()
+
+	m := &Manifest{
+		Name:         "test",
+		Model:        "gpt-4",
+		Tools:        []string{"web_fetch", "search"},
+		MaxToolCalls: 20,
+		MaxDuration:  3 * 60_000_000_000, // 3 minutes in nanoseconds
+		MaxTokens:    5000,
+		MaxCostUSD:   0.25,
+		MemoryPolicy: "read_only",
+	}
+
+	job := m.ToDelegationJob()
+
+	if job.Model != "gpt-4" {
+		t.Errorf("Model = %q, want %q", job.Model, "gpt-4")
+	}
+	if len(job.ToolAllowlist) != 2 {
+		t.Errorf("ToolAllowlist = %v, want [web_fetch search]", job.ToolAllowlist)
+	}
+	if job.MaxToolCalls != 20 {
+		t.Errorf("MaxToolCalls = %d, want 20", job.MaxToolCalls)
+	}
+	if job.MaxTokens != 5000 {
+		t.Errorf("MaxTokens = %d, want 5000", job.MaxTokens)
+	}
+	if job.MaxCostUSD != 0.25 {
+		t.Errorf("MaxCostUSD = %f, want 0.25", job.MaxCostUSD)
+	}
+	if job.MemoryPolicy != "read_only" {
+		t.Errorf("MemoryPolicy = %q, want %q", job.MemoryPolicy, "read_only")
 	}
 }
 

--- a/internal/role/prebuilt/homelab-runbook.md
+++ b/internal/role/prebuilt/homelab-runbook.md
@@ -1,7 +1,7 @@
 ---
 worker: standard
 tools: [obsidian, memory_get, memory_search]
-budget: 10
+max_tool_calls: 10
 approval: auto
 report_template: |
   📋 *Runbook*

--- a/internal/role/prebuilt/monitor.md
+++ b/internal/role/prebuilt/monitor.md
@@ -2,7 +2,7 @@
 worker: cheap
 tools: [web_fetch]
 schedule: "0 */30 * * * *"
-budget: 10
+max_tool_calls: 10
 approval: auto
 report_template: |
   🔍 *Monitor Report*

--- a/internal/role/prebuilt/release-watch.md
+++ b/internal/role/prebuilt/release-watch.md
@@ -2,7 +2,7 @@
 worker: standard
 tools: [web_fetch, search, memory_get, memory_search]
 schedule: "0 0 10 * * 1"
-budget: 15
+max_tool_calls: 15
 approval: auto
 report_template: |
   🚀 *Release Watch*

--- a/internal/role/prebuilt/researcher.md
+++ b/internal/role/prebuilt/researcher.md
@@ -1,7 +1,7 @@
 ---
 worker: standard
 tools: [search, web_fetch, memory_search]
-budget: 15
+max_tool_calls: 15
 approval: auto
 report_template: |
   📚 *Research Brief*

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -354,7 +354,11 @@ func (s *JobService) run(parentCtx context.Context, job *storage.Job, timeout ti
 
 	switch {
 	case errors.As(runErr, &budgetErr):
-		if err := s.store.MarkJobBudgetExceeded(job.JobID, budgetErr.Report.Summary, string(budgetErr.Reason)); err != nil {
+		summary := budgetErr.Report.Summary
+		if summary == "" {
+			summary = result.Summary
+		}
+		if err := s.store.MarkJobBudgetExceeded(job.JobID, summary, string(budgetErr.Reason)); err != nil {
 			log.Printf("[jobs] failed to mark %s budget_exceeded: %v", job.JobID, err)
 			return
 		}

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/storage"
 )
 
@@ -18,12 +19,13 @@ import (
 type JobStatus string
 
 const (
-	JobStatusPending   JobStatus = "pending"
-	JobStatusRunning   JobStatus = "running"
-	JobStatusSucceeded JobStatus = "succeeded"
-	JobStatusFailed    JobStatus = "failed"
-	JobStatusCancelled JobStatus = "cancelled"
-	JobStatusTimedOut  JobStatus = "timed_out"
+	JobStatusPending        JobStatus = "pending"
+	JobStatusRunning        JobStatus = "running"
+	JobStatusSucceeded      JobStatus = "succeeded"
+	JobStatusFailed         JobStatus = "failed"
+	JobStatusCancelled      JobStatus = "cancelled"
+	JobStatusTimedOut       JobStatus = "timed_out"
+	JobStatusBudgetExceeded JobStatus = "budget_exceeded"
 )
 
 // JobEventType is the persisted event stream for a job.
@@ -40,6 +42,7 @@ const (
 	JobEventTimedOut        JobEventType = "timed_out"
 	JobEventRetryRequested  JobEventType = "retry_requested"
 	JobEventArtifactAdded   JobEventType = "artifact_added"
+	JobEventBudgetExceeded  JobEventType = "budget_exceeded"
 )
 
 // JobSpec describes a new durable background job.
@@ -56,6 +59,7 @@ type JobSpec struct {
 	Attempt            int
 	MaxAttempts        int
 	Timeout            time.Duration
+	MaxToolCalls       int
 }
 
 // JobArtifactSpec describes one durable artifact emitted by a job.
@@ -270,6 +274,7 @@ func (s *JobService) createJob(spec JobSpec) (*storage.Job, error) {
 		Attempt:            attempt,
 		MaxAttempts:        maxAttempts,
 		TimeoutSeconds:     timeoutSeconds,
+		MaxToolCalls:       spec.MaxToolCalls,
 		RoleName:           strings.TrimSpace(spec.RoleName),
 		ModelTier:          strings.TrimSpace(spec.ModelTier),
 	}); err != nil {
@@ -345,7 +350,21 @@ func (s *JobService) run(parentCtx context.Context, job *storage.Job, timeout ti
 		cancelRequested = storedJob.CancelRequested
 	}
 
+	var budgetErr *delegation.BudgetExceededError
+
 	switch {
+	case errors.As(runErr, &budgetErr):
+		if err := s.store.MarkJobBudgetExceeded(job.JobID, budgetErr.Report.Summary, string(budgetErr.Reason)); err != nil {
+			log.Printf("[jobs] failed to mark %s budget_exceeded: %v", job.JobID, err)
+			return
+		}
+		if err := s.AppendEvent(job.JobID, JobEventBudgetExceeded, budgetErr.Error(), map[string]any{
+			"limit_reason":    string(budgetErr.Reason),
+			"tool_calls_used": budgetErr.Report.ToolCallsUsed,
+			"tool_call_max":   budgetErr.Report.ToolCallMax,
+		}); err != nil {
+			log.Printf("[jobs] failed to persist budget event for %s: %v", job.JobID, err)
+		}
 	case errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(runErr, context.DeadlineExceeded):
 		if err := s.store.MarkJobTimedOut(job.JobID, runErr.Error()); err != nil {
 			log.Printf("[jobs] failed to mark %s timed out: %v", job.JobID, err)

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -285,6 +285,52 @@ func TestJobServiceBudgetExceededMarksBudgetExceeded(t *testing.T) {
 	}
 }
 
+func TestJobServiceBudgetExceededFallsBackToRunnerSummary(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const routeKey = "agent:test:telegram:group:89"
+	if err := store.SaveSessionRoute(storage.SessionRoute{
+		SessionKey: routeKey,
+		Channel:    "telegram",
+		ChatID:     89,
+	}); err != nil {
+		t.Fatalf("SaveSessionRoute failed: %v", err)
+	}
+
+	svc := NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:               "background_task",
+		Worker:             "budget_runner",
+		SessionKey:         "agent:test:main",
+		DeliverySessionKey: routeKey,
+		Description:        "hit budget with runner summary",
+		MaxToolCalls:       5,
+		Timeout:            5 * time.Second,
+	}, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{Summary: "runner produced this"}, &delegation.BudgetExceededError{
+			Reason: delegation.LimitToolCalls,
+			Report: delegation.RunReport{
+				Status:        "budget_exceeded",
+				LimitReason:   delegation.LimitToolCalls,
+				ToolCallsUsed: 5,
+				ToolCallMax:   5,
+				Summary:       "", // intentionally empty
+			},
+		}
+	})
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	finished := waitForJobStatus(t, store, job.JobID, string(JobStatusBudgetExceeded))
+	if finished.Summary != "runner produced this" {
+		t.Fatalf("Summary = %q, want %q (fallback to runner summary)", finished.Summary, "runner produced this")
+	}
+}
+
 func TestJobServiceMaxToolCallsPersistedInSpec(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/storage"
 )
 
@@ -226,6 +227,98 @@ func TestJobServiceRetryDetachedClonesAttempt(t *testing.T) {
 	events := waitForJobEvents(t, store, original.JobID, 4)
 	if events[len(events)-1].EventType != string(JobEventRetryRequested) {
 		t.Fatalf("expected final original event retry_requested, got %+v", events)
+	}
+}
+
+func TestJobServiceBudgetExceededMarksBudgetExceeded(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const routeKey = "agent:test:telegram:group:88"
+	if err := store.SaveSessionRoute(storage.SessionRoute{
+		SessionKey: routeKey,
+		Channel:    "telegram",
+		ChatID:     88,
+	}); err != nil {
+		t.Fatalf("SaveSessionRoute failed: %v", err)
+	}
+
+	svc := NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:               "background_task",
+		Worker:             "budget_runner",
+		SessionKey:         "agent:test:main",
+		DeliverySessionKey: routeKey,
+		Description:        "hit budget",
+		MaxToolCalls:       10,
+		Timeout:            5 * time.Second,
+	}, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{Summary: "partial work done"}, &delegation.BudgetExceededError{
+			Reason: delegation.LimitToolCalls,
+			Report: delegation.RunReport{
+				Status:        "budget_exceeded",
+				LimitReason:   delegation.LimitToolCalls,
+				ToolCallsUsed: 10,
+				ToolCallMax:   10,
+				Summary:       "partial work done",
+			},
+		}
+	})
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	finished := waitForJobStatus(t, store, job.JobID, string(JobStatusBudgetExceeded))
+	if finished.LimitReason != string(delegation.LimitToolCalls) {
+		t.Fatalf("LimitReason = %q, want %q", finished.LimitReason, delegation.LimitToolCalls)
+	}
+	if finished.Summary != "partial work done" {
+		t.Fatalf("Summary = %q, want %q", finished.Summary, "partial work done")
+	}
+
+	events := waitForJobEvents(t, store, job.JobID, 3)
+	lastEvent := events[len(events)-1]
+	if lastEvent.EventType != string(JobEventBudgetExceeded) {
+		t.Fatalf("expected final event budget_exceeded, got %q", lastEvent.EventType)
+	}
+}
+
+func TestJobServiceMaxToolCallsPersistedInSpec(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const routeKey = "agent:test:telegram:group:66"
+	if err := store.SaveSessionRoute(storage.SessionRoute{
+		SessionKey: routeKey,
+		Channel:    "telegram",
+		ChatID:     66,
+	}); err != nil {
+		t.Fatalf("SaveSessionRoute failed: %v", err)
+	}
+
+	svc := NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:               "background_task",
+		Worker:             "test_runner",
+		SessionKey:         "agent:test:main",
+		DeliverySessionKey: routeKey,
+		Description:        "budget test",
+		MaxToolCalls:       25,
+		Timeout:            2 * time.Second,
+	}, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{Summary: "done"}, nil
+	})
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	finished := waitForJobStatus(t, store, job.JobID, string(JobStatusSucceeded))
+	if finished.MaxToolCalls != 25 {
+		t.Fatalf("MaxToolCalls = %d, want 25", finished.MaxToolCalls)
 	}
 }
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -422,6 +422,19 @@ func (s *Store) migrateCanonicalSchema() error {
 		}
 	}
 
+	// Job budget columns.
+	for _, stmt := range []string{
+		`ALTER TABLE jobs ADD COLUMN max_tool_calls INTEGER NOT NULL DEFAULT 0;`,
+		`ALTER TABLE jobs ADD COLUMN limit_reason TEXT NOT NULL DEFAULT '';`,
+	} {
+		if _, err := s.db.Exec(stmt); err != nil {
+			if strings.Contains(err.Error(), "duplicate column") {
+				continue
+			}
+			return fmt.Errorf("job budget migration failed: %w", err)
+		}
+	}
+
 	if err := s.backfillCanonicalSessionData(); err != nil {
 		return err
 	}
@@ -1441,6 +1454,8 @@ type Job struct {
 	Attempt            int
 	MaxAttempts        int
 	TimeoutSeconds     int
+	MaxToolCalls       int
+	LimitReason        string
 	Summary            string
 	Error              string
 	RoleName           string
@@ -1506,8 +1521,8 @@ func (s *Store) CreateJob(job Job) error {
 		INSERT INTO jobs (
 			job_id, kind, worker, session_key, delivery_session_key, retry_of_job_id,
 			description, status, cancel_requested, attempt, max_attempts, timeout_seconds,
-			summary, error, role_name, model_tier, tool_call_count
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			max_tool_calls, limit_reason, summary, error, role_name, model_tier, tool_call_count
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		jobID,
 		kind,
@@ -1521,6 +1536,8 @@ func (s *Store) CreateJob(job Job) error {
 		attempt,
 		maxAttempts,
 		job.TimeoutSeconds,
+		job.MaxToolCalls,
+		job.LimitReason,
 		job.Summary,
 		job.Error,
 		strings.TrimSpace(job.RoleName),
@@ -1545,6 +1562,7 @@ func (s *Store) GetJob(jobID string) (*Job, error) {
 	err := s.db.QueryRow(`
 		SELECT job_id, kind, worker, session_key, delivery_session_key, retry_of_job_id,
 		       description, status, cancel_requested, attempt, max_attempts, timeout_seconds,
+		       max_tool_calls, limit_reason,
 		       summary, error, role_name, model_tier, tool_call_count,
 		       created_at, COALESCE(started_at, ''), COALESCE(completed_at, ''), updated_at
 		FROM jobs
@@ -1562,6 +1580,8 @@ func (s *Store) GetJob(jobID string) (*Job, error) {
 		&job.Attempt,
 		&job.MaxAttempts,
 		&job.TimeoutSeconds,
+		&job.MaxToolCalls,
+		&job.LimitReason,
 		&job.Summary,
 		&job.Error,
 		&job.RoleName,
@@ -1603,6 +1623,7 @@ func (s *Store) ListJobsByStatus(status string, limit int) ([]Job, error) {
 		rows, err = s.db.Query(`
 			SELECT job_id, kind, worker, session_key, delivery_session_key, retry_of_job_id,
 			       description, status, cancel_requested, attempt, max_attempts, timeout_seconds,
+			       max_tool_calls, limit_reason,
 			       summary, error, role_name, model_tier, tool_call_count,
 			       created_at, COALESCE(started_at, ''), COALESCE(completed_at, ''), updated_at
 			FROM jobs
@@ -1613,6 +1634,7 @@ func (s *Store) ListJobsByStatus(status string, limit int) ([]Job, error) {
 		rows, err = s.db.Query(`
 			SELECT job_id, kind, worker, session_key, delivery_session_key, retry_of_job_id,
 			       description, status, cancel_requested, attempt, max_attempts, timeout_seconds,
+			       max_tool_calls, limit_reason,
 			       summary, error, role_name, model_tier, tool_call_count,
 			       created_at, COALESCE(started_at, ''), COALESCE(completed_at, ''), updated_at
 			FROM jobs
@@ -1645,6 +1667,8 @@ func (s *Store) ListJobsByStatus(status string, limit int) ([]Job, error) {
 			&job.Attempt,
 			&job.MaxAttempts,
 			&job.TimeoutSeconds,
+			&job.MaxToolCalls,
+			&job.LimitReason,
 			&job.Summary,
 			&job.Error,
 			&job.RoleName,
@@ -1739,6 +1763,20 @@ func (s *Store) IncrementJobToolCallCount(jobID string) error {
 		SET tool_call_count = tool_call_count + 1, updated_at = CURRENT_TIMESTAMP
 		WHERE job_id = ?
 	`, strings.TrimSpace(jobID))
+	return err
+}
+
+// MarkJobBudgetExceeded marks the job as stopped due to a budget limit.
+func (s *Store) MarkJobBudgetExceeded(jobID, summary, limitReason string) error {
+	_, err := s.db.Exec(`
+		UPDATE jobs
+		SET status = 'budget_exceeded',
+		    summary = ?,
+		    limit_reason = ?,
+		    completed_at = CURRENT_TIMESTAMP,
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE job_id = ?
+	`, summary, limitReason, strings.TrimSpace(jobID))
 	return err
 }
 


### PR DESCRIPTION
Implements #287

## Changes

Add enforceable runtime budgets for role and subagent jobs:

- **delegation.Job** contract with `MaxToolCalls`, `MaxDuration`, `MaxTokens`, `MaxCostUSD`, `MemoryPolicy`, and model override
- **delegation.RunReport** structured summary with Telegram-safe formatting
- **delegation.BudgetExceededError** propagated from agent → hub → executor → job runner
- **role.Manifest** budget fields (`max_tool_calls`, `max_duration`, `max_tokens`, `max_cost_usd`, `memory_policy`, `model`) parsed from frontmatter with validation (rejects negative values)
- **runtime.JobService** distinguishes completed / failed / timed_out / budget_exceeded / cancelled with persisted limit reason
- **cron.Scheduler** looks up manifest budget and passes it through the executor into the agent runtime (`SetMaxToolCalls`, context timeout, contract prompt)
- **ToolCallingAgent** returns `BudgetExceededError` when tool-call limit interrupts execution

## Review Fixes (all addressed)

1. **BudgetExceeded flag wired to error** — `ProcessRequestWithContent` constructs and returns `*BudgetExceededError` which propagates through hub → RunCronTask → runLLM → jobs.go `run()` → `MarkJobBudgetExceeded`
2. **Negative budget fields rejected** — `Validate()` rejects negative `MaxToolCalls`, `MaxDuration`, `MaxTokens`, and `MaxCostUSD`
3. **Manifest budget wired into production path** — `runLLM()` calls `ToDelegationJob()` and passes budget to executor; `fireDurable()` uses manifest `MaxToolCalls` and `MaxDuration`

## Testing

```
go fmt ./...    # clean
go vet ./...    # clean
go test ./...   # all pass
go build ./cmd/ok-gobot/  # succeeds
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds enforceable runtime budgets (`max_tool_calls`, `max_duration`, `max_tokens`, `max_cost_usd`) to delegation contracts, role manifests, and durable jobs, wiring `BudgetExceededError` through the agent, scheduler, storage, and reporting layers. The data model changes, storage migrations, and cron report formatting are clean.

- **P1 (`tool_agent.go:380`):** When the tool-call budget is hit, `ProcessRequestWithContent` now returns `(result, budgetErr)`. Because `budgetErr != nil`, the hub emits `RunEventError` and discards `result`. In interactive chat sessions this causes `hub_handler.go` to send `\"❌ Sorry, I encountered an error processing your request.\"` instead of the informative `\"⚠️ Reached tool-call budget\"` message. The `case budgetHit:` branch inside the `if finalResponse == \"\"` block is also unreachable dead code since line 271 always sets `finalResponse` before `budgetHit` can be true.

<h3>Confidence Score: 3/5</h3>

Merging introduces a regression where interactive users hitting the tool-call budget receive a generic error instead of the budget message.

One confirmed P1 behavioral regression in the interactive chat path (budget hit → generic error to user), plus two P2 issues (RetryDetached drops MaxToolCalls, startup race in manifest lookup). The P1 lowers the ceiling to 4; the additional P2s bring it to 3.

internal/agent/tool_agent.go and internal/agent/runtime.go — the hub needs to handle BudgetExceededError as a semi-success (emit RunEventDone with the partial result) rather than a hard error.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/agent/tool_agent.go | Adds BudgetExceededError return from ProcessRequestWithContent, but the hub discards the result when err != nil, sending a generic error to interactive users instead of the budget message; case budgetHit in the finalResponse=="" block is dead code. |
| internal/runtime/jobs.go | Adds budget_exceeded status and BudgetExceededError detection; RetryDetached does not forward MaxToolCalls from the original job spec. |
| internal/cron/scheduler.go | Manifest budget (MaxToolCalls, MaxDuration) is now looked up at fire time and passed to both JobSpec and runLLM; narrow startup race exists if jobs fire before RegisterRoleJobs populates s.manifests. |
| internal/delegation/job.go | Adds MaxTokens/MaxCostUSD to Job, LimitReason enum, RunReport with FormatTelegram, and BudgetExceededError — all well-structured. |
| internal/role/manifest.go | Adds budget frontmatter fields and ToDelegationJob() converter; validation logic is clean. |
| internal/storage/sqlite.go | Adds max_tool_calls/limit_reason columns via migration and MarkJobBudgetExceeded() — migration is idempotent (duplicate column guard). |
| internal/cron/report.go | Adds budget_exceeded and cancelled formatting with emoji indicators in FormatTelegram; straightforward and correct. |
| internal/control/tui_types.go | Adds MaxToolCalls and LimitReason to job dashboard types; no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/agent/tool_agent.go
Line: 380-403

Comment:
**Budget-hit response discarded; interactive users see generic error**

When `budgetHit == true`, line 271 always sets `finalResponse` to the `"⚠️ Reached tool-call budget…"` string before reaching this block. Consequently `finalResponse == ""` is `false` and this code falls through to the second `return` at line 405, returning `(result, budgetErr)`.

The hub in `runtime.go` (line 254) sees `err != nil` and emits `RunEventError{Err: budgetErr}`, discarding `result` entirely. In interactive sessions, `hub_handler.go` then sends `"❌ Sorry, I encountered an error processing your request."` instead of the informative `"⚠️ Reached tool-call budget"` message. Two secondary effects:

1. `case budgetHit:` at line 382 is dead code — `finalResponse` is already set when `budgetHit` is true.
2. For cron jobs the operator only learns about the stop via the `JobReport`; the partial agent output is never delivered.

The cleanest fix is to have the hub (or `RunCronTask`) check `errors.As(err, &budgetErr)` and emit `RunEventDone` with the existing result rather than `RunEventError`, or alternatively inspect the `BudgetExceeded` flag on the response in the error handler and re-send `result.Message`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/runtime/jobs.go
Line: 133-153

Comment:
**`RetryDetached` does not propagate `MaxToolCalls`**

When cloning a job for retry, `existing.MaxToolCalls` (which is persisted to the DB) is not forwarded in the new `JobSpec`. A `budget_exceeded` job retried through this path would silently run with `MaxToolCalls: 0` (the default/unlimited value in the spec), meaning the same manifest-defined budget is not re-applied to the retry attempt.

```go
retryJob, err := s.StartDetached(parentCtx, JobSpec{
    ...
    Timeout:      time.Duration(existing.TimeoutSeconds) * time.Second,
    MaxToolCalls: existing.MaxToolCalls, // add this
}, runner)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/cron/scheduler.go
Line: 176-196

Comment:
**Startup race: manifest budget not available when jobs fire immediately after restart**

`loadJobs` is called from `Start()` (line 84), which runs before `RegisterRoleJobs` populates `s.manifests`. If a cron expression fires within the first few seconds after startup (e.g. a sub-minute schedule), `s.manifests[name]` will be `nil` here and the role's budget fields will be silently ignored for that first fire. The concurrent `s.manifests = make(...)` in `RegisterRoleJobs` is protected by `s.mu`, but `fireDurable` takes only `RLock`, so there's no ordering guarantee between the first cron trigger and map population.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(budget): reject negative max\_duratio..."](https://github.com/befeast/ok-gobot/commit/9b0dd2a4317eaec8f393ba08508d297dcdc43137) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30156922)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->