### PR TITLE
feat: hybrid memory search backend (#304)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -266,11 +266,14 @@ func (a *App) Start(ctx context.Context) error {
 		if apiKey == "" {
 			apiKey = a.config.AI.APIKey
 		}
-		embClient := memory.NewEmbeddingClient(
-			a.config.Memory.EmbeddingsBaseURL,
-			apiKey,
-			a.config.Memory.EmbeddingsModel,
-		)
+		var embClient *memory.EmbeddingClient
+		if memory.EmbeddingProviderConfigured(a.config.Memory.EmbeddingsBaseURL, apiKey) {
+			embClient = memory.NewEmbeddingClient(
+				a.config.Memory.EmbeddingsBaseURL,
+				apiKey,
+				a.config.Memory.EmbeddingsModel,
+			)
+		}
 		memStore, err := memory.NewMemoryStore(a.store.DB())
 		if err != nil {
 			log.Printf("⚠️ Failed to initialize memory store: %v", err)
@@ -303,7 +306,11 @@ func (a *App) Start(ctx context.Context) error {
 			}
 
 			a.memoryManager = memory.NewMemoryManager(embClient, memStore, options...)
-			log.Println("🧠 Semantic memory initialized")
+			if embClient == nil {
+				log.Println("🧠 Memory initialized (lexical search only; embeddings not configured)")
+			} else {
+				log.Println("🧠 Hybrid memory initialized")
+			}
 			a.startMemoryIndexer(ctx, soulPath, memStore, embClient)
 		}
 	}
@@ -470,7 +477,7 @@ func (a *App) startBootstrapWatcher(name string, personality *agent.Personality)
 }
 
 func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *memory.MemoryStore, embedder memory.EmbeddingBatchClient) {
-	if strings.TrimSpace(rootPath) == "" || store == nil || embedder == nil {
+	if strings.TrimSpace(rootPath) == "" || store == nil {
 		return
 	}
 

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -72,11 +72,14 @@ func newMemoryIndexCommand(cfg *config.Config) *cobra.Command {
 			if apiKey == "" {
 				apiKey = cfg.AI.APIKey
 			}
-			embedder := memory.NewEmbeddingClient(
-				cfg.Memory.EmbeddingsBaseURL,
-				apiKey,
-				cfg.Memory.EmbeddingsModel,
-			)
+			var embedder memory.EmbeddingBatchClient
+			if memory.EmbeddingProviderConfigured(cfg.Memory.EmbeddingsBaseURL, apiKey) {
+				embedder = memory.NewEmbeddingClient(
+					cfg.Memory.EmbeddingsBaseURL,
+					apiKey,
+					cfg.Memory.EmbeddingsModel,
+				)
+			}
 			stats, err := runMemoryIndex(cmd.Context(), cfg, memStore, embedder, force)
 			if err != nil {
 				return err

--- a/internal/memory/embeddings.go
+++ b/internal/memory/embeddings.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
+
+const defaultEmbeddingsBaseURL = "https://api.openai.com/v1"
 
 // EmbeddingClient handles communication with embedding API
 type EmbeddingClient struct {
@@ -23,14 +26,28 @@ func NewEmbeddingClient(baseURL, apiKey, model string) *EmbeddingClient {
 	if model == "" {
 		model = "text-embedding-3-small"
 	}
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = defaultEmbeddingsBaseURL
+	}
 	return &EmbeddingClient{
-		baseURL: baseURL,
+		baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"),
 		apiKey:  apiKey,
 		model:   model,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
 	}
+}
+
+// EmbeddingProviderConfigured reports whether configuration points at a usable
+// embedding provider. The default OpenAI endpoint requires an API key, while
+// custom OpenAI-compatible local endpoints may intentionally use no key.
+func EmbeddingProviderConfigured(baseURL, apiKey string) bool {
+	if strings.TrimSpace(apiKey) != "" {
+		return true
+	}
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	return baseURL != "" && !strings.EqualFold(baseURL, defaultEmbeddingsBaseURL)
 }
 
 // embeddingRequest represents the API request body

--- a/internal/memory/fts.go
+++ b/internal/memory/fts.go
@@ -1,47 +1,91 @@
 package memory
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
 
-func (s *MemoryStore) ensureChunksFTS() error {
+var errMemoryFTSUnavailable = errors.New("memory fts5 unavailable")
+
+func (s *MemoryStore) ensureChunksFTS() (bool, error) {
 	if s == nil || s.db == nil {
-		return fmt.Errorf("memory store is not configured")
+		return false, fmt.Errorf("memory store is not configured")
+	}
+
+	if _, err := s.db.Exec(fmt.Sprintf(`
+		CREATE VIRTUAL TABLE IF NOT EXISTS %s USING fts5(
+			content,
+			content='%s',
+			content_rowid='id',
+			tokenize='unicode61'
+		);
+	`, memoryChunksFTSTable, memoryChunksTable)); err != nil {
+		if isFTSUnavailable(err) {
+			dropMemoryFTSTriggers(s)
+			return false, nil
+		}
+		return false, fmt.Errorf("create memory FTS index: %w", err)
 	}
 
 	statements := []string{
-		`CREATE VIRTUAL TABLE IF NOT EXISTS memory_chunks_fts USING fts5(
-			content,
-			source_file UNINDEXED,
-			header_path UNINDEXED,
-			chunk_ordinal UNINDEXED,
-			content='memory_chunks',
-			content_rowid='id',
-			tokenize='unicode61'
-		);`,
-		`CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_ai AFTER INSERT ON memory_chunks BEGIN
-			INSERT INTO memory_chunks_fts(rowid, content, source_file, header_path, chunk_ordinal)
-			VALUES (new.id, new.content, new.source_file, new.header_path, new.chunk_ordinal);
-		END;`,
-		`CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_ad AFTER DELETE ON memory_chunks BEGIN
-			INSERT INTO memory_chunks_fts(memory_chunks_fts, rowid, content, source_file, header_path, chunk_ordinal)
-			VALUES ('delete', old.id, old.content, old.source_file, old.header_path, old.chunk_ordinal);
-		END;`,
-		`CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_au AFTER UPDATE ON memory_chunks BEGIN
-			INSERT INTO memory_chunks_fts(memory_chunks_fts, rowid, content, source_file, header_path, chunk_ordinal)
-			VALUES ('delete', old.id, old.content, old.source_file, old.header_path, old.chunk_ordinal);
-			INSERT INTO memory_chunks_fts(rowid, content, source_file, header_path, chunk_ordinal)
-			VALUES (new.id, new.content, new.source_file, new.header_path, new.chunk_ordinal);
-		END;`,
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_ai AFTER INSERT ON %s BEGIN
+				INSERT INTO %s(rowid, content) VALUES (new.id, new.content);
+			END;
+		`, memoryChunksTable, memoryChunksFTSTable),
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_ad AFTER DELETE ON %s BEGIN
+				INSERT INTO %s(%s, rowid, content) VALUES('delete', old.id, old.content);
+			END;
+		`, memoryChunksTable, memoryChunksFTSTable, memoryChunksFTSTable),
+		fmt.Sprintf(`
+			CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_au AFTER UPDATE OF content ON %s BEGIN
+				INSERT INTO %s(%s, rowid, content) VALUES('delete', old.id, old.content);
+				INSERT INTO %s(rowid, content) VALUES (new.id, new.content);
+			END;
+		`, memoryChunksTable, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksFTSTable),
 	}
 
 	for _, statement := range statements {
 		if _, err := s.db.Exec(statement); err != nil {
-			return err
+			if isFTSUnavailable(err) {
+				dropMemoryFTSTriggers(s)
+				return false, nil
+			}
+			return false, fmt.Errorf("create memory FTS trigger: %w", err)
 		}
 	}
 
-	if _, err := s.db.Exec(`INSERT INTO memory_chunks_fts(memory_chunks_fts) VALUES ('rebuild')`); err != nil {
-		return err
+	if _, err := s.db.Exec(fmt.Sprintf(`INSERT INTO %s(%s) VALUES('rebuild')`, memoryChunksFTSTable, memoryChunksFTSTable)); err != nil {
+		if isFTSUnavailable(err) {
+			dropMemoryFTSTriggers(s)
+			return false, nil
+		}
+		return false, fmt.Errorf("rebuild memory FTS index: %w", err)
 	}
 
-	return nil
+	return true, nil
+}
+
+func dropMemoryFTSTriggers(s *MemoryStore) {
+	if s == nil || s.db == nil {
+		return
+	}
+	for _, name := range []string{"memory_chunks_fts_ai", "memory_chunks_fts_ad", "memory_chunks_fts_au"} {
+		_, _ = s.db.Exec("DROP TRIGGER IF EXISTS " + name)
+	}
+}
+
+func isFTSUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errMemoryFTSUnavailable) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no such module: fts5") ||
+		strings.Contains(msg, "no such table: "+memoryChunksFTSTable) ||
+		strings.Contains(msg, "no such module") && strings.Contains(msg, "fts5")
 }

--- a/internal/memory/fts.go
+++ b/internal/memory/fts.go
@@ -1,0 +1,47 @@
+package memory
+
+import "fmt"
+
+func (s *MemoryStore) ensureChunksFTS() error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("memory store is not configured")
+	}
+
+	statements := []string{
+		`CREATE VIRTUAL TABLE IF NOT EXISTS memory_chunks_fts USING fts5(
+			content,
+			source_file UNINDEXED,
+			header_path UNINDEXED,
+			chunk_ordinal UNINDEXED,
+			content='memory_chunks',
+			content_rowid='id',
+			tokenize='unicode61'
+		);`,
+		`CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_ai AFTER INSERT ON memory_chunks BEGIN
+			INSERT INTO memory_chunks_fts(rowid, content, source_file, header_path, chunk_ordinal)
+			VALUES (new.id, new.content, new.source_file, new.header_path, new.chunk_ordinal);
+		END;`,
+		`CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_ad AFTER DELETE ON memory_chunks BEGIN
+			INSERT INTO memory_chunks_fts(memory_chunks_fts, rowid, content, source_file, header_path, chunk_ordinal)
+			VALUES ('delete', old.id, old.content, old.source_file, old.header_path, old.chunk_ordinal);
+		END;`,
+		`CREATE TRIGGER IF NOT EXISTS memory_chunks_fts_au AFTER UPDATE ON memory_chunks BEGIN
+			INSERT INTO memory_chunks_fts(memory_chunks_fts, rowid, content, source_file, header_path, chunk_ordinal)
+			VALUES ('delete', old.id, old.content, old.source_file, old.header_path, old.chunk_ordinal);
+			INSERT INTO memory_chunks_fts(rowid, content, source_file, header_path, chunk_ordinal)
+			VALUES (new.id, new.content, new.source_file, new.header_path, new.chunk_ordinal);
+		END;`,
+	}
+
+	for _, statement := range statements {
+		if _, err := s.db.Exec(statement); err != nil {
+			return err
+		}
+	}
+
+	if _, err := s.db.Exec(`INSERT INTO memory_chunks_fts(memory_chunks_fts) VALUES ('rebuild')`); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/memory/hybrid_search.go
+++ b/internal/memory/hybrid_search.go
@@ -1,0 +1,481 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	defaultMemoryStoreTopK      = 5
+	memorySearchCandidateMin    = 50
+	memorySearchCandidateMax    = 500
+	memorySearchCandidateFactor = 20
+	hybridLexicalWeight         = 0.45
+	hybridVectorWeight          = 0.55
+)
+
+type memorySearchCandidate struct {
+	result MemoryResult
+
+	embeddingRaw     []byte
+	vectorNormalized float32
+	vectorScored     bool
+}
+
+type lexicalCandidate struct {
+	candidate memorySearchCandidate
+	bm25      float64
+}
+
+// SearchChunksHybrid combines FTS5/BM25 lexical candidates with bounded vector
+// scoring. When either backend is unavailable, it falls back to the other.
+func (s *MemoryStore) SearchChunksHybrid(ctx context.Context, query string, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("memory store is not configured")
+	}
+	if topK <= 0 {
+		topK = defaultMemoryStoreTopK
+	}
+	candidateLimit := memorySearchCandidateLimit(topK)
+
+	candidates := make(map[int64]*memorySearchCandidate)
+	lexicalUsed := false
+	lexicalTokens := tokenizeSearchQuery(query)
+	if len(lexicalTokens) > 0 {
+		lexical, err := s.searchLexicalCandidates(ctx, buildFTS5Query(lexicalTokens), candidateLimit)
+		if err != nil || !s.ftsAvailable {
+			lexical, err = s.searchLikeCandidates(ctx, lexicalTokens, candidateLimit)
+		}
+		if err == nil {
+			lexicalUsed = len(lexical) > 0
+			for i := range lexical {
+				candidate := lexical[i]
+				candidates[candidate.result.ID] = &candidate
+			}
+		}
+	}
+
+	queryVector, vectorUsed := normalizeEmbedding(queryEmbedding)
+	if vectorUsed {
+		for _, candidate := range candidates {
+			scoreCandidateVector(candidate, queryVector)
+		}
+
+		if len(candidates) < candidateLimit {
+			recent, err := s.loadRecentVectorCandidates(ctx, candidateLimit-len(candidates), candidates)
+			if err != nil {
+				return nil, fmt.Errorf("failed to query memory vector candidates: %w", err)
+			}
+			for i := range recent {
+				candidate := recent[i]
+				scoreCandidateVector(&candidate, queryVector)
+				if candidate.vectorScored {
+					candidates[candidate.result.ID] = &candidate
+				}
+			}
+		}
+	}
+
+	return rankMemoryCandidates(candidates, lexicalUsed, vectorUsed, topK), nil
+}
+
+// SearchChunks is kept as the semantic-only compatibility API. It uses the same
+// bounded vector candidate path as hybrid search instead of scanning every row.
+func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+	return s.SearchChunksHybrid(ctx, "", queryEmbedding, topK)
+}
+
+// Search is kept as a compatibility alias for callers that still use the old name.
+func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+	return s.SearchChunks(ctx, queryEmbedding, topK)
+}
+
+func (s *MemoryStore) searchLexicalCandidates(ctx context.Context, ftsQuery string, limit int) ([]memorySearchCandidate, error) {
+	if !s.ftsAvailable || ftsQuery == "" {
+		return nil, fmt.Errorf("memory FTS index is unavailable")
+	}
+
+	query := fmt.Sprintf(`
+		SELECT c.id, c.source_file, c.header_path, c.chunk_ordinal, c.content, c.content_hash, c.embedding, c.indexed_at,
+		       bm25(%s) AS bm25_score
+		FROM %s
+		JOIN memory_chunks c ON c.id = %s.rowid
+		WHERE %s MATCH ?
+		ORDER BY bm25(%s) ASC, c.id DESC
+		LIMIT ?
+	`, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksFTSTable)
+
+	rows, err := s.db.QueryContext(ctx, query, ftsQuery, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	raw := make([]lexicalCandidate, 0, limit)
+	for rows.Next() {
+		candidate, bm25, err := scanLexicalCandidate(rows)
+		if err != nil {
+			continue
+		}
+		raw = append(raw, lexicalCandidate{candidate: candidate, bm25: bm25})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return normalizeLexicalCandidates(raw), nil
+}
+
+func (s *MemoryStore) searchLikeCandidates(ctx context.Context, tokens []string, limit int) ([]memorySearchCandidate, error) {
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+	if len(tokens) > 8 {
+		tokens = tokens[:8]
+	}
+
+	clauses := make([]string, 0, len(tokens))
+	args := make([]interface{}, 0, len(tokens)+1)
+	for _, token := range tokens {
+		clauses = append(clauses, `LOWER(content) LIKE ?`)
+		args = append(args, "%"+strings.ToLower(token)+"%")
+	}
+	args = append(args, limit)
+
+	query := fmt.Sprintf(`
+		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
+		FROM memory_chunks
+		WHERE %s
+		ORDER BY indexed_at DESC, id DESC
+		LIMIT ?
+	`, strings.Join(clauses, " OR "))
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	candidates := make([]memorySearchCandidate, 0, limit)
+	for rows.Next() {
+		candidate, err := scanMemorySearchCandidate(rows)
+		if err != nil {
+			continue
+		}
+		candidate.result.LexicalScore = likeLexicalScore(candidate.result.Content, tokens)
+		if candidate.result.LexicalScore > 0 {
+			candidates = append(candidates, candidate)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].result.LexicalScore != candidates[j].result.LexicalScore {
+			return candidates[i].result.LexicalScore > candidates[j].result.LexicalScore
+		}
+		return candidates[i].result.ID > candidates[j].result.ID
+	})
+	return candidates, nil
+}
+
+func scanLexicalCandidate(scanner memoryCandidateScanner) (memorySearchCandidate, float64, error) {
+	var (
+		id           int64
+		sourceFile   string
+		headerPath   string
+		chunkOrdinal int
+		content      string
+		contentHash  string
+		embeddingRaw []byte
+		indexedAt    time.Time
+		bm25         float64
+	)
+
+	if err := scanner.Scan(&id, &sourceFile, &headerPath, &chunkOrdinal, &content, &contentHash, &embeddingRaw, &indexedAt, &bm25); err != nil {
+		return memorySearchCandidate{}, 0, err
+	}
+
+	return newMemorySearchCandidate(id, sourceFile, headerPath, chunkOrdinal, content, contentHash, embeddingRaw, indexedAt), bm25, nil
+}
+
+func (s *MemoryStore) loadRecentVectorCandidates(ctx context.Context, limit int, existing map[int64]*memorySearchCandidate) ([]memorySearchCandidate, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	fetchLimit := limit + len(existing)
+	if fetchLimit < limit {
+		fetchLimit = limit
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
+		FROM memory_chunks
+		ORDER BY indexed_at DESC, id DESC
+		LIMIT ?
+	`, fetchLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	candidates := make([]memorySearchCandidate, 0, limit)
+	for rows.Next() {
+		candidate, err := scanMemorySearchCandidate(rows)
+		if err != nil {
+			continue
+		}
+		if _, ok := existing[candidate.result.ID]; ok {
+			continue
+		}
+		candidates = append(candidates, candidate)
+		if len(candidates) >= limit {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return candidates, nil
+}
+
+type memoryCandidateScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanMemorySearchCandidate(scanner memoryCandidateScanner) (memorySearchCandidate, error) {
+	var (
+		id           int64
+		sourceFile   string
+		headerPath   string
+		chunkOrdinal int
+		content      string
+		contentHash  string
+		embeddingRaw []byte
+		indexedAt    time.Time
+	)
+
+	if err := scanner.Scan(&id, &sourceFile, &headerPath, &chunkOrdinal, &content, &contentHash, &embeddingRaw, &indexedAt); err != nil {
+		return memorySearchCandidate{}, err
+	}
+
+	return newMemorySearchCandidate(id, sourceFile, headerPath, chunkOrdinal, content, contentHash, embeddingRaw, indexedAt), nil
+}
+
+func newMemorySearchCandidate(id int64, sourceFile, headerPath string, chunkOrdinal int, content, contentHash string, embeddingRaw []byte, indexedAt time.Time) memorySearchCandidate {
+	return memorySearchCandidate{
+		result: MemoryResult{
+			ID:           id,
+			Source:       sourceFile,
+			SourceFile:   sourceFile,
+			HeaderPath:   headerPath,
+			StartLine:    chunkOrdinal,
+			EndLine:      chunkOrdinal,
+			ChunkOrdinal: chunkOrdinal,
+			Content:      content,
+			ContentHash:  contentHash,
+			UpdatedAt:    indexedAt,
+			IndexedAt:    indexedAt,
+		},
+		embeddingRaw: embeddingRaw,
+	}
+}
+
+func normalizeLexicalCandidates(raw []lexicalCandidate) []memorySearchCandidate {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	best := raw[0].bm25
+	worst := raw[0].bm25
+	for _, candidate := range raw[1:] {
+		if candidate.bm25 < best {
+			best = candidate.bm25
+		}
+		if candidate.bm25 > worst {
+			worst = candidate.bm25
+		}
+	}
+
+	out := make([]memorySearchCandidate, 0, len(raw))
+	for _, item := range raw {
+		score := float32(1)
+		if worst > best && !math.IsNaN(item.bm25) {
+			score = float32(1 - ((item.bm25 - best) / (worst - best)))
+			if score < 0 {
+				score = 0
+			}
+		}
+		item.candidate.result.LexicalScore = score
+		out = append(out, item.candidate)
+	}
+	return out
+}
+
+func scoreCandidateVector(candidate *memorySearchCandidate, queryVector []float32) {
+	embedding, err := decodeChunkEmbedding(candidate.embeddingRaw)
+	if err != nil {
+		return
+	}
+	normalized, ok := normalizeEmbedding(embedding)
+	if !ok || len(normalized) != len(queryVector) {
+		return
+	}
+
+	cosine := dotProduct(queryVector, normalized)
+	candidate.result.VectorScore = cosine
+	candidate.vectorNormalized = normalizeCosineScore(cosine)
+	candidate.vectorScored = true
+}
+
+func normalizeCosineScore(score float32) float32 {
+	if score < -1 {
+		score = -1
+	}
+	if score > 1 {
+		score = 1
+	}
+	return (score + 1) / 2
+}
+
+func rankMemoryCandidates(candidates map[int64]*memorySearchCandidate, lexicalUsed, vectorUsed bool, topK int) []MemoryResult {
+	if len(candidates) == 0 || topK == 0 {
+		return nil
+	}
+
+	results := make([]MemoryResult, 0, len(candidates))
+	for _, candidate := range candidates {
+		result := candidate.result
+		if lexicalUsed && vectorUsed {
+			result.HybridScore = hybridLexicalWeight*result.LexicalScore + hybridVectorWeight*candidate.vectorNormalized
+		} else if lexicalUsed {
+			result.HybridScore = result.LexicalScore
+		} else if vectorUsed && candidate.vectorScored {
+			result.HybridScore = candidate.vectorNormalized
+		} else {
+			continue
+		}
+
+		result.Score = result.HybridScore
+		result.Similarity = result.HybridScore
+		if result.Score > 0 || result.LexicalScore > 0 || candidate.vectorScored {
+			results = append(results, result)
+		}
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		if results[i].VectorScore != results[j].VectorScore {
+			return results[i].VectorScore > results[j].VectorScore
+		}
+		if results[i].LexicalScore != results[j].LexicalScore {
+			return results[i].LexicalScore > results[j].LexicalScore
+		}
+		if results[i].SourceFile != results[j].SourceFile {
+			return results[i].SourceFile < results[j].SourceFile
+		}
+		if results[i].HeaderPath != results[j].HeaderPath {
+			return results[i].HeaderPath < results[j].HeaderPath
+		}
+		return results[i].ChunkOrdinal < results[j].ChunkOrdinal
+	})
+
+	if len(results) > topK {
+		results = results[:topK]
+	}
+	return results
+}
+
+func memorySearchCandidateLimit(topK int) int {
+	if topK <= 0 {
+		topK = defaultMemoryStoreTopK
+	}
+	limit := topK * memorySearchCandidateFactor
+	if limit < memorySearchCandidateMin {
+		limit = memorySearchCandidateMin
+	}
+	if limit > memorySearchCandidateMax {
+		limit = memorySearchCandidateMax
+	}
+	return limit
+}
+
+func tokenizeSearchQuery(query string) []string {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return nil
+	}
+
+	var (
+		tokens  []string
+		current strings.Builder
+	)
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		token := current.String()
+		current.Reset()
+		tokens = append(tokens, token)
+	}
+
+	for _, r := range query {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			current.WriteRune(r)
+			continue
+		}
+		flush()
+	}
+	flush()
+
+	return tokens
+}
+
+func buildFTS5Query(tokens []string) string {
+	if len(tokens) == 0 {
+		return ""
+	}
+	quoted := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		quoted = append(quoted, `"`+strings.ReplaceAll(token, `"`, `""`)+`"`)
+	}
+	return strings.Join(quoted, " OR ")
+}
+
+func likeLexicalScore(content string, tokens []string) float32 {
+	if len(tokens) == 0 {
+		return 0
+	}
+	content = strings.ToLower(content)
+	matched := 0
+	totalCount := 0
+	for _, token := range tokens {
+		count := strings.Count(content, strings.ToLower(token))
+		if count == 0 {
+			continue
+		}
+		matched++
+		totalCount += count
+	}
+	if matched == 0 {
+		return 0
+	}
+
+	score := float32(matched) / float32(len(tokens))
+	if totalCount > matched {
+		score += float32(totalCount-matched) * 0.05
+	}
+	if score > 1 {
+		return 1
+	}
+	return score
+}

--- a/internal/memory/hybrid_search.go
+++ b/internal/memory/hybrid_search.go
@@ -193,7 +193,7 @@ func (s *MemoryStore) searchVectorCandidateRows(ctx context.Context, ids []int64
 		rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
 			SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, indexed_at, embedding
 			FROM %s
-			WHERE id IN (%s)
+			WHERE id IN (%s) AND length(embedding) > 0
 		`, memoryChunksTable, strings.Join(placeholders, ",")), args...)
 		if err != nil {
 			return nil, err
@@ -211,6 +211,7 @@ func (s *MemoryStore) searchVectorCandidateRows(ctx context.Context, ids []int64
 	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
 		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, indexed_at, embedding
 		FROM %s
+		WHERE length(embedding) > 0
 		ORDER BY indexed_at DESC, id DESC
 		LIMIT ?
 	`, memoryChunksTable), limit)

