### PR TITLE
feat(memory): wire markdown index lifecycle

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,5 +1,10 @@
 # Semantic Memory System
 
+> Current architecture note: memory v2 is markdown-first. `MEMORY.md` and
+> `memory/*.md` are the source of truth; SQLite stores an embedding index over
+> those files. Legacy record-style commands such as `memory save/list/forget`
+> are deprecated.
+
 The semantic memory system allows the bot to store and recall information using vector embeddings for similarity search. This enables long-term memory beyond the conversation context window.
 
 ## Features
@@ -51,7 +56,43 @@ memory:
 
 ## Usage
 
-### Memory Tool Commands
+### Operational CLI
+
+Inspect the persisted index:
+
+```bash
+ok-gobot memory status
+```
+
+Force a rebuild of the managed markdown sources:
+
+```bash
+ok-gobot memory index --force
+```
+
+When `memory.enabled: true`, bot startup automatically indexes:
+
+- `MEMORY.md`
+- `memory/*.md`
+
+The bot also starts a debounced filesystem watcher for those managed sources.
+Changes update the `memory_chunks` index; deleted files remove their chunks.
+Other markdown files are intentionally ignored until external memory paths are
+introduced.
+
+### Agent Tool Commands
+
+The active agent tools are:
+
+- `memory_search <query> [limit] [expand]`
+- `memory_get <source> [header_path]`
+
+`memory_search` returns matching indexed chunks. With `expand=true`, each hit is
+expanded to the full markdown branch sharing the same source file and header
+path. `memory_get` reads exact source content or a section path from the
+markdown source of truth.
+
+### Legacy Memory Tool Commands
 
 The memory tool provides four subcommands:
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -37,6 +37,7 @@ type App struct {
 	scheduler     *cron.Scheduler
 	memoryManager *memory.MemoryManager
 	memoryMCP     *memorymcp.Server
+	memoryWatcher *memory.Watcher
 	apiServer     *api.APIServer
 	watcher       *config.ConfigWatcher
 	controlServer *control.Server
@@ -303,6 +304,7 @@ func (a *App) Start(ctx context.Context) error {
 
 			a.memoryManager = memory.NewMemoryManager(embClient, memStore, options...)
 			log.Println("🧠 Semantic memory initialized")
+			a.startMemoryIndexer(ctx, soulPath, memStore, embClient)
 		}
 	}
 
