### PR TITLE
feat: add hybrid memory search backend (#304)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -266,11 +266,14 @@ func (a *App) Start(ctx context.Context) error {
 		if apiKey == "" {
 			apiKey = a.config.AI.APIKey
 		}
-		embClient := memory.NewEmbeddingClient(
-			a.config.Memory.EmbeddingsBaseURL,
-			apiKey,
-			a.config.Memory.EmbeddingsModel,
-		)
+		var embClient *memory.EmbeddingClient
+		if memory.EmbeddingProviderConfigured(a.config.Memory.EmbeddingsBaseURL, apiKey) {
+			embClient = memory.NewEmbeddingClient(
+				a.config.Memory.EmbeddingsBaseURL,
+				apiKey,
+				a.config.Memory.EmbeddingsModel,
+			)
+		}
 		memStore, err := memory.NewMemoryStore(a.store.DB())
 		if err != nil {
 			log.Printf("⚠️ Failed to initialize memory store: %v", err)
@@ -303,7 +306,11 @@ func (a *App) Start(ctx context.Context) error {
 			}
 
 			a.memoryManager = memory.NewMemoryManager(embClient, memStore, options...)
-			log.Println("🧠 Semantic memory initialized")
+			if embClient == nil {
+				log.Println("🧠 Memory initialized (lexical search only; embeddings not configured)")
+			} else {
+				log.Println("🧠 Hybrid memory initialized")
+			}
 			a.startMemoryIndexer(ctx, soulPath, memStore, embClient)
 		}
 	}