--- a/internal/memory/hybrid_search.go
+++ b/internal/memory/hybrid_search.go
@@ -2,160 +2,164 @@ package memory
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
-	"math"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
-	"unicode"
 )
 
 const (
-	defaultMemoryStoreTopK      = 5
-	memorySearchCandidateMin    = 50
-	memorySearchCandidateMax    = 500
-	memorySearchCandidateFactor = 20
-	hybridLexicalWeight         = 0.45
-	hybridVectorWeight          = 0.55
+	memoryLexicalCandidateMultiplier = 20
+	memoryVectorCandidateMultiplier  = 50
+	memoryMaxLexicalCandidates       = 200
+	memoryMaxVectorCandidates        = 1000
+	memoryHybridLexicalWeight        = 0.45
+	memoryHybridVectorWeight         = 0.55
 )
+
+var memorySearchTokenRegexp = regexp.MustCompile(`[\p{L}\p{N}_]+`)
 
 type memorySearchCandidate struct {
 	result MemoryResult
 
-	embeddingRaw     []byte
-	vectorNormalized float32
-	vectorScored     bool
+	lexicalRank  int
+	lexicalScore float32
+	bm25         float64
+	hasLexical   bool
+
+	vectorScore float32
+	hasVector   bool
 }
 
-type lexicalCandidate struct {
-	candidate memorySearchCandidate
-	bm25      float64
+type memoryVectorCandidate struct {
+	result       MemoryResult
+	embeddingRaw []byte
 }
 
-// SearchChunksHybrid combines FTS5/BM25 lexical candidates with bounded vector
-// scoring. When either backend is unavailable, it falls back to the other.
-func (s *MemoryStore) SearchChunksHybrid(ctx context.Context, query string, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+// SearchText searches memory chunks using the lexical index only.
+func (s *MemoryStore) SearchText(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
+	return s.SearchHybrid(ctx, query, nil, topK)
+}
+
+// SearchHybrid combines FTS5/BM25 lexical candidates with bounded vector scoring.
+func (s *MemoryStore) SearchHybrid(ctx context.Context, query string, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
 	if s == nil || s.db == nil {
 		return nil, fmt.Errorf("memory store is not configured")
 	}
-	if topK <= 0 {
-		topK = defaultMemoryStoreTopK
-	}
-	candidateLimit := memorySearchCandidateLimit(topK)
+
+	topK = normalizeMemoryTopK(topK)
+	query = strings.TrimSpace(query)
+	queryVector, hasQueryVector := normalizeEmbedding(queryEmbedding)
 
 	candidates := make(map[int64]*memorySearchCandidate)
-	lexicalUsed := false
-	lexicalTokens := tokenizeSearchQuery(query)
-	if len(lexicalTokens) > 0 {
-		lexical, err := s.searchLexicalCandidates(ctx, buildFTS5Query(lexicalTokens), candidateLimit)
-		if err != nil || !s.ftsAvailable {
-			lexical, err = s.searchLikeCandidates(ctx, lexicalTokens, candidateLimit)
-		}
-		if err == nil {
-			lexicalUsed = len(lexical) > 0
-			for i := range lexical {
-				candidate := lexical[i]
-				candidates[candidate.result.ID] = &candidate
-			}
-		}
-	}
+	lexicalCount := 0
 
-	queryVector, vectorUsed := normalizeEmbedding(queryEmbedding)
-	if vectorUsed {
-		for _, candidate := range candidates {
-			scoreCandidateVector(candidate, queryVector)
-		}
-
-		if len(candidates) < candidateLimit {
-			recent, err := s.loadRecentVectorCandidates(ctx, candidateLimit-len(candidates), candidates)
-			if err != nil {
-				return nil, fmt.Errorf("failed to query memory vector candidates: %w", err)
-			}
-			for i := range recent {
-				candidate := recent[i]
-				scoreCandidateVector(&candidate, queryVector)
-				if candidate.vectorScored {
-					candidates[candidate.result.ID] = &candidate
+	if query != "" {
+		lexicalLimit := memoryCandidateLimit(topK, memoryLexicalCandidateMultiplier, memoryMaxLexicalCandidates)
+		lexical, err := s.searchLexicalCandidates(ctx, query, lexicalLimit)
+		if err != nil {
+			fallback, fallbackErr := s.searchLikeCandidates(ctx, query, lexicalLimit)
+			if fallbackErr != nil {
+				if !hasQueryVector {
+					return nil, fallbackErr
 				}
+			} else {
+				lexical = fallback
+				err = nil
 			}
+		}
+		if err != nil && !hasQueryVector {
+			return nil, err
+		}
+		for rank, candidate := range lexical {
+			entry := ensureMemorySearchCandidate(candidates, candidate.result)
+			entry.hasLexical = true
+			entry.lexicalRank = rank
+			entry.lexicalScore = lexicalRankScore(rank)
+			entry.bm25 = candidate.bm25
+			lexicalCount++
 		}
 	}
 
-	return rankMemoryCandidates(candidates, lexicalUsed, vectorUsed, topK), nil
-}
+	if hasQueryVector {
+		vectorLimit := memoryCandidateLimit(topK, memoryVectorCandidateMultiplier, memoryMaxVectorCandidates)
+		vectorRows, err := s.searchVectorCandidateRows(ctx, memoryCandidateIDs(candidates), vectorLimit)
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range vectorRows {
+			embedding, err := decodeChunkEmbedding(row.embeddingRaw)
+			if err != nil {
+				continue
+			}
+			normalized, ok := normalizeEmbedding(embedding)
+			if !ok || len(normalized) != len(queryVector) {
+				continue
+			}
 
-// SearchChunks is kept as the semantic-only compatibility API. It uses the same
-// bounded vector candidate path as hybrid search instead of scanning every row.
-func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
-	return s.SearchChunksHybrid(ctx, "", queryEmbedding, topK)
-}
-
-// Search is kept as a compatibility alias for callers that still use the old name.
-func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
-	return s.SearchChunks(ctx, queryEmbedding, topK)
-}
-
-func (s *MemoryStore) searchLexicalCandidates(ctx context.Context, ftsQuery string, limit int) ([]memorySearchCandidate, error) {
-	if !s.ftsAvailable || ftsQuery == "" {
-		return nil, fmt.Errorf("memory FTS index is unavailable")
+			score := dotProduct(queryVector, normalized)
+			entry := ensureMemorySearchCandidate(candidates, row.result)
+			entry.hasVector = true
+			entry.vectorScore = score
+		}
 	}
 
-	query := fmt.Sprintf(`
-		SELECT c.id, c.source_file, c.header_path, c.chunk_ordinal, c.content, c.content_hash, c.embedding, c.indexed_at,
-		       bm25(%s) AS bm25_score
-		FROM %s
-		JOIN memory_chunks c ON c.id = %s.rowid
-		WHERE %s MATCH ?
-		ORDER BY bm25(%s) ASC, c.id DESC
-		LIMIT ?
-	`, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksFTSTable)
+	return rankMemoryCandidates(candidates, topK, hasQueryVector && lexicalCount > 0), nil
+}
 
-	rows, err := s.db.QueryContext(ctx, query, ftsQuery, limit)
+func (s *MemoryStore) searchLexicalCandidates(ctx context.Context, query string, limit int) ([]memorySearchCandidate, error) {
+	if !s.ftsAvailable {
+		return nil, errMemoryFTSUnavailable
+	}
+
+	ftsQuery := buildMemoryFTSQuery(query)
+	if ftsQuery == "" {
+		return nil, nil
+	}
+
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT c.id, c.source_file, c.header_path, c.chunk_ordinal, c.content, c.content_hash, c.indexed_at,
+		       bm25(%s) AS rank
+		FROM %s
+		JOIN %s AS c ON c.id = %s.rowid
+		WHERE %s MATCH ?
+		ORDER BY rank ASC, c.indexed_at DESC, c.id DESC
+		LIMIT ?
+	`, memoryChunksFTSTable, memoryChunksFTSTable, memoryChunksTable, memoryChunksFTSTable, memoryChunksFTSTable), ftsQuery, limit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	raw := make([]lexicalCandidate, 0, limit)
-	for rows.Next() {
-		candidate, bm25, err := scanLexicalCandidate(rows)
-		if err != nil {
-			continue
-		}
-		raw = append(raw, lexicalCandidate{candidate: candidate, bm25: bm25})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return normalizeLexicalCandidates(raw), nil
+	return scanLexicalRows(rows)
 }
 
-func (s *MemoryStore) searchLikeCandidates(ctx context.Context, tokens []string, limit int) ([]memorySearchCandidate, error) {
-	if len(tokens) == 0 {
+func (s *MemoryStore) searchLikeCandidates(ctx context.Context, query string, limit int) ([]memorySearchCandidate, error) {
+	terms := memorySearchTerms(query)
+	if len(terms) == 0 {
 		return nil, nil
 	}
-	if len(tokens) > 8 {
-		tokens = tokens[:8]
+	if len(terms) > 5 {
+		terms = terms[:5]
 	}
 
-	clauses := make([]string, 0, len(tokens))
-	args := make([]interface{}, 0, len(tokens)+1)
-	for _, token := range tokens {
-		clauses = append(clauses, `LOWER(content) LIKE ?`)
-		args = append(args, "%"+strings.ToLower(token)+"%")
+	conditions := make([]string, 0, len(terms))
+	args := make([]interface{}, 0, len(terms)+1)
+	for _, term := range terms {
+		conditions = append(conditions, `content LIKE ? ESCAPE '\'`)
+		args = append(args, "%"+escapeLikeTerm(term)+"%")
 	}
 	args = append(args, limit)
 
-	query := fmt.Sprintf(`
-		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
-		FROM memory_chunks
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, indexed_at
+		FROM %s
 		WHERE %s
 		ORDER BY indexed_at DESC, id DESC
 		LIMIT ?
-	`, strings.Join(clauses, " OR "))
-
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	`, memoryChunksTable, strings.Join(conditions, " OR ")), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -163,94 +167,114 @@ func (s *MemoryStore) searchLikeCandidates(ctx context.Context, tokens []string,
 
 	candidates := make([]memorySearchCandidate, 0, limit)
 	for rows.Next() {
-		candidate, err := scanMemorySearchCandidate(rows)
+		result, err := scanMemoryResult(rows)
 		if err != nil {
 			continue
 		}
-		candidate.result.LexicalScore = likeLexicalScore(candidate.result.Content, tokens)
-		if candidate.result.LexicalScore > 0 {
-			candidates = append(candidates, candidate)
-		}
+		candidates = append(candidates, memorySearchCandidate{result: result})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-
-	sort.SliceStable(candidates, func(i, j int) bool {
-		if candidates[i].result.LexicalScore != candidates[j].result.LexicalScore {
-			return candidates[i].result.LexicalScore > candidates[j].result.LexicalScore
-		}
-		return candidates[i].result.ID > candidates[j].result.ID
-	})
 	return candidates, nil
 }
 
-func scanLexicalCandidate(scanner memoryCandidateScanner) (memorySearchCandidate, float64, error) {
-	var (
-		id           int64
-		sourceFile   string
-		headerPath   string
-		chunkOrdinal int
-		content      string
-		contentHash  string
-		embeddingRaw []byte
-		indexedAt    time.Time
-		bm25         float64
-	)
+func (s *MemoryStore) searchVectorCandidateRows(ctx context.Context, ids []int64, limit int) ([]memoryVectorCandidate, error) {
+	seen := make(map[int64]bool)
+	candidates := make([]memoryVectorCandidate, 0, limit+len(ids))
 
-	if err := scanner.Scan(&id, &sourceFile, &headerPath, &chunkOrdinal, &content, &contentHash, &embeddingRaw, &indexedAt, &bm25); err != nil {
-		return memorySearchCandidate{}, 0, err
+	if len(ids) > 0 {
+		placeholders := make([]string, len(ids))
+		args := make([]interface{}, len(ids))
+		for i, id := range ids {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+			SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, indexed_at, embedding
+			FROM %s
+			WHERE id IN (%s)
+		`, memoryChunksTable, strings.Join(placeholders, ",")), args...)
+		if err != nil {
+			return nil, err
+		}
+		loaded, err := scanVectorRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range loaded {
+			seen[row.result.ID] = true
+			candidates = append(candidates, row)
+		}
 	}
 
-	return newMemorySearchCandidate(id, sourceFile, headerPath, chunkOrdinal, content, contentHash, embeddingRaw, indexedAt), bm25, nil
-}
-
-func (s *MemoryStore) loadRecentVectorCandidates(ctx context.Context, limit int, existing map[int64]*memorySearchCandidate) ([]memorySearchCandidate, error) {
-	if limit <= 0 {
-		return nil, nil
-	}
-	fetchLimit := limit + len(existing)
-	if fetchLimit < limit {
-		fetchLimit = limit
-	}
-
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
-		FROM memory_chunks
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, indexed_at, embedding
+		FROM %s
 		ORDER BY indexed_at DESC, id DESC
 		LIMIT ?
-	`, fetchLimit)
+	`, memoryChunksTable), limit)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
-	candidates := make([]memorySearchCandidate, 0, limit)
-	for rows.Next() {
-		candidate, err := scanMemorySearchCandidate(rows)
-		if err != nil {
-			continue
-		}
-		if _, ok := existing[candidate.result.ID]; ok {
-			continue
-		}
-		candidates = append(candidates, candidate)
-		if len(candidates) >= limit {
-			break
-		}
-	}
-	if err := rows.Err(); err != nil {
+	loaded, err := scanVectorRows(rows)
+	if err != nil {
 		return nil, err
+	}
+	for _, row := range loaded {
+		if seen[row.result.ID] {
+			continue
+		}
+		seen[row.result.ID] = true
+		candidates = append(candidates, row)
 	}
 
 	return candidates, nil
 }
 