@@ -418,6 +420,9 @@ func (a *App) Stop() error {
 	if a.watcher != nil {
 		a.watcher.Stop()
 	}
+	if a.memoryWatcher != nil {
+		a.memoryWatcher.Stop()
+	}
 	for _, watcher := range a.bootstraps {
 		watcher.Stop()
 	}
@@ -462,4 +467,54 @@ func (a *App) startBootstrapWatcher(name string, personality *agent.Personality)
 
 	a.bootstraps = append(a.bootstraps, watcher)
 	a.bootstrapSeen[personality.BasePath] = struct{}{}
+}
+
+func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *memory.MemoryStore, embedder memory.EmbeddingBatchClient) {
+	if strings.TrimSpace(rootPath) == "" || store == nil || embedder == nil {
+		return
+	}
+
+	indexer := memory.NewIndexer(rootPath, store, embedder)
+	stats, err := memory.IndexManagedSources(ctx, rootPath, indexer)
+	if err != nil {
+		log.Printf("⚠️ [memory] initial index failed: %v", err)
+	} else {
+		log.Printf("🧠 [memory] indexed %d managed source file(s)", stats.FilesIndexed)
+	}
+
+	watcher, err := memory.NewWatcher(rootPath)
+	if err != nil {
+		log.Printf("⚠️ [memory] failed to start memory watcher: %v", err)
+		return
+	}
+	a.memoryWatcher = watcher
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				watcher.Stop()
+				return
+			case err, ok := <-watcher.Errors():
+				if !ok {
+					return
+				}
+				log.Printf("⚠️ [memory] watcher error: %v", err)
+			case event, ok := <-watcher.Events():
+				if !ok {
+					return
+				}
+				rel, ok := memory.ManagedRelativePath(rootPath, event.Path)
+				if !ok {
+					continue
+				}
+				if err := indexer.IndexFile(ctx, event.Path, rel); err != nil {
+					log.Printf("⚠️ [memory] reindex failed for %s: %v", rel, err)
+					continue
+				}
+				log.Printf("🧠 [memory] reindexed %s", rel)
+			}
+		}
+	}()
+	log.Printf("🧠 [memory] watcher active for %s", rootPath)
 }

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/memory"
+	"ok-gobot/internal/storage"
+)
+
+func newMemoryCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "memory",
+		Short: "Inspect and maintain the markdown memory index",
+	}
+	cmd.AddCommand(newMemoryStatusCommand(cfg))
+	cmd.AddCommand(newMemoryIndexCommand(cfg))
+	return cmd
+}
+
+func newMemoryStatusCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show memory index status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, memStore, err := openMemoryStore(cfg)
+			if err != nil {
+				return err
+			}
+			defer store.Close() //nolint:errcheck
+
+			status, err := memStore.Status(cmd.Context(), cfg.Memory.Enabled, cfg.GetSoulPath())
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Memory enabled: %v\n", status.Enabled)
+			fmt.Fprintf(out, "Root: %s\n", status.RootPath)
+			fmt.Fprintf(out, "Sources: %d\n", status.SourceCount)
+			fmt.Fprintf(out, "Chunks: %d\n", status.ChunkCount)
+			if status.LastIndexedAt != "" {
+				fmt.Fprintf(out, "Last indexed: %s\n", status.LastIndexedAt)
+			} else {
+				fmt.Fprintln(out, "Last indexed: never")
+			}
+			return nil
+		},
+	}
+}
+
+func newMemoryIndexCommand(cfg *config.Config) *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "index",
+		Short: "Index managed markdown memory files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cfg.Memory.Enabled {
+				return fmt.Errorf("memory.enabled is false; enable memory before indexing")
+			}
+
+			store, memStore, err := openMemoryStore(cfg)
+			if err != nil {
+				return err
+			}
+			defer store.Close() //nolint:errcheck
+
+			apiKey := cfg.Memory.EmbeddingsAPIKey
+			if apiKey == "" {
+				apiKey = cfg.AI.APIKey
+			}
+			embedder := memory.NewEmbeddingClient(
+				cfg.Memory.EmbeddingsBaseURL,
+				apiKey,
+				cfg.Memory.EmbeddingsModel,
+			)
+			stats, err := runMemoryIndex(cmd.Context(), cfg, memStore, embedder, force)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Indexed %d managed memory source file(s)\n", stats.FilesIndexed)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "clear existing managed memory chunks before indexing")
+	return cmd
+}
+
+func openMemoryStore(cfg *config.Config) (*storage.Store, *memory.MemoryStore, error) {
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("config is nil")
+	}
+	store, err := storage.New(cfg.StoragePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open storage: %w", err)
+	}
+	memStore, err := memory.NewMemoryStore(store.DB())
+	if err != nil {
+		store.Close() //nolint:errcheck
+		return nil, nil, fmt.Errorf("open memory store: %w", err)
+	}
+	return store, memStore, nil
+}
+
+func runMemoryIndex(ctx context.Context, cfg *config.Config, memStore *memory.MemoryStore, embedder memory.EmbeddingBatchClient, force bool) (memory.IndexRunStats, error) {
+	if force {
+		if err := memStore.ClearManagedSources(ctx); err != nil {
+			return memory.IndexRunStats{}, err
+		}
+	}
+	indexer := memory.NewIndexer(cfg.GetSoulPath(), memStore, embedder)
+	return memory.IndexManagedSources(ctx, cfg.GetSoulPath(), indexer)
+}

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/memory"
+)
+
+func TestMemoryStatusShowsIndexedSources(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+	cfg.Memory.Enabled = true
+	cfg.SoulPath = t.TempDir()
+	writeCLITestFile(t, filepath.Join(cfg.SoulPath, "MEMORY.md"), "# Memory\n\nDurable fact.")
+	writeCLITestFile(t, filepath.Join(cfg.SoulPath, "memory", "2026-04-29.md"), "# Daily\n\nDaily note.")
+
+	memStore, err := memory.NewMemoryStore(store.DB())
+	if err != nil {
+		t.Fatalf("memoryStoreFromDB failed: %v", err)
+	}
+	if _, err := runMemoryIndex(context.Background(), cfg, memStore, &stubCLIEmbedder{}, true); err != nil {
+		t.Fatalf("runMemoryIndex failed: %v", err)
+	}
+
+	cmd := newMemoryCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	output := out.String()
+	for _, want := range []string{"Memory enabled: true", "Sources: 2", "Chunks: 2"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
+func TestMemoryIndexRequiresMemoryEnabled(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+	cfg.Memory.Enabled = false
+	cfg.SoulPath = t.TempDir()
+
+	cmd := newMemoryCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"index", "--force"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "memory.enabled is false") {
+		t.Fatalf("expected memory.enabled error, got %v", err)
+	}
+}
+
+func writeCLITestFile(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+type stubCLIEmbedder struct{}
+
+func (s *stubCLIEmbedder) GetEmbeddings(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{float32(len(texts[i])), float32(i + 1)}
+	}
+	return out, nil
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -42,6 +42,7 @@ Supports Telegram bot integration with personality and memory.`,
 	root.AddCommand(newJobsCommand(cfg))
 	root.AddCommand(newProvidersCommand(cfg))
 	root.AddCommand(newModelsCommand(cfg))
+	root.AddCommand(newMemoryCommand(cfg))
 	root.AddCommand(newSkillsCommand(cfg))
 	root.AddCommand(newSessionsCommand(cfg))
 	root.AddCommand(newWorkCommand(cfg))

--- a/internal/memory/lifecycle.go
+++ b/internal/memory/lifecycle.go
@@ -1,0 +1,179 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ManagedSource describes a markdown memory file managed by the built-in
+// workspace memory index.
+type ManagedSource struct {
+	Path         string
+	RelativePath string
+}
+
+// IndexRunStats describes one index pass over managed memory sources.
+type IndexRunStats struct {
+	FilesIndexed int
+}
+
+// IndexStatus describes the current state of the persisted memory index.
+type IndexStatus struct {
+	Enabled       bool
+	RootPath      string
+	ChunkCount    int
+	SourceCount   int
+	LastIndexedAt string
+}
+
+// ManagedSources returns the canonical markdown memory files for rootPath:
+// MEMORY.md plus memory/*.md. Missing files/directories are skipped.
+func ManagedSources(rootPath string) ([]ManagedSource, error) {
+	rootPath = strings.TrimSpace(rootPath)
+	if rootPath == "" {
+		return nil, fmt.Errorf("memory root path is empty")
+	}
+	absRoot, err := filepath.Abs(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve memory root: %w", err)
+	}
+	absRoot = filepath.Clean(absRoot)
+
+	var sources []ManagedSource
+	rootMemory := filepath.Join(absRoot, "MEMORY.md")
+	if info, err := os.Stat(rootMemory); err == nil && !info.IsDir() {
+		sources = append(sources, ManagedSource{Path: rootMemory, RelativePath: "MEMORY.md"})
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("stat MEMORY.md: %w", err)
+	}
+
+	dailyPattern := filepath.Join(absRoot, "memory", "*.md")
+	matches, err := filepath.Glob(dailyPattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob daily memory files: %w", err)
+	}
+	sort.Strings(matches)
+	for _, match := range matches {
+		info, err := os.Stat(match)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("stat daily memory %s: %w", match, err)
+		}
+		if info.IsDir() {
+			continue
+		}
+		rel, err := filepath.Rel(absRoot, match)
+		if err != nil {
+			return nil, fmt.Errorf("rel daily memory %s: %w", match, err)
+		}
+		sources = append(sources, ManagedSource{
+			Path:         filepath.Clean(match),
+			RelativePath: filepath.ToSlash(rel),
+		})
+	}
+
+	return sources, nil
+}
+
+// ManagedRelativePath returns the canonical relative source path when absPath is
+// part of the built-in memory source set. It intentionally excludes unrelated
+// markdown files until extra indexed paths are introduced.
+func ManagedRelativePath(rootPath, absPath string) (string, bool) {
+	rootPath = strings.TrimSpace(rootPath)
+	absPath = strings.TrimSpace(absPath)
+	if rootPath == "" || absPath == "" {
+		return "", false
+	}
+
+	absRoot, err := filepath.Abs(rootPath)
+	if err != nil {
+		return "", false
+	}
+	resolved, err := filepath.Abs(absPath)
+	if err != nil {
+		return "", false
+	}
+
+	rel, err := filepath.Rel(filepath.Clean(absRoot), filepath.Clean(resolved))
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "MEMORY.md" {
+		return rel, true
+	}
+	if strings.HasPrefix(rel, "memory/") && strings.Count(rel, "/") == 1 && strings.EqualFold(filepath.Ext(rel), ".md") {
+		return rel, true
+	}
+	return "", false
+}
+
+// IndexManagedSources indexes all canonical memory markdown files.
+func IndexManagedSources(ctx context.Context, rootPath string, indexer *Indexer) (IndexRunStats, error) {
+	if indexer == nil {
+		return IndexRunStats{}, fmt.Errorf("memory indexer is nil")
+	}
+	sources, err := ManagedSources(rootPath)
+	if err != nil {
+		return IndexRunStats{}, err
+	}
+
+	stats := IndexRunStats{}
+	for _, source := range sources {
+		if err := indexer.IndexFile(ctx, source.Path, source.RelativePath); err != nil {
+			return stats, err
+		}
+		stats.FilesIndexed++
+	}
+	return stats, nil
+}
+
+// ClearManagedSources removes built-in workspace memory chunks from the index.
+func (s *MemoryStore) ClearManagedSources(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("memory store is not configured")
+	}
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM memory_chunks
+		WHERE source_file = 'MEMORY.md'
+		   OR source_file LIKE 'memory/%'
+	`)
+	if err != nil {
+		return fmt.Errorf("clear managed memory sources: %w", err)
+	}
+	return nil
+}
+
+// Status returns lightweight diagnostics for the persisted memory index.
+func (s *MemoryStore) Status(ctx context.Context, enabled bool, rootPath string) (IndexStatus, error) {
+	status := IndexStatus{
+		Enabled:  enabled,
+		RootPath: rootPath,
+	}
+	if s == nil || s.db == nil {
+		return status, fmt.Errorf("memory store is not configured")
+	}
+
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM memory_chunks`).Scan(&status.ChunkCount); err != nil {
+		return status, fmt.Errorf("count memory chunks: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT source_file) FROM memory_chunks`).Scan(&status.SourceCount); err != nil {
+		return status, fmt.Errorf("count memory sources: %w", err)
+	}
+
+	var last sql.NullString
+	if err := s.db.QueryRowContext(ctx, `SELECT MAX(indexed_at) FROM memory_chunks`).Scan(&last); err != nil {
+		return status, fmt.Errorf("read last indexed time: %w", err)
+	}
+	if last.Valid {
+		status.LastIndexedAt = last.String
+	}
+	return status, nil
+}