@@ -470,7 +477,7 @@ func (a *App) startBootstrapWatcher(name string, personality *agent.Personality)
 }
 
 func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *memory.MemoryStore, embedder memory.EmbeddingBatchClient) {
-	if strings.TrimSpace(rootPath) == "" || store == nil || embedder == nil {
+	if strings.TrimSpace(rootPath) == "" || store == nil {
 		return
 	}
 

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -72,11 +72,14 @@ func newMemoryIndexCommand(cfg *config.Config) *cobra.Command {
 			if apiKey == "" {
 				apiKey = cfg.AI.APIKey
 			}
-			embedder := memory.NewEmbeddingClient(
-				cfg.Memory.EmbeddingsBaseURL,
-				apiKey,
-				cfg.Memory.EmbeddingsModel,
-			)
+			var embedder memory.EmbeddingBatchClient
+			if memory.EmbeddingProviderConfigured(cfg.Memory.EmbeddingsBaseURL, apiKey) {
+				embedder = memory.NewEmbeddingClient(
+					cfg.Memory.EmbeddingsBaseURL,
+					apiKey,
+					cfg.Memory.EmbeddingsModel,
+				)
+			}
 			stats, err := runMemoryIndex(cmd.Context(), cfg, memStore, embedder, force)
 			if err != nil {
 				return err

--- a/internal/memory/embeddings.go
+++ b/internal/memory/embeddings.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
+
+const defaultEmbeddingsBaseURL = "https://api.openai.com/v1"
 
 // EmbeddingClient handles communication with embedding API
 type EmbeddingClient struct {
@@ -23,14 +26,28 @@ func NewEmbeddingClient(baseURL, apiKey, model string) *EmbeddingClient {
 	if model == "" {
 		model = "text-embedding-3-small"
 	}
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = defaultEmbeddingsBaseURL
+	}
 	return &EmbeddingClient{
-		baseURL: baseURL,
+		baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"),
 		apiKey:  apiKey,
 		model:   model,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
 	}
+}
+
+// EmbeddingProviderConfigured reports whether configuration points at a usable
+// embedding provider. The default OpenAI endpoint requires an API key, while
+// custom OpenAI-compatible local endpoints may intentionally use no key.
+func EmbeddingProviderConfigured(baseURL, apiKey string) bool {
+	if strings.TrimSpace(apiKey) != "" {
+		return true
+	}
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	return baseURL != "" && !strings.EqualFold(baseURL, defaultEmbeddingsBaseURL)
 }
 
 // embeddingRequest represents the API request body

--- a/internal/memory/fts.go
+++ b/internal/memory/fts.go
@@ -1,0 +1,47 @@
+package memory
+
+import "fmt"
+
+func (s *MemoryStore) ensureChunksFTS() error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("memory store is not configured")
+	}
+
+	statements := []string{
+		`CREATE VIRTUAL TABLE IF NOT EXISTS memory_chunks_fts USING fts5(
+			content,
+			source_file UNINDEXED,
+			header_path UNINDEXED,
+			chunk_ordinal UNINDEXED,
+			content='memory_chunks',
+			content_rowid='id',
+			tokenize='unicode61'
+		);`,
+		`CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_ai AFTER INSERT ON memory_chunks BEGIN
+			INSERT INTO memory_chunks_fts(rowid, content, source_file, header_path, chunk_ordinal)
+			VALUES (new.id, new.content, new.source_file, new.header_path, new.chunk_ordinal);
+		END;`,
+		`CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_ad AFTER DELETE ON memory_chunks BEGIN
+			INSERT INTO memory_chunks_fts(memory_chunks_fts, rowid, content, source_file, header_path, chunk_ordinal)
+			VALUES ('delete', old.id, old.content, old.source_file, old.header_path, old.chunk_ordinal);
+		END;`,
+		`CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_au AFTER UPDATE ON memory_chunks BEGIN
+			INSERT INTO memory_chunks_fts(memory_chunks_fts, rowid, content, source_file, header_path, chunk_ordinal)
+			VALUES ('delete', old.id, old.content, old.source_file, old.header_path, old.chunk_ordinal);
+			INSERT INTO memory_chunks_fts(rowid, content, source_file, header_path, chunk_ordinal)
+			VALUES (new.id, new.content, new.source_file, new.header_path, new.chunk_ordinal);
+		END;`,
+	}
+
+	for _, statement := range statements {
+		if _, err := s.db.Exec(statement); err != nil {
+			return err
+		}
+	}
+
+	if _, err := s.db.Exec(`INSERT INTO memory_chunks_fts(memory_chunks_fts) VALUES ('rebuild')`); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/memory/hybrid_search.go
+++ b/internal/memory/hybrid_search.go
@@ -1,0 +1,481 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	defaultMemoryStoreTopK      = 5
+	memorySearchCandidateMin    = 50
+	memorySearchCandidateMax    = 500
+	memorySearchCandidateFactor = 20
+	hybridLexicalWeight         = 0.45
+	hybridVectorWeight          = 0.55
+)
+
+type memorySearchCandidate struct {
+	result MemoryResult
+
+	embeddingRaw     []byte
+	vectorNormalized float32
+	vectorScored     bool
+}
+
+type lexicalCandidate struct {
+	candidate memorySearchCandidate
+	bm25      float64
+}
+
+// SearchChunksHybrid combines FTS5/BM25 lexical candidates with bounded vector
+// scoring. When either backend is unavailable, it falls back to the other.
+func (s *MemoryStore) SearchChunksHybrid(ctx context.Context, query string, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("memory store is not configured")
+	}
+	if topK <= 0 {
+		topK = defaultMemoryStoreTopK
+	}
+	candidateLimit := memorySearchCandidateLimit(topK)
+
+	candidates := make(map[int64]*memorySearchCandidate)
+	lexicalUsed := false
+	lexicalTokens := tokenizeSearchQuery(query)
+	if len(lexicalTokens) > 0 {
+		lexical, err := s.searchLexicalCandidates(ctx, buildFTS5Query(lexicalTokens), candidateLimit)
+		if err != nil || !s.ftsAvailable {
+			lexical, err = s.searchLikeCandidates(ctx, lexicalTokens, candidateLimit)
+		}
+		if err == nil {
+			lexicalUsed = len(lexical) > 0
+			for i := range lexical {
+				candidate := lexical[i]
+				candidates[candidate.result.ID] = &candidate
+			}
+		}
+	}
+
+	queryVector, vectorUsed := normalizeEmbedding(queryEmbedding)
+	if vectorUsed {
+		for _, candidate := range candidates {
+			scoreCandidateVector(candidate, queryVector)
+		}
+
+		if len(candidates) < candidateLimit {
+			recent, err := s.loadRecentVectorCandidates(ctx, candidateLimit-len(candidates), candidates)
+			if err != nil {
+				return nil, fmt.Errorf("failed to query memory vector candidates: %w", err)
+			}
+			for i := range recent {
+				candidate := recent[i]
+				scoreCandidateVector(&candidate, queryVector)
+				if candidate.vectorScored {
+					candidates[candidate.result.ID] = &candidate
+				}
+			}
+		}
+	}
+
+	return rankMemoryCandidates(candidates, lexicalUsed, vectorUsed, topK), nil
+}
+
+// SearchChunks is kept as the semantic-only compatibility API. It uses the same
+// bounded vector candidate path as hybrid search instead of scanning every row.
+func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+	return s.SearchChunksHybrid(ctx, "", queryEmbedding, topK)
+}
+
+// Search is kept as a compatibility alias for callers that still use the old name.
+func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+	return s.SearchChunks(ctx, queryEmbedding, topK)
+}
+
+func (s *MemoryStore) searchLexicalCandidates(ctx context.Context, ftsQuery string, limit int) ([]memorySearchCandidate, error) {
+	if !s.ftsAvailable || ftsQuery == "" {
+		return nil, fmt.Errorf("memory FTS index is unavailable")
+	}
+
+	query := fmt.Sprintf(`
+		SELECT c.id, c.source_file, c.header_path, c.chunk_ordinal, c.content, c.content_hash, c.embedding, c.indexed_at,
+		       bm25(%s) AS bm25_score
+		FROM %s
+		JOIN memory_chunks c ON c.id = %s.rowid
+		WHERE %s MATCH ?
+		ORDER BY bm25(%s) ASC, c.id DESC
+		LIMIT ?
+	`, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksFTSTable)
+
+	rows, err := s.db.QueryContext(ctx, query, ftsQuery, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	raw := make([]lexicalCandidate, 0, limit)
+	for rows.Next() {
+		candidate, bm25, err := scanLexicalCandidate(rows)
+		if err != nil {
+			continue
+		}
+		raw = append(raw, lexicalCandidate{candidate: candidate, bm25: bm25})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return normalizeLexicalCandidates(raw), nil
+}
+
+func (s *MemoryStore) searchLikeCandidates(ctx context.Context, tokens []string, limit int) ([]memorySearchCandidate, error) {
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+	if len(tokens) > 8 {
+		tokens = tokens[:8]
+	}
+
+	clauses := make([]string, 0, len(tokens))
+	args := make([]interface{}, 0, len(tokens)+1)
+	for _, token := range tokens {
+		clauses = append(clauses, `LOWER(content) LIKE ?`)
+		args = append(args, "%"+strings.ToLower(token)+"%")
+	}
+	args = append(args, limit)
+
+	query := fmt.Sprintf(`
+		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
+		FROM memory_chunks
+		WHERE %s
+		ORDER BY indexed_at DESC, id DESC
+		LIMIT ?
+	`, strings.Join(clauses, " OR "))
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	candidates := make([]memorySearchCandidate, 0, limit)
+	for rows.Next() {
+		candidate, err := scanMemorySearchCandidate(rows)
+		if err != nil {
+			continue
+		}
+		candidate.result.LexicalScore = likeLexicalScore(candidate.result.Content, tokens)
+		if candidate.result.LexicalScore > 0 {
+			candidates = append(candidates, candidate)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].result.LexicalScore != candidates[j].result.LexicalScore {
+			return candidates[i].result.LexicalScore > candidates[j].result.LexicalScore
+		}
+		return candidates[i].result.ID > candidates[j].result.ID
+	})
+	return candidates, nil
+}
+
+func scanLexicalCandidate(scanner memoryCandidateScanner) (memorySearchCandidate, float64, error) {
+	var (
+		id           int64
+		sourceFile   string
+		headerPath   string
+		chunkOrdinal int
+		content      string
+		contentHash  string
+		embeddingRaw []byte
+		indexedAt    time.Time
+		bm25         float64
+	)
+
+	if err := scanner.Scan(&id, &sourceFile, &headerPath, &chunkOrdinal, &content, &contentHash, &embeddingRaw, &indexedAt, &bm25); err != nil {
+		return memorySearchCandidate{}, 0, err
+	}
+
+	return newMemorySearchCandidate(id, sourceFile, headerPath, chunkOrdinal, content, contentHash, embeddingRaw, indexedAt), bm25, nil
+}
+
+func (s *MemoryStore) loadRecentVectorCandidates(ctx context.Context, limit int, existing map[int64]*memorySearchCandidate) ([]memorySearchCandidate, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	fetchLimit := limit + len(existing)
+	if fetchLimit < limit {
+		fetchLimit = limit
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
+		FROM memory_chunks
+		ORDER BY indexed_at DESC, id DESC
+		LIMIT ?
+	`, fetchLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	candidates := make([]memorySearchCandidate, 0, limit)
+	for rows.Next() {
+		candidate, err := scanMemorySearchCandidate(rows)
+		if err != nil {
+			continue
+		}
+		if _, ok := existing[candidate.result.ID]; ok {
+			continue
+		}
+		candidates = append(candidates, candidate)
+		if len(candidates) >= limit {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return candidates, nil
+}
+
+type memoryCandidateScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanMemorySearchCandidate(scanner memoryCandidateScanner) (memorySearchCandidate, error) {
+	var (
+		id           int64
+		sourceFile   string
+		headerPath   string
+		chunkOrdinal int
+		content      string
+		contentHash  string
+		embeddingRaw []byte
+		indexedAt    time.Time
+	)
+
+	if err := scanner.Scan(&id, &sourceFile, &headerPath, &chunkOrdinal, &content, &contentHash, &embeddingRaw, &indexedAt); err != nil {
+		return memorySearchCandidate{}, err
+	}
+
+	return newMemorySearchCandidate(id, sourceFile, headerPath, chunkOrdinal, content, contentHash, embeddingRaw, indexedAt), nil
+}
+
+func newMemorySearchCandidate(id int64, sourceFile, headerPath string, chunkOrdinal int, content, contentHash string, embeddingRaw []byte, indexedAt time.Time) memorySearchCandidate {
+	return memorySearchCandidate{
+		result: MemoryResult{
+			ID:           id,
+			Source:       sourceFile,
+			SourceFile:   sourceFile,
+			HeaderPath:   headerPath,
+			StartLine:    chunkOrdinal,
+			EndLine:      chunkOrdinal,
+			ChunkOrdinal: chunkOrdinal,
+			Content:      content,
+			ContentHash:  contentHash,
+			UpdatedAt:    indexedAt,
+			IndexedAt:    indexedAt,
+		},
+		embeddingRaw: embeddingRaw,
+	}
+}
+
+func normalizeLexicalCandidates(raw []lexicalCandidate) []memorySearchCandidate {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	best := raw[0].bm25
+	worst := raw[0].bm25
+	for _, candidate := range raw[1:] {
+		if candidate.bm25 < best {
+			best = candidate.bm25
+		}
+		if candidate.bm25 > worst {
+			worst = candidate.bm25
+		}
+	}
+
+	out := make([]memorySearchCandidate, 0, len(raw))
+	for _, item := range raw {
+		score := float32(1)
+		if worst > best && !math.IsNaN(item.bm25) {
+			score = float32(1 - ((item.bm25 - best) / (worst - best)))
+			if score < 0 {
+				score = 0
+			}
+		}
+		item.candidate.result.LexicalScore = score
+		out = append(out, item.candidate)
+	}
+	return out
+}
+
+func scoreCandidateVector(candidate *memorySearchCandidate, queryVector []float32) {
+	embedding, err := decodeChunkEmbedding(candidate.embeddingRaw)
+	if err != nil {
+		return
+	}
+	normalized, ok := normalizeEmbedding(embedding)
+	if !ok || len(normalized) != len(queryVector) {
+		return
+	}
+
+	cosine := dotProduct(queryVector, normalized)
+	candidate.result.VectorScore = cosine
+	candidate.vectorNormalized = normalizeCosineScore(cosine)
+	candidate.vectorScored = true
+}
+
+func normalizeCosineScore(score float32) float32 {
+	if score < -1 {
+		score = -1
+	}
+	if score > 1 {
+		score = 1
+	}
+	return (score + 1) / 2
+}
+
+func rankMemoryCandidates(candidates map[int64]*memorySearchCandidate, lexicalUsed, vectorUsed bool, topK int) []MemoryResult {
+	if len(candidates) == 0 || topK == 0 {
+		return nil
+	}
+
+	results := make([]MemoryResult, 0, len(candidates))
+	for _, candidate := range candidates {
+		result := candidate.result
+		if lexicalUsed && vectorUsed {
+			result.HybridScore = hybridLexicalWeight*result.LexicalScore + hybridVectorWeight*candidate.vectorNormalized
+		} else if lexicalUsed {
+			result.HybridScore = result.LexicalScore
+		} else if vectorUsed && candidate.vectorScored {
+			result.HybridScore = candidate.vectorNormalized
+		} else {
+			continue
+		}
+
+		result.Score = result.HybridScore
+		result.Similarity = result.HybridScore
+		if result.Score > 0 || result.LexicalScore > 0 || candidate.vectorScored {
+			results = append(results, result)
+		}
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		if results[i].VectorScore != results[j].VectorScore {
+			return results[i].VectorScore > results[j].VectorScore
+		}
+		if results[i].LexicalScore != results[j].LexicalScore {
+			return results[i].LexicalScore > results[j].LexicalScore
+		}
+		if results[i].SourceFile != results[j].SourceFile {
+			return results[i].SourceFile < results[j].SourceFile
+		}
+		if results[i].HeaderPath != results[j].HeaderPath {
+			return results[i].HeaderPath < results[j].HeaderPath
+		}
+		return results[i].ChunkOrdinal < results[j].ChunkOrdinal
+	})
+
+	if len(results) > topK {
+		results = results[:topK]
+	}
+	return results
+}
+
+func memorySearchCandidateLimit(topK int) int {
+	if topK <= 0 {
+		topK = defaultMemoryStoreTopK
+	}
+	limit := topK * memorySearchCandidateFactor
+	if limit < memorySearchCandidateMin {
+		limit = memorySearchCandidateMin
+	}
+	if limit > memorySearchCandidateMax {
+		limit = memorySearchCandidateMax
+	}
+	return limit
+}
+
+func tokenizeSearchQuery(query string) []string {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return nil
+	}
+
+	var (
+		tokens  []string
+		current strings.Builder
+	)
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		token := current.String()
+		current.Reset()
+		tokens = append(tokens, token)
+	}
+
+	for _, r := range query {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			current.WriteRune(r)
+			continue
+		}
+		flush()
+	}
+	flush()
+
+	return tokens
+}
+
+func buildFTS5Query(tokens []string) string {
+	if len(tokens) == 0 {
+		return ""
+	}
+	quoted := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		quoted = append(quoted, `"`+strings.ReplaceAll(token, `"`, `""`)+`"`)
+	}
+	return strings.Join(quoted, " OR ")
+}
+
+func likeLexicalScore(content string, tokens []string) float32 {
+	if len(tokens) == 0 {
+		return 0
+	}
+	content = strings.ToLower(content)
+	matched := 0
+	totalCount := 0
+	for _, token := range tokens {
+		count := strings.Count(content, strings.ToLower(token))
+		if count == 0 {
+			continue
+		}
+		matched++
+		totalCount += count
+	}
+	if matched == 0 {
+		return 0
+	}
+
+	score := float32(matched) / float32(len(tokens))
+	if totalCount > matched {
+		score += float32(totalCount-matched) * 0.05
+	}
+	if score > 1 {
+		return 1
+	}
+	return score
+}

--- a/internal/memory/indexer.go
+++ b/internal/memory/indexer.go
@@ -131,7 +131,7 @@ func (i *Indexer) HandleEvent(ctx context.Context, event FileChangedEvent) error
 
 // IndexFile indexes a single file into memory_chunks.
 func (i *Indexer) IndexFile(ctx context.Context, absPath, relativePath string) error {
-	if i == nil || i.store == nil || i.embedder == nil {
+	if i == nil || i.store == nil {
 		return fmt.Errorf("indexer is not fully configured")
 	}
 
@@ -187,6 +187,9 @@ func (i *Indexer) IndexFile(ctx context.Context, absPath, relativePath string) e
 func (i *Indexer) embedChangedChunks(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil
+	}
+	if i.embedder == nil {
+		return make([][]float32, len(texts)), nil
 	}
 
 	allEmbeddings := make([][]float32, 0, len(texts))

--- a/internal/memory/indexer_test.go
+++ b/internal/memory/indexer_test.go
@@ -137,6 +137,35 @@ func TestIndexerDeletesStaleChunksWhenFileShrinks(t *testing.T) {
 	}
 }
 
+func TestIndexerIndexesWithoutEmbedderForLexicalSearch(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "MEMORY.md")
+	if err := os.WriteFile(filePath, []byte("# Memory\n\nEspresso beans go in the top drawer."), 0o644); err != nil {
+		t.Fatalf("write file failed: %v", err)
+	}
+
+	indexer := NewIndexer(tmpDir, store, nil, WithIndexerChunking(32, 0))
+	if err := indexer.IndexFile(context.Background(), filePath, "MEMORY.md"); err != nil {
+		t.Fatalf("IndexFile without embedder failed: %v", err)
+	}
+
+	results, err := store.SearchChunksHybrid(context.Background(), "espresso", nil, 3)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed: %v", err)
+	}
+	if len(results) != 1 || results[0].SourceFile != "MEMORY.md" {
+		t.Fatalf("expected lexical hit from unembedded index, got %+v", results)
+	}
+}
+
 func openIndexerTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 

