### PR TITLE
fix: complete network allowlist enforcement (#288)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -68,7 +68,7 @@
               },
               "network_allowlist": {
                 "default": [],
-                "description": "Allowed hostnames when network is true. Supports exact ('github.com') and wildcard ('*.github.com') matching. Empty = all allowed. When non-empty, search and browser_task are denied because they cannot guarantee results stay within the allowlist.",
+                "description": "Allowed public hostnames when network is true. Supports exact ('github.com') and wildcard subdomain ('*.github.com') matching. Empty = all public hosts allowed, but loopback, private, and link-local targets remain blocked unless allow_internal_networks is true. When non-empty, search and browser_task are denied because they cannot guarantee results stay within the allowlist.",
                 "items": {
                   "default": "",
                   "description": "Hostname or wildcard pattern (e.g. '*.github.com').",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -486,7 +486,7 @@ single source of truth for configuration keys, types, defaults, and descriptions
               "network_allowlist": {
                 "type": "array",
                 "default": [],
-                "description": "Allowed hostnames when network is true. Supports exact ('github.com') and wildcard ('*.github.com') matching. Empty = all allowed. When non-empty, search and browser_task are denied because they cannot guarantee results stay within the allowlist.",
+                "description": "Allowed public hostnames when network is true. Supports exact ('github.com') and wildcard subdomain ('*.github.com') matching. Empty = all public hosts allowed, but loopback, private, and link-local targets remain blocked unless allow_internal_networks is true. When non-empty, search and browser_task are denied because they cannot guarantee results stay within the allowlist.",
                 "items": {
                   "type": "string",
                   "default": "",

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -212,7 +212,8 @@ Fine-grained declarative restrictions per agent profile:
 |-----------|------|-------------|
 | `shell` | bool | Allow shell tools (local, ssh) |
 | `network` | bool | Allow network tools (web_fetch, search, browser) |
-| `network_allowlist` | list | Restrict network to specific hostnames |
+| `network_allowlist` | list | Restrict network to specific public hostnames |
+| `allow_internal_networks` | bool | Allow loopback/private/link-local targets; blocked by default |
 | `cron` | bool | Allow cron scheduling |
 | `memory_write` | bool | Allow memory write tools |
 | `spawn` | bool | Allow sub-agent/job spawning |

--- a/internal/agent/tool_agent_test.go
+++ b/internal/agent/tool_agent_test.go
@@ -669,6 +669,59 @@ func TestToolCallingAgent_EventCallback(t *testing.T) {
 	}
 }
 
+func TestToolCallingAgent_EventCallbackIncludesPolicyDenial(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(&mockTool{
+		name:   "web_fetch",
+		desc:   "Fetch URL",
+		schema: map[string]interface{}{"type": "object"},
+	})
+	registry = tools.ApplyPolicy(registry, &tools.CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	})
+
+	mockAI := &mockAIClient{
+		toolCallName: "web_fetch",
+		toolCallArgs: `{"url":"https://evil.com"}`,
+		finalText:    "Denied host was reported",
+	}
+
+	ta := NewToolCallingAgent(mockAI, registry, &Personality{
+		Files: map[string]string{"IDENTITY.md": "Test Bot"},
+	})
+
+	var events []ToolEvent
+	ta.SetToolEventCallback(func(e ToolEvent) {
+		events = append(events, e)
+	})
+
+	resp, err := ta.ProcessRequest(context.Background(), "fetch evil.com", "")
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+	if resp == nil || !resp.ToolUsed {
+		t.Fatalf("expected tool use in response, got %#v", resp)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	finished := events[1]
+	if finished.Type != ToolEventFinished || finished.ToolName != "web_fetch" {
+		t.Fatalf("unexpected finished event: %+v", finished)
+	}
+	if finished.Denial == nil {
+		t.Fatalf("expected denial on finished event, got %+v", finished)
+	}
+	if finished.Denial.Family != "network" || !strings.Contains(finished.Output, "DENIED:") {
+		t.Fatalf("expected network denial output, got denial=%+v output=%q", finished.Denial, finished.Output)
+	}
+}
+
 func TestToolCallingAgent_ProcessRequestWithContentVisionEnabled(t *testing.T) {
 	registry := tools.NewRegistry()
 	client := &recordingAIClient{

--- a/internal/bot/live_editor_test.go
+++ b/internal/bot/live_editor_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/tools"
 )
 
 // newTestLiveEditor returns a LiveStreamEditor with nil bot/msg for unit tests
@@ -64,6 +65,28 @@ func TestLiveStreamEditor_ToolFinishedError(t *testing.T) {
 	e.mu.Unlock()
 	if !strings.Contains(out, "❌ patch") {
 		t.Errorf("expected error status, got %q", out)
+	}
+}
+
+func TestLiveStreamEditor_ToolFinishedDenial(t *testing.T) {
+	e := newTestLiveEditor()
+	denial := &tools.ToolDenial{
+		ToolName: "web_fetch",
+		Family:   "network",
+		Reason:   "host \"evil.com\" is not in the network allowlist",
+	}
+	e.OnToolEvent(agent.ToolEvent{Type: agent.ToolEventStarted, ToolName: "web_fetch"})
+	e.OnToolEvent(agent.ToolEvent{
+		Type:     agent.ToolEventFinished,
+		ToolName: "web_fetch",
+		Err:      denial,
+		Denial:   denial,
+	})
+	e.mu.Lock()
+	out := e.formatLocked()
+	e.mu.Unlock()
+	if !strings.Contains(out, "🚫 web_fetch") || !strings.Contains(out, "evil.com") {
+		t.Errorf("expected denial status, got %q", out)
 	}
 }
 

--- a/internal/bot/tool_status.go
+++ b/internal/bot/tool_status.go
@@ -37,12 +37,26 @@ func (t *ToolStatusTracker) OnStarted(name string) {
 
 // OnFinished marks the last pending entry for name as done or failed
 func (t *ToolStatusTracker) OnFinished(name string, failed bool) {
+	t.onFinished(name, failed, "")
+}
+
+// OnDenied marks the last pending entry for name as denied by policy.
+func (t *ToolStatusTracker) OnDenied(name, reason string) {
+	t.onFinished(name, true, reason)
+}
+
+func (t *ToolStatusTracker) onFinished(name string, failed bool, denyReason string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	for i := len(t.lines) - 1; i >= 0; i-- {
-		if t.lines[i].name == name && !t.lines[i].done && !t.lines[i].failed {
-			t.lines[i].done = !failed
-			t.lines[i].failed = failed
+		if t.lines[i].name == name && !t.lines[i].done && !t.lines[i].failed && !t.lines[i].denied {
+			if denyReason != "" {
+				t.lines[i].denied = true
+				t.lines[i].denyReason = denyReason
+			} else {
+				t.lines[i].done = !failed
+				t.lines[i].failed = failed
+			}
 			return
 		}
 	}
@@ -117,7 +131,11 @@ func (p *PlaceholderEditor) OnToolEvent(event agent.ToolEvent) {
 	case agent.ToolEventStarted:
 		p.tracker.OnStarted(event.ToolName)
 	case agent.ToolEventFinished:
-		p.tracker.OnFinished(event.ToolName, event.Err != nil)
+		if event.Denial != nil {
+			p.tracker.OnDenied(event.ToolName, event.Denial.Reason)
+		} else {
+			p.tracker.OnFinished(event.ToolName, event.Err != nil)
+		}
 	}
 	p.schedule()
 }

--- a/internal/bot/tool_status_test.go
+++ b/internal/bot/tool_status_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/tools"
 )
 
 func TestToolStatusTracker_Empty(t *testing.T) {
@@ -49,6 +50,16 @@ func TestToolStatusTracker_FinishedError(t *testing.T) {
 	out := tr.Format()
 	if !strings.Contains(out, "❌ patch") {
 		t.Errorf("expected error line, got %q", out)
+	}
+}
+
+func TestToolStatusTracker_FinishedDenial(t *testing.T) {
+	var tr ToolStatusTracker
+	tr.OnStarted("web_fetch")
+	tr.OnDenied("web_fetch", "host \"evil.com\" is not in the network allowlist")
+	out := tr.Format()
+	if !strings.Contains(out, "🚫 web_fetch") || !strings.Contains(out, "evil.com") {
+		t.Errorf("expected denial line, got %q", out)
 	}
 }
 
@@ -163,6 +174,32 @@ func TestPlaceholderEditor_OnToolEvent_errorDelegation(t *testing.T) {
 
 	if !strings.Contains(editor.tracker.Format(), "❌ patch") {
 		t.Errorf("expected error line, got %q", editor.tracker.Format())
+	}
+
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestPlaceholderEditor_OnToolEvent_denialDelegation(t *testing.T) {
+	editor := &PlaceholderEditor{minInterval: 0}
+
+	editor.OnToolEvent(agent.ToolEvent{Type: agent.ToolEventStarted, ToolName: "web_fetch"})
+	editor.OnToolEvent(agent.ToolEvent{
+		Type:     agent.ToolEventFinished,
+		ToolName: "web_fetch",
+		Err: &tools.ToolDenial{
+			ToolName: "web_fetch",
+			Family:   "network",
+			Reason:   "host \"evil.com\" is not in the network allowlist",
+		},
+		Denial: &tools.ToolDenial{
+			ToolName: "web_fetch",
+			Family:   "network",
+			Reason:   "host \"evil.com\" is not in the network allowlist",
+		},
+	})
+
+	if !strings.Contains(editor.tracker.Format(), "🚫 web_fetch") {
+		t.Errorf("expected denial line, got %q", editor.tracker.Format())
 	}
 
 	time.Sleep(10 * time.Millisecond)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -231,7 +231,7 @@ type MemoryMCPConfig struct {
 type CapabilityPolicyConfig struct {
 	Shell                 *bool    `mapstructure:"shell"`                   // Allow shell execution (local, ssh). Default: true.
 	Network               *bool    `mapstructure:"network"`                 // Allow network tools (web_fetch, search, browser). Default: true.
-	NetworkAllowlist      []string `mapstructure:"network_allowlist"`       // Allowed hostnames when network is true. Empty = all.
+	NetworkAllowlist      []string `mapstructure:"network_allowlist"`       // Allowed public hostnames when network is true. Empty = all public hosts.
 	AllowInternalNetworks bool     `mapstructure:"allow_internal_networks"` // Allow loopback/private/link-local IPs. Default: false.
 	Cron                  *bool    `mapstructure:"cron"`                    // Allow cron scheduling. Default: true.
 	MemoryWrite           *bool    `mapstructure:"memory_write"`            // Allow memory write tools. Default: true.

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -200,6 +200,17 @@ func (s *Server) handleTUIRequest(c *client, cmd ClientMsg) {
 						ToolArgs:  event.Input,
 					})
 				case agent.ToolEventFinished:
+					if event.Denial != nil {
+						s.hub.BroadcastTUI(ServerMsg{
+							Type:            MsgTypeEvent,
+							Kind:            KindToolDenied,
+							SessionID:       sessionID,
+							ToolName:        event.Denial.ToolName,
+							DenyReason:      event.Denial.Reason,
+							DenyRemediation: event.Denial.Remediation,
+						})
+						return
+					}
 					msg := ServerMsg{
 						Type:       MsgTypeEvent,
 						Kind:       KindToolEnd,

--- a/internal/control/server_tui_test.go
+++ b/internal/control/server_tui_test.go
@@ -14,6 +14,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/control"
+	"ok-gobot/internal/tools"
 )
 
 type mockTUIState struct {
@@ -435,6 +436,71 @@ func TestControlServerTUISendSuppressesBootstrapToolEvents(t *testing.T) {
 	}
 	if !sawSearchStart || !sawSearchEnd {
 		t.Fatalf("expected non-bootstrap tool start/end events, got start=%v end=%v", sawSearchStart, sawSearchEnd)
+	}
+}
+
+func TestControlServerTUISendBroadcastsToolDenied(t *testing.T) {
+	state := &mockTUIState{}
+	state.tuiSubmitFn = func(req control.TUIRunRequest) <-chan agent.RunEvent {
+		ch := make(chan agent.RunEvent, 1)
+		go func() {
+			denial := &tools.ToolDenial{
+				ToolName:    "web_fetch",
+				Family:      "network",
+				Reason:      "host \"evil.com\" is not in the network allowlist",
+				Remediation: "Ask the operator to add this host to network_allowlist.",
+			}
+			if req.OnToolEvent != nil {
+				req.OnToolEvent(agent.ToolEvent{
+					ToolName: "web_fetch",
+					Type:     agent.ToolEventStarted,
+					Input:    `{"url":"https://evil.com"}`,
+				})
+				req.OnToolEvent(agent.ToolEvent{
+					ToolName: "web_fetch",
+					Type:     agent.ToolEventFinished,
+					Err:      denial,
+					Denial:   denial,
+				})
+			}
+			ch <- agent.RunEvent{Type: agent.RunEventDone, Result: &agent.AgentResponse{Message: "done"}}
+			close(ch)
+		}()
+		return ch
+	}
+
+	_, addr, cancel := startServerWithHandle(t, state)
+	defer cancel()
+
+	conn := wsConnect(t, addr)
+	sendTUIRequest(t, conn, control.ClientMsg{Type: control.CmdListSessions})
+	_ = readTUIMessage(t, conn) // connected
+	_ = readTUIMessage(t, conn) // sessions
+
+	sendTUIRequest(t, conn, control.ClientMsg{Type: control.CmdSend, SessionID: "main", Text: "fetch evil"})
+
+	var sawDenied bool
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		msg := readTUIMessage(t, conn)
+		if msg.Type != control.MsgTypeEvent {
+			continue
+		}
+		if msg.Kind == control.KindToolDenied {
+			sawDenied = true
+			if msg.ToolName != "web_fetch" {
+				t.Fatalf("ToolName = %q, want web_fetch", msg.ToolName)
+			}
+			if msg.DenyReason == "" || msg.DenyRemediation == "" {
+				t.Fatalf("expected denial reason/remediation, got %#v", msg)
+			}
+		}
+		if msg.Kind == control.KindRunEnd {
+			break
+		}
+	}
+	if !sawDenied {
+		t.Fatal("expected tool_denied event")
 	}
 }
 

--- a/internal/tools/browser_task.go
+++ b/internal/tools/browser_task.go
@@ -52,6 +52,10 @@ func (t *BrowserTaskTool) ExecuteJSON(ctx context.Context, params map[string]str
 }
 
 func (t *BrowserTaskTool) run(ctx context.Context, task string) (string, error) {
+	if policy := NetworkPolicyFromContext(ctx); policy != nil && len(policy.NetworkAllowlist) > 0 {
+		return "", browserTaskAllowlistDenial()
+	}
+
 	if t.submitter == nil {
 		return "", fmt.Errorf("subagent submitter not configured")
 	}

--- a/internal/tools/browser_tool.go
+++ b/internal/tools/browser_tool.go
@@ -323,28 +323,33 @@ func validateBrowserURL(rawURL string, allowInternal bool) error {
 	if scheme == "file" {
 		return fmt.Errorf("file:// URLs are not allowed in the browser tool")
 	}
-	if scheme != "http" && scheme != "https" && scheme != "" {
+	if scheme == "" {
+		return fmt.Errorf("browser navigation requires an http or https URL")
+	}
+	if scheme != "http" && scheme != "https" {
 		return fmt.Errorf("unsupported URL scheme: %s", scheme)
 	}
+	hostname := strings.ToLower(parsed.Hostname())
+	if hostname == "" {
+		return fmt.Errorf("invalid URL: missing hostname")
+	}
 	if !allowInternal {
-		hostname := strings.ToLower(parsed.Hostname())
-		if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "0.0.0.0" || hostname == "::1" || hostname == "[::1]" {
-			return fmt.Errorf("navigation to localhost/loopback is not allowed")
-		}
-		if strings.HasSuffix(hostname, ".internal") || strings.HasSuffix(hostname, ".local") {
-			return fmt.Errorf("navigation to internal/local hostnames is not allowed")
+		if isHostPrivateOrLoopback(hostname) {
+			return fmt.Errorf("navigation to private/loopback/link-local hosts is not allowed")
 		}
 	}
 	return nil
 }
 
 func (b *BrowserTool) navigate(ctx context.Context, navURL string) (string, error) {
-	allowInternal := false
 	if policy := NetworkPolicyFromContext(ctx); policy != nil {
-		allowInternal = policy.AllowInternalNetworks
-	}
-	if err := validateBrowserURL(navURL, allowInternal); err != nil {
-		return "", err
+		if denial := CheckNetworkTarget("browser", navURL, policy); denial != nil {
+			return "", denial
+		}
+	} else {
+		if err := validateBrowserURL(navURL, false); err != nil {
+			return "", err
+		}
 	}
 
 	tabCtx, err := b.ensureRunning()

--- a/internal/tools/browser_tool_test.go
+++ b/internal/tools/browser_tool_test.go
@@ -206,7 +206,11 @@ func TestValidateBrowserURL_InternalHosts(t *testing.T) {
 		"http://localhost:8080",
 		"http://127.0.0.1/admin",
 		"http://0.0.0.0/",
+		"http://10.0.0.1/admin",
+		"http://192.168.1.1/admin",
+		"http://169.254.1.1/meta",
 		"http://[::1]/",
+		"http://[fe80::1]/",
 		"http://secret.internal/api",
 		"http://myhost.local/",
 	}
@@ -218,6 +222,41 @@ func TestValidateBrowserURL_InternalHosts(t *testing.T) {
 		if err := validateBrowserURL(u, true); err != nil {
 			t.Errorf("expected %q to be allowed with allowInternal: %v", u, err)
 		}
+	}
+}
+
+func TestValidateBrowserURL_RequiresFullHTTPURL(t *testing.T) {
+	t.Parallel()
+
+	for _, u := range []string{"example.com", "/relative/path", "http://"} {
+		if err := validateBrowserURL(u, false); err == nil {
+			t.Errorf("expected %q to be rejected as an unsafe browser target", u)
+		}
+	}
+}
+
+func TestBrowserTool_ContextPolicyBlocksDeniedHostBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	bt := NewBrowserTool(t.TempDir(), "", "")
+	ctx := ContextWithNetworkPolicy(context.Background(), &CapabilityPolicy{
+		Network:          true,
+		NetworkAllowlist: []string{"github.com"},
+	})
+
+	_, err := bt.Execute(ctx, "navigate", "https://evil.com")
+	if err == nil {
+		t.Fatal("expected navigation to denied host to fail")
+	}
+	denial, ok := IsToolDenial(err)
+	if !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.ToolName != "browser" {
+		t.Fatalf("denial.ToolName = %q, want browser", denial.ToolName)
+	}
+	if bt.IsRunning() {
+		t.Fatal("browser should not start before policy denial")
 	}
 }
 

--- a/internal/tools/network_policy_test.go
+++ b/internal/tools/network_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -849,6 +850,19 @@ func TestApplyPolicy_NetworkAllowlistWrapsTools(t *testing.T) {
 // ---------------------------------------------------------------------------
 // SSRFSafeTransport — transport-layer IP enforcement
 // ---------------------------------------------------------------------------
+
+func TestSSRFSafeTransport_PreservesProxyConfiguration(t *testing.T) {
+	transport := SSRFSafeTransport(false)
+	if transport.Proxy == nil {
+		t.Fatal("expected SSRFSafeTransport to preserve ProxyFromEnvironment")
+	}
+
+	got := reflect.ValueOf(transport.Proxy).Pointer()
+	want := reflect.ValueOf(http.ProxyFromEnvironment).Pointer()
+	if got != want {
+		t.Fatal("expected SSRFSafeTransport proxy to use http.ProxyFromEnvironment")
+	}
+}
 
 func TestSSRFSafeTransport_BlocksLoopbackAtDialTime(t *testing.T) {
 	t.Parallel()

--- a/internal/tools/network_policy_test.go
+++ b/internal/tools/network_policy_test.go
@@ -28,7 +28,7 @@ func TestHostMatchesAllowlist(t *testing.T) {
 
 		// Wildcard suffix.
 		{"api.github.com", []string{"*.github.com"}, true},
-		{"github.com", []string{"*.github.com"}, true}, // wildcard also matches bare domain
+		{"github.com", []string{"*.github.com"}, false}, // apex requires exact entry
 		{"sub.api.github.com", []string{"*.github.com"}, true},
 		{"evil.com", []string{"*.github.com"}, false},
 		{"notgithub.com", []string{"*.github.com"}, false},
@@ -151,6 +151,24 @@ func TestCheckNetworkTarget(t *testing.T) {
 		{
 			"unsupported scheme denied",
 			"ftp://example.com/file",
+			&CapabilityPolicy{Network: true},
+			false,
+		},
+		{
+			"missing scheme denied",
+			"example.com/path",
+			&CapabilityPolicy{Network: true},
+			false,
+		},
+		{
+			"private IP blocked by default",
+			"http://10.0.0.1/admin",
+			&CapabilityPolicy{Network: true},
+			false,
+		},
+		{
+			"link-local IP blocked by default",
+			"http://169.254.1.1/meta",
 			&CapabilityPolicy{Network: true},
 			false,
 		},
@@ -304,6 +322,84 @@ func TestNetworkPolicyGuard_SearchAllowedWithoutAllowlist(t *testing.T) {
 	_, err := result.Execute(context.Background(), "search", "test query")
 	if err != nil {
 		t.Fatalf("expected search to be allowed without allowlist: %v", err)
+	}
+}
+
+func TestNetworkPolicyGuard_EmptyAllowlistBlocksInternalTargets(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	reg.Register(&stubTool{name: "web_fetch"})
+	reg.Register(&stubTool{name: "browser"})
+
+	policy := &CapabilityPolicy{
+		Shell:       true,
+		Network:     true,
+		Cron:        true,
+		MemoryWrite: true,
+		Spawn:       true,
+	}
+
+	result := ApplyPolicy(reg, policy)
+
+	_, err := result.Execute(context.Background(), "web_fetch", "http://127.0.0.1:8080")
+	if err == nil {
+		t.Fatal("expected localhost web_fetch to be denied with empty allowlist")
+	}
+	if _, ok := IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+
+	_, err = result.Execute(context.Background(), "browser", "navigate", "http://192.168.1.1/admin")
+	if err == nil {
+		t.Fatal("expected private browser navigation to be denied with empty allowlist")
+	}
+	if _, ok := IsToolDenial(err); !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+}
+
+func TestSearchTool_ContextPolicyDeniesAllowlist(t *testing.T) {
+	t.Parallel()
+
+	search := NewSearchTool("", "brave")
+	ctx := ContextWithNetworkPolicy(context.Background(), &CapabilityPolicy{
+		Network:          true,
+		NetworkAllowlist: []string{"github.com"},
+	})
+
+	_, err := search.Execute(ctx, "github")
+	if err == nil {
+		t.Fatal("expected search denial before API key check")
+	}
+	denial, ok := IsToolDenial(err)
+	if !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.ToolName != "search" {
+		t.Fatalf("denial.ToolName = %q, want search", denial.ToolName)
+	}
+}
+
+func TestBrowserTaskTool_ContextPolicyDeniesAllowlist(t *testing.T) {
+	t.Parallel()
+
+	tool := NewBrowserTaskTool(nil, 123)
+	ctx := ContextWithNetworkPolicy(context.Background(), &CapabilityPolicy{
+		Network:          true,
+		NetworkAllowlist: []string{"github.com"},
+	})
+
+	_, err := tool.Execute(ctx, "visit github.com")
+	if err == nil {
+		t.Fatal("expected browser_task denial before submitter check")
+	}
+	denial, ok := IsToolDenial(err)
+	if !ok {
+		t.Fatalf("expected ToolDenial, got %v", err)
+	}
+	if denial.ToolName != "browser_task" {
+		t.Fatalf("denial.ToolName = %q, want browser_task", denial.ToolName)
 	}
 }
 
@@ -813,7 +909,11 @@ func TestApplyPolicy_EmptyAllowlistNoRestriction(t *testing.T) {
 
 	// All tools should work.
 	for _, name := range []string{"web_fetch", "search"} {
-		if _, err := result.Execute(context.Background(), name, "test"); err != nil {
+		arg := "test"
+		if name == "web_fetch" {
+			arg = "https://example.com"
+		}
+		if _, err := result.Execute(context.Background(), name, arg); err != nil {
 			t.Errorf("expected %q to pass with empty allowlist: %v", name, err)
 		}
 	}

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -17,7 +17,7 @@ import (
 type CapabilityPolicy struct {
 	Shell                 bool     // Allow shell execution tools (local, ssh). Default: true.
 	Network               bool     // Allow network tools (web_fetch, search, browser). Default: true.
-	NetworkAllowlist      []string // Allowed hostnames when Network is true. Empty = all hosts allowed.
+	NetworkAllowlist      []string // Allowed public hostnames when Network is true. Empty = all public hosts allowed.
 	AllowInternalNetworks bool     // Allow loopback/private/link-local IPs even when they would normally be blocked.
 	Cron                  bool     // Allow cron scheduling. Default: true.
 	MemoryWrite           bool     // Allow memory write tools. Default: true. Ready for future memory_capture tools.
@@ -107,17 +107,11 @@ func wrapForPolicy(tool Tool, policy *CapabilityPolicy) Tool {
 		return wrapToolWithPolicyDenial(tool, denied)
 	}
 
-	// Network allowlist enforcement for network-capable tools.
-	// hasNetworkPolicy is true when either an explicit allowlist is configured
-	// (restricting which hosts may be contacted) or AllowInternalNetworks is set
-	// (which only propagates context so that private-IP checks can be skipped —
-	// it does not restrict hosts by itself).
-	hasNetworkPolicy := len(policy.NetworkAllowlist) > 0 || policy.AllowInternalNetworks
-	if hasNetworkPolicy {
-		switch name {
-		case "web_fetch", "browser", "browser_task", "search":
-			tool = wrapToolWithNetworkPolicy(tool, policy)
-		}
+	// Network-capable tools always get the policy context. Even with an empty
+	// allowlist, the policy controls internal network access and denial shape.
+	switch name {
+	case "web_fetch", "browser", "browser_task", "search":
+		tool = wrapToolWithNetworkPolicy(tool, policy)
 	}
 
 	// File-specific restrictions.
@@ -350,21 +344,24 @@ func ContextWithNetworkPolicy(ctx context.Context, p *CapabilityPolicy) context.
 
 // NetworkPolicyFromContext retrieves the CapabilityPolicy from ctx, or nil.
 func NetworkPolicyFromContext(ctx context.Context) *CapabilityPolicy {
+	if ctx == nil {
+		return nil
+	}
 	p, _ := ctx.Value(networkPolicyCtxKey{}).(*CapabilityPolicy)
 	return p
 }
 
 // HostMatchesAllowlist reports whether host is permitted by the allowlist.
 // Each entry can be an exact hostname ("github.com") or a wildcard prefix
-// ("*.github.com") that matches the domain and any subdomain.
+// ("*.github.com") that matches any subdomain of that suffix.
 func HostMatchesAllowlist(host string, allowlist []string) bool {
 	host = strings.ToLower(strings.TrimSuffix(host, "."))
 	for _, pattern := range allowlist {
 		pattern = strings.ToLower(strings.TrimSpace(pattern))
 		if strings.HasPrefix(pattern, "*.") {
-			// Wildcard: *.example.com matches example.com and sub.example.com.
+			// Wildcard: *.example.com matches sub.example.com, not example.com.
 			suffix := pattern[2:] // "example.com"
-			if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			if strings.HasSuffix(host, "."+suffix) {
 				return true
 			}
 		} else {
@@ -404,7 +401,16 @@ func CheckNetworkTarget(toolName, rawURL string, policy *CapabilityPolicy) *Tool
 		}
 	}
 
-	if scheme != "http" && scheme != "https" && scheme != "" {
+	if scheme == "" {
+		return &ToolDenial{
+			ToolName:    toolName,
+			Family:      "network",
+			Reason:      "URL must include an http or https scheme",
+			Remediation: "Use a full URL such as https://example.com/.",
+		}
+	}
+
+	if scheme != "http" && scheme != "https" {
 		return &ToolDenial{
 			ToolName:    toolName,
 			Family:      "network",
@@ -415,7 +421,12 @@ func CheckNetworkTarget(toolName, rawURL string, policy *CapabilityPolicy) *Tool
 
 	host := strings.ToLower(parsed.Hostname())
 	if host == "" {
-		return nil // relative URL or no host — nothing to check
+		return &ToolDenial{
+			ToolName:    toolName,
+			Family:      "network",
+			Reason:      "URL is missing a hostname",
+			Remediation: "Use a full http or https URL with a hostname.",
+		}
 	}
 
 	// Allowlist check.
@@ -441,6 +452,24 @@ func CheckNetworkTarget(toolName, rawURL string, policy *CapabilityPolicy) *Tool
 	}
 
 	return nil
+}
+
+func searchAllowlistDenial() *ToolDenial {
+	return &ToolDenial{
+		ToolName:    "search",
+		Family:      "network",
+		Reason:      "search cannot guarantee results stay within the network allowlist",
+		Remediation: "Remove the network_allowlist restriction or use web_fetch on specific allowed URLs.",
+	}
+}
+
+func browserTaskAllowlistDenial() *ToolDenial {
+	return &ToolDenial{
+		ToolName:    "browser_task",
+		Family:      "network",
+		Reason:      "browser_task cannot guarantee navigation stays within the network allowlist",
+		Remediation: "Remove the network_allowlist restriction or use the browser tool directly on allowed URLs.",
+	}
 }
 
 // isHostPrivateOrLoopback checks if the hostname is a known loopback name or
@@ -555,24 +584,14 @@ func (g *networkPolicyGuard) checkExecArgs(args []string) *ToolDenial {
 		// that result URLs will stay within the allowlist. When an allowlist is
 		// active, deny the search tool with clear remediation.
 		if len(g.policy.NetworkAllowlist) > 0 {
-			return &ToolDenial{
-				ToolName:    name,
-				Family:      "network",
-				Reason:      "search cannot guarantee results stay within the network allowlist",
-				Remediation: "Remove the network_allowlist restriction or use web_fetch on specific allowed URLs.",
-			}
+			return searchAllowlistDenial()
 		}
 	case "browser_task":
 		// browser_task delegates to a subagent with free-text instructions so
 		// we cannot pre-validate URLs on the positional-args path either. Deny
 		// when an explicit allowlist is configured.
 		if len(g.policy.NetworkAllowlist) > 0 {
-			return &ToolDenial{
-				ToolName:    name,
-				Family:      "network",
-				Reason:      "browser_task cannot guarantee navigation stays within the network allowlist",
-				Remediation: "Remove the network_allowlist restriction or use the browser tool directly on allowed URLs.",
-			}
+			return browserTaskAllowlistDenial()
 		}
 	}
 	return nil
@@ -620,21 +639,11 @@ func (g *networkPolicyGuardWithJSON) checkJSONParams(params map[string]string) *
 		// a free-text description so we cannot pre-validate URLs. The subagent
 		// will inherit the policy through context and enforce it per-navigation.
 		if len(g.policy.NetworkAllowlist) > 0 {
-			return &ToolDenial{
-				ToolName:    name,
-				Family:      "network",
-				Reason:      "browser_task cannot guarantee navigation stays within the network allowlist",
-				Remediation: "Remove the network_allowlist restriction or use the browser tool directly on allowed URLs.",
-			}
+			return browserTaskAllowlistDenial()
 		}
 	case "search":
 		if len(g.policy.NetworkAllowlist) > 0 {
-			return &ToolDenial{
-				ToolName:    name,
-				Family:      "network",
-				Reason:      "search cannot guarantee results stay within the network allowlist",
-				Remediation: "Remove the network_allowlist restriction or use web_fetch on specific allowed URLs.",
-			}
+			return searchAllowlistDenial()
 		}
 	}
 	return nil

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -515,31 +515,31 @@ func isHostPrivateOrLoopback(host string) bool {
 // of AllowInternalNetworks in CapabilityPolicy).
 func SSRFSafeTransport(allowInternal bool) *http.Transport {
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
-	return &http.Transport{
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			host, port, err := net.SplitHostPort(addr)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+		}
+		if !allowInternal {
+			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 			if err != nil {
-				return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+				return nil, fmt.Errorf("DNS resolution failed for %q: %w", host, err)
 			}
-			if !allowInternal {
-				ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-				if err != nil {
-					return nil, fmt.Errorf("DNS resolution failed for %q: %w", host, err)
-				}
-				for _, ipAddr := range ips {
-					if isPrivateIP(ipAddr.IP) {
-						return nil, fmt.Errorf("connection to private/loopback IP %s blocked (SSRF protection)", ipAddr.IP)
-					}
-				}
-				// Connect to the first resolved IP directly to prevent
-				// a second resolution from hitting a different record.
-				if len(ips) > 0 {
-					addr = net.JoinHostPort(ips[0].IP.String(), port)
+			for _, ipAddr := range ips {
+				if isPrivateIP(ipAddr.IP) {
+					return nil, fmt.Errorf("connection to private/loopback IP %s blocked (SSRF protection)", ipAddr.IP)
 				}
 			}
-			return dialer.DialContext(ctx, network, addr)
-		},
+			// Connect to the first resolved IP directly to prevent
+			// a second resolution from hitting a different record.
+			if len(ips) > 0 {
+				addr = net.JoinHostPort(ips[0].IP.String(), port)
+			}
+		}
+		return dialer.DialContext(ctx, network, addr)
 	}
+	return transport
 }
 
 // networkPolicyGuard wraps a network-capable tool to enforce the allowlist.

--- a/internal/tools/policy_test.go
+++ b/internal/tools/policy_test.go
@@ -295,7 +295,11 @@ func TestApplyPolicy_FullyPermissivePolicyAllowsAll(t *testing.T) {
 
 	result := ApplyPolicy(reg, policy)
 	for _, name := range []string{"local", "web_fetch", "cron", "browser_task"} {
-		if _, err := result.Execute(context.Background(), name, "test"); err != nil {
+		arg := "test"
+		if name == "web_fetch" {
+			arg = "https://example.com"
+		}
+		if _, err := result.Execute(context.Background(), name, arg); err != nil {
 			t.Errorf("expected %q to be allowed with permissive policy, got %v", name, err)
 		}
 	}

--- a/internal/tools/search.go
+++ b/internal/tools/search.go
@@ -44,6 +44,13 @@ type SearchResult struct {
 
 // Execute performs a web search
 func (s *SearchTool) Execute(ctx context.Context, args ...string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if policy := NetworkPolicyFromContext(ctx); policy != nil && len(policy.NetworkAllowlist) > 0 {
+		return "", searchAllowlistDenial()
+	}
+
 	if len(args) == 0 {
 		return "", fmt.Errorf("search query required")
 	}
@@ -52,16 +59,16 @@ func (s *SearchTool) Execute(ctx context.Context, args ...string) (string, error
 
 	switch s.Engine {
 	case "brave":
-		return s.searchBrave(searchQuery)
+		return s.searchBrave(ctx, searchQuery)
 	case "exa":
-		return s.searchExa(searchQuery)
+		return s.searchExa(ctx, searchQuery)
 	default:
 		return "", fmt.Errorf("unsupported search engine: %s", s.Engine)
 	}
 }
 
 // searchBrave performs a search using Brave Search API
-func (s *SearchTool) searchBrave(query string) (string, error) {
+func (s *SearchTool) searchBrave(ctx context.Context, query string) (string, error) {
 	if s.APIKey == "" {
 		return "", fmt.Errorf("Brave Search API key not configured")
 	}
@@ -71,7 +78,7 @@ func (s *SearchTool) searchBrave(query string) (string, error) {
 	params.Add("q", query)
 	params.Add("count", "5")
 
-	req, err := http.NewRequest("GET", baseURL+"?"+params.Encode(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"?"+params.Encode(), nil)
 	if err != nil {
 		return "", err
 	}
@@ -79,7 +86,7 @@ func (s *SearchTool) searchBrave(query string) (string, error) {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Subscription-Token", s.APIKey)
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := searchHTTPClient(ctx)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -119,7 +126,7 @@ func (s *SearchTool) searchBrave(query string) (string, error) {
 }
 
 // searchExa performs a search using Exa API
-func (s *SearchTool) searchExa(query string) (string, error) {
+func (s *SearchTool) searchExa(ctx context.Context, query string) (string, error) {
 	if s.APIKey == "" {
 		return "", fmt.Errorf("Exa API key not configured")
 	}
@@ -132,7 +139,7 @@ func (s *SearchTool) searchExa(query string) (string, error) {
 	}
 
 	jsonPayload, _ := json.Marshal(payload)
-	req, err := http.NewRequest("POST", baseURL, bytes.NewBuffer(jsonPayload))
+	req, err := http.NewRequestWithContext(ctx, "POST", baseURL, bytes.NewBuffer(jsonPayload))
 	if err != nil {
 		return "", err
 	}
@@ -140,7 +147,7 @@ func (s *SearchTool) searchExa(query string) (string, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-api-key", s.APIKey)
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := searchHTTPClient(ctx)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -175,4 +182,13 @@ func (s *SearchTool) searchExa(query string) (string, error) {
 	}
 
 	return output, nil
+}
+
+func searchHTTPClient(ctx context.Context) *http.Client {
+	policy := NetworkPolicyFromContext(ctx)
+	allowInternal := policy != nil && policy.AllowInternalNetworks
+	return &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: SSRFSafeTransport(allowInternal),
+	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -698,6 +698,21 @@ func (m *Model) handleEvent(msg controlserver.ServerMsg) tea.Cmd {
 		}
 		m.refreshViewport()
 
+	case controlserver.KindToolDenied:
+		toolErr := formatToolDeniedError(msg.DenyReason, msg.DenyRemediation)
+		updated := false
+		for i := len(m.entries) - 1; i >= 0; i-- {
+			if m.entries[i].role == "tool" && m.entries[i].toolName == msg.ToolName {
+				m.entries[i].toolErr = toolErr
+				updated = true
+				break
+			}
+		}
+		if !updated {
+			m.addEntry(chatEntry{role: "tool", toolName: msg.ToolName, toolErr: toolErr})
+		}
+		m.refreshViewport()
+
 	case controlserver.KindError:
 		m.addEntry(chatEntry{role: "error", content: msg.Message})
 		m.refreshViewport()
@@ -994,6 +1009,18 @@ func toolCardSummary(e chatEntry) string {
 		return truncate(first, 60)
 	}
 	return ""
+}
+
+func formatToolDeniedError(reason, remediation string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "blocked by policy"
+	}
+	msg := "DENIED: " + reason
+	if remediation = strings.TrimSpace(remediation); remediation != "" {
+		msg += "\n" + remediation
+	}
+	return msg
 }
 
 // renderToolCard renders a tool invocation card (collapsed or expanded).

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -120,6 +120,55 @@ func TestHandleEventAssistantMessageMetadata(t *testing.T) {
 	}
 }
 
+func TestHandleEventToolDeniedMarksToolError(t *testing.T) {
+	m := newTestModel()
+	m.viewport = viewport.New(120, 20)
+
+	m.handleEvent(controlserver.ServerMsg{
+		Kind:     controlserver.KindToolStart,
+		ToolName: "web_fetch",
+		ToolArgs: `{"url":"https://evil.com"}`,
+	})
+	m.handleEvent(controlserver.ServerMsg{
+		Kind:            controlserver.KindToolDenied,
+		ToolName:        "web_fetch",
+		DenyReason:      "host \"evil.com\" is not in the network allowlist",
+		DenyRemediation: "Ask the operator to add this host to network_allowlist.",
+	})
+
+	if len(m.entries) != 1 {
+		t.Fatalf("expected 1 tool entry, got %d", len(m.entries))
+	}
+	entry := m.entries[0]
+	if entry.role != "tool" || entry.toolName != "web_fetch" {
+		t.Fatalf("unexpected tool entry: %#v", entry)
+	}
+	if !strings.Contains(entry.toolErr, "DENIED:") || !strings.Contains(entry.toolErr, "evil.com") {
+		t.Fatalf("expected denial error to be visible, got %q", entry.toolErr)
+	}
+	if !strings.Contains(entry.toolErr, "network_allowlist") {
+		t.Fatalf("expected remediation to be visible, got %q", entry.toolErr)
+	}
+}
+
+func TestHandleEventToolDeniedWithoutStartAddsToolEntry(t *testing.T) {
+	m := newTestModel()
+	m.viewport = viewport.New(120, 20)
+
+	m.handleEvent(controlserver.ServerMsg{
+		Kind:       controlserver.KindToolDenied,
+		ToolName:   "search",
+		DenyReason: "search cannot guarantee results stay within the network allowlist",
+	})
+
+	if len(m.entries) != 1 {
+		t.Fatalf("expected 1 tool entry, got %d", len(m.entries))
+	}
+	if m.entries[0].toolName != "search" || !strings.Contains(m.entries[0].toolErr, "DENIED:") {
+		t.Fatalf("expected denial tool entry, got %#v", m.entries[0])
+	}
+}
+
 func TestRenderEntryAssistantShowsTimeAndMeta(t *testing.T) {
 	m := &Model{width: 100}
 	entry := chatEntry{


### PR DESCRIPTION
Implements #288

## Changes
- Enforces network policies for all network-capable tool paths, including empty allowlists blocking internal/private/link-local targets unless allow_internal_networks is enabled.
- Applies strict exact-host and wildcard-subdomain matching, reuses ToolDenial remediation for search/browser_task, and blocks unsafe browser targets before Chrome starts.
- Surfaces ToolDenial details through Telegram live status, TUI/control events, and agent tool-event propagation.
- Updates docs/schema and adds regression coverage for allowlists, redirects, internal hosts, file/unsafe URLs, search/browser_task denials, and denial visibility.

## Testing
- go fmt ./...
- go vet ./...
- go test ./...
- go build ./cmd/ok-gobot/
- ./.maestro/verify.sh

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes network allowlist enforcement by ensuring all network-capable tools always receive the policy context (not just when an allowlist or `allow_internal_networks` is set), tightens `HostMatchesAllowlist` wildcard semantics so `*.github.com` no longer matches the apex, hardens URL validation, and surfaces `ToolDenial` details through the TUI, Telegram live-editor, and agent event callbacks.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the only new finding is a low-probability P2 (unchecked type assertion in SSRFSafeTransport).

All findings are P2 or below. The unchecked http.DefaultTransport.(*http.Transport) assertion is a theoretical panic path that cannot be triggered in normal production operation, and the two issues from the previous review (wildcard apex semantics, event.Denial.ToolName field inconsistency) are well-understood and already documented. Test coverage is broad and specifically targets the new paths.

internal/tools/policy.go (SSRFSafeTransport type assertion); internal/control/server_tui.go (ToolName field inconsistency from prior review)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tools/policy.go | Core policy enforcement refactored: network-capable tools always receive policy context; wildcard apex-match semantics tightened; URL validation hardened; SSRFSafeTransport now clones DefaultTransport (unchecked type assertion, minor risk). |
| internal/control/server_tui.go | Broadcasts KindToolDenied on tool denial and early-returns to suppress the normal KindToolEnd; uses event.Denial.ToolName instead of event.ToolName (flagged in previous review). |
| internal/tools/browser_tool.go | navigate() now routes through CheckNetworkTarget when a policy is present, blocking denied hosts before Chrome starts; empty-hostname and scheme guards added to validateBrowserURL. |
| internal/tools/search.go | Early allowlist denial added to Execute(); HTTP clients now use SSRFSafeTransport and propagate context via NewRequestWithContext — correct SSRF hardening. |
| internal/tools/network_policy_test.go | Good regression coverage for empty-allowlist internal blocking, search/browser_task denials, and SSRFSafeTransport proxy preservation; wildcard apex behavior reversal noted in prior review. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/control/server_tui.go`, line 278 ([link](https://github.com/befeast/ok-gobot/blob/0d31ad83f1ec0b3a5669b8d268e6283935261e9f/internal/control/server_tui.go#L278)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`event.Denial.ToolName` vs `event.ToolName` for the broadcast**

   The `KindToolStart` message (a few lines above) uses `event.ToolName`, but the `KindToolDenied` message here uses `event.Denial.ToolName`. The TUI model's `KindToolDenied` handler matches entries by `msg.ToolName`, so if these two values ever diverge (e.g., a custom tool wrapper sets a different name in its `ToolDenial`), the handler won't find the entry added by `KindToolStart` and will add an orphaned entry instead. Using `event.ToolName` consistently would be safer.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/control/server_tui.go
   Line: 278

   Comment:
   **`event.Denial.ToolName` vs `event.ToolName` for the broadcast**

   The `KindToolStart` message (a few lines above) uses `event.ToolName`, but the `KindToolDenied` message here uses `event.Denial.ToolName`. The TUI model's `KindToolDenied` handler matches entries by `msg.ToolName`, so if these two values ever diverge (e.g., a custom tool wrapper sets a different name in its `ToolDenial`), the handler won't find the entry added by `KindToolStart` and will add an orphaned entry instead. Using `event.ToolName` consistently would be safer.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/tools/network_policy_test.go`, line 503 ([link](https://github.com/befeast/ok-gobot/blob/0d31ad83f1ec0b3a5669b8d268e6283935261e9f/internal/tools/network_policy_test.go#L503)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Wildcard apex-match semantic break not covered by an upgrade note**

   The test now asserts `{"github.com", []string{"*.github.com"}, false}` — the opposite of the previous behaviour. Any operator whose `network_allowlist` contained only `"*.github.com"` and relied on it allowing the apex will silently start blocking that apex after upgrading. A comment here (or in the schema description) noting the migration path (`["github.com", "*.github.com"]`) would help operators catch this before it becomes a runtime surprise.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tools/network_policy_test.go
   Line: 503

   Comment:
   **Wildcard apex-match semantic break not covered by an upgrade note**

   The test now asserts `{"github.com", []string{"*.github.com"}, false}` — the opposite of the previous behaviour. Any operator whose `network_allowlist` contained only `"*.github.com"` and relied on it allowing the apex will silently start blocking that apex after upgrading. A comment here (or in the schema description) noting the migration path (`["github.com", "*.github.com"]`) would help operators catch this before it becomes a runtime surprise.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tools/policy.go
Line: 518

Comment:
**Unchecked type assertion on `http.DefaultTransport`**

`http.DefaultTransport.(*http.Transport)` panics if `http.DefaultTransport` has been replaced with any other `RoundTripper` (common in test mocks or third-party instrumentation libraries). The previous implementation built a fresh `http.Transport{}` and had no dependency on `DefaultTransport`, so this is a new panic path. Use the comma-ok form to fall back gracefully:

```go
base, ok := http.DefaultTransport.(*http.Transport)
if !ok {
    base = &http.Transport{}
}
transport := base.Clone()
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tools): preserve proxy transport set..."](https://github.com/befeast/ok-gobot/commit/87086e41f4ec63aadb76978a63e838751145ae66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30197148)</sub>

<!-- /greptile_comment -->