### PR TITLE
feat(role): prebuilt role pack with budget, templates, and tool restrictions (#286)

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -270,3 +270,39 @@ Vector embeddings stored in SQLite. Cosine similarity search in Go. OpenAI-compa
 Periodic background checks: context usage warnings, email monitoring (IMAP). Custom checker registration.
 
 **Files:** `internal/agent/heartbeat.go`
+
+---
+
+## Prebuilt Roles
+
+ok-gobot ships a small pack of prebuilt role manifests as markdown files with YAML frontmatter. Roles are disabled by default — operators copy them to their `roles_path` directory to activate.
+
+Each role defines allowed tools, a default budget (max tool calls per run), a report template, and an approval mode.
+
+| Role | Purpose | Default tools | Schedule |
+|---|---|---|---|
+| `release-watch` | Watch repos/releases and report changes | `web_fetch`, `search`, `memory_get`, `memory_search` | Weekly (disabled by default) |
+| `monitor` | Check URLs/services and post status changes | `web_fetch` | Every 30 min (disabled by default) |
+| `researcher` | Run bounded research and produce a brief | `search`, `web_fetch`, `memory_search` | Manual only |
+| `homelab-runbook` | Turn requests into checklist/runbook notes | `obsidian`, `memory_get`, `memory_search` | Manual only |
+
+### Usage
+
+1. Export bundled roles to your roles directory:
+   ```
+   ok-gobot roles init ~/my-roles
+   ```
+   Or copy individual files from `internal/role/prebuilt/`.
+
+2. Set `roles_path` in `config.yaml`:
+   ```yaml
+   roles_path: ~/my-roles
+   ```
+
+3. Roles with a `schedule` field are auto-registered as cron jobs on startup.
+   Manual-only roles (no schedule) are available via `/role run <name>`.
+
+4. Customise tools, budget, schedule, or prompt in your copy — the bundled
+   originals are never modified.
+
+**Files:** `internal/role/prebuilt/`, `internal/role/bundled.go`, `internal/role/loader.go`

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -50,3 +50,21 @@ As a [role], I want [behavior] so that [benefit].
    configuration.
 5. Infrastructure sub-tasks may reference internal components, but each must
    link back to the parent outcome issue.
+
+## 2. Prebuilt Role Conventions
+
+When adding or modifying prebuilt roles in `internal/role/prebuilt/`:
+
+1. **Markdown-first.** Roles are plain `.md` files with YAML frontmatter — no
+   hardcoded Go branches or switch statements.
+2. **Disabled by default.** Bundled roles are templates. They are only active
+   when an operator copies them to `roles_path` and the bot loads them on
+   startup.
+3. **Explicit tool allowlist.** Every role must set `tools:` to the minimum set
+   it needs. Never leave it empty (which means "all tools allowed").
+4. **Budget required.** Every role must set `budget:` to cap tool calls per run.
+5. **Report template required.** Every role must include a `report_template:`
+   so output is formatted consistently for Telegram delivery.
+6. **Tests.** `internal/role/bundled_test.go` verifies that all prebuilt roles
+   parse successfully, have budgets, have report templates, have tool
+   restrictions, and render their templates without error.

--- a/internal/role/bundled_test.go
+++ b/internal/role/bundled_test.go
@@ -8,14 +8,15 @@ import (
 
 func TestBundledNames(t *testing.T) {
 	names := BundledNames()
-	if len(names) < 3 {
-		t.Fatalf("BundledNames() = %v, want at least 3 bundled roles", names)
+	if len(names) < 4 {
+		t.Fatalf("BundledNames() = %v, want at least 4 bundled roles", names)
 	}
 
 	want := map[string]bool{
-		"researcher":    false,
-		"monitor":       false,
-		"release-watch": false,
+		"researcher":      false,
+		"monitor":         false,
+		"release-watch":   false,
+		"homelab-runbook": false,
 	}
 	for _, n := range names {
 		want[n] = true
@@ -32,8 +33,8 @@ func TestLoadBundled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadBundled() failed: %v", err)
 	}
-	if len(manifests) < 3 {
-		t.Fatalf("LoadBundled() returned %d manifests, want at least 3", len(manifests))
+	if len(manifests) < 4 {
+		t.Fatalf("LoadBundled() returned %d manifests, want at least 4", len(manifests))
 	}
 
 	byName := make(map[string]*Manifest, len(manifests))
@@ -41,7 +42,7 @@ func TestLoadBundled(t *testing.T) {
 		byName[m.Name] = m
 	}
 
-	// Researcher
+	// Researcher — manual only (no schedule).
 	r := byName["researcher"]
 	if r == nil {
 		t.Fatal("bundled role 'researcher' not found")
@@ -49,14 +50,14 @@ func TestLoadBundled(t *testing.T) {
 	if r.Worker == "" {
 		t.Error("researcher.Worker should be set")
 	}
-	if !r.HasSchedule() {
-		t.Error("researcher should have a schedule")
+	if r.HasSchedule() {
+		t.Error("researcher should be manual-only (no schedule)")
 	}
 	if r.Prompt == "" {
 		t.Error("researcher.Prompt should be non-empty")
 	}
 
-	// Monitor
+	// Monitor — has a default schedule.
 	mon := byName["monitor"]
 	if mon == nil {
 		t.Fatal("bundled role 'monitor' not found")
@@ -65,13 +66,158 @@ func TestLoadBundled(t *testing.T) {
 		t.Error("monitor should have a schedule")
 	}
 
-	// Release-watch
+	// Release-watch — has a default schedule.
 	rw := byName["release-watch"]
 	if rw == nil {
 		t.Fatal("bundled role 'release-watch' not found")
 	}
 	if !rw.HasSchedule() {
 		t.Error("release-watch should have a schedule")
+	}
+
+	// Homelab-runbook — manual only (no schedule).
+	hr := byName["homelab-runbook"]
+	if hr == nil {
+		t.Fatal("bundled role 'homelab-runbook' not found")
+	}
+	if hr.HasSchedule() {
+		t.Error("homelab-runbook should be manual-only (no schedule)")
+	}
+}
+
+func TestLoadBundled_AllHaveBudget(t *testing.T) {
+	manifests, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() failed: %v", err)
+	}
+	for _, m := range manifests {
+		if m.Budget <= 0 {
+			t.Errorf("bundled role %q has no budget (got %d)", m.Name, m.Budget)
+		}
+	}
+}
+
+func TestLoadBundled_AllHaveReportTemplate(t *testing.T) {
+	manifests, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() failed: %v", err)
+	}
+	for _, m := range manifests {
+		if m.ReportTemplate == "" {
+			t.Errorf("bundled role %q has no report_template", m.Name)
+		}
+	}
+}
+
+func TestLoadBundled_AllHaveToolRestrictions(t *testing.T) {
+	manifests, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() failed: %v", err)
+	}
+	for _, m := range manifests {
+		if !m.HasToolRestrictions() {
+			t.Errorf("bundled role %q has no tool restrictions", m.Name)
+		}
+	}
+}
+
+func TestLoadBundled_ToolRestrictions(t *testing.T) {
+	manifests, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() failed: %v", err)
+	}
+
+	byName := make(map[string]*Manifest, len(manifests))
+	for _, m := range manifests {
+		byName[m.Name] = m
+	}
+
+	// Monitor should only allow web_fetch.
+	mon := byName["monitor"]
+	if mon.IsToolAllowed("web_fetch") != true {
+		t.Error("monitor should allow web_fetch")
+	}
+	if mon.IsToolAllowed("local") != false {
+		t.Error("monitor should not allow local by default")
+	}
+	if mon.IsToolAllowed("search") != false {
+		t.Error("monitor should not allow search")
+	}
+
+	// Researcher should allow search, web_fetch, memory_search.
+	r := byName["researcher"]
+	for _, tool := range []string{"search", "web_fetch", "memory_search"} {
+		if !r.IsToolAllowed(tool) {
+			t.Errorf("researcher should allow %s", tool)
+		}
+	}
+	if r.IsToolAllowed("local") {
+		t.Error("researcher should not allow local")
+	}
+
+	// Release-watch should allow web_fetch, search, memory_get, memory_search.
+	rw := byName["release-watch"]
+	for _, tool := range []string{"web_fetch", "search", "memory_get", "memory_search"} {
+		if !rw.IsToolAllowed(tool) {
+			t.Errorf("release-watch should allow %s", tool)
+		}
+	}
+	if rw.IsToolAllowed("local") {
+		t.Error("release-watch should not allow local")
+	}
+
+	// Homelab-runbook should allow obsidian, memory_get, memory_search.
+	hr := byName["homelab-runbook"]
+	for _, tool := range []string{"obsidian", "memory_get", "memory_search"} {
+		if !hr.IsToolAllowed(tool) {
+			t.Errorf("homelab-runbook should allow %s", tool)
+		}
+	}
+	if hr.IsToolAllowed("local") {
+		t.Error("homelab-runbook should not allow local")
+	}
+}
+
+func TestLoadBundled_ReportTemplatesRender(t *testing.T) {
+	manifests, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() failed: %v", err)
+	}
+
+	data := map[string]string{
+		"Summary": "Test summary content.",
+		"Date":    "2026-04-29",
+	}
+
+	for _, m := range manifests {
+		result, err := m.RenderReport(data)
+		if err != nil {
+			t.Errorf("RenderReport for %q failed: %v", m.Name, err)
+			continue
+		}
+		if result == "" {
+			t.Errorf("RenderReport for %q returned empty string", m.Name)
+		}
+	}
+}
+
+func TestLoadBundled_DisabledByDefault(t *testing.T) {
+	// Bundled roles are templates — they are NOT automatically registered
+	// into the cron system. Only roles copied to the operator's roles_path
+	// and loaded via LoadDir are eligible for RegisterRoleJobs.
+	//
+	// Manual-only roles (researcher, homelab-runbook) have no schedule,
+	// so even if loaded they won't be registered.
+	manifests, err := LoadBundled()
+	if err != nil {
+		t.Fatalf("LoadBundled() failed: %v", err)
+	}
+
+	manualOnly := map[string]bool{"researcher": true, "homelab-runbook": true}
+	for _, m := range manifests {
+		if manualOnly[m.Name] && m.HasSchedule() {
+			t.Errorf("manual-only role %q should have no schedule", m.Name)
+		}
 	}
 }
 
@@ -82,8 +228,8 @@ func TestWriteBundledTo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteBundledTo failed: %v", err)
 	}
-	if len(written) < 3 {
-		t.Fatalf("WriteBundledTo wrote %d files, want at least 3", len(written))
+	if len(written) < 4 {
+		t.Fatalf("WriteBundledTo wrote %d files, want at least 4", len(written))
 	}
 
 	// Verify files exist and are parseable.
@@ -132,7 +278,7 @@ func TestWriteBundledTo_Overwrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("overwrite WriteBundledTo failed: %v", err)
 	}
-	if len(written) < 3 {
-		t.Errorf("overwrite WriteBundledTo wrote %d files, want at least 3", len(written))
+	if len(written) < 4 {
+		t.Errorf("overwrite WriteBundledTo wrote %d files, want at least 4", len(written))
 	}
 }

--- a/internal/role/manifest.go
+++ b/internal/role/manifest.go
@@ -60,6 +60,7 @@ type frontmatter struct {
 	Schedule       string   `yaml:"schedule"`
 	ReportTemplate string   `yaml:"report_template"`
 	Approval       string   `yaml:"approval"`
+	Budget         int      `yaml:"budget"`
 }
 
 // Manifest is a parsed role definition loaded from a markdown file.
@@ -91,6 +92,10 @@ type Manifest struct {
 	// Defaults to ApprovalAuto when not specified.
 	Approval ApprovalMode
 
+	// Budget is the maximum number of tool calls allowed per execution.
+	// Zero means no explicit limit (caller decides).
+	Budget int
+
 	// SourcePath is the absolute path to the source .md file.
 	SourcePath string
 }
@@ -119,6 +124,7 @@ func Parse(name string, data []byte) (*Manifest, error) {
 		Schedule:       strings.TrimSpace(fm.Schedule),
 		ReportTemplate: fm.ReportTemplate,
 		Approval:       approval,
+		Budget:         fm.Budget,
 	}
 
 	if err := m.Validate(); err != nil {
@@ -132,6 +138,10 @@ func Parse(name string, data []byte) (*Manifest, error) {
 func (m *Manifest) Validate() error {
 	if m.Name == "" {
 		return fmt.Errorf("role manifest: name is required")
+	}
+
+	if m.Budget < 0 {
+		return fmt.Errorf("role %q: budget must be non-negative, got %d", m.Name, m.Budget)
 	}
 
 	if m.ReportTemplate != "" {

--- a/internal/role/manifest_test.go
+++ b/internal/role/manifest_test.go
@@ -11,6 +11,7 @@ func TestParse_FullManifest(t *testing.T) {
 worker: premium
 tools: [web_fetch, search, memory_search]
 schedule: "0 9 * * *"
+budget: 20
 report_template: |
   ## {{.Title}}
   {{.Body}}
@@ -44,6 +45,9 @@ You are a research agent. Your job is to gather information and compile reports.
 	if m.Approval != ApprovalAlways {
 		t.Errorf("Approval = %q, want %q", m.Approval, ApprovalAlways)
 	}
+	if m.Budget != 20 {
+		t.Errorf("Budget = %d, want 20", m.Budget)
+	}
 	if m.ReportTemplate == "" {
 		t.Error("ReportTemplate is empty, want non-empty")
 	}
@@ -63,6 +67,19 @@ You are a research agent. Your job is to gather information and compile reports.
 	expected := "# Researcher\n\nYou are a research agent. Your job is to gather information and compile reports."
 	if m.Prompt != expected {
 		t.Errorf("Prompt = %q, want %q", m.Prompt, expected)
+	}
+}
+
+func TestParse_NegativeBudget(t *testing.T) {
+	data := []byte(`---
+budget: -5
+---
+Some prompt.
+`)
+
+	_, err := Parse("bad-budget", data)
+	if err == nil {
+		t.Fatal("Parse should fail for negative budget")
 	}
 }
 

--- a/internal/role/prebuilt/homelab-runbook.md
+++ b/internal/role/prebuilt/homelab-runbook.md
@@ -1,0 +1,40 @@
+---
+worker: standard
+tools: [obsidian, memory_get, memory_search]
+budget: 10
+approval: auto
+report_template: |
+  📋 *Runbook*
+  ━━━━━━━━━━━━
+  {{.Summary}}
+
+  _{{.Date}}_
+---
+# Homelab Runbook
+
+You are a runbook agent. Your job is to turn operator requests into structured
+checklist and runbook notes stored in Obsidian.
+
+## Instructions
+
+1. Parse the operator's request to identify the task or procedure.
+2. Search existing notes for related runbooks to avoid duplication.
+3. Break the task into clear, ordered steps.
+4. Write the runbook as a checklist note in Obsidian.
+5. Cross-reference related notes where applicable.
+
+## Output Format
+
+Write a structured runbook in markdown:
+
+- Title: descriptive name of the procedure
+- Each step is a checkbox item (`- [ ] Step description`)
+- Group related steps under headings
+- Include expected outputs or verification commands where relevant
+- Keep each step atomic — one action per checkbox
+- Add warnings or prerequisites at the top if any
+
+## Scheduling
+
+This role is manual only — trigger it on demand when you need to document
+a procedure or create a maintenance checklist.

--- a/internal/role/prebuilt/monitor.md
+++ b/internal/role/prebuilt/monitor.md
@@ -1,7 +1,8 @@
 ---
 worker: cheap
-tools: [web_fetch, search]
+tools: [web_fetch]
 schedule: "0 */30 * * * *"
+budget: 10
 approval: auto
 report_template: |
   🔍 *Monitor Report*
@@ -17,10 +18,11 @@ availability of configured services, URLs, or resources and report their status.
 
 ## Instructions
 
-1. For each item in your monitoring list, perform a fetch or search to check status.
+1. For each item in your monitoring list, perform a fetch to check status.
 2. Determine whether each item is UP, DEGRADED, or DOWN.
 3. Note any anomalies, errors, or unexpected changes.
 4. Compare against expected behaviour and flag deviations.
+5. Only report when something has changed or is unhealthy.
 
 ## Output Format
 
@@ -39,5 +41,5 @@ If all services are healthy, a one-line "All systems operational" is sufficient.
 ## Scheduling
 
 Default schedule: every 30 minutes (`0 */30 * * * *`).
-Copy this file to your `roles/` directory and adjust the schedule as needed.
-List the URLs or services to monitor in the cron task description.
+This role is disabled by default. Copy this file to your `roles/` directory
+and list the URLs or services to monitor in the cron task description.

--- a/internal/role/prebuilt/release-watch.md
+++ b/internal/role/prebuilt/release-watch.md
@@ -1,7 +1,8 @@
 ---
 worker: standard
-tools: [web_fetch, search]
+tools: [web_fetch, search, memory_get, memory_search]
 schedule: "0 0 10 * * 1"
+budget: 15
 approval: auto
 report_template: |
   🚀 *Release Watch*
@@ -22,6 +23,7 @@ new software releases for the projects and tools listed in your task.
 3. Extract for each release: project name, version, release date, and key changes.
 4. Prioritise security patches and breaking changes — mark them prominently.
 5. Skip projects with no new releases.
+6. Use memory_search to check what was reported last time and avoid duplicates.
 
 ## Output Format
 
@@ -29,7 +31,7 @@ Write a concise release digest in plain markdown for Telegram:
 
 - One section per project that has a new release
 - Header format: `*ProjectName vX.Y.Z* (YYYY-MM-DD)`
-- Follow each header with 2–3 bullet points of key changes
+- Follow each header with 2-3 bullet points of key changes
 - Mark security fixes with 🔒 and breaking changes with ⚠️
 - Keep total length under 3000 characters
 - If no releases were found for any project, state that clearly
@@ -37,4 +39,5 @@ Write a concise release digest in plain markdown for Telegram:
 ## Scheduling
 
 Default schedule: 10:00 UTC every Monday (`0 0 10 * * 1`).
-Copy this file to your `roles/` directory and set your project list in the task.
+This role is disabled by default. Copy this file to your `roles/` directory
+and set your project list in the task to activate it.

--- a/internal/role/prebuilt/researcher.md
+++ b/internal/role/prebuilt/researcher.md
@@ -1,26 +1,26 @@
 ---
 worker: standard
-tools: [web_fetch, search, memory_search]
-schedule: "0 0 9 * * *"
+tools: [search, web_fetch, memory_search]
+budget: 15
 approval: auto
 report_template: |
-  📚 *Daily Research Report*
-  ━━━━━━━━━━━━━━━━━━━━━━
+  📚 *Research Brief*
+  ━━━━━━━━━━━━━━━━━━
   {{.Summary}}
 
   _{{.Date}}_
 ---
 # Researcher
 
-You are a scheduled research agent. Your job is to research the topic defined in
-your task and compile a concise, factual daily report.
+You are a research agent. Your job is to research a given topic and compile a
+concise, factual brief.
 
 ## Instructions
 
-1. Search for the latest information on the assigned topic (last 24 hours preferred).
+1. Search for the latest information on the assigned topic.
 2. Fetch and read the most relevant sources (up to 3 pages).
 3. Synthesize findings into a brief report (max 400 words).
-4. Focus on what is new, changed, or actionable since the last report.
+4. Focus on what is new, changed, or actionable.
 5. Avoid filler text — every sentence must add value.
 
 ## Output Format
@@ -32,10 +32,10 @@ Write your report in plain markdown suitable for Telegram:
 - Keep total length under 3500 characters
 - End with a one-line summary of sources consulted
 
-If nothing new was found, state that clearly rather than padding the report.
+If nothing relevant was found, state that clearly rather than padding the report.
 
 ## Scheduling
 
-Default schedule: 09:00 UTC daily (`0 0 9 * * *`).
-Copy this file to your `roles/` directory and set the schedule to your preference.
-Set a specific research topic in the cron task description when registering.
+This role is manual only — trigger it on demand via `/role run researcher`
+or by referencing it in a task. Add a schedule in your copy if you want
+periodic research runs.


### PR DESCRIPTION
Implements #286

## Changes

Ships a prebuilt role pack of four markdown-first role manifests that demonstrate the intended operator workflow for Mission Control v1:

| Role | Purpose | Schedule |
|---|---|---|
| `release-watch` | Watch repos/releases and report changes | Weekly (disabled by default) |
| `monitor` | Check URLs/services and post status | Every 30 min (disabled by default) |
| `researcher` | Run bounded research and produce a brief | Manual only |
| `homelab-runbook` | Turn requests into checklist/runbook notes | Manual only |

Key changes:
- **Budget field** added to manifest frontmatter (`budget:` controls max tool calls per run)
- **homelab-runbook** new prebuilt role for Obsidian-based runbook generation
- **researcher** changed to manual-only (no default schedule per issue spec)
- **Tool restrictions** tightened per issue spec (monitor: `web_fetch` only; release-watch: adds `memory_get`, `memory_search`)
- **Comprehensive tests** for budgets, report templates, tool restrictions, disabled-by-default behavior
- **Documentation** updated in FEATURES.md (role pack reference table + usage guide) and PROCESS.md (role conventions)

All acceptance criteria met:
- [x] Prebuilt roles are ordinary markdown manifests, not hardcoded Go branches
- [x] Roles are disabled unless explicitly scheduled or manually run
- [x] Every role has a default budget
- [x] Every role has a report template
- [x] Every role respects `allowed_tools` and capability policy
- [x] Role pack is documented with examples

## Testing

```
go fmt ./...    # clean
go vet ./...    # clean
go test ./...   # all pass
go build ./cmd/ok-gobot/  # success
```

Test coverage includes:
- All 4 prebuilt roles parse successfully
- Budget field parsed and validated (including negative budget rejection)
- Report templates render with sample data
- Tool restrictions verified per-role (allowed and denied tools)
- Manual-only roles have no schedule; scheduled roles have schedules
- WriteBundledTo exports all 4 roles

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships four prebuilt role manifests (`release-watch`, `monitor`, `researcher`, `homelab-runbook`) as markdown files with YAML frontmatter, adds a `budget` field to the manifest schema with non-negative validation, and extends the test suite to cover budgets, report template rendering, tool restrictions, and disabled-by-default behavior. The implementation is clean: the `Budget` field is correctly parsed, validated, and stored; all bundled roles satisfy the documented conventions (explicit tool allowlist, `budget > 0`, `report_template` present); and the test data in `TestLoadBundled_ReportTemplatesRender` matches the `{{.Summary}}`/`{{.Date}}` fields used across all four templates.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — no logic errors, security concerns, or behavioral regressions identified.

All changed files are additive (new manifest field, new prebuilt roles, new tests, docs). The Budget field validation is correct and well-tested. Template field names in tests match the actual templates. No P0 or P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/role/manifest.go | Adds Budget field to frontmatter and Manifest, with non-negative validation in Validate(); implementation is clean and consistent with existing patterns. |
| internal/role/bundled_test.go | Expands test suite for 4 bundled roles with coverage for budget, report template rendering, tool restrictions, schedule presence, and WriteBundledTo; all assertions are correct and consistent with the manifest contract. |
| internal/role/manifest_test.go | Adds TestParse_NegativeBudget and a Budget assertion to TestParse_FullManifest; correctly validates the new field's parsing and rejection behavior. |
| internal/role/prebuilt/homelab-runbook.md | New manual-only role with obsidian/memory tools, budget 10, report template, and no schedule; satisfies all documented prebuilt role conventions. |
| internal/role/prebuilt/monitor.md | Tool list tightened to web_fetch only (removes search), budget 10 added, and instruction #5 added for change-only reporting; all required fields present. |
| internal/role/prebuilt/release-watch.md | Adds memory_get and memory_search to tool allowlist and budget 15; deduplication instruction added to leverage memory tools. |
| internal/role/prebuilt/researcher.md | Schedule removed (manual-only), budget 15 added, report template title updated; change is correct and tested. |
| docs/FEATURES.md | Adds prebuilt roles section with reference table and usage guide; content is accurate and matches implementation. |
| docs/PROCESS.md | Adds prebuilt role conventions (markdown-first, disabled by default, explicit tools, budget, report template, tests); well-aligned with the changes in this PR. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(role): prebuilt role pack with rese..."](https://github.com/befeast/ok-gobot/commit/1ba9844b4805e6b056f5710c04512a5bc8390fbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30159375)</sub>

<!-- /greptile_comment -->