--- a/internal/memory/lifecycle_test.go
+++ b/internal/memory/lifecycle_test.go
@@ -1,0 +1,160 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestManagedSourcesFindsOnlyCanonicalMemoryFiles(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "MEMORY.md"), "# Memory\n")
+	mustWrite(t, filepath.Join(root, "memory", "2026-04-28.md"), "# Yesterday\n")
+	mustWrite(t, filepath.Join(root, "memory", "2026-04-29.md"), "# Today\n")
+	mustWrite(t, filepath.Join(root, "notes.md"), "# Not indexed yet\n")
+	mustWrite(t, filepath.Join(root, "memory", "nested", "ignore.md"), "# Nested\n")
+
+	sources, err := ManagedSources(root)
+	if err != nil {
+		t.Fatalf("ManagedSources failed: %v", err)
+	}
+
+	got := make([]string, len(sources))
+	for i, source := range sources {
+		got[i] = source.RelativePath
+	}
+	want := []string{"MEMORY.md", "memory/2026-04-28.md", "memory/2026-04-29.md"}
+	if len(got) != len(want) {
+		t.Fatalf("sources = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sources = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestManagedRelativePath(t *testing.T) {
+	root := t.TempDir()
+	tests := []struct {
+		name string
+		path string
+		want string
+		ok   bool
+	}{
+		{name: "root memory", path: filepath.Join(root, "MEMORY.md"), want: "MEMORY.md", ok: true},
+		{name: "daily memory", path: filepath.Join(root, "memory", "2026-04-29.md"), want: "memory/2026-04-29.md", ok: true},
+		{name: "other markdown", path: filepath.Join(root, "notes.md"), ok: false},
+		{name: "nested memory", path: filepath.Join(root, "memory", "nested", "x.md"), ok: false},
+		{name: "outside", path: filepath.Join(filepath.Dir(root), "MEMORY.md"), ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ManagedRelativePath(root, tt.path)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("ManagedRelativePath() = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestIndexManagedSourcesAndClear(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "MEMORY.md"), "# Memory\n\nDurable fact.")
+	mustWrite(t, filepath.Join(root, "memory", "2026-04-29.md"), "# Daily\n\nToday we fixed memory.")
+	mustWrite(t, filepath.Join(root, "notes.md"), "# Not managed\n\nIgnore me.")
+
+	indexer := NewIndexer(root, store, &stubBatchEmbedder{}, WithIndexerChunking(64, 0))
+	stats, err := IndexManagedSources(context.Background(), root, indexer)
+	if err != nil {
+		t.Fatalf("IndexManagedSources failed: %v", err)
+	}
+	if stats.FilesIndexed != 2 {
+		t.Fatalf("FilesIndexed = %d, want 2", stats.FilesIndexed)
+	}
+	if count := countAllChunks(t, db); count != 2 {
+		t.Fatalf("chunk count = %d, want 2", count)
+	}
+	if count := countSourceChunks(t, db, "notes.md"); count != 0 {
+		t.Fatalf("notes.md should not be indexed, got %d chunk(s)", count)
+	}
+
+	status, err := store.Status(context.Background(), true, root)
+	if err != nil {
+		t.Fatalf("Status failed: %v", err)
+	}
+	if !status.Enabled || status.SourceCount != 2 || status.ChunkCount != 2 || status.LastIndexedAt == "" {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+
+	if err := store.ClearManagedSources(context.Background()); err != nil {
+		t.Fatalf("ClearManagedSources failed: %v", err)
+	}
+	if count := countAllChunks(t, db); count != 0 {
+		t.Fatalf("chunk count after clear = %d, want 0", count)
+	}
+}
+
+func TestIndexerDeletesManagedChunksWhenSourceIsRemoved(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "MEMORY.md")
+	mustWrite(t, sourcePath, "# Memory\n\nTemporary fact.")
+
+	indexer := NewIndexer(root, store, &stubBatchEmbedder{}, WithIndexerChunking(64, 0))
+	if err := indexer.IndexFile(context.Background(), sourcePath, "MEMORY.md"); err != nil {
+		t.Fatalf("IndexFile failed: %v", err)
+	}
+	if count := countSourceChunks(t, db, "MEMORY.md"); count != 1 {
+		t.Fatalf("chunk count = %d, want 1", count)
+	}
+
+	if err := os.Remove(sourcePath); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if err := indexer.IndexFile(context.Background(), sourcePath, "MEMORY.md"); err != nil {
+		t.Fatalf("IndexFile delete failed: %v", err)
+	}
+	if count := countSourceChunks(t, db, "MEMORY.md"); count != 0 {
+		t.Fatalf("chunk count after delete = %d, want 0", count)
+	}
+}
+
+func mustWrite(t *testing.T, path string, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func countAllChunks(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM memory_chunks`).Scan(&count); err != nil {
+		t.Fatalf("count all chunks failed: %v", err)
+	}
+	return count
+}

--- a/internal/memory/watcher.go
+++ b/internal/memory/watcher.go
@@ -262,7 +262,7 @@ func (w *Watcher) addDirectory(path string) error {
 }
 
 func isTrackedMemoryEvent(rootPath, path string, op fsnotify.Op) bool {
-	if op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename) == 0 {
+	if op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename|fsnotify.Remove) == 0 {
 		return false
 	}
 	if isIgnoredMemoryPath(rootPath, path) {


### PR DESCRIPTION
## Summary

Closes #303.

This wires the existing markdown memory primitives into the app/runtime path:

- indexes managed memory files (`MEMORY.md`, `memory/*.md`) on startup when `memory.enabled` is true
- starts a debounced watcher and reindexes/deletes chunks for managed memory source changes
- keeps unrelated markdown files out of the managed memory index until extra paths are introduced
- adds `ok-gobot memory status`
- adds `ok-gobot memory index --force`
- documents the current markdown-first memory v2 operational flow

## Notes

This does not implement hybrid FTS/BM25 search; that remains #304.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the existing markdown-memory primitives into the app lifecycle: `IndexManagedSources` runs on startup when `memory.enabled` is true, a debounced fsnotify watcher re-indexes or removes chunks for managed-source changes, and two CLI commands (`memory status`, `memory index --force`) are added. The `watcher.go` one-liner to include `fsnotify.Remove` in the tracked-event mask is the key enabler for file-deletion cleanup. Test coverage for the new lifecycle and CLI paths is solid.

<h3>Confidence Score: 4/5</h3>

Safe to merge; logic is correct and well-tested with one minor scope concern in the status queries.

No definite logic bugs found. The watcher event loop correctly delegates file-not-found detection to IndexFile (which calls deleteBySourceFile on ErrNotExist), double-stop is guarded by sync.Once, and ManagedRelativePath correctly filters non-managed paths. Score kept at 4 rather than 5 because Status() aggregates the entire memory_chunks table, which could silently include legacy-migrated rows and mislead operators.

internal/memory/lifecycle.go — Status() query scope

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/memory/lifecycle.go | New file: ManagedSources, ManagedRelativePath, IndexManagedSources, ClearManagedSources, Status — well-structured, but Status() counts all memory_chunks rows rather than only managed-source rows. |
| internal/app/app.go | Adds startMemoryIndexer: runs initial index, starts a watcher goroutine, and stops watcher on ctx cancellation and App.Stop(); double-stop is safe via sync.Once. |
| internal/memory/watcher.go | Adds fsnotify.Remove to isTrackedMemoryEvent so file deletions are forwarded to the indexer for chunk cleanup. |
| internal/cli/memory.go | New file: memory status and memory index --force CLI commands; correct error propagation and deferred store close. |
| internal/memory/lifecycle_test.go | New tests covering ManagedSources filtering, ManagedRelativePath, full index+clear cycle, and delete-on-remove; good coverage of the new lifecycle paths. |
| internal/cli/memory_test.go | New tests for status output correctness and memory.enabled guard on the index command. |
| internal/cli/root.go | Wires the new memory command into the CLI root; trivial change. |
| docs/MEMORY.md | Documents the markdown-first v2 operational flow, new CLI commands, and deprecation of legacy record-style commands. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/memory/lifecycle.go
Line: 154-178

Comment:
**Status() counts all chunks, not just managed sources**

The three aggregate queries scan the entire `memory_chunks` table. If the store contains rows with non-managed `source_file` values — for example `legacy://migrated` records produced by the v1→v2 schema migration — `SourceCount` and `ChunkCount` will exceed the number of managed markdown chunks. Users running `ok-gobot memory status` after an upgrade may see unexpectedly large counts that don't reflect the managed markdown index. Consider filtering to `WHERE source_file = 'MEMORY.md' OR source_file LIKE 'memory/%'` (matching the scope already used in `ClearManagedSources`) if the intent is to surface only managed-source statistics.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(memory): wire markdown index lifecy..."](https://github.com/befeast/ok-gobot/commit/340be31f75b363b50d35b07f1b432a1147b903f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30185252)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->