### PR TITLE
feat(security): security baseline with SECURITY.md and doctor warnings (#284)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ ok-gobot/
 └── Makefile
 ```
 
+## Security
+
+See [SECURITY.md](SECURITY.md) for the security policy, threat model, and hardening checklist.
+
 ## Documentation
 
 - [Competitive Landscape](docs/COMPETITORS.md) -- OpenFang, ZeroClaw, OpenClaw, and ok-gobot comparison

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,104 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest `main` | Yes |
+| older releases | Best-effort |
+
+ok-gobot follows a rolling-release model. Security fixes are applied to the latest `main` branch. If you are running an older checkout, pull the latest changes and rebuild.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do NOT open a public GitHub issue.**
+2. Email the maintainers at **security@befeast.dev** with:
+   - A description of the vulnerability.
+   - Steps to reproduce.
+   - Any relevant logs or screenshots (redact secrets).
+3. You will receive an acknowledgment within 72 hours.
+4. A fix will be developed privately and disclosed after a patch is available.
+
+## Threat Model
+
+ok-gobot is a Telegram-first AI agent that runs tools on the operator's machine. The following surfaces are in scope:
+
+### Shell execution (`local` tool)
+- Commands run as the OS user that started ok-gobot.
+- Dangerous commands require explicit inline-keyboard approval (see `internal/bot/approval.go`).
+- Emergency stop (`/estop on`) disables shell, SSH, browser, and cron tools at runtime.
+
+### SSH (`ssh` tool)
+- Connects to hosts defined in the operator's soul/TOOLS.md.
+- Uses `StrictHostKeyChecking=accept-new` (trust-on-first-use).
+- Subject to the same approval flow as local shell.
+
+### Browser automation (`browser` tool)
+- ChromeDP-based; `file://`, localhost, and internal hostnames are blocked before navigation.
+- Runs in the operator's Chrome profile if configured.
+
+### Network fetch (`web_fetch` tool)
+- SSRF protection blocks private/loopback IPs and revalidates on redirects.
+- Scheme restricted to `http` and `https`.
+
+### Memory (`memory_search`, `memory_get` tools)
+- Backed by a local SQLite database and markdown files on disk.
+- Embeddings are sent to the configured embeddings API (default: OpenAI).
+- MCP server, when enabled, binds to loopback by default.
+
+### HTTP API server (`api.*` config)
+- Disabled by default (`api.enabled: false`).
+- When enabled, binds to `127.0.0.1` by default.
+- Requires an API key (`api.api_key`) for all endpoints.
+- CORS restricted to loopback origins.
+
+### WebSocket control server (`control.*` config)
+- Disabled by default (`control.enabled: false`).
+- Origin validation accepts only loopback origins; non-browser clients (empty Origin) are allowed.
+- Token auth uses constant-time comparison.
+- `control.allow_loopback_without_token` is true by default for local development; set to `false` and configure `control.token` for hardened setups.
+
+### DM authorization (`auth.*` config)
+- Default mode is `open` -- any Telegram user can interact.
+- Switch to `allowlist` or `pairing` mode for restricted access.
+- Auth check is fail-closed: unknown modes deny access.
+- Pairing codes have brute-force protection (5 attempts / 15-minute lockout).
+
+## Safe Defaults
+
+ok-gobot ships with conservative defaults:
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| `api.enabled` | `false` | HTTP API is off |
+| `control.enabled` | `false` | WebSocket control server is off |
+| `api.bind_addr` | `127.0.0.1` | Loopback only when enabled |
+| `auth.mode` | `open` | Convenient but not hardened; see `doctor` warnings |
+| `memory.mcp.enabled` | `false` | MCP server is off |
+| `memory.mcp.host` | `127.0.0.1` | Loopback only when enabled |
+
+Run `ok-gobot doctor` to check for risky configurations. The doctor command warns when:
+- `auth.mode` is `open` while the API or control server is enabled.
+- The API server is enabled without an API key.
+- The control server is enabled without a token.
+- The API server binds to a non-loopback address.
+
+## Hardening Checklist
+
+1. Set `auth.mode` to `allowlist` or `pairing` and configure `auth.admin_id`.
+2. If enabling `api`, set a strong `api.api_key` and keep `api.bind_addr` as `127.0.0.1`.
+3. If enabling `control`, set `control.token` and set `control.allow_loopback_without_token` to `false`.
+4. Review tool access per agent via `agents[].capabilities` policies.
+5. Use `/estop on` to disable dangerous tool families when not needed.
+
+## Automated Security Checks
+
+- **gitleaks**: scans for leaked secrets on every PR and push to `main` (`.github/workflows/secret-scan.yml`).
+- **govulncheck**: checks Go dependencies for known vulnerabilities (`.github/workflows/security.yml`).
+- **CodeQL**: GitHub's static analysis for Go (`.github/workflows/codeql.yml`).
+
+## Prior Security Work
+
+See [docs/SECURITY-FIXES.md](docs/SECURITY-FIXES.md) for the detailed changelog of security hardening applied to the codebase.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -96,8 +96,13 @@ Run `ok-gobot doctor` to check for risky configurations. The doctor command warn
 ## Automated Security Checks
 
 - **gitleaks**: scans for leaked secrets on every PR and push to `main` (`.github/workflows/secret-scan.yml`).
-- **govulncheck**: checks Go dependencies for known vulnerabilities (`.github/workflows/security.yml`).
-- **CodeQL**: GitHub's static analysis for Go (`.github/workflows/codeql.yml`).
+
+### Recommended additions
+
+Operators should add the following CI jobs to their fork or deployment pipeline:
+
+- **govulncheck**: `go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...` — checks Go dependencies for known vulnerabilities.
+- **CodeQL**: GitHub's built-in static analysis for Go — enable via repository Settings > Code security > Code scanning.
 
 ## Prior Security Work
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -51,6 +51,7 @@ func newDoctorCommand(cfg *config.Config) *cobra.Command {
 			results = append(results, checkTelegramToken(cfg))
 			results = append(results, checkProvider(cfg)...)
 			results = append(results, checkStoragePath(cfg))
+			results = append(results, checkSecuritySettings(cfg)...)
 			results = append(results, checkPDFToText())
 			results = append(results, checkWhisper())
 			results = append(results, checkFFmpeg())
@@ -421,4 +422,97 @@ func checkChrome() checkResult {
 	result.passed = false
 	result.message = "Not found. Install Chrome or Chromium for browser automation."
 	return result
+}
+
+// checkSecuritySettings warns about risky auth, control, and API configurations.
+func checkSecuritySettings(cfg *config.Config) []checkResult {
+	var results []checkResult
+
+	hasRemoteSurface := cfg.API.Enabled || cfg.Control.Enabled
+
+	// Warn if auth mode is open and any remote-facing surface is enabled.
+	if cfg.Auth.Mode == "open" && hasRemoteSurface {
+		results = append(results, checkResult{
+			name:     "Auth mode with remote surfaces",
+			required: true,
+			warning:  true,
+			message: "auth.mode is \"open\" while API or control server is enabled. " +
+				"Any Telegram user can interact with the bot.\n" +
+				"  Harden: set auth.mode to \"allowlist\" or \"pairing\" and configure auth.admin_id.",
+		})
+	} else if cfg.Auth.Mode == "open" {
+		results = append(results, checkResult{
+			name:     "Auth mode",
+			required: true,
+			warning:  true,
+			message: "auth.mode is \"open\" -- any Telegram user can interact.\n" +
+				"  Harden: set auth.mode to \"allowlist\" or \"pairing\".",
+		})
+	} else {
+		results = append(results, checkResult{
+			name:    "Auth mode",
+			passed:  true,
+			message: fmt.Sprintf("auth.mode is %q", cfg.Auth.Mode),
+		})
+	}
+
+	// API server checks.
+	if cfg.API.Enabled {
+		if cfg.API.APIKey == "" {
+			results = append(results, checkResult{
+				name:     "API server authentication",
+				required: true,
+				warning:  true,
+				message: "api.enabled is true but api.api_key is empty -- API is unauthenticated.\n" +
+					"  Harden: set a strong api.api_key.",
+			})
+		} else {
+			results = append(results, checkResult{
+				name:    "API server authentication",
+				passed:  true,
+				message: "api.api_key is set",
+			})
+		}
+
+		if cfg.API.BindAddr != "127.0.0.1" && cfg.API.BindAddr != "localhost" && cfg.API.BindAddr != "::1" {
+			results = append(results, checkResult{
+				name:     "API server bind address",
+				required: true,
+				warning:  true,
+				message: fmt.Sprintf("api.bind_addr is %q -- API is reachable beyond loopback.\n"+
+					"  Harden: set api.bind_addr to \"127.0.0.1\" unless a reverse proxy is in front.", cfg.API.BindAddr),
+			})
+		}
+	}
+
+	// Control server checks.
+	if cfg.Control.Enabled {
+		if cfg.Control.Token == "" {
+			results = append(results, checkResult{
+				name:     "Control server token",
+				required: true,
+				warning:  true,
+				message: "control.enabled is true but control.token is empty.\n" +
+					"  Harden: set control.token to a strong secret.",
+			})
+		} else {
+			results = append(results, checkResult{
+				name:    "Control server token",
+				passed:  true,
+				message: "control.token is set",
+			})
+		}
+
+		if cfg.Control.AllowLoopbackWithoutToken {
+			results = append(results, checkResult{
+				name:     "Control server loopback auth",
+				required: true,
+				warning:  true,
+				message: "control.allow_loopback_without_token is true -- loopback clients skip token auth.\n" +
+					"  Harden: set control.allow_loopback_without_token to false.",
+			})
+		}
+	}
+
+	return results
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -474,7 +474,11 @@ func checkSecuritySettings(cfg *config.Config) []checkResult {
 			})
 		}
 
-		if cfg.API.BindAddr != "127.0.0.1" && cfg.API.BindAddr != "localhost" && cfg.API.BindAddr != "::1" {
+		bindAddr := cfg.API.BindAddr
+		if bindAddr == "" {
+			bindAddr = "127.0.0.1" // matches documented default; treat as loopback
+		}
+		if bindAddr != "127.0.0.1" && bindAddr != "localhost" && bindAddr != "::1" {
 			results = append(results, checkResult{
 				name:     "API server bind address",
 				required: true,

--- a/internal/cli/doctor_security_test.go
+++ b/internal/cli/doctor_security_test.go
@@ -94,6 +94,22 @@ func TestCheckSecuritySettings_APIWithKey(t *testing.T) {
 	}
 }
 
+func TestCheckSecuritySettings_APIEmptyBindAddrNoWarning(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "allowlist"
+	cfg.API.Enabled = true
+	cfg.API.APIKey = "secret"
+	cfg.API.BindAddr = "" // empty defaults to loopback, no warning
+
+	results := checkSecuritySettings(cfg)
+
+	found := findResult(results, "API server bind address")
+	if found != nil {
+		t.Error("expected no bind address warning for empty (default loopback) bind_addr")
+	}
+}
+
 func TestCheckSecuritySettings_APINonLoopbackBind(t *testing.T) {
 	t.Parallel()
 	cfg := &config.Config{}

--- a/internal/cli/doctor_security_test.go
+++ b/internal/cli/doctor_security_test.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"testing"
+
+	"ok-gobot/internal/config"
+)
+
+func TestCheckSecuritySettings_OpenAuthNoRemote(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "open"
+	cfg.API.Enabled = false
+	cfg.Control.Enabled = false
+
+	results := checkSecuritySettings(cfg)
+
+	found := findResult(results, "Auth mode")
+	if found == nil {
+		t.Fatal("expected Auth mode result")
+	}
+	if !found.warning {
+		t.Error("expected warning for open auth mode")
+	}
+}
+
+func TestCheckSecuritySettings_OpenAuthWithAPI(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "open"
+	cfg.API.Enabled = true
+
+	results := checkSecuritySettings(cfg)
+
+	found := findResult(results, "Auth mode with remote surfaces")
+	if found == nil {
+		t.Fatal("expected 'Auth mode with remote surfaces' result")
+	}
+	if !found.warning {
+		t.Error("expected warning")
+	}
+}
+
+func TestCheckSecuritySettings_AllowlistAuthPasses(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "allowlist"
+
+	results := checkSecuritySettings(cfg)
+
+	found := findResult(results, "Auth mode")
+	if found == nil {
+		t.Fatal("expected Auth mode result")
+	}
+	if !found.passed {
+		t.Error("expected passed for allowlist auth")
+	}
+}
+
+func TestCheckSecuritySettings_APINoKey(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "allowlist"
+	cfg.API.Enabled = true
+	cfg.API.APIKey = ""
+
+	results := checkSecuritySettings(cfg)
+
+	found := findResult(results, "API server authentication")
+	if found == nil {
+		t.Fatal("expected API server authentication result")
+	}
+	if !found.warning {
+		t.Error("expected warning for missing API key")
+	}
+}
+
+func TestCheckSecuritySettings_APIWithKey(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "allowlist"
+	cfg.API.Enabled = true
+	cfg.API.APIKey = "secret-key"
+	cfg.API.BindAddr = "127.0.0.1"
+
+	results := checkSecuritySettings(cfg)
+
+	found := findResult(results, "API server authentication")
+	if found == nil {
+		t.Fatal("expected API server authentication result")
+	}
+	if !found.passed {
+		t.Error("expected passed for API with key set")
+	}
+}
+
+func TestCheckSecuritySettings_APINonLoopbackBind(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "allowlist"
+	cfg.API.Enabled = true
+	cfg.API.APIKey = "secret"
+	cfg.API.BindAddr = "0.0.0.0"
+
+	results := checkSecuritySettings(cfg)
+
+	found := findResult(results, "API server bind address")
+	if found == nil {
+		t.Fatal("expected API server bind address result")
+	}
+	if !found.warning {
+		t.Error("expected warning for non-loopback bind")
+	}
+}
+
+func TestCheckSecuritySettings_ControlNoToken(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "allowlist"
+	cfg.Control.Enabled = true
+	cfg.Control.Token = ""
+
+	results := checkSecuritySettings(cfg)
+
+	found := findResult(results, "Control server token")
+	if found == nil {
+		t.Fatal("expected Control server token result")
+	}
+	if !found.warning {
+		t.Error("expected warning for missing control token")
+	}
+}
+
+func TestCheckSecuritySettings_ControlWithToken(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "allowlist"
+	cfg.Control.Enabled = true
+	cfg.Control.Token = "strong-token"
+
+	results := checkSecuritySettings(cfg)
+
+	found := findResult(results, "Control server token")
+	if found == nil {
+		t.Fatal("expected Control server token result")
+	}
+	if !found.passed {
+		t.Error("expected passed for control with token set")
+	}
+}
+
+func TestCheckSecuritySettings_ControlLoopbackWithoutToken(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "allowlist"
+	cfg.Control.Enabled = true
+	cfg.Control.Token = "token"
+	cfg.Control.AllowLoopbackWithoutToken = true
+
+	results := checkSecuritySettings(cfg)
+
+	found := findResult(results, "Control server loopback auth")
+	if found == nil {
+		t.Fatal("expected Control server loopback auth result")
+	}
+	if !found.warning {
+		t.Error("expected warning for allow_loopback_without_token")
+	}
+}
+
+func TestCheckSecuritySettings_DisabledRemoteNoExtraChecks(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Auth.Mode = "pairing"
+	cfg.API.Enabled = false
+	cfg.Control.Enabled = false
+
+	results := checkSecuritySettings(cfg)
+
+	// Should only have the auth mode check (passed).
+	if len(results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].passed {
+		t.Error("expected pairing mode to pass")
+	}
+}
+
+func findResult(results []checkResult, name string) *checkResult {
+	for i := range results {
+		if results[i].name == name {
+			return &results[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Implements #284

## Changes

- Add root `SECURITY.md` with supported versions, vulnerability reporting path, local threat model (shell, SSH, browser, network fetch, memory, API, control server), safe defaults table, and hardening checklist.
- Link `SECURITY.md` from `README.md`.
- Add `checkSecuritySettings()` to `doctor` command, warning on:
  - `auth.mode: open` (with or without remote surfaces)
  - API server enabled without `api.api_key`
  - API server binding to non-loopback address
  - Control server enabled without `control.token`
  - `control.allow_loopback_without_token: true`
- Each warning includes a "Harden:" hint explaining what to change.
- Treat empty `api.bind_addr` as loopback default (no false warning).
- Add `doctor_security_test.go` with 11 table-driven tests covering all security check paths.

### Not included (OAuth scope limitation)

The `govulncheck` and `CodeQL` workflow files (`.github/workflows/security.yml`, `.github/workflows/codeql.yml`) were written but could not be pushed because the CI token lacks `workflow` scope. `SECURITY.md` documents these as recommended additions operators should enable. The existing gitleaks workflow remains active.

## Testing

```
go fmt ./...    # no changes
go vet ./...    # clean
go test ./...   # all pass
go build ./cmd/ok-gobot/  # success
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a security baseline: a `SECURITY.md` threat model and hardening guide, a new `checkSecuritySettings()` function in the `doctor` command that warns on risky auth/API/control configurations, and 10 tests covering all check branches. The empty `BindAddr` edge case flagged in a prior review thread is correctly handled in this version.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic bugs found; all security check branches are tested and correct.

No P0 or P1 findings. The empty BindAddr default was addressed before this review. Warning/passed result structs are consistent in their effect on the `hasFailures` path since every non-passed result carries `warning: true`. Tests are thorough and all branches are covered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cli/doctor.go | Adds `checkSecuritySettings()` with correct auth/API/control warnings; empty BindAddr default handling from prior review thread is addressed; warning results use `required: true` while passed results omit it, but this does not affect `hasFailures` logic since all non-passed results carry `warning: true`. |
| internal/cli/doctor_security_test.go | 10 parallel tests covering all branches (open auth with/without remote surfaces, allowlist pass, API key missing/present, empty bind addr, non-loopback bind, control token missing/present, loopback-without-token, no-remote baseline). All paths exercised. |
| SECURITY.md | New security policy with threat model, safe defaults table, hardening checklist, and automated checks section. Accurately reflects that govulncheck/CodeQL are recommended additions (not yet wired up in CI) rather than implemented checks. |
| README.md | Adds a "Security" section linking to SECURITY.md; straightforward addition. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(security): remove references to work..."](https://github.com/befeast/ok-gobot/commit/6d1e44854ca39cb835653b357c365c475bc4d035) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30161312)</sub>

<!-- /greptile_comment -->