--- a/internal/memory/manager.go
+++ b/internal/memory/manager.go
@@ -43,18 +43,21 @@ func NewMemoryManager(client *EmbeddingClient, store *MemoryStore, opts ...Memor
 	return manager
 }
 
-// Search searches indexed markdown chunks by semantic similarity.
+// Search searches indexed markdown chunks using hybrid lexical/vector ranking.
 func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
-	if m.client == nil || m.store == nil {
+	if m == nil || m.store == nil {
 		return nil, fmt.Errorf("memory manager is not fully configured")
 	}
 
-	queryEmbedding, err := m.client.GetEmbedding(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate query embedding: %w", err)
+	var queryEmbedding []float32
+	if m.client != nil {
+		embedding, err := m.client.GetEmbedding(ctx, query)
+		if err == nil {
+			queryEmbedding = embedding
+		}
 	}
 
-	results, err := m.store.SearchChunks(ctx, queryEmbedding, topK)
+	results, err := m.store.SearchChunksHybrid(ctx, query, queryEmbedding, topK)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search memory chunks: %w", err)
 	}
@@ -66,7 +69,7 @@ func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]M
 // include all chunks from the same branch (source_file + header_path).
 // This gives full section context without replaying the entire history.
 func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
-	if m.client == nil || m.store == nil {
+	if m == nil || m.store == nil {
 		return nil, fmt.Errorf("memory manager is not fully configured")
 	}
 
@@ -81,12 +84,12 @@ func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK i
 	type branch struct{ file, header string }
 	var branches []branch
 	seen := make(map[branch]bool)
-	bestScores := make(map[branch]float32)
+	bestByBranch := make(map[branch]MemoryResult)
 
 	for _, h := range hits {
 		b := branch{h.SourceFile, h.HeaderPath}
-		if h.Similarity > bestScores[b] {
-			bestScores[b] = h.Similarity
+		if best, ok := bestByBranch[b]; !ok || h.Score > best.Score {
+			bestByBranch[b] = h
 		}
 		if !seen[b] {
 			seen[b] = true
@@ -106,12 +109,24 @@ func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK i
 			texts[i] = c.Content
 		}
 
+		best := bestByBranch[b]
 		expanded = append(expanded, MemoryResult{
-			Source:     b.file,
-			SourceFile: b.file,
-			HeaderPath: b.header,
-			Content:    strings.Join(texts, "\n\n"),
-			Similarity: bestScores[b],
+			ID:           best.ID,
+			Source:       b.file,
+			SourceFile:   b.file,
+			HeaderPath:   b.header,
+			StartLine:    best.StartLine,
+			EndLine:      best.EndLine,
+			ChunkOrdinal: best.ChunkOrdinal,
+			Content:      strings.Join(texts, "\n\n"),
+			ContentHash:  best.ContentHash,
+			Similarity:   best.Similarity,
+			Score:        best.Score,
+			LexicalScore: best.LexicalScore,
+			VectorScore:  best.VectorScore,
+			HybridScore:  best.HybridScore,
+			UpdatedAt:    best.UpdatedAt,
+			IndexedAt:    best.IndexedAt,
 		})
 	}
 

--- a/internal/memory/search.go
+++ b/internal/memory/search.go
@@ -344,7 +344,7 @@ func resolveMemoryChunkColumns(ctx context.Context, db *sql.DB) (memoryChunkColu
 	}
 
 	columns := memoryChunkColumns{
-		File:      pickColumn(available, "file", "file_path", "filepath", "path"),
+		File:      pickColumn(available, "source_file", "file", "file_path", "filepath", "path"),
 		Header:    pickColumn(available, "header_path", "heading_path", "section_path", "header"),
 		Ordinal:   pickColumn(available, "chunk_ordinal", "ordinal", "chunk_order"),
 		Text:      pickColumn(available, "text", "chunk_text", "content"),

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -7,13 +7,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"sort"
 	"strings"
 	"time"
 )
 
 const (
 	memoryChunksTable     = "memory_chunks"
+	memoryChunksFTSTable  = "memory_chunks_fts"
 	defaultMigratedSource = "legacy://migrated"
 	defaultHeaderPath     = "root"
 )
@@ -31,9 +31,13 @@ type MemoryResult struct {
 	EndLine      int `json:"end_line"`
 	ChunkOrdinal int `json:"chunk_ordinal"`
 
-	Content     string  `json:"content"`
-	ContentHash string  `json:"content_hash"`
-	Similarity  float32 `json:"similarity"`
+	Content      string  `json:"content"`
+	ContentHash  string  `json:"content_hash"`
+	Similarity   float32 `json:"similarity"`
+	Score        float32 `json:"score"`
+	LexicalScore float32 `json:"lexical_score"`
+	VectorScore  float32 `json:"vector_score"`
+	HybridScore  float32 `json:"hybrid_score"`
 
 	UpdatedAt time.Time `json:"updated_at"`
 	IndexedAt time.Time `json:"indexed_at"`
@@ -42,7 +46,8 @@ type MemoryResult struct {
 // MemoryStore handles storage and retrieval of memory chunks with embeddings.
 // Markdown files are the source of truth; SQLite is index-only.
 type MemoryStore struct {
-	db *sql.DB
+	db           *sql.DB
+	ftsAvailable bool
 }
 
 // NewMemoryStore creates a new memory store.
@@ -99,6 +104,11 @@ func (s *MemoryStore) migrate() error {
 
 	if err := s.ensureChunksIndexes(); err != nil {
 		return err
+	}
+	if err := s.ensureChunksFTS(); err != nil {
+		s.ftsAvailable = false
+	} else {
+		s.ftsAvailable = true
 	}
 	return nil
 }
@@ -384,80 +394,6 @@ func (s *MemoryStore) nextOrdinal(ctx context.Context, sourceFile, headerPath st
 	return next, err
 }
 
-// SearchChunks finds the most similar indexed chunks using cosine similarity.
-func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
-	if topK <= 0 {
-		topK = 5
-	}
-
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
-		FROM memory_chunks
-		ORDER BY indexed_at DESC
-	`)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query memory chunks: %w", err)
-	}
-	defer rows.Close()
-
-	var results []MemoryResult
-	for rows.Next() {
-		var (
-			id           int64
-			sourceFile   string
-			headerPath   string
-			chunkOrdinal int
-			content      string
-			contentHash  string
-			embeddingRaw []byte
-			indexedAt    time.Time
-		)
-
-		if err := rows.Scan(
-			&id,
-			&sourceFile,
-			&headerPath,
-			&chunkOrdinal,
-			&content,
-			&contentHash,
-			&embeddingRaw,
-			&indexedAt,
-		); err != nil {
-			continue
-		}
-
-		embedding, err := decodeEmbedding(embeddingRaw)
-		if err != nil {
-			continue
-		}
-
-		similarity := cosineSimilarity(queryEmbedding, embedding)
-		results = append(results, MemoryResult{
-			ID:           id,
-			Source:       sourceFile,
-			SourceFile:   sourceFile,
-			HeaderPath:   headerPath,
-			StartLine:    chunkOrdinal,
-			EndLine:      chunkOrdinal,
-			ChunkOrdinal: chunkOrdinal,
-			Content:      content,
-			ContentHash:  contentHash,
-			Similarity:   similarity,
-			UpdatedAt:    indexedAt,
-			IndexedAt:    indexedAt,
-		})
-	}
-
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Similarity > results[j].Similarity
-	})
-
-	if len(results) > topK {
-		results = results[:topK]
-	}
-	return results, nil
-}
-
 // GetBranchChunks loads all chunks for a specific (sourceFile, headerPath) branch,
 // ordered by chunk_ordinal. Used by branch expansion to reconstruct full sections.
 func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPath string) ([]MemoryResult, error) {
@@ -490,6 +426,8 @@ func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPat
 			Source:       sf,
 			SourceFile:   sf,
 			HeaderPath:   hp,
+			StartLine:    ordinal,
+			EndLine:      ordinal,
 			ChunkOrdinal: ordinal,
 			Content:      content,
 			ContentHash:  hash,
@@ -498,11 +436,6 @@ func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPat
 		})
 	}
 	return results, rows.Err()
-}
-
-// Search is kept as a compatibility alias for callers that still use the old name.
-func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
-	return s.SearchChunks(ctx, queryEmbedding, topK)
 }
 
 // Save is deprecated in v2 where markdown is canonical.
@@ -577,6 +510,9 @@ func cosineSimilarity(a, b []float32) float32 {
 
 // encodeEmbedding converts a float32 slice to binary format.
 func encodeEmbedding(embedding []float32) ([]byte, error) {
+	if len(embedding) == 0 {
+		return []byte{}, nil
+	}
 	buf := new(bytes.Buffer)
 	if err := binary.Write(buf, binary.LittleEndian, embedding); err != nil {
 		return nil, err

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -230,7 +230,7 @@ func TestMemoryStoreMigrateRecreatesLegacyMemoryChunksSchema(t *testing.T) {
 		t.Fatalf("NewMemoryStore failed: %v", err)
 	}
 
-	if err := store.IndexChunk(context.Background(), "MEMORY.md", "root", 1, 2, "content", []float32{1, 0}); err != nil {
+	if err := store.IndexChunk(context.Background(), "MEMORY.md", "root", 2, 3, "content", []float32{1, 0}); err != nil {
 		t.Fatalf("IndexChunk failed after migration: %v", err)
 	}
 
@@ -242,6 +242,35 @@ func TestMemoryStoreMigrateRecreatesLegacyMemoryChunksSchema(t *testing.T) {
 	}
 	if hasSourceFile != 1 {
 		t.Fatalf("expected migrated memory_chunks table to contain source_file column")
+	}
+
+	results, err := store.SearchChunksHybrid(context.Background(), "legacy", nil, 5)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed after migration: %v", err)
+	}
+	if len(results) == 0 || results[0].SourceFile != "MEMORY.md" {
+		t.Fatalf("expected migrated legacy chunk to be searchable, got %+v", results)
+	}
+}
+
+func TestMemoryStoreCreatesFTSIndexWhenAvailable(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+	if !store.ftsAvailable {
+		t.Skip("sqlite FTS5 is unavailable in this build")
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE name = ?`, memoryChunksFTSTable).Scan(&count); err != nil {
+		t.Fatalf("failed to inspect FTS table: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected %s to exist", memoryChunksFTSTable)
 	}
 }
 
@@ -305,6 +334,160 @@ func TestMemoryStoreSearchChunks(t *testing.T) {
 	}
 	if got.Similarity <= 0 {
 		t.Fatalf("expected positive similarity, got %f", got.Similarity)
+	}
+}
+
+func TestMemoryStoreSearchChunksLexicalOnlyWithoutEmbedding(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.IndexChunk(ctx, "MEMORY.md", "People > Alice", 0, 0, "Alice likes espresso and ristretto.", nil); err != nil {
+		t.Fatalf("failed to index lexical chunk: %v", err)
+	}
+	if err := store.IndexChunk(ctx, "memory/other.md", "Journal", 0, 0, "Walked the dog after lunch.", nil); err != nil {
+		t.Fatalf("failed to index unrelated chunk: %v", err)
+	}
+
+	results, err := store.SearchChunksHybrid(ctx, "espresso", nil, 5)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 lexical result, got %d (%+v)", len(results), results)
+	}
+	if results[0].SourceFile != "MEMORY.md" {
+		t.Fatalf("unexpected lexical source: %s", results[0].SourceFile)
+	}
+	if results[0].LexicalScore <= 0 || results[0].Score <= 0 {
+		t.Fatalf("expected lexical score components, got %+v", results[0])
+	}
+	if results[0].VectorScore != 0 {
+		t.Fatalf("expected no vector score without embeddings, got %+v", results[0])
+	}
+	if results[0].ChunkOrdinal != 0 {
+		t.Fatalf("expected stable chunk ordinal 0, got %d", results[0].ChunkOrdinal)
+	}
+}
+
+func TestMemoryManagerSearchLexicalOnlyWithoutEmbeddingProvider(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+	if err := store.IndexChunk(context.Background(), "MEMORY.md", "Preferences", 0, 0, "Favorite drink: espresso.", nil); err != nil {
+		t.Fatalf("failed to index chunk: %v", err)
+	}
+
+	manager := NewMemoryManager(nil, store)
+	results, err := manager.Search(context.Background(), "espresso", 3)
+	if err != nil {
+		t.Fatalf("manager Search failed: %v", err)
+	}
+	if len(results) != 1 || results[0].SourceFile != "MEMORY.md" {
+		t.Fatalf("expected lexical-only manager hit, got %+v", results)
+	}
+}
+
+func TestMemoryStoreSearchChunksSemanticOnlyWhenFTSUnavailable(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+	store.ftsAvailable = false
+
+	ctx := context.Background()
+	if err := store.IndexChunk(ctx, "memory/semantic.md", "Ideas", 0, 0, "Codename notes with no query words.", []float32{1, 0}); err != nil {
+		t.Fatalf("failed to index semantic chunk: %v", err)
+	}
+	if err := store.IndexChunk(ctx, "memory/other.md", "Ideas", 0, 0, "Unrelated text.", []float32{-1, 0}); err != nil {
+		t.Fatalf("failed to index unrelated chunk: %v", err)
+	}
+
+	results, err := store.SearchChunksHybrid(ctx, "tokens absent from content", []float32{1, 0}, 1)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 semantic result, got %d", len(results))
+	}
+	if results[0].SourceFile != "memory/semantic.md" {
+		t.Fatalf("unexpected semantic source: %+v", results[0])
+	}
+	if results[0].VectorScore < 0.99 || results[0].LexicalScore != 0 {
+		t.Fatalf("expected semantic-only score components, got %+v", results[0])
+	}
+}
+
+func TestMemoryStoreSearchChunksHybridReranksLexicalAndSemanticCandidates(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.IndexChunk(ctx, "memory/lexical.md", "Launch", 0, 0, "Phoenix launch checklist and rollout notes.", []float32{-1, 0}); err != nil {
+		t.Fatalf("failed to index lexical chunk: %v", err)
+	}
+	if err := store.IndexChunk(ctx, "memory/semantic.md", "Launch", 0, 0, "Roadmap notes for the codename initiative.", []float32{1, 0}); err != nil {
+		t.Fatalf("failed to index semantic chunk: %v", err)
+	}
+
+	results, err := store.SearchChunksHybrid(ctx, "phoenix launch", []float32{1, 0}, 2)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 hybrid results, got %d (%+v)", len(results), results)
+	}
+	if results[0].SourceFile != "memory/semantic.md" {
+		t.Fatalf("expected semantic candidate to rerank first, got %+v", results[0])
+	}
+	if results[0].VectorScore < 0.99 || results[1].LexicalScore <= 0 {
+		t.Fatalf("expected vector and lexical score components, got %+v", results)
+	}
+}
+
+func TestMemoryStoreSearchChunksKeepsLexicalHitWithMalformedVector(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	content := "Malformed embedding row still mentions espresso."
+	if _, err := db.Exec(`
+		INSERT INTO memory_chunks (source_file, header_path, chunk_ordinal, content, content_hash, embedding)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, "memory/bad.md", "Root", 0, content, hashChunkContent(content), []byte{1, 2, 3}); err != nil {
+		t.Fatalf("failed to insert malformed vector row: %v", err)
+	}
+
+	results, err := store.SearchChunksHybrid(context.Background(), "espresso", []float32{1, 0}, 5)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected malformed-vector lexical hit, got %+v", results)
+	}
+	if results[0].LexicalScore <= 0 || results[0].VectorScore != 0 {
+		t.Fatalf("expected lexical-only score for malformed vector, got %+v", results[0])
 	}
 }
 

--- a/internal/memorymcp/server.go
+++ b/internal/memorymcp/server.go
@@ -172,23 +172,35 @@ func (s *Server) handleMemorySearch(ctx context.Context, request mcp.CallToolReq
 	}
 
 	type searchResult struct {
-		ID         int64   `json:"id"`
-		Content    string  `json:"content"`
-		Source     string  `json:"source"`
-		HeaderPath string  `json:"header_path"`
-		Similarity float32 `json:"similarity"`
-		UpdatedAt  string  `json:"updated_at"`
+		ID           int64   `json:"id"`
+		Content      string  `json:"content"`
+		Source       string  `json:"source"`
+		SourceFile   string  `json:"source_file"`
+		HeaderPath   string  `json:"header_path"`
+		ChunkOrdinal int     `json:"chunk_ordinal"`
+		Score        float32 `json:"score"`
+		LexicalScore float32 `json:"lexical_score"`
+		VectorScore  float32 `json:"vector_score"`
+		HybridScore  float32 `json:"hybrid_score"`
+		Similarity   float32 `json:"similarity"`
+		UpdatedAt    string  `json:"updated_at"`
 	}
 
 	out := make([]searchResult, 0, len(results))
 	for _, r := range results {
 		out = append(out, searchResult{
-			ID:         r.ID,
-			Content:    r.Content,
-			Source:     r.Source,
-			HeaderPath: r.HeaderPath,
-			Similarity: r.Similarity,
-			UpdatedAt:  r.UpdatedAt.Format(time.RFC3339),
+			ID:           r.ID,
+			Content:      r.Content,
+			Source:       r.Source,
+			SourceFile:   r.SourceFile,
+			HeaderPath:   r.HeaderPath,
+			ChunkOrdinal: r.ChunkOrdinal,
+			Score:        r.Score,
+			LexicalScore: r.LexicalScore,
+			VectorScore:  r.VectorScore,
+			HybridScore:  r.HybridScore,
+			Similarity:   r.Similarity,
+			UpdatedAt:    r.UpdatedAt.Format(time.RFC3339),
 		})
 	}
 

--- a/internal/tools/memory_search_tool.go
+++ b/internal/tools/memory_search_tool.go
@@ -9,7 +9,7 @@ import (
 	"ok-gobot/internal/memory"
 )
 
-// MemorySearchTool performs semantic search over indexed markdown memory chunks.
+// MemorySearchTool performs hybrid search over indexed markdown memory chunks.
 type MemorySearchTool struct {
 	manager *memory.MemoryManager
 }
@@ -24,7 +24,7 @@ func (m *MemorySearchTool) Name() string {
 }
 
 func (m *MemorySearchTool) Description() string {
-	return "Semantic search over indexed markdown memory chunks."
+	return "Hybrid lexical and semantic search over indexed markdown memory chunks."
 }
 
 func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string, error) {
@@ -76,12 +76,16 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 		if headerPath == "" {
 			headerPath = "(root)"
 		}
-		out.WriteString(fmt.Sprintf("%d. Source: %s\n", i+1, result.Source))
+		source := result.SourceFile
+		if source == "" {
+			source = result.Source
+		}
+		out.WriteString(fmt.Sprintf("%d. Source: %s\n", i+1, source))
 		out.WriteString(fmt.Sprintf("   Header Path: %s\n", headerPath))
 		if !expand {
-			out.WriteString(fmt.Sprintf("   Lines: %d-%d\n", result.StartLine, result.EndLine))
+			out.WriteString(fmt.Sprintf("   Chunk: %d\n", result.ChunkOrdinal))
 		}
-		out.WriteString(fmt.Sprintf("   Similarity: %.2f\n", result.Similarity))
+		out.WriteString(fmt.Sprintf("   Score: %.2f (lexical %.2f, vector %.2f)\n", result.Score, result.LexicalScore, result.VectorScore))
 		out.WriteString(fmt.Sprintf("   %s\n\n", result.Content))
 	}
 
@@ -94,7 +98,7 @@ func (m *MemorySearchTool) GetSchema() map[string]interface{} {
 		"properties": map[string]interface{}{
 			"query": map[string]interface{}{
 				"type":        "string",
-				"description": "Natural-language query to search memory chunks",
+				"description": "Natural-language query to search memory chunks lexically and semantically",
 			},
 			"limit": map[string]interface{}{
 				"type":        "integer",


### PR DESCRIPTION
Implements #304

## Changes
- Adds an optional FTS5/BM25 memory chunk index with migration backfill and triggers, with graceful fallback when FTS5 is unavailable.
- Adds hybrid memory retrieval that combines lexical candidates with bounded vector scoring and exposes source/score metadata.
- Allows lexical-only indexing/search when embeddings are not configured, while preserving semantic-only search when FTS is unavailable.
- Updates memory search tool/MCP output and adds focused tests for lexical, semantic, hybrid, malformed vectors, missing embeddings, and migration behavior.

## Testing
- bash .maestro/verify.sh
- git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a hybrid FTS5/BM25 + vector memory search backend with graceful fallback, lexical-only mode when embeddings are unconfigured, and expanded score metadata exposed through the search tool and MCP server. The overall architecture is well-structured, but two logic issues on the hot path need attention before merging:

- `ensureChunksFTS` unconditionally issues an FTS `rebuild` on every `NewMemoryStore()` call, causing a full O(N) re-index of all chunks at every app startup rather than only on the initial migration.
- `MemoryManager.Search` silently discards runtime errors from `GetEmbedding` (network failures, rate limits, expired keys) and falls back to lexical-only search without propagating any error to the caller.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: startup performance degrades with store size and embedding failures are silently masked.

Two P1 findings on the core search path: an unconditional FTS rebuild on every startup and silent swallowing of embedding API errors. Both affect correctness or observability in production use.

internal/memory/fts.go (unconditional rebuild) and internal/memory/manager.go (silent embedding error drop)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/memory/fts.go | New file that sets up FTS5 virtual table and triggers; unconditional `rebuild` on every startup is a correctness/performance issue |
| internal/memory/manager.go | Updated Search to call hybrid search; silently swallows runtime embedding errors, degrading to lexical-only without caller visibility |
| internal/memory/hybrid_search.go | New file implementing hybrid FTS5/BM25 + vector scoring with normalization, fallback paths, and ranking logic; logic is sound |
| internal/memory/store.go | Adds `ftsAvailable` flag and new score fields to MemoryResult; removes old full-scan SearchChunks, minor clean-up changes look correct |
| internal/memory/store_test.go | Good coverage added for lexical-only, semantic-only, hybrid, malformed vector, and FTS availability scenarios |
| internal/memory/indexer.go | Allows indexing without embedder for lexical-only mode; returns nil embeddings slice when embedder is absent |
| internal/app/app.go | Conditionally creates embedding client based on provider configuration; removes embedder nil-guard from indexer start, correctly wired |
| internal/memory/embeddings.go | Adds EmbeddingProviderConfigured helper and default base URL constant; trailing slash trim and default URL fallback look correct |
| internal/memory/indexer_test.go | Adds test for lexical-only indexing without an embedder; coverage is appropriate |
| internal/cli/memory.go | CLI memory index command conditionally creates embedder using EmbeddingProviderConfigured; mirrors app.go wiring correctly |
| internal/memorymcp/server.go | Expands MCP search result struct to include score metadata fields; backwards-compatible addition |
| internal/tools/memory_search_tool.go | Updates tool output to show hybrid score breakdown and uses SourceFile field with Source fallback; output format change is intentional |
| internal/memory/search.go | Adds `source_file` as the first candidate in column resolution priority for legacy schema compatibility |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/memory/fts.go
Line: 42-44

Comment:
**FTS rebuild runs on every app startup**

`ensureChunksFTS` is called from `migrate()` on every `NewMemoryStore()` invocation. The `CREATE VIRTUAL TABLE IF NOT EXISTS` and `CREATE TRIGGER IF NOT EXISTS` guards are idempotent, but the `rebuild` command always executes regardless of whether the table was just created or already exists with up-to-date content. For any non-trivial memory store this means an O(N) full re-index of all chunks on every startup.

The rebuild is only needed on the very first migration to backfill pre-existing rows. Subsequent starts should skip it because the triggers maintain incremental consistency. One approach is to check whether the table was newly created before issuing the rebuild, or track the migration state in a separate metadata table.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/memory/manager.go
Line: 53-58

Comment:
**Embedding errors are silently swallowed**

When `GetEmbedding` fails at runtime (network error, rate-limit, expired API key), the error is discarded and `queryEmbedding` stays `nil`. `SearchChunksHybrid` then silently degrades to lexical-only search. The caller receives no indication that vector scoring was skipped, so an agent that expects hybrid results will silently receive lower-quality answers without any diagnostic signal.

The previous implementation returned the embedding error to the caller. The nil-client path (embeddings intentionally not configured) is a different case and should be handled with a separate guard rather than swallowing runtime failures from a configured client.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(memory): add hybrid memory search b..."](https://github.com/befeast/ok-gobot/commit/829deb90e2bf1c7dcb79b97c47a9a113ded74c2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30195256)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->