-type memoryCandidateScanner interface {
-	Scan(dest ...interface{}) error
+func scanLexicalRows(rows *sql.Rows) ([]memorySearchCandidate, error) {
+	candidates := make([]memorySearchCandidate, 0)
+	for rows.Next() {
+		var bm25 float64
+		result, err := scanMemoryResultWithExtra(rows, &bm25)
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, memorySearchCandidate{result: result, bm25: bm25})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return candidates, nil
 }
 
-func scanMemorySearchCandidate(scanner memoryCandidateScanner) (memorySearchCandidate, error) {
+func scanVectorRows(rows *sql.Rows) ([]memoryVectorCandidate, error) {
+	defer rows.Close()
+
+	candidates := make([]memoryVectorCandidate, 0)
+	for rows.Next() {
+		var embeddingRaw []byte
+		result, err := scanMemoryResultWithExtra(rows, &embeddingRaw)
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, memoryVectorCandidate{result: result, embeddingRaw: embeddingRaw})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return candidates, nil
+}
+
+func scanMemoryResult(rows interface {
+	Scan(dest ...interface{}) error
+}) (MemoryResult, error) {
+	return scanMemoryResultWithExtra(rows)
+}
+
+func scanMemoryResultWithExtra(rows interface {
+	Scan(dest ...interface{}) error
+}, extra ...interface{}) (MemoryResult, error) {
 	var (
 		id           int64
 		sourceFile   string
@@ -258,224 +282,186 @@ func scanMemorySearchCandidate(scanner memoryCandidateScanner) (memorySearchCand
 		chunkOrdinal int
 		content      string
 		contentHash  string
-		embeddingRaw []byte
 		indexedAt    time.Time
 	)
 
-	if err := scanner.Scan(&id, &sourceFile, &headerPath, &chunkOrdinal, &content, &contentHash, &embeddingRaw, &indexedAt); err != nil {
-		return memorySearchCandidate{}, err
+	dest := []interface{}{
+		&id,
+		&sourceFile,
+		&headerPath,
+		&chunkOrdinal,
+		&content,
+		&contentHash,
+		&indexedAt,
+	}
+	dest = append(dest, extra...)
+	if err := rows.Scan(dest...); err != nil {
+		return MemoryResult{}, err
 	}
 
-	return newMemorySearchCandidate(id, sourceFile, headerPath, chunkOrdinal, content, contentHash, embeddingRaw, indexedAt), nil
+	return MemoryResult{
+		ID:           id,
+		Source:       sourceFile,
+		SourceFile:   sourceFile,
+		HeaderPath:   headerPath,
+		StartLine:    chunkOrdinal,
+		EndLine:      chunkOrdinal,
+		ChunkOrdinal: chunkOrdinal,
+		Content:      content,
+		ContentHash:  contentHash,
+		UpdatedAt:    indexedAt,
+		IndexedAt:    indexedAt,
+	}, nil
 }
 
-func newMemorySearchCandidate(id int64, sourceFile, headerPath string, chunkOrdinal int, content, contentHash string, embeddingRaw []byte, indexedAt time.Time) memorySearchCandidate {
-	return memorySearchCandidate{
-		result: MemoryResult{
-			ID:           id,
-			Source:       sourceFile,
-			SourceFile:   sourceFile,
-			HeaderPath:   headerPath,
-			StartLine:    chunkOrdinal,
-			EndLine:      chunkOrdinal,
-			ChunkOrdinal: chunkOrdinal,
-			Content:      content,
-			ContentHash:  contentHash,
-			UpdatedAt:    indexedAt,
-			IndexedAt:    indexedAt,
-		},
-		embeddingRaw: embeddingRaw,
+func ensureMemorySearchCandidate(candidates map[int64]*memorySearchCandidate, result MemoryResult) *memorySearchCandidate {
+	if entry, ok := candidates[result.ID]; ok {
+		return entry
 	}
+	entry := &memorySearchCandidate{result: result, lexicalRank: int(^uint(0) >> 1)}
+	candidates[result.ID] = entry
+	return entry
 }
 
-func normalizeLexicalCandidates(raw []lexicalCandidate) []memorySearchCandidate {
-	if len(raw) == 0 {
+func rankMemoryCandidates(candidates map[int64]*memorySearchCandidate, topK int, useHybridWeights bool) []MemoryResult {
+	if len(candidates) == 0 {
 		return nil
 	}
 
-	best := raw[0].bm25
-	worst := raw[0].bm25
-	for _, candidate := range raw[1:] {
-		if candidate.bm25 < best {
-			best = candidate.bm25
-		}
-		if candidate.bm25 > worst {
-			worst = candidate.bm25
-		}
-	}
-
-	out := make([]memorySearchCandidate, 0, len(raw))
-	for _, item := range raw {
-		score := float32(1)
-		if worst > best && !math.IsNaN(item.bm25) {
-			score = float32(1 - ((item.bm25 - best) / (worst - best)))
-			if score < 0 {
-				score = 0
-			}
-		}
-		item.candidate.result.LexicalScore = score
-		out = append(out, item.candidate)
-	}
-	return out
-}
-
-func scoreCandidateVector(candidate *memorySearchCandidate, queryVector []float32) {
-	embedding, err := decodeChunkEmbedding(candidate.embeddingRaw)
-	if err != nil {
-		return
-	}
-	normalized, ok := normalizeEmbedding(embedding)
-	if !ok || len(normalized) != len(queryVector) {
-		return
-	}
-
-	cosine := dotProduct(queryVector, normalized)
-	candidate.result.VectorScore = cosine
-	candidate.vectorNormalized = normalizeCosineScore(cosine)
-	candidate.vectorScored = true
-}
-
-func normalizeCosineScore(score float32) float32 {
-	if score < -1 {
-		score = -1
-	}
-	if score > 1 {
-		score = 1
-	}
-	return (score + 1) / 2
-}
-
-func rankMemoryCandidates(candidates map[int64]*memorySearchCandidate, lexicalUsed, vectorUsed bool, topK int) []MemoryResult {
-	if len(candidates) == 0 || topK == 0 {
-		return nil
-	}
-
-	results := make([]MemoryResult, 0, len(candidates))
+	ordered := make([]*memorySearchCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
-		result := candidate.result
-		if lexicalUsed && vectorUsed {
-			result.HybridScore = hybridLexicalWeight*result.LexicalScore + hybridVectorWeight*candidate.vectorNormalized
-		} else if lexicalUsed {
-			result.HybridScore = result.LexicalScore
-		} else if vectorUsed && candidate.vectorScored {
-			result.HybridScore = candidate.vectorNormalized
-		} else {
+		if !candidate.hasLexical && !candidate.hasVector {
 			continue
 		}
-
-		result.Score = result.HybridScore
-		result.Similarity = result.HybridScore
-		if result.Score > 0 || result.LexicalScore > 0 || candidate.vectorScored {
-			results = append(results, result)
+		score := candidate.combinedScore(useHybridWeights)
+		candidate.result.Score = score
+		candidate.result.Similarity = score
+		candidate.result.HybridScore = score
+		if candidate.hasLexical {
+			candidate.result.LexicalScore = candidate.lexicalScore
+			candidate.result.BM25 = candidate.bm25
 		}
+		if candidate.hasVector {
+			candidate.result.VectorScore = candidate.vectorScore
+		}
+		ordered = append(ordered, candidate)
 	}
 
-	sort.SliceStable(results, func(i, j int) bool {
-		if results[i].Score != results[j].Score {
-			return results[i].Score > results[j].Score
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left := ordered[i]
+		right := ordered[j]
+		if left.result.Score != right.result.Score {
+			return left.result.Score > right.result.Score
 		}
-		if results[i].VectorScore != results[j].VectorScore {
-			return results[i].VectorScore > results[j].VectorScore
+		if left.vectorScore != right.vectorScore {
+			return left.vectorScore > right.vectorScore
 		}
-		if results[i].LexicalScore != results[j].LexicalScore {
-			return results[i].LexicalScore > results[j].LexicalScore
+		if left.lexicalRank != right.lexicalRank {
+			return left.lexicalRank < right.lexicalRank
 		}
-		if results[i].SourceFile != results[j].SourceFile {
-			return results[i].SourceFile < results[j].SourceFile
+		if !left.result.IndexedAt.Equal(right.result.IndexedAt) {
+			return left.result.IndexedAt.After(right.result.IndexedAt)
 		}
-		if results[i].HeaderPath != results[j].HeaderPath {
-			return results[i].HeaderPath < results[j].HeaderPath
-		}
-		return results[i].ChunkOrdinal < results[j].ChunkOrdinal
+		return left.result.ID < right.result.ID
 	})
 
-	if len(results) > topK {
-		results = results[:topK]
+	if len(ordered) > topK {
+		ordered = ordered[:topK]
+	}
+	results := make([]MemoryResult, len(ordered))
+	for i, candidate := range ordered {
+		results[i] = candidate.result
 	}
 	return results
 }
 
-func memorySearchCandidateLimit(topK int) int {
+func (c *memorySearchCandidate) combinedScore(useHybridWeights bool) float32 {
+	if !useHybridWeights {
+		if c.hasVector {
+			return c.vectorScore
+		}
+		return c.lexicalScore
+	}
+
+	var score float32
+	if c.hasLexical {
+		score += memoryHybridLexicalWeight * c.lexicalScore
+	}
+	if c.hasVector && c.vectorScore > 0 {
+		score += memoryHybridVectorWeight * c.vectorScore
+	}
+	return score
+}
+
+func normalizeMemoryTopK(topK int) int {
 	if topK <= 0 {
-		topK = defaultMemoryStoreTopK
+		return DefaultSearchTopK
 	}
-	limit := topK * memorySearchCandidateFactor
-	if limit < memorySearchCandidateMin {
-		limit = memorySearchCandidateMin
+	return topK
+}
+
+func memoryCandidateLimit(topK, multiplier, maxLimit int) int {
+	limit := topK * multiplier
+	if limit < topK {
+		limit = topK
 	}
-	if limit > memorySearchCandidateMax {
-		limit = memorySearchCandidateMax
+	if limit > maxLimit {
+		if topK > maxLimit {
+			return topK
+		}
+		return maxLimit
 	}
 	return limit
 }
 
-func tokenizeSearchQuery(query string) []string {
-	query = strings.ToLower(strings.TrimSpace(query))
-	if query == "" {
-		return nil
+func memoryCandidateIDs(candidates map[int64]*memorySearchCandidate) []int64 {
+	ids := make([]int64, 0, len(candidates))
+	for id := range candidates {
+		ids = append(ids, id)
 	}
-
-	var (
-		tokens  []string
-		current strings.Builder
-	)
-	flush := func() {
-		if current.Len() == 0 {
-			return
-		}
-		token := current.String()
-		current.Reset()
-		tokens = append(tokens, token)
-	}
-
-	for _, r := range query {
-		if unicode.IsLetter(r) || unicode.IsNumber(r) {
-			current.WriteRune(r)
-			continue
-		}
-		flush()
-	}
-	flush()
-
-	return tokens
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
 }
 
-func buildFTS5Query(tokens []string) string {
-	if len(tokens) == 0 {
+func lexicalRankScore(rank int) float32 {
+	return 1 / float32(rank+1)
+}
+
+func buildMemoryFTSQuery(query string) string {
+	terms := memorySearchTerms(query)
+	if len(terms) == 0 {
 		return ""
 	}
-	quoted := make([]string, 0, len(tokens))
-	for _, token := range tokens {
-		quoted = append(quoted, `"`+strings.ReplaceAll(token, `"`, `""`)+`"`)
+
+	quoted := make([]string, len(terms))
+	for i, term := range terms {
+		quoted[i] = `"` + strings.ReplaceAll(term, `"`, `""`) + `"`
 	}
 	return strings.Join(quoted, " OR ")
 }
 
-func likeLexicalScore(content string, tokens []string) float32 {
-	if len(tokens) == 0 {
-		return 0
-	}
-	content = strings.ToLower(content)
-	matched := 0
-	totalCount := 0
-	for _, token := range tokens {
-		count := strings.Count(content, strings.ToLower(token))
-		if count == 0 {
+func memorySearchTerms(query string) []string {
+	raw := memorySearchTokenRegexp.FindAllString(query, -1)
+	terms := make([]string, 0, len(raw))
+	seen := make(map[string]bool, len(raw))
+	for _, term := range raw {
+		term = strings.TrimSpace(term)
+		if term == "" {
 			continue
 		}
-		matched++
-		totalCount += count
+		key := strings.ToLower(term)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		terms = append(terms, term)
 	}
-	if matched == 0 {
-		return 0
-	}
+	return terms
+}
 
-	score := float32(matched) / float32(len(tokens))
-	if totalCount > matched {
-		score += float32(totalCount-matched) * 0.05
-	}
-	if score > 1 {
-		return 1
-	}
-	return score
+func escapeLikeTerm(term string) string {
+	term = strings.ReplaceAll(term, `\`, `\\`)
+	term = strings.ReplaceAll(term, `%`, `\%`)
+	term = strings.ReplaceAll(term, `_`, `\_`)
+	return term
 }

--- a/internal/memory/indexer.go
+++ b/internal/memory/indexer.go
@@ -68,6 +68,7 @@ func WithIndexerChunking(maxTokens, overlap int) IndexerOption {
 }
 
 // Indexer consumes file-change events and keeps memory_chunks synchronized.
+// The embedder is optional; when absent, chunks are still indexed for lexical search.
 type Indexer struct {
 	rootPath string
 	store    *MemoryStore

--- a/internal/memory/indexer.go
+++ b/internal/memory/indexer.go
@@ -131,7 +131,7 @@ func (i *Indexer) HandleEvent(ctx context.Context, event FileChangedEvent) error
 
 // IndexFile indexes a single file into memory_chunks.
 func (i *Indexer) IndexFile(ctx context.Context, absPath, relativePath string) error {
-	if i == nil || i.store == nil || i.embedder == nil {
+	if i == nil || i.store == nil {
 		return fmt.Errorf("indexer is not fully configured")
 	}
 
@@ -187,6 +187,9 @@ func (i *Indexer) IndexFile(ctx context.Context, absPath, relativePath string) e
 func (i *Indexer) embedChangedChunks(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil
+	}
+	if i.embedder == nil {
+		return make([][]float32, len(texts)), nil
 	}
 
 	allEmbeddings := make([][]float32, 0, len(texts))

--- a/internal/memory/indexer_test.go
+++ b/internal/memory/indexer_test.go
@@ -137,6 +137,35 @@ func TestIndexerDeletesStaleChunksWhenFileShrinks(t *testing.T) {
 	}
 }
 
+func TestIndexerIndexesWithoutEmbedderForLexicalSearch(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "MEMORY.md")
+	if err := os.WriteFile(filePath, []byte("# Memory\n\nEspresso beans go in the top drawer."), 0o644); err != nil {
+		t.Fatalf("write file failed: %v", err)
+	}
+
+	indexer := NewIndexer(tmpDir, store, nil, WithIndexerChunking(32, 0))
+	if err := indexer.IndexFile(context.Background(), filePath, "MEMORY.md"); err != nil {
+		t.Fatalf("IndexFile without embedder failed: %v", err)
+	}
+
+	results, err := store.SearchChunksHybrid(context.Background(), "espresso", nil, 3)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed: %v", err)
+	}
+	if len(results) != 1 || results[0].SourceFile != "MEMORY.md" {
+		t.Fatalf("expected lexical hit from unembedded index, got %+v", results)
+	}
+}
+
 func openIndexerTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 

--- a/internal/memory/indexer_test.go
+++ b/internal/memory/indexer_test.go
@@ -137,7 +137,7 @@ func TestIndexerDeletesStaleChunksWhenFileShrinks(t *testing.T) {
 	}
 }
 
-func TestIndexerIndexesWithoutEmbedderForLexicalSearch(t *testing.T) {
+func TestIndexerIndexesLexicalChunksWithoutEmbedder(t *testing.T) {
 	db := openIndexerTestDB(t)
 	defer db.Close() //nolint:errcheck
 
@@ -148,21 +148,21 @@ func TestIndexerIndexesWithoutEmbedderForLexicalSearch(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "MEMORY.md")
-	if err := os.WriteFile(filePath, []byte("# Memory\n\nEspresso beans go in the top drawer."), 0o644); err != nil {
+	if err := os.WriteFile(filePath, []byte("# Memory\n\nEspresso workflow lives here."), 0o644); err != nil {
 		t.Fatalf("write file failed: %v", err)
 	}
 
 	indexer := NewIndexer(tmpDir, store, nil, WithIndexerChunking(32, 0))
 	if err := indexer.IndexFile(context.Background(), filePath, "MEMORY.md"); err != nil {
-		t.Fatalf("IndexFile without embedder failed: %v", err)
+		t.Fatalf("IndexFile failed: %v", err)
 	}
 
-	results, err := store.SearchChunksHybrid(context.Background(), "espresso", nil, 3)
+	results, err := store.SearchText(context.Background(), "espresso", 1)
 	if err != nil {
-		t.Fatalf("SearchChunksHybrid failed: %v", err)
+		t.Fatalf("SearchText failed: %v", err)
 	}
 	if len(results) != 1 || results[0].SourceFile != "MEMORY.md" {
-		t.Fatalf("expected lexical hit from unembedded index, got %+v", results)
+		t.Fatalf("expected lexical result from nil-embedder index, got %+v", results)
 	}
 }
 

--- a/internal/memory/manager.go
+++ b/internal/memory/manager.go
@@ -43,18 +43,21 @@ func NewMemoryManager(client *EmbeddingClient, store *MemoryStore, opts ...Memor
 	return manager
 }
 
-// Search searches indexed markdown chunks by semantic similarity.
+// Search searches indexed markdown chunks using hybrid lexical/vector ranking.
 func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
-	if m.client == nil || m.store == nil {
+	if m == nil || m.store == nil {
 		return nil, fmt.Errorf("memory manager is not fully configured")
 	}
 
-	queryEmbedding, err := m.client.GetEmbedding(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate query embedding: %w", err)
+	var queryEmbedding []float32
+	if m.client != nil {
+		embedding, err := m.client.GetEmbedding(ctx, query)
+		if err == nil {
+			queryEmbedding = embedding
+		}
 	}
 
-	results, err := m.store.SearchChunks(ctx, queryEmbedding, topK)
+	results, err := m.store.SearchChunksHybrid(ctx, query, queryEmbedding, topK)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search memory chunks: %w", err)
 	}
@@ -66,7 +69,7 @@ func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]M
 // include all chunks from the same branch (source_file + header_path).
 // This gives full section context without replaying the entire history.
 func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
-	if m.client == nil || m.store == nil {
+	if m == nil || m.store == nil {
 		return nil, fmt.Errorf("memory manager is not fully configured")
 	}
 
@@ -81,12 +84,12 @@ func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK i
 	type branch struct{ file, header string }
 	var branches []branch
 	seen := make(map[branch]bool)
-	bestScores := make(map[branch]float32)
+	bestByBranch := make(map[branch]MemoryResult)
 
 	for _, h := range hits {
 		b := branch{h.SourceFile, h.HeaderPath}
-		if h.Similarity > bestScores[b] {
-			bestScores[b] = h.Similarity
+		if best, ok := bestByBranch[b]; !ok || h.Score > best.Score {
+			bestByBranch[b] = h
 		}
 		if !seen[b] {
 			seen[b] = true
@@ -106,12 +109,24 @@ func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK i
 			texts[i] = c.Content
 		}
 
+		best := bestByBranch[b]
 		expanded = append(expanded, MemoryResult{
-			Source:     b.file,
-			SourceFile: b.file,
-			HeaderPath: b.header,
-			Content:    strings.Join(texts, "\n\n"),
-			Similarity: bestScores[b],
+			ID:           best.ID,
+			Source:       b.file,
+			SourceFile:   b.file,
+			HeaderPath:   b.header,
+			StartLine:    best.StartLine,
+			EndLine:      best.EndLine,
+			ChunkOrdinal: best.ChunkOrdinal,
+			Content:      strings.Join(texts, "\n\n"),
+			ContentHash:  best.ContentHash,
+			Similarity:   best.Similarity,
+			Score:        best.Score,
+			LexicalScore: best.LexicalScore,
+			VectorScore:  best.VectorScore,
+			HybridScore:  best.HybridScore,
+			UpdatedAt:    best.UpdatedAt,
+			IndexedAt:    best.IndexedAt,
 		})
 	}
 

--- a/internal/memory/manager.go
+++ b/internal/memory/manager.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+// EmbeddingQueryClient produces one embedding for a search query.
+type EmbeddingQueryClient interface {
+	GetEmbedding(ctx context.Context, text string) ([]float32, error)
+}
+
 // MetadataExtractor extracts structured metadata from raw memory content.
 // Kept for API compatibility, but Remember() is deprecated in memory v2.
 type MetadataExtractor interface {
@@ -14,7 +19,7 @@ type MetadataExtractor interface {
 
 // MemoryManager coordinates embeddings and indexed markdown memory chunk search.
 type MemoryManager struct {
-	client    *EmbeddingClient
+	client    EmbeddingQueryClient
 	store     *MemoryStore
 	extractor MetadataExtractor
 }
@@ -30,7 +35,7 @@ func WithMetadataExtractor(extractor MetadataExtractor) MemoryManagerOption {
 }
 
 // NewMemoryManager creates a new memory manager.
-func NewMemoryManager(client *EmbeddingClient, store *MemoryStore, opts ...MemoryManagerOption) *MemoryManager {
+func NewMemoryManager(client EmbeddingQueryClient, store *MemoryStore, opts ...MemoryManagerOption) *MemoryManager {
 	manager := &MemoryManager{
 		client: client,
 		store:  store,
@@ -43,21 +48,24 @@ func NewMemoryManager(client *EmbeddingClient, store *MemoryStore, opts ...Memor
 	return manager
 }
 
-// Search searches indexed markdown chunks using hybrid lexical/vector ranking.
+// Search searches indexed markdown chunks with hybrid lexical and semantic ranking.
 func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
 	if m == nil || m.store == nil {
-		return nil, fmt.Errorf("memory manager is not fully configured")
+		return nil, fmt.Errorf("memory manager is not configured")
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, fmt.Errorf("memory search query is empty")
 	}
 
 	var queryEmbedding []float32
 	if m.client != nil {
-		embedding, err := m.client.GetEmbedding(ctx, query)
-		if err == nil {
+		if embedding, err := m.client.GetEmbedding(ctx, query); err == nil {
 			queryEmbedding = embedding
 		}
 	}
 
-	results, err := m.store.SearchChunksHybrid(ctx, query, queryEmbedding, topK)
+	results, err := m.store.SearchHybrid(ctx, query, queryEmbedding, topK)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search memory chunks: %w", err)
 	}
@@ -70,7 +78,7 @@ func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]M
 // This gives full section context without replaying the entire history.
 func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
 	if m == nil || m.store == nil {
-		return nil, fmt.Errorf("memory manager is not fully configured")
+		return nil, fmt.Errorf("memory manager is not configured")
 	}
 
 	hits, err := m.Search(ctx, query, topK)
@@ -84,12 +92,12 @@ func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK i
 	type branch struct{ file, header string }
 	var branches []branch
 	seen := make(map[branch]bool)
-	bestByBranch := make(map[branch]MemoryResult)
+	bestScores := make(map[branch]float32)
 
 	for _, h := range hits {
 		b := branch{h.SourceFile, h.HeaderPath}
-		if best, ok := bestByBranch[b]; !ok || h.Score > best.Score {
-			bestByBranch[b] = h
+		if h.Similarity > bestScores[b] {
+			bestScores[b] = h.Similarity
 		}
 		if !seen[b] {
 			seen[b] = true
@@ -109,24 +117,12 @@ func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK i
 			texts[i] = c.Content
 		}
 
-		best := bestByBranch[b]
 		expanded = append(expanded, MemoryResult{
-			ID:           best.ID,
-			Source:       b.file,
-			SourceFile:   b.file,
-			HeaderPath:   b.header,
-			StartLine:    best.StartLine,
-			EndLine:      best.EndLine,
-			ChunkOrdinal: best.ChunkOrdinal,
-			Content:      strings.Join(texts, "\n\n"),
-			ContentHash:  best.ContentHash,
-			Similarity:   best.Similarity,
-			Score:        best.Score,
-			LexicalScore: best.LexicalScore,
-			VectorScore:  best.VectorScore,
-			HybridScore:  best.HybridScore,
-			UpdatedAt:    best.UpdatedAt,
-			IndexedAt:    best.IndexedAt,
+			Source:     b.file,
+			SourceFile: b.file,
+			HeaderPath: b.header,
+			Content:    strings.Join(texts, "\n\n"),
+			Similarity: bestScores[b],
 		})
 	}
 

--- a/internal/memory/search.go
+++ b/internal/memory/search.go
@@ -344,7 +344,7 @@ func resolveMemoryChunkColumns(ctx context.Context, db *sql.DB) (memoryChunkColu
 	}
 
 	columns := memoryChunkColumns{
-		File:      pickColumn(available, "file", "file_path", "filepath", "path"),
+		File:      pickColumn(available, "source_file", "file", "file_path", "filepath", "path"),
 		Header:    pickColumn(available, "header_path", "heading_path", "section_path", "header"),
 		Ordinal:   pickColumn(available, "chunk_ordinal", "ordinal", "chunk_order"),
 		Text:      pickColumn(available, "text", "chunk_text", "content"),

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -7,13 +7,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"sort"
 	"strings"
 	"time"
 )
 
 const (
 	memoryChunksTable     = "memory_chunks"
+	memoryChunksFTSTable  = "memory_chunks_fts"
 	defaultMigratedSource = "legacy://migrated"
 	defaultHeaderPath     = "root"
 )
@@ -31,9 +31,13 @@ type MemoryResult struct {
 	EndLine      int `json:"end_line"`
 	ChunkOrdinal int `json:"chunk_ordinal"`
 
-	Content     string  `json:"content"`
-	ContentHash string  `json:"content_hash"`
-	Similarity  float32 `json:"similarity"`
+	Content      string  `json:"content"`
+	ContentHash  string  `json:"content_hash"`
+	Similarity   float32 `json:"similarity"`
+	Score        float32 `json:"score"`
+	LexicalScore float32 `json:"lexical_score"`
+	VectorScore  float32 `json:"vector_score"`
+	HybridScore  float32 `json:"hybrid_score"`
 
 	UpdatedAt time.Time `json:"updated_at"`
 	IndexedAt time.Time `json:"indexed_at"`
@@ -42,7 +46,8 @@ type MemoryResult struct {
 // MemoryStore handles storage and retrieval of memory chunks with embeddings.
 // Markdown files are the source of truth; SQLite is index-only.
 type MemoryStore struct {
-	db *sql.DB
+	db           *sql.DB
+	ftsAvailable bool
 }
 
 // NewMemoryStore creates a new memory store.
@@ -99,6 +104,11 @@ func (s *MemoryStore) migrate() error {
 
 	if err := s.ensureChunksIndexes(); err != nil {
 		return err
+	}
+	if err := s.ensureChunksFTS(); err != nil {
+		s.ftsAvailable = false
+	} else {
+		s.ftsAvailable = true
 	}
 	return nil
 }
@@ -384,80 +394,6 @@ func (s *MemoryStore) nextOrdinal(ctx context.Context, sourceFile, headerPath st
 	return next, err
 }
 
-// SearchChunks finds the most similar indexed chunks using cosine similarity.
-func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
-	if topK <= 0 {
-		topK = 5
-	}
-
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
-		FROM memory_chunks
-		ORDER BY indexed_at DESC
-	`)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query memory chunks: %w", err)
-	}
-	defer rows.Close()
-
-	var results []MemoryResult
-	for rows.Next() {
-		var (
-			id           int64
-			sourceFile   string
-			headerPath   string
-			chunkOrdinal int
-			content      string
-			contentHash  string
-			embeddingRaw []byte
-			indexedAt    time.Time
-		)
-
-		if err := rows.Scan(
-			&id,
-			&sourceFile,
-			&headerPath,
-			&chunkOrdinal,
-			&content,
-			&contentHash,
-			&embeddingRaw,
-			&indexedAt,
-		); err != nil {
-			continue
-		}
-
-		embedding, err := decodeEmbedding(embeddingRaw)
-		if err != nil {
-			continue
-		}
-
-		similarity := cosineSimilarity(queryEmbedding, embedding)
-		results = append(results, MemoryResult{
-			ID:           id,
-			Source:       sourceFile,
-			SourceFile:   sourceFile,
-			HeaderPath:   headerPath,
-			StartLine:    chunkOrdinal,
-			EndLine:      chunkOrdinal,
-			ChunkOrdinal: chunkOrdinal,
-			Content:      content,
-			ContentHash:  contentHash,
-			Similarity:   similarity,
-			UpdatedAt:    indexedAt,
-			IndexedAt:    indexedAt,
-		})
-	}
-
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Similarity > results[j].Similarity
-	})
-
-	if len(results) > topK {
-		results = results[:topK]
-	}
-	return results, nil
-}
-
 // GetBranchChunks loads all chunks for a specific (sourceFile, headerPath) branch,
 // ordered by chunk_ordinal. Used by branch expansion to reconstruct full sections.
 func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPath string) ([]MemoryResult, error) {
@@ -490,6 +426,8 @@ func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPat
 			Source:       sf,
 			SourceFile:   sf,
 			HeaderPath:   hp,
+			StartLine:    ordinal,
+			EndLine:      ordinal,
 			ChunkOrdinal: ordinal,
 			Content:      content,
 			ContentHash:  hash,
@@ -498,11 +436,6 @@ func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPat
 		})
 	}
 	return results, rows.Err()
-}
-
-// Search is kept as a compatibility alias for callers that still use the old name.
-func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
-	return s.SearchChunks(ctx, queryEmbedding, topK)
 }
 
 // Save is deprecated in v2 where markdown is canonical.
@@ -577,6 +510,9 @@ func cosineSimilarity(a, b []float32) float32 {
 
 // encodeEmbedding converts a float32 slice to binary format.
 func encodeEmbedding(embedding []float32) ([]byte, error) {
+	if len(embedding) == 0 {
+		return []byte{}, nil
+	}
 	buf := new(bytes.Buffer)
 	if err := binary.Write(buf, binary.LittleEndian, embedding); err != nil {
 		return nil, err

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -33,11 +33,12 @@ type MemoryResult struct {
 
 	Content      string  `json:"content"`
 	ContentHash  string  `json:"content_hash"`
-	Similarity   float32 `json:"similarity"`
 	Score        float32 `json:"score"`
-	LexicalScore float32 `json:"lexical_score"`
-	VectorScore  float32 `json:"vector_score"`
-	HybridScore  float32 `json:"hybrid_score"`
+	Similarity   float32 `json:"similarity"`
+	LexicalScore float32 `json:"lexical_score,omitempty"`
+	VectorScore  float32 `json:"vector_score,omitempty"`
+	HybridScore  float32 `json:"hybrid_score,omitempty"`
+	BM25         float64 `json:"bm25,omitempty"`
 
 	UpdatedAt time.Time `json:"updated_at"`
 	IndexedAt time.Time `json:"indexed_at"`
@@ -105,11 +106,11 @@ func (s *MemoryStore) migrate() error {
 	if err := s.ensureChunksIndexes(); err != nil {
 		return err
 	}
-	if err := s.ensureChunksFTS(); err != nil {
-		s.ftsAvailable = false
-	} else {
-		s.ftsAvailable = true
+	ftsAvailable, err := s.ensureChunksFTS()
+	if err != nil {
+		return err
 	}
+	s.ftsAvailable = ftsAvailable
 	return nil
 }
 
@@ -394,6 +395,11 @@ func (s *MemoryStore) nextOrdinal(ctx context.Context, sourceFile, headerPath st
 	return next, err
 }
 
+// SearchChunks finds semantically similar indexed chunks using a bounded vector candidate pool.
+func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+	return s.SearchHybrid(ctx, "", queryEmbedding, topK)
+}
+
 // GetBranchChunks loads all chunks for a specific (sourceFile, headerPath) branch,
 // ordered by chunk_ordinal. Used by branch expansion to reconstruct full sections.
 func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPath string) ([]MemoryResult, error) {
@@ -426,8 +432,6 @@ func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPat
 			Source:       sf,
 			SourceFile:   sf,
 			HeaderPath:   hp,
-			StartLine:    ordinal,
-			EndLine:      ordinal,
 			ChunkOrdinal: ordinal,
 			Content:      content,
 			ContentHash:  hash,
@@ -436,6 +440,11 @@ func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPat
 		})
 	}
 	return results, rows.Err()
+}
+
+// Search is kept as a compatibility alias for callers that still use the old name.
+func (s *MemoryStore) Search(ctx context.Context, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+	return s.SearchChunks(ctx, queryEmbedding, topK)
 }
 
 // Save is deprecated in v2 where markdown is canonical.
@@ -522,10 +531,5 @@ func encodeEmbedding(embedding []float32) ([]byte, error) {
 
 // decodeEmbedding converts binary data back to a float32 slice.
 func decodeEmbedding(data []byte) ([]float32, error) {
-	buf := bytes.NewReader(data)
-	embedding := make([]float32, len(data)/4)
-	if err := binary.Read(buf, binary.LittleEndian, &embedding); err != nil {
-		return nil, err
-	}
-	return embedding, nil
+	return decodeChunkEmbedding(data)
 }

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -230,7 +230,7 @@ func TestMemoryStoreMigrateRecreatesLegacyMemoryChunksSchema(t *testing.T) {
 		t.Fatalf("NewMemoryStore failed: %v", err)
 	}
 
-	if err := store.IndexChunk(context.Background(), "MEMORY.md", "root", 1, 2, "content", []float32{1, 0}); err != nil {
+	if err := store.IndexChunk(context.Background(), "MEMORY.md", "root", 2, 3, "content", []float32{1, 0}); err != nil {
 		t.Fatalf("IndexChunk failed after migration: %v", err)
 	}
 
@@ -242,6 +242,35 @@ func TestMemoryStoreMigrateRecreatesLegacyMemoryChunksSchema(t *testing.T) {
 	}
 	if hasSourceFile != 1 {
 		t.Fatalf("expected migrated memory_chunks table to contain source_file column")
+	}
+
+	results, err := store.SearchChunksHybrid(context.Background(), "legacy", nil, 5)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed after migration: %v", err)
+	}
+	if len(results) == 0 || results[0].SourceFile != "MEMORY.md" {
+		t.Fatalf("expected migrated legacy chunk to be searchable, got %+v", results)
+	}
+}
+
+func TestMemoryStoreCreatesFTSIndexWhenAvailable(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+	if !store.ftsAvailable {
+		t.Skip("sqlite FTS5 is unavailable in this build")
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE name = ?`, memoryChunksFTSTable).Scan(&count); err != nil {
+		t.Fatalf("failed to inspect FTS table: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected %s to exist", memoryChunksFTSTable)
 	}
 }
 
@@ -305,6 +334,160 @@ func TestMemoryStoreSearchChunks(t *testing.T) {
 	}
 	if got.Similarity <= 0 {
 		t.Fatalf("expected positive similarity, got %f", got.Similarity)
+	}
+}
+
+func TestMemoryStoreSearchChunksLexicalOnlyWithoutEmbedding(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.IndexChunk(ctx, "MEMORY.md", "People > Alice", 0, 0, "Alice likes espresso and ristretto.", nil); err != nil {
+		t.Fatalf("failed to index lexical chunk: %v", err)
+	}
+	if err := store.IndexChunk(ctx, "memory/other.md", "Journal", 0, 0, "Walked the dog after lunch.", nil); err != nil {
+		t.Fatalf("failed to index unrelated chunk: %v", err)
+	}
+
+	results, err := store.SearchChunksHybrid(ctx, "espresso", nil, 5)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 lexical result, got %d (%+v)", len(results), results)
+	}
+	if results[0].SourceFile != "MEMORY.md" {
+		t.Fatalf("unexpected lexical source: %s", results[0].SourceFile)
+	}
+	if results[0].LexicalScore <= 0 || results[0].Score <= 0 {
+		t.Fatalf("expected lexical score components, got %+v", results[0])
+	}
+	if results[0].VectorScore != 0 {
+		t.Fatalf("expected no vector score without embeddings, got %+v", results[0])
+	}
+	if results[0].ChunkOrdinal != 0 {
+		t.Fatalf("expected stable chunk ordinal 0, got %d", results[0].ChunkOrdinal)
+	}
+}
+
+func TestMemoryManagerSearchLexicalOnlyWithoutEmbeddingProvider(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+	if err := store.IndexChunk(context.Background(), "MEMORY.md", "Preferences", 0, 0, "Favorite drink: espresso.", nil); err != nil {
+		t.Fatalf("failed to index chunk: %v", err)
+	}
+
+	manager := NewMemoryManager(nil, store)
+	results, err := manager.Search(context.Background(), "espresso", 3)
+	if err != nil {
+		t.Fatalf("manager Search failed: %v", err)
+	}
+	if len(results) != 1 || results[0].SourceFile != "MEMORY.md" {
+		t.Fatalf("expected lexical-only manager hit, got %+v", results)
+	}
+}
+
+func TestMemoryStoreSearchChunksSemanticOnlyWhenFTSUnavailable(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+	store.ftsAvailable = false
+
+	ctx := context.Background()
+	if err := store.IndexChunk(ctx, "memory/semantic.md", "Ideas", 0, 0, "Codename notes with no query words.", []float32{1, 0}); err != nil {
+		t.Fatalf("failed to index semantic chunk: %v", err)
+	}
+	if err := store.IndexChunk(ctx, "memory/other.md", "Ideas", 0, 0, "Unrelated text.", []float32{-1, 0}); err != nil {
+		t.Fatalf("failed to index unrelated chunk: %v", err)
+	}
+
+	results, err := store.SearchChunksHybrid(ctx, "tokens absent from content", []float32{1, 0}, 1)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 semantic result, got %d", len(results))
+	}
+	if results[0].SourceFile != "memory/semantic.md" {
+		t.Fatalf("unexpected semantic source: %+v", results[0])
+	}
+	if results[0].VectorScore < 0.99 || results[0].LexicalScore != 0 {
+		t.Fatalf("expected semantic-only score components, got %+v", results[0])
+	}
+}
+
+func TestMemoryStoreSearchChunksHybridReranksLexicalAndSemanticCandidates(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.IndexChunk(ctx, "memory/lexical.md", "Launch", 0, 0, "Phoenix launch checklist and rollout notes.", []float32{-1, 0}); err != nil {
+		t.Fatalf("failed to index lexical chunk: %v", err)
+	}
+	if err := store.IndexChunk(ctx, "memory/semantic.md", "Launch", 0, 0, "Roadmap notes for the codename initiative.", []float32{1, 0}); err != nil {
+		t.Fatalf("failed to index semantic chunk: %v", err)
+	}
+
+	results, err := store.SearchChunksHybrid(ctx, "phoenix launch", []float32{1, 0}, 2)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 hybrid results, got %d (%+v)", len(results), results)
+	}
+	if results[0].SourceFile != "memory/semantic.md" {
+		t.Fatalf("expected semantic candidate to rerank first, got %+v", results[0])
+	}
+	if results[0].VectorScore < 0.99 || results[1].LexicalScore <= 0 {
+		t.Fatalf("expected vector and lexical score components, got %+v", results)
+	}
+}
+
+func TestMemoryStoreSearchChunksKeepsLexicalHitWithMalformedVector(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	content := "Malformed embedding row still mentions espresso."
+	if _, err := db.Exec(`
+		INSERT INTO memory_chunks (source_file, header_path, chunk_ordinal, content, content_hash, embedding)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, "memory/bad.md", "Root", 0, content, hashChunkContent(content), []byte{1, 2, 3}); err != nil {
+		t.Fatalf("failed to insert malformed vector row: %v", err)
+	}
+
+	results, err := store.SearchChunksHybrid(context.Background(), "espresso", []float32{1, 0}, 5)
+	if err != nil {
+		t.Fatalf("SearchChunksHybrid failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected malformed-vector lexical hit, got %+v", results)
+	}
+	if results[0].LexicalScore <= 0 || results[0].VectorScore != 0 {
+		t.Fatalf("expected lexical-only score for malformed vector, got %+v", results[0])
 	}
 }
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -475,6 +476,38 @@ func TestMemoryStoreSearchSkipsMalformedVectors(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].SourceFile != "good.md" {
 		t.Fatalf("expected malformed vector to be skipped, got %+v", results)
+	}
+}
+
+func TestMemoryStoreVectorSearchSkipsUnembeddedCandidateRows(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	if err := store.IndexChunk(context.Background(), "embedded.md", "Root", 1, 1, "older embedded vector", []float32{1, 0}); err != nil {
+		t.Fatalf("IndexChunk failed: %v", err)
+	}
+
+	for i := 0; i < memoryVectorCandidateMultiplier+5; i++ {
+		content := fmt.Sprintf("recent unembedded chunk %02d", i)
+		if _, err := db.Exec(`
+			INSERT INTO memory_chunks (source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at)
+			VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		`, "empty.md", "Root", i+1, content, hashChunkContent(content), []byte{}); err != nil {
+			t.Fatalf("failed to insert unembedded chunk: %v", err)
+		}
+	}
+
+	results, err := store.SearchChunks(context.Background(), []float32{1, 0}, 1)
+	if err != nil {
+		t.Fatalf("SearchChunks failed: %v", err)
+	}
+	if len(results) != 1 || results[0].SourceFile != "embedded.md" {
+		t.Fatalf("expected embedded row to survive unembedded candidate pool, got %+v", results)
 	}
 }
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 	"testing"
 
@@ -230,7 +231,7 @@ func TestMemoryStoreMigrateRecreatesLegacyMemoryChunksSchema(t *testing.T) {
 		t.Fatalf("NewMemoryStore failed: %v", err)
 	}
 
-	if err := store.IndexChunk(context.Background(), "MEMORY.md", "root", 2, 3, "content", []float32{1, 0}); err != nil {
+	if err := store.IndexChunk(context.Background(), "MEMORY.md", "root", 1, 2, "content", []float32{1, 0}); err != nil {
 		t.Fatalf("IndexChunk failed after migration: %v", err)
 	}
 
@@ -242,35 +243,6 @@ func TestMemoryStoreMigrateRecreatesLegacyMemoryChunksSchema(t *testing.T) {
 	}
 	if hasSourceFile != 1 {
 		t.Fatalf("expected migrated memory_chunks table to contain source_file column")
-	}
-
-	results, err := store.SearchChunksHybrid(context.Background(), "legacy", nil, 5)
-	if err != nil {
-		t.Fatalf("SearchChunksHybrid failed after migration: %v", err)
-	}
-	if len(results) == 0 || results[0].SourceFile != "MEMORY.md" {
-		t.Fatalf("expected migrated legacy chunk to be searchable, got %+v", results)
-	}
-}
-
-func TestMemoryStoreCreatesFTSIndexWhenAvailable(t *testing.T) {
-	db := openTestDB(t)
-	defer db.Close()
-
-	store, err := NewMemoryStore(db)
-	if err != nil {
-		t.Fatalf("NewMemoryStore failed: %v", err)
-	}
-	if !store.ftsAvailable {
-		t.Skip("sqlite FTS5 is unavailable in this build")
-	}
-
-	var count int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE name = ?`, memoryChunksFTSTable).Scan(&count); err != nil {
-		t.Fatalf("failed to inspect FTS table: %v", err)
-	}
-	if count != 1 {
-		t.Fatalf("expected %s to exist", memoryChunksFTSTable)
 	}
 }
 
@@ -337,7 +309,28 @@ func TestMemoryStoreSearchChunks(t *testing.T) {
 	}
 }
 
-func TestMemoryStoreSearchChunksLexicalOnlyWithoutEmbedding(t *testing.T) {
+func TestMemoryStoreCreatesFTSIndexWhenAvailable(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+	if !store.ftsAvailable {
+		t.Skip("sqlite fts5 is not available in this build")
+	}
+
+	ok, err := store.tableExists(memoryChunksFTSTable)
+	if err != nil {
+		t.Fatalf("tableExists(%q) failed: %v", memoryChunksFTSTable, err)
+	}
+	if !ok {
+		t.Fatalf("expected %s table to exist", memoryChunksFTSTable)
+	}
+}
+
+func TestMemoryStoreSearchTextWorksWithoutEmbeddings(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
@@ -347,35 +340,30 @@ func TestMemoryStoreSearchChunksLexicalOnlyWithoutEmbedding(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	if err := store.IndexChunk(ctx, "MEMORY.md", "People > Alice", 0, 0, "Alice likes espresso and ristretto.", nil); err != nil {
-		t.Fatalf("failed to index lexical chunk: %v", err)
+	if err := store.IndexChunk(ctx, "MEMORY.md", "Projects > Coffee", 7, 8, "Alice keeps espresso calibration notes.", nil); err != nil {
+		t.Fatalf("IndexChunk failed: %v", err)
 	}
-	if err := store.IndexChunk(ctx, "memory/other.md", "Journal", 0, 0, "Walked the dog after lunch.", nil); err != nil {
-		t.Fatalf("failed to index unrelated chunk: %v", err)
+	if err := store.IndexChunk(ctx, "memory/other.md", "Journal", 1, 1, "Walked the dog after lunch.", nil); err != nil {
+		t.Fatalf("IndexChunk failed: %v", err)
 	}
 
-	results, err := store.SearchChunksHybrid(ctx, "espresso", nil, 5)
+	results, err := store.SearchText(ctx, "espresso", 3)
 	if err != nil {
-		t.Fatalf("SearchChunksHybrid failed: %v", err)
+		t.Fatalf("SearchText failed: %v", err)
 	}
 	if len(results) != 1 {
-		t.Fatalf("expected 1 lexical result, got %d (%+v)", len(results), results)
+		t.Fatalf("expected 1 lexical result, got %d", len(results))
 	}
-	if results[0].SourceFile != "MEMORY.md" {
-		t.Fatalf("unexpected lexical source: %s", results[0].SourceFile)
+	got := results[0]
+	if got.SourceFile != "MEMORY.md" || got.HeaderPath != "Projects > Coffee" || got.ChunkOrdinal != 7 {
+		t.Fatalf("unexpected source metadata: %+v", got)
 	}
-	if results[0].LexicalScore <= 0 || results[0].Score <= 0 {
-		t.Fatalf("expected lexical score components, got %+v", results[0])
-	}
-	if results[0].VectorScore != 0 {
-		t.Fatalf("expected no vector score without embeddings, got %+v", results[0])
-	}
-	if results[0].ChunkOrdinal != 0 {
-		t.Fatalf("expected stable chunk ordinal 0, got %d", results[0].ChunkOrdinal)
+	if got.LexicalScore <= 0 || got.VectorScore != 0 {
+		t.Fatalf("unexpected score components: lexical=%f vector=%f", got.LexicalScore, got.VectorScore)
 	}
 }
 
-func TestMemoryManagerSearchLexicalOnlyWithoutEmbeddingProvider(t *testing.T) {
+func TestMemoryManagerFallsBackToLexicalWhenEmbeddingUnavailable(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
@@ -383,21 +371,21 @@ func TestMemoryManagerSearchLexicalOnlyWithoutEmbeddingProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewMemoryStore failed: %v", err)
 	}
-	if err := store.IndexChunk(context.Background(), "MEMORY.md", "Preferences", 0, 0, "Favorite drink: espresso.", nil); err != nil {
-		t.Fatalf("failed to index chunk: %v", err)
+	if err := store.IndexChunk(context.Background(), "MEMORY.md", "Fallback", 1, 1, "Lexical fallback finds espresso.", nil); err != nil {
+		t.Fatalf("IndexChunk failed: %v", err)
 	}
 
-	manager := NewMemoryManager(nil, store)
-	results, err := manager.Search(context.Background(), "espresso", 3)
+	manager := NewMemoryManager(failingQueryEmbedder{}, store)
+	results, err := manager.Search(context.Background(), "espresso", 1)
 	if err != nil {
-		t.Fatalf("manager Search failed: %v", err)
+		t.Fatalf("Search failed: %v", err)
 	}
-	if len(results) != 1 || results[0].SourceFile != "MEMORY.md" {
-		t.Fatalf("expected lexical-only manager hit, got %+v", results)
+	if len(results) != 1 || !strings.Contains(results[0].Content, "espresso") {
+		t.Fatalf("expected lexical fallback result, got %+v", results)
 	}
 }
 
-func TestMemoryStoreSearchChunksSemanticOnlyWhenFTSUnavailable(t *testing.T) {
+func TestMemoryStoreHybridReranksCombinedSignals(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
@@ -405,32 +393,64 @@ func TestMemoryStoreSearchChunksSemanticOnlyWhenFTSUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewMemoryStore failed: %v", err)
 	}
+
+	ctx := context.Background()
+	if err := store.IndexChunk(ctx, "lexical.md", "Root", 1, 1, "phoenix keyword only", []float32{0, 1}); err != nil {
+		t.Fatalf("IndexChunk lexical failed: %v", err)
+	}
+	if err := store.IndexChunk(ctx, "hybrid.md", "Root", 1, 1, "phoenix semantic plan", []float32{1, 0}); err != nil {
+		t.Fatalf("IndexChunk hybrid failed: %v", err)
+	}
+	if err := store.IndexChunk(ctx, "semantic.md", "Root", 1, 1, "semantic plan without the keyword", []float32{1, 0}); err != nil {
+		t.Fatalf("IndexChunk semantic failed: %v", err)
+	}
+
+	results, err := store.SearchHybrid(ctx, "phoenix", []float32{1, 0}, 3)
+	if err != nil {
+		t.Fatalf("SearchHybrid failed: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected hybrid results")
+	}
+	if results[0].SourceFile != "hybrid.md" {
+		t.Fatalf("expected combined lexical+semantic hit first, got %+v", results)
+	}
+	if results[0].LexicalScore <= 0 || results[0].VectorScore <= 0 || results[0].HybridScore <= 0 {
+		t.Fatalf("expected score components on top result, got %+v", results[0])
+	}
+}
+
+func TestMemoryStoreSemanticOnlyWhenFTSUnavailable(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.IndexChunk(ctx, "lexical.md", "Root", 1, 1, "espresso exact lexical hit", []float32{0, 1}); err != nil {
+		t.Fatalf("IndexChunk lexical failed: %v", err)
+	}
+	if err := store.IndexChunk(ctx, "semantic.md", "Root", 1, 1, "tea note with semantic vector", []float32{1, 0}); err != nil {
+		t.Fatalf("IndexChunk semantic failed: %v", err)
+	}
+
 	store.ftsAvailable = false
-
-	ctx := context.Background()
-	if err := store.IndexChunk(ctx, "memory/semantic.md", "Ideas", 0, 0, "Codename notes with no query words.", []float32{1, 0}); err != nil {
-		t.Fatalf("failed to index semantic chunk: %v", err)
-	}
-	if err := store.IndexChunk(ctx, "memory/other.md", "Ideas", 0, 0, "Unrelated text.", []float32{-1, 0}); err != nil {
-		t.Fatalf("failed to index unrelated chunk: %v", err)
-	}
-
-	results, err := store.SearchChunksHybrid(ctx, "tokens absent from content", []float32{1, 0}, 1)
+	results, err := store.SearchChunks(ctx, []float32{1, 0}, 1)
 	if err != nil {
-		t.Fatalf("SearchChunksHybrid failed: %v", err)
+		t.Fatalf("SearchChunks failed: %v", err)
 	}
-	if len(results) != 1 {
-		t.Fatalf("expected 1 semantic result, got %d", len(results))
+	if len(results) != 1 || results[0].SourceFile != "semantic.md" {
+		t.Fatalf("expected semantic-only result when FTS is unavailable, got %+v", results)
 	}
-	if results[0].SourceFile != "memory/semantic.md" {
-		t.Fatalf("unexpected semantic source: %+v", results[0])
-	}
-	if results[0].VectorScore < 0.99 || results[0].LexicalScore != 0 {
-		t.Fatalf("expected semantic-only score components, got %+v", results[0])
+	if results[0].LexicalScore != 0 || results[0].VectorScore <= 0 {
+		t.Fatalf("unexpected score components: %+v", results[0])
 	}
 }
 
-func TestMemoryStoreSearchChunksHybridReranksLexicalAndSemanticCandidates(t *testing.T) {
+func TestMemoryStoreSearchSkipsMalformedVectors(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
@@ -439,55 +459,60 @@ func TestMemoryStoreSearchChunksHybridReranksLexicalAndSemanticCandidates(t *tes
 		t.Fatalf("NewMemoryStore failed: %v", err)
 	}
 
-	ctx := context.Background()
-	if err := store.IndexChunk(ctx, "memory/lexical.md", "Launch", 0, 0, "Phoenix launch checklist and rollout notes.", []float32{-1, 0}); err != nil {
-		t.Fatalf("failed to index lexical chunk: %v", err)
-	}
-	if err := store.IndexChunk(ctx, "memory/semantic.md", "Launch", 0, 0, "Roadmap notes for the codename initiative.", []float32{1, 0}); err != nil {
-		t.Fatalf("failed to index semantic chunk: %v", err)
-	}
-
-	results, err := store.SearchChunksHybrid(ctx, "phoenix launch", []float32{1, 0}, 2)
-	if err != nil {
-		t.Fatalf("SearchChunksHybrid failed: %v", err)
-	}
-	if len(results) != 2 {
-		t.Fatalf("expected 2 hybrid results, got %d (%+v)", len(results), results)
-	}
-	if results[0].SourceFile != "memory/semantic.md" {
-		t.Fatalf("expected semantic candidate to rerank first, got %+v", results[0])
-	}
-	if results[0].VectorScore < 0.99 || results[1].LexicalScore <= 0 {
-		t.Fatalf("expected vector and lexical score components, got %+v", results)
-	}
-}
-
-func TestMemoryStoreSearchChunksKeepsLexicalHitWithMalformedVector(t *testing.T) {
-	db := openTestDB(t)
-	defer db.Close()
-
-	store, err := NewMemoryStore(db)
-	if err != nil {
-		t.Fatalf("NewMemoryStore failed: %v", err)
-	}
-
-	content := "Malformed embedding row still mentions espresso."
 	if _, err := db.Exec(`
-		INSERT INTO memory_chunks (source_file, header_path, chunk_ordinal, content, content_hash, embedding)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, "memory/bad.md", "Root", 0, content, hashChunkContent(content), []byte{1, 2, 3}); err != nil {
-		t.Fatalf("failed to insert malformed vector row: %v", err)
+		INSERT INTO memory_chunks (source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	`, "bad.md", "Root", 1, "bad vector", hashChunkContent("bad vector"), []byte{1, 2, 3}); err != nil {
+		t.Fatalf("failed to insert malformed vector: %v", err)
+	}
+	if err := store.IndexChunk(context.Background(), "good.md", "Root", 1, 1, "good vector", []float32{1, 0}); err != nil {
+		t.Fatalf("IndexChunk failed: %v", err)
 	}
 
-	results, err := store.SearchChunksHybrid(context.Background(), "espresso", []float32{1, 0}, 5)
+	results, err := store.SearchChunks(context.Background(), []float32{1, 0}, 2)
 	if err != nil {
-		t.Fatalf("SearchChunksHybrid failed: %v", err)
+		t.Fatalf("SearchChunks failed: %v", err)
 	}
-	if len(results) != 1 {
-		t.Fatalf("expected malformed-vector lexical hit, got %+v", results)
+	if len(results) != 1 || results[0].SourceFile != "good.md" {
+		t.Fatalf("expected malformed vector to be skipped, got %+v", results)
 	}
-	if results[0].LexicalScore <= 0 || results[0].VectorScore != 0 {
-		t.Fatalf("expected lexical-only score for malformed vector, got %+v", results[0])
+}
+
+func TestMemoryStoreSearchTextFindsExistingRowsAfterMigration(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE memory_chunks (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		source_file TEXT NOT NULL,
+		header_path TEXT NOT NULL,
+		chunk_ordinal INTEGER NOT NULL DEFAULT 0,
+		content TEXT NOT NULL,
+		content_hash TEXT NOT NULL,
+		embedding BLOB NOT NULL,
+		indexed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(source_file, header_path, chunk_ordinal)
+	);`); err != nil {
+		t.Fatalf("failed to create current memory_chunks table: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO memory_chunks (source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at)
+		VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	`, "MEMORY.md", "Migrated", 3, "backfilled lexical migration row", hashChunkContent("backfilled lexical migration row"), []byte{}); err != nil {
+		t.Fatalf("failed to seed current memory_chunks row: %v", err)
+	}
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	results, err := store.SearchText(context.Background(), "backfilled", 1)
+	if err != nil {
+		t.Fatalf("SearchText failed: %v", err)
+	}
+	if len(results) != 1 || results[0].SourceFile != "MEMORY.md" || results[0].HeaderPath != "Migrated" {
+		t.Fatalf("expected migrated lexical row, got %+v", results)
 	}
 }
 
@@ -509,6 +534,12 @@ func TestMemoryStoreLegacyMutationsAreDeprecated(t *testing.T) {
 	if _, err := store.List(10); err == nil || !strings.Contains(err.Error(), "deprecated") {
 		t.Fatalf("expected deprecated list error, got %v", err)
 	}
+}
+
+type failingQueryEmbedder struct{}
+
+func (f failingQueryEmbedder) GetEmbedding(context.Context, string) ([]float32, error) {
+	return nil, errors.New("embedding provider unavailable")
 }
 
 func openTestDB(t *testing.T) *sql.DB {

--- a/internal/memorymcp/server.go
+++ b/internal/memorymcp/server.go
@@ -178,11 +178,10 @@ func (s *Server) handleMemorySearch(ctx context.Context, request mcp.CallToolReq
 		SourceFile   string  `json:"source_file"`
 		HeaderPath   string  `json:"header_path"`
 		ChunkOrdinal int     `json:"chunk_ordinal"`
-		Score        float32 `json:"score"`
-		LexicalScore float32 `json:"lexical_score"`
-		VectorScore  float32 `json:"vector_score"`
-		HybridScore  float32 `json:"hybrid_score"`
 		Similarity   float32 `json:"similarity"`
+		LexicalScore float32 `json:"lexical_score,omitempty"`
+		VectorScore  float32 `json:"vector_score,omitempty"`
+		HybridScore  float32 `json:"hybrid_score,omitempty"`
 		UpdatedAt    string  `json:"updated_at"`
 	}
 
@@ -195,11 +194,10 @@ func (s *Server) handleMemorySearch(ctx context.Context, request mcp.CallToolReq
 			SourceFile:   r.SourceFile,
 			HeaderPath:   r.HeaderPath,
 			ChunkOrdinal: r.ChunkOrdinal,
-			Score:        r.Score,
+			Similarity:   r.Similarity,
 			LexicalScore: r.LexicalScore,
 			VectorScore:  r.VectorScore,
 			HybridScore:  r.HybridScore,
-			Similarity:   r.Similarity,
 			UpdatedAt:    r.UpdatedAt.Format(time.RFC3339),
 		})
 	}

--- a/internal/memorymcp/server.go
+++ b/internal/memorymcp/server.go
@@ -172,23 +172,35 @@ func (s *Server) handleMemorySearch(ctx context.Context, request mcp.CallToolReq
 	}
 
 	type searchResult struct {
-		ID         int64   `json:"id"`
-		Content    string  `json:"content"`
-		Source     string  `json:"source"`
-		HeaderPath string  `json:"header_path"`
-		Similarity float32 `json:"similarity"`
-		UpdatedAt  string  `json:"updated_at"`
+		ID           int64   `json:"id"`
+		Content      string  `json:"content"`
+		Source       string  `json:"source"`
+		SourceFile   string  `json:"source_file"`
+		HeaderPath   string  `json:"header_path"`
+		ChunkOrdinal int     `json:"chunk_ordinal"`
+		Score        float32 `json:"score"`
+		LexicalScore float32 `json:"lexical_score"`
+		VectorScore  float32 `json:"vector_score"`
+		HybridScore  float32 `json:"hybrid_score"`
+		Similarity   float32 `json:"similarity"`
+		UpdatedAt    string  `json:"updated_at"`
 	}
 
 	out := make([]searchResult, 0, len(results))
 	for _, r := range results {
 		out = append(out, searchResult{
-			ID:         r.ID,
-			Content:    r.Content,
-			Source:     r.Source,
-			HeaderPath: r.HeaderPath,
-			Similarity: r.Similarity,
-			UpdatedAt:  r.UpdatedAt.Format(time.RFC3339),
+			ID:           r.ID,
+			Content:      r.Content,
+			Source:       r.Source,
+			SourceFile:   r.SourceFile,
+			HeaderPath:   r.HeaderPath,
+			ChunkOrdinal: r.ChunkOrdinal,
+			Score:        r.Score,
+			LexicalScore: r.LexicalScore,
+			VectorScore:  r.VectorScore,
+			HybridScore:  r.HybridScore,
+			Similarity:   r.Similarity,
+			UpdatedAt:    r.UpdatedAt.Format(time.RFC3339),
 		})
 	}
 

--- a/internal/tools/memory_search_tool.go
+++ b/internal/tools/memory_search_tool.go
@@ -9,7 +9,7 @@ import (
 	"ok-gobot/internal/memory"
 )
 
-// MemorySearchTool performs hybrid search over indexed markdown memory chunks.
+// MemorySearchTool performs hybrid lexical and semantic search over indexed markdown memory chunks.
 type MemorySearchTool struct {
 	manager *memory.MemoryManager
 }
@@ -76,16 +76,16 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 		if headerPath == "" {
 			headerPath = "(root)"
 		}
-		source := result.SourceFile
-		if source == "" {
-			source = result.Source
-		}
-		out.WriteString(fmt.Sprintf("%d. Source: %s\n", i+1, source))
+		out.WriteString(fmt.Sprintf("%d. Source: %s\n", i+1, result.Source))
 		out.WriteString(fmt.Sprintf("   Header Path: %s\n", headerPath))
 		if !expand {
+			out.WriteString(fmt.Sprintf("   Lines: %d-%d\n", result.StartLine, result.EndLine))
 			out.WriteString(fmt.Sprintf("   Chunk: %d\n", result.ChunkOrdinal))
 		}
-		out.WriteString(fmt.Sprintf("   Score: %.2f (lexical %.2f, vector %.2f)\n", result.Score, result.LexicalScore, result.VectorScore))
+		out.WriteString(fmt.Sprintf("   Similarity: %.2f\n", result.Similarity))
+		if result.LexicalScore > 0 || result.VectorScore != 0 {
+			out.WriteString(fmt.Sprintf("   Score Components: lexical=%.2f vector=%.2f\n", result.LexicalScore, result.VectorScore))
+		}
 		out.WriteString(fmt.Sprintf("   %s\n\n", result.Content))
 	}
 
@@ -98,7 +98,7 @@ func (m *MemorySearchTool) GetSchema() map[string]interface{} {
 		"properties": map[string]interface{}{
 			"query": map[string]interface{}{
 				"type":        "string",
-				"description": "Natural-language query to search memory chunks lexically and semantically",
+				"description": "Natural-language query to search memory chunks",
 			},
 			"limit": map[string]interface{}{
 				"type":        "integer",

--- a/internal/tools/memory_search_tool.go
+++ b/internal/tools/memory_search_tool.go
@@ -9,7 +9,7 @@ import (
 	"ok-gobot/internal/memory"
 )
 
-// MemorySearchTool performs semantic search over indexed markdown memory chunks.
+// MemorySearchTool performs hybrid search over indexed markdown memory chunks.
 type MemorySearchTool struct {
 	manager *memory.MemoryManager
 }
@@ -24,7 +24,7 @@ func (m *MemorySearchTool) Name() string {
 }
 
 func (m *MemorySearchTool) Description() string {
-	return "Semantic search over indexed markdown memory chunks."
+	return "Hybrid lexical and semantic search over indexed markdown memory chunks."
 }
 
 func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string, error) {
@@ -76,12 +76,16 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 		if headerPath == "" {
 			headerPath = "(root)"
 		}
-		out.WriteString(fmt.Sprintf("%d. Source: %s\n", i+1, result.Source))
+		source := result.SourceFile
+		if source == "" {
+			source = result.Source
+		}
+		out.WriteString(fmt.Sprintf("%d. Source: %s\n", i+1, source))
 		out.WriteString(fmt.Sprintf("   Header Path: %s\n", headerPath))
 		if !expand {
-			out.WriteString(fmt.Sprintf("   Lines: %d-%d\n", result.StartLine, result.EndLine))
+			out.WriteString(fmt.Sprintf("   Chunk: %d\n", result.ChunkOrdinal))
 		}
-		out.WriteString(fmt.Sprintf("   Similarity: %.2f\n", result.Similarity))
+		out.WriteString(fmt.Sprintf("   Score: %.2f (lexical %.2f, vector %.2f)\n", result.Score, result.LexicalScore, result.VectorScore))
 		out.WriteString(fmt.Sprintf("   %s\n\n", result.Content))
 	}
 
@@ -94,7 +98,7 @@ func (m *MemorySearchTool) GetSchema() map[string]interface{} {
 		"properties": map[string]interface{}{
 			"query": map[string]interface{}{
 				"type":        "string",
-				"description": "Natural-language query to search memory chunks",
+				"description": "Natural-language query to search memory chunks lexically and semantically",
 			},
 			"limit": map[string]interface{}{
 				"type":        "integer",


### PR DESCRIPTION
Implements #304

## Changes
- Adds an FTS5-backed memory chunk index with trigger-based sync and migration backfill, with graceful fallback when FTS5 is unavailable.
- Adds hybrid memory retrieval that combines lexical candidates with bounded vector scoring and returns source metadata plus score components.
- Allows lexical indexing/search when embeddings are missing and expands memory_search/MCP output with chunk locators and score details.

## Testing
- bash .maestro/verify.sh
- git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a hybrid memory retrieval backend that combines FTS5/BM25 lexical candidates with bounded vector scoring, adds trigger-based FTS5 sync with graceful fallback, and allows memory indexing and search without embeddings configured. The changes are well-structured with good test coverage across lexical-only, hybrid, and degraded-embedding scenarios.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the previously flagged FTS rebuild-on-startup issue; no new blocking defects found.

The implementation is solid and well-tested. The ceiling is 4/5 due to the P1 FTS rebuild issue already flagged in the previous review round (ensureChunksFTS unconditionally runs an O(n) rebuild on every application start). No new P1 or P0 issues were found in this pass.

internal/memory/fts.go — the unconditional rebuild on startup needs to be conditioned on whether the FTS table was just created.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/memory/hybrid_search.go | New file implementing hybrid FTS5/BM25 + vector search with bounded candidate pools, fallback chains, and RRF-style fusion scoring; vector pool second pass correctly filters un-embedded rows. |
| internal/memory/fts.go | New file adding FTS5 virtual table with trigger-based sync; unconditionally runs O(n) rebuild on every NewMemoryStore call regardless of whether the table already existed (already flagged in previous review). |
| internal/memory/manager.go | Widens client field to EmbeddingQueryClient interface, relaxes nil guard to allow lexical-only operation; embedding errors are silently dropped (already flagged in previous review). |
| internal/memory/store.go | Adds ftsAvailable flag and score fields to MemoryResult; SearchChunks now delegates to SearchHybrid with bounded candidate pool; encodeEmbedding handles nil slices safely. |
| internal/memory/embeddings.go | Adds EmbeddingProviderConfigured gating function and defaults baseURL to OpenAI; NewEmbeddingClient now trims trailing slashes from baseURL. |
| internal/memory/indexer.go | Relaxes nil-embedder guard in IndexFile; embedChangedChunks returns zero-valued embeddings when embedder is nil, enabling lexical-only indexing. |
| internal/memory/store_test.go | Adds comprehensive tests for FTS creation, lexical-only search, hybrid reranking, FTS-unavailable fallback, malformed vector skipping, and migration backfill scenarios. |
| internal/memory/indexer_test.go | Adds test verifying lexical indexing works end-to-end without an embedder configured. |
| internal/memory/search.go | Minimal change: adds source_file as the first candidate column name in resolveMemoryChunkColumns to fix legacy schema resolution. |
| internal/app/app.go | Gates EmbeddingClient construction behind EmbeddingProviderConfigured; allows memory indexer to start without an embedder; updates startup log message. |
| internal/cli/memory.go | CLI memory-index command now proceeds without an embedder when embedding provider is not configured, enabling lexical-only indexing from the command line. |
| internal/memorymcp/server.go | MCP search response enriched with source_file, chunk_ordinal, and score breakdown fields (lexical, vector, hybrid). |
| internal/tools/memory_search_tool.go | Tool output extended with chunk ordinal and score component lines; description updated to reflect hybrid search. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/memory/fts.go`, line 184-190 ([link](https://github.com/befeast/ok-gobot/blob/8c11e6359144bdce5921ff64f5c4c954dcc68f74/internal/memory/fts.go#L184-L190)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **FTS5 rebuild runs on every startup**

   `ensureChunksFTS` unconditionally fires `VALUES('rebuild')` every time `NewMemoryStore` is called, which happens on every application start. The FTS5 `rebuild` command re-indexes every row in `memory_chunks` from scratch — O(n) work — and holds a write lock for the duration. A database with thousands of chunks will noticeably slow startup each time.

   The rebuild is only necessary when the FTS table is newly created to backfill pre-existing rows; once the triggers are in place they keep the index in sync incrementally. The fix is to track whether the table was just created (e.g. check row count before running `CREATE VIRTUAL TABLE`, or return a boolean from the DDL step) and skip the rebuild when the table already existed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/memory/fts.go
   Line: 184-190

   Comment:
   **FTS5 rebuild runs on every startup**

   `ensureChunksFTS` unconditionally fires `VALUES('rebuild')` every time `NewMemoryStore` is called, which happens on every application start. The FTS5 `rebuild` command re-indexes every row in `memory_chunks` from scratch — O(n) work — and holds a write lock for the duration. A database with thousands of chunks will noticeably slow startup each time.

   The rebuild is only necessary when the FTS table is newly created to backfill pre-existing rows; once the triggers are in place they keep the index in sync incrementally. The fix is to track whether the table was just created (e.g. check row count before running `CREATE VIRTUAL TABLE`, or return a boolean from the DDL step) and skip the rebuild when the table already existed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/memory/manager.go`, line 815-819 ([link](https://github.com/befeast/ok-gobot/blob/8c11e6359144bdce5921ff64f5c4c954dcc68f74/internal/memory/manager.go#L815-L819)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Embedding failure silently drops vector ranking**

   When `GetEmbedding` returns an error (transient network failure, rate-limit, expired key), the error is discarded and the search proceeds as lexical-only with no log line or surfaced warning. Callers receive results that look normal but are missing vector ranking, making infrastructure regressions invisible. At minimum the error should be logged so operators can detect when embedding-backed retrieval has degraded silently.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/memory/manager.go
   Line: 815-819

   Comment:
   **Embedding failure silently drops vector ranking**

   When `GetEmbedding` returns an error (transient network failure, rate-limit, expired key), the error is discarded and the search proceeds as lexical-only with no log line or surfaced warning. Callers receive results that look normal but are missing vector ranking, making infrastructure regressions invisible. At minimum the error should be logged so operators can detect when embedding-backed retrieval has degraded silently.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(memory): exclude unembedded vector c..."](https://github.com/befeast/ok-gobot/commit/73396eceade7eb9051d31e39b22f97b4519f76a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30198320)</sub>

<!-- /greptile_comment -->