### PR TITLE
feat(memory): external markdown roots via memory.extra_paths (#308)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ tts:
 memory:
   enabled: false
   embeddings_model: "text-embedding-3-small"
+  # Optional: index Obsidian/shared markdown roots alongside MEMORY.md.
+  # Sources surface as "extra:<name>/..." in memory_search/memory_get.
+  # See docs/MEMORY.md for full options.
+  extra_paths: []
 
 control:
   enabled: false         # disabled by default for security

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -65,6 +65,22 @@ memory:
   embeddings_model: "text-embedding-3-small"
   metadata_extraction: false
   metadata_model: "haiku"  # Lightweight model alias/name for metadata extraction
+  # Extra named markdown roots indexed alongside the primary workspace
+  # (Obsidian vaults, shared-memory exports, HomeLab docs). Sources are
+  # surfaced in memory_search results and memory_get with the prefix
+  # "extra:<name>/...". Hidden directories are skipped. Writes are never
+  # performed automatically.
+  extra_paths: []
+  # Example:
+  # extra_paths:
+  #   - name: "obsidian"
+  #     path: "~/Obsidian/Personal"
+  #     patterns: ["**/*.md"]   # default if omitted
+  #     read_only: true         # default true
+  #     scope: "personal"       # optional human-readable label
+  #   - name: "homelab"
+  #     path: "/mnt/shared/memory/homelab"
+  #     patterns: ["docs/**/*.md", "runbooks/**/*.md"]
   mcp:
     enabled: false       # Optional MCP server for cross-tool memory access
     host: "127.0.0.1"    # Local-only by default

--- a/config.schema.json
+++ b/config.schema.json
@@ -330,6 +330,49 @@
           "default": false,
           "description": "Enable semantic memory index and tools.",
           "type": "boolean"
+        },
+        "extra_paths": {
+          "default": [],
+          "description": "Named markdown roots indexed alongside the workspace memory (Obsidian vaults, shared-memory exports). Sources surface as 'extra:\u003cname\u003e/...' in memory_search and memory_get; missing/unmounted paths are reported in 'memory status' without crashing the bot.",
+          "items": {
+            "additionalProperties": false,
+            "default": {},
+            "description": "One additional markdown collection to index.",
+            "properties": {
+              "name": {
+                "default": "",
+                "description": "Collection identifier; must match [a-z0-9][a-z0-9_-]* and be unique.",
+                "type": "string"
+              },
+              "path": {
+                "default": "",
+                "description": "Absolute or '~/'-prefixed path to the markdown root. NFS/shared mounts supported.",
+                "type": "string"
+              },
+              "patterns": {
+                "default": [],
+                "description": "Glob patterns (relative to path). Defaults to ['**/*.md'] when empty.",
+                "items": {
+                  "default": "",
+                  "description": "Glob pattern; '**' matches any number of path segments.",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "read_only": {
+                "default": true,
+                "description": "Reserved for future write enablement; this issue never performs automatic writes.",
+                "type": "boolean"
+              },
+              "scope": {
+                "default": "",
+                "description": "Optional human-readable scope label, e.g. 'obsidian' or 'homelab'.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
         }
       },
       "type": "object"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -431,6 +431,48 @@ single source of truth for configuration keys, types, defaults, and descriptions
           "type": "string",
           "default": "text-embedding-3-small",
           "description": "Embeddings model identifier."
+        },
+        "extra_paths": {
+          "type": "array",
+          "default": [],
+          "description": "Named markdown roots indexed alongside the workspace memory (Obsidian vaults, shared-memory exports). Sources surface as 'extra:<name>/...' in memory_search and memory_get; missing/unmounted paths are reported in 'memory status' without crashing the bot.",
+          "items": {
+            "type": "object",
+            "default": {},
+            "description": "One additional markdown collection to index.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "default": "",
+                "description": "Collection identifier; must match [a-z0-9][a-z0-9_-]* and be unique."
+              },
+              "path": {
+                "type": "string",
+                "default": "",
+                "description": "Absolute or '~/'-prefixed path to the markdown root. NFS/shared mounts supported."
+              },
+              "patterns": {
+                "type": "array",
+                "default": [],
+                "description": "Glob patterns (relative to path). Defaults to ['**/*.md'] when empty.",
+                "items": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Glob pattern; '**' matches any number of path segments."
+                }
+              },
+              "read_only": {
+                "type": "boolean",
+                "default": true,
+                "description": "Reserved for future write enablement; this issue never performs automatic writes."
+              },
+              "scope": {
+                "type": "string",
+                "default": "",
+                "description": "Optional human-readable scope label, e.g. 'obsidian' or 'homelab'."
+              }
+            }
+          }
         }
       }
     },

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -28,6 +28,15 @@ memory:
   embeddings_model: "text-embedding-3-small"
   metadata_extraction: false
   metadata_model: "haiku"
+  extra_paths:
+    - name: "obsidian"
+      path: "~/Obsidian/Personal"
+      patterns: ["**/*.md"]   # default if omitted
+      read_only: true         # default true
+      scope: "personal"
+    - name: "homelab"
+      path: "/mnt/shared/memory/homelab"
+      patterns: ["docs/**/*.md", "runbooks/**/*.md"]
   mcp:
     enabled: false
     host: "127.0.0.1"
@@ -44,9 +53,43 @@ memory:
 - **embeddings_model**: Embedding model to use (default: `text-embedding-3-small`)
 - **metadata_extraction**: When `true`, extracts structured metadata (`people/topics/action_items/type`) during indexing
 - **metadata_model**: Lightweight LLM model used for metadata extraction (default: `haiku`)
+- **extra_paths**: Additional named markdown roots to index (Obsidian vaults, shared-memory exports). See "External markdown collections" below.
 - **mcp.enabled**: Enable optional MCP server exposing `memory_search`, `memory_get`, `memory_capture`
 - **mcp.host / mcp.port / mcp.endpoint**: MCP bind/interface settings (`127.0.0.1` by default for local-only access)
 - **mcp.allow_writes**: Must be explicitly `true` to allow `memory_capture` writes
+
+### External markdown collections (`extra_paths`)
+
+`memory.extra_paths` indexes additional markdown roots — Obsidian vaults,
+shared-memory exports, HomeLab documentation — into the same retrieval
+pipeline as the workspace `MEMORY.md` / `memory/*.md` files. Each entry has:
+
+| Field       | Required | Default      | Notes                                                                              |
+| ----------- | -------- | ------------ | ---------------------------------------------------------------------------------- |
+| `name`      | yes      | —            | Collection identifier (`[a-z0-9][a-z0-9_-]*`); must be unique.                     |
+| `path`      | yes      | —            | Absolute or `~/`-prefixed path. NFS / shared mounts are supported.                 |
+| `patterns`  | no       | `["**/*.md"]`| Globs relative to `path`. `**` matches any number of segments.                     |
+| `read_only` | no       | `true`       | Reserved for future write enablement; this issue never writes to extra paths.      |
+| `scope`     | no       | `""`         | Optional human-readable label (shown in `memory status`).                          |
+
+Behavior:
+
+- **Source labels.** Every chunk indexed from an extra path is stored with
+  the `source_file = "extra:<name>/<relative-path>"` prefix. Both
+  `memory_search` and `memory_get` surface this label so callers can tell
+  workspace memory and external collections apart.
+- **Hidden directories are skipped.** Any directory or file whose name starts
+  with `.` is excluded by default — this keeps secrets, `.git`, `.obsidian`
+  metadata, and the like out of the index.
+- **Missing roots are non-fatal.** If a configured path is not mounted (or has
+  not yet been created), the bot logs a warning, skips indexing, and
+  `ok-gobot memory status` reports `[missing]` with a diagnostic message.
+- **Watcher.** A best-effort filesystem watcher refreshes the index when files
+  change. If the underlying filesystem doesn't support watches (some NFS
+  mounts), indexing still happens at startup and on `memory index --force`.
+- **Path-traversal protection.** `memory_get extra:<name>/<path>` validates
+  that the resolved path stays inside the configured collection root and
+  rejects symlink escapes.
 
 ### Supported Embedding Providers
 
@@ -74,11 +117,12 @@ When `memory.enabled: true`, bot startup automatically indexes:
 
 - `MEMORY.md`
 - `memory/*.md`
+- Every collection configured under `memory.extra_paths` (see "External
+  markdown collections" above).
 
-The bot also starts a debounced filesystem watcher for those managed sources.
-Changes update the `memory_chunks` index; deleted files remove their chunks.
-Other markdown files are intentionally ignored until external memory paths are
-introduced.
+The bot also starts debounced filesystem watchers for the workspace memory
+sources and for each extra path. Changes update the `memory_chunks` index;
+deleted files remove their chunks.
 
 ### Agent Tool Commands
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -344,7 +344,12 @@ func (a *App) Start(ctx context.Context) error {
 		DefaultThinking: a.config.AI.DefaultThinking,
 		Routing:         a.config.AI.Routing,
 	}
-	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.config.Browser, a.config.STT, a.scheduler, a.memoryManager, a.config.Contacts)
+	memoryExtras, err := a.normalizedExtraPaths()
+	if err != nil {
+		log.Printf("⚠️ [memory] extra paths config error: %v", err)
+		memoryExtras = nil
+	}
+	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.config.Browser, a.config.STT, a.scheduler, a.memoryManager, memoryExtras, a.config.Contacts)
 	if err != nil {
 		return fmt.Errorf("failed to create bot: %w", err)
 	}
@@ -489,39 +494,108 @@ func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *me
 		log.Printf("🧠 [memory] indexed %d managed source file(s)", stats.FilesIndexed)
 	}
 
+	extras, extraErr := a.normalizedExtraPaths()
+	if extraErr != nil {
+		log.Printf("⚠️ [memory] extra paths config error: %v", extraErr)
+	}
+	if len(extras) > 0 {
+		extraStats, errs := memory.IndexExtraPaths(ctx, extras, indexer)
+		log.Printf("🧠 [memory] indexed %d extra source file(s) across %d collection(s)", extraStats.FilesIndexed, len(extras))
+		for _, e := range errs {
+			log.Printf("⚠️ [memory] extra path indexing: %v", e)
+		}
+	}
+
 	watcher, err := memory.NewWatcher(rootPath)
 	if err != nil {
 		log.Printf("⚠️ [memory] failed to start memory watcher: %v", err)
-		return
+	} else {
+		a.memoryWatcher = watcher
+		go a.runMemoryWatcher(ctx, rootPath, watcher, indexer)
+		log.Printf("🧠 [memory] watcher active for %s", rootPath)
 	}
-	a.memoryWatcher = watcher
 
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				watcher.Stop()
-				return
-			case err, ok := <-watcher.Errors():
-				if !ok {
-					return
-				}
-				log.Printf("⚠️ [memory] watcher error: %v", err)
-			case event, ok := <-watcher.Events():
-				if !ok {
-					return
-				}
-				rel, ok := memory.ManagedRelativePath(rootPath, event.Path)
-				if !ok {
-					continue
-				}
-				if err := indexer.IndexFile(ctx, event.Path, rel); err != nil {
-					log.Printf("⚠️ [memory] reindex failed for %s: %v", rel, err)
-					continue
-				}
-				log.Printf("🧠 [memory] reindexed %s", rel)
-			}
+	for _, extra := range extras {
+		extraWatcher, err := memory.NewWatcher(extra.Path)
+		if err != nil {
+			log.Printf("⚠️ [memory] extra path %q watcher unavailable (%v) — index won't auto-refresh", extra.Name, err)
+			continue
 		}
-	}()
-	log.Printf("🧠 [memory] watcher active for %s", rootPath)
+		go a.runExtraPathWatcher(ctx, extra, extraWatcher, indexer)
+		log.Printf("🧠 [memory] watcher active for extra path %q (%s)", extra.Name, extra.Path)
+	}
+}
+
+func (a *App) runMemoryWatcher(ctx context.Context, rootPath string, watcher *memory.Watcher, indexer *memory.Indexer) {
+	for {
+		select {
+		case <-ctx.Done():
+			watcher.Stop()
+			return
+		case err, ok := <-watcher.Errors():
+			if !ok {
+				return
+			}
+			log.Printf("⚠️ [memory] watcher error: %v", err)
+		case event, ok := <-watcher.Events():
+			if !ok {
+				return
+			}
+			rel, ok := memory.ManagedRelativePath(rootPath, event.Path)
+			if !ok {
+				continue
+			}
+			if err := indexer.IndexFile(ctx, event.Path, rel); err != nil {
+				log.Printf("⚠️ [memory] reindex failed for %s: %v", rel, err)
+				continue
+			}
+			log.Printf("🧠 [memory] reindexed %s", rel)
+		}
+	}
+}
+
+func (a *App) runExtraPathWatcher(ctx context.Context, extra memory.ExtraPath, watcher *memory.Watcher, indexer *memory.Indexer) {
+	for {
+		select {
+		case <-ctx.Done():
+			watcher.Stop()
+			return
+		case err, ok := <-watcher.Errors():
+			if !ok {
+				return
+			}
+			log.Printf("⚠️ [memory] extra path %q watcher error: %v", extra.Name, err)
+		case event, ok := <-watcher.Events():
+			if !ok {
+				return
+			}
+			rel, ok := memory.ExtraPathRelative(extra, event.Path)
+			if !ok {
+				continue
+			}
+			label := memory.SourceLabelForExtra(extra.Name, rel)
+			if err := indexer.IndexFile(ctx, event.Path, label); err != nil {
+				log.Printf("⚠️ [memory] reindex failed for %s: %v", label, err)
+				continue
+			}
+			log.Printf("🧠 [memory] reindexed %s", label)
+		}
+	}
+}
+
+func (a *App) normalizedExtraPaths() ([]memory.ExtraPath, error) {
+	if a.config == nil || len(a.config.Memory.ExtraPaths) == 0 {
+		return nil, nil
+	}
+	raw := make([]memory.RawExtraPath, 0, len(a.config.Memory.ExtraPaths))
+	for _, e := range a.config.Memory.ExtraPaths {
+		raw = append(raw, memory.RawExtraPath{
+			Name:     e.Name,
+			Path:     e.Path,
+			Patterns: e.Patterns,
+			ReadOnly: e.ReadOnly,
+			Scope:    e.Scope,
+		})
+	}
+	return memory.NormalizeExtraPaths(raw)
 }

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -71,7 +71,7 @@ type AIConfig struct {
 }
 
 // New creates a new bot instance
-func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, browserCfg config.BrowserConfig, sttCfg config.STTConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager, contacts map[string]int64) (*Bot, error) {
+func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, browserCfg config.BrowserConfig, sttCfg config.STTConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager, memoryExtraPaths []memory.ExtraPath, contacts map[string]int64) (*Bot, error) {
 	pref := telebot.Settings{
 		Token:  token,
 		Poller: &telebot.LongPoller{Timeout: 10 * time.Second},
@@ -88,16 +88,17 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 	// root so that file/path tools resolve relative paths against the configured soul
 	// directory instead of the process working directory.
 	toolsConfig := &tools.ToolsConfig{
-		OpenAIAPIKey:    aiCfg.APIKey,
-		TTSProvider:     ttsCfg.Provider,
-		TTSVoice:        ttsCfg.DefaultVoice,
-		ChromePath:      browserCfg.ChromePath,
-		BrowserProfile:  browserCfg.ProfilePath,
-		BrowserDebugURL: browserCfg.DebugURL,
-		MemoryManager:   memoryManager,
-		PatternStore:    store,
-		EmergencyStop:   store,
-		AIClient:        aiClient,
+		OpenAIAPIKey:     aiCfg.APIKey,
+		TTSProvider:      ttsCfg.Provider,
+		TTSVoice:         ttsCfg.DefaultVoice,
+		ChromePath:       browserCfg.ChromePath,
+		BrowserProfile:   browserCfg.ProfilePath,
+		BrowserDebugURL:  browserCfg.DebugURL,
+		MemoryManager:    memoryManager,
+		MemoryExtraPaths: memoryExtraPaths,
+		PatternStore:     store,
+		EmergencyStop:    store,
+		AIClient:         aiClient,
 		SkillVersionSaveFunc: func(path string) error {
 			return bootstrap.SaveSkillVersion(path, bootstrap.DefaultMaxVersions)
 		},

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -47,6 +47,27 @@ func newMemoryStatusCommand(cfg *config.Config) *cobra.Command {
 			} else {
 				fmt.Fprintln(out, "Last indexed: never")
 			}
+
+			extras, err := extraPathsFromConfig(cfg)
+			if err != nil {
+				fmt.Fprintf(out, "Extra paths: configuration error: %v\n", err)
+				return nil
+			}
+			if len(extras) == 0 {
+				return nil
+			}
+			fmt.Fprintf(out, "Extra paths (%d):\n", len(extras))
+			for _, diag := range memStore.ExtraPathDiagnostics(cmd.Context(), extras) {
+				state := "ok"
+				if !diag.Available {
+					state = "missing"
+				}
+				fmt.Fprintf(out, "  - %s [%s] path=%s sources=%d chunks=%d read_only=%v\n",
+					diag.Name, state, diag.Path, diag.SourceCount, diag.ChunkCount, diag.ReadOnly)
+				if diag.Error != "" {
+					fmt.Fprintf(out, "    error: %s\n", diag.Error)
+				}
+			}
 			return nil
 		},
 	}
@@ -114,7 +135,49 @@ func runMemoryIndex(ctx context.Context, cfg *config.Config, memStore *memory.Me
 		if err := memStore.ClearManagedSources(ctx); err != nil {
 			return memory.IndexRunStats{}, err
 		}
+		if err := memStore.ClearExtraSources(ctx, ""); err != nil {
+			return memory.IndexRunStats{}, err
+		}
 	}
 	indexer := memory.NewIndexer(cfg.GetSoulPath(), memStore, embedder)
-	return memory.IndexManagedSources(ctx, cfg.GetSoulPath(), indexer)
+	stats, err := memory.IndexManagedSources(ctx, cfg.GetSoulPath(), indexer)
+	if err != nil {
+		return stats, err
+	}
+
+	extras, err := extraPathsFromConfig(cfg)
+	if err != nil {
+		return stats, err
+	}
+	if len(extras) == 0 {
+		return stats, nil
+	}
+
+	extraStats, extraErrs := memory.IndexExtraPaths(ctx, extras, indexer)
+	stats.FilesIndexed += extraStats.FilesIndexed
+	if len(extraErrs) > 0 {
+		// Surface non-fatal extra-path errors; missing/unmounted paths return
+		// no error and just contribute zero files.
+		return stats, fmt.Errorf("extra path indexing reported %d issue(s); first: %w", len(extraErrs), extraErrs[0])
+	}
+	return stats, nil
+}
+
+// extraPathsFromConfig converts MemoryExtraPathConfig entries into normalized
+// ExtraPath values. An empty config returns no entries and no error.
+func extraPathsFromConfig(cfg *config.Config) ([]memory.ExtraPath, error) {
+	if cfg == nil || len(cfg.Memory.ExtraPaths) == 0 {
+		return nil, nil
+	}
+	raw := make([]memory.RawExtraPath, 0, len(cfg.Memory.ExtraPaths))
+	for _, e := range cfg.Memory.ExtraPaths {
+		raw = append(raw, memory.RawExtraPath{
+			Name:     e.Name,
+			Path:     e.Path,
+			Patterns: e.Patterns,
+			ReadOnly: e.ReadOnly,
+			Scope:    e.Scope,
+		})
+	}
+	return memory.NormalizeExtraPaths(raw)
 }

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -101,9 +101,12 @@ func newMemoryIndexCommand(cfg *config.Config) *cobra.Command {
 					cfg.Memory.EmbeddingsModel,
 				)
 			}
-			stats, err := runMemoryIndex(cmd.Context(), cfg, memStore, embedder, force)
+			stats, extraErrs, err := runMemoryIndex(cmd.Context(), cfg, memStore, embedder, force)
 			if err != nil {
 				return err
+			}
+			for _, e := range extraErrs {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: extra path indexing: %v\n", e)
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Indexed %d managed memory source file(s)\n", stats.FilesIndexed)
@@ -130,37 +133,37 @@ func openMemoryStore(cfg *config.Config) (*storage.Store, *memory.MemoryStore, e
 	return store, memStore, nil
 }
 
-func runMemoryIndex(ctx context.Context, cfg *config.Config, memStore *memory.MemoryStore, embedder memory.EmbeddingBatchClient, force bool) (memory.IndexRunStats, error) {
+// runMemoryIndex indexes the managed sources and any configured extra paths.
+// Errors from individual extra-path entries are returned as a separate slice
+// rather than aborting the whole pass — this matches the daemon's behavior
+// (see app.startMemoryIndexer) so `ok-gobot memory index` does not fail hard
+// while the long-running bot keeps quietly indexing partial results.
+func runMemoryIndex(ctx context.Context, cfg *config.Config, memStore *memory.MemoryStore, embedder memory.EmbeddingBatchClient, force bool) (memory.IndexRunStats, []error, error) {
 	if force {
 		if err := memStore.ClearManagedSources(ctx); err != nil {
-			return memory.IndexRunStats{}, err
+			return memory.IndexRunStats{}, nil, err
 		}
 		if err := memStore.ClearExtraSources(ctx, ""); err != nil {
-			return memory.IndexRunStats{}, err
+			return memory.IndexRunStats{}, nil, err
 		}
 	}
 	indexer := memory.NewIndexer(cfg.GetSoulPath(), memStore, embedder)
 	stats, err := memory.IndexManagedSources(ctx, cfg.GetSoulPath(), indexer)
 	if err != nil {
-		return stats, err
+		return stats, nil, err
 	}
 
 	extras, err := extraPathsFromConfig(cfg)
 	if err != nil {
-		return stats, err
+		return stats, nil, err
 	}
 	if len(extras) == 0 {
-		return stats, nil
+		return stats, nil, nil
 	}
 
 	extraStats, extraErrs := memory.IndexExtraPaths(ctx, extras, indexer)
 	stats.FilesIndexed += extraStats.FilesIndexed
-	if len(extraErrs) > 0 {
-		// Surface non-fatal extra-path errors; missing/unmounted paths return
-		// no error and just contribute zero files.
-		return stats, fmt.Errorf("extra path indexing reported %d issue(s); first: %w", len(extraErrs), extraErrs[0])
-	}
-	return stats, nil
+	return stats, extraErrs, nil
 }
 
 // extraPathsFromConfig converts MemoryExtraPathConfig entries into normalized

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"ok-gobot/internal/config"
 	"ok-gobot/internal/memory"
 )
 
@@ -69,6 +70,79 @@ func writeCLITestFile(t *testing.T, path, data string) {
 	}
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func TestMemoryStatusReportsExtraPathsAndMissingMounts(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+	cfg.Memory.Enabled = true
+	cfg.SoulPath = t.TempDir()
+	writeCLITestFile(t, filepath.Join(cfg.SoulPath, "MEMORY.md"), "# M")
+
+	vault := t.TempDir()
+	writeCLITestFile(t, filepath.Join(vault, "notes", "today.md"), "# Today\n\nbody")
+
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	cfg.Memory.ExtraPaths = []config.MemoryExtraPathConfig{
+		{Name: "obsidian", Path: vault, Patterns: []string{"**/*.md"}},
+		{Name: "homelab", Path: missing},
+	}
+
+	memStore, err := memory.NewMemoryStore(store.DB())
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+	if _, err := runMemoryIndex(context.Background(), cfg, memStore, &stubCLIEmbedder{}, true); err != nil {
+		t.Fatalf("runMemoryIndex failed: %v", err)
+	}
+
+	cmd := newMemoryCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	output := out.String()
+	for _, want := range []string{
+		"Extra paths (2)",
+		"obsidian [ok]",
+		"homelab [missing]",
+		"path does not exist",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
+func TestMemoryStatusReportsConfigError(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+	cfg.Memory.Enabled = true
+	cfg.SoulPath = t.TempDir()
+	cfg.Memory.ExtraPaths = []config.MemoryExtraPathConfig{
+		{Name: "bad name", Path: "/tmp/x"},
+	}
+
+	if _, err := memory.NewMemoryStore(store.DB()); err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	cmd := newMemoryCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Extra paths: configuration error") {
+		t.Fatalf("expected config error in output: %q", out.String())
 	}
 }
 

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -24,7 +24,7 @@ func TestMemoryStatusShowsIndexedSources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("memoryStoreFromDB failed: %v", err)
 	}
-	if _, err := runMemoryIndex(context.Background(), cfg, memStore, &stubCLIEmbedder{}, true); err != nil {
+	if _, _, err := runMemoryIndex(context.Background(), cfg, memStore, &stubCLIEmbedder{}, true); err != nil {
 		t.Fatalf("runMemoryIndex failed: %v", err)
 	}
 
@@ -93,7 +93,7 @@ func TestMemoryStatusReportsExtraPathsAndMissingMounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewMemoryStore failed: %v", err)
 	}
-	if _, err := runMemoryIndex(context.Background(), cfg, memStore, &stubCLIEmbedder{}, true); err != nil {
+	if _, _, err := runMemoryIndex(context.Background(), cfg, memStore, &stubCLIEmbedder{}, true); err != nil {
 		t.Fatalf("runMemoryIndex failed: %v", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,13 +207,27 @@ type STTConfig struct {
 
 // MemoryConfig holds semantic memory configuration
 type MemoryConfig struct {
-	Enabled            bool            `mapstructure:"enabled"`             // Enable semantic memory
-	EmbeddingsBaseURL  string          `mapstructure:"embeddings_base_url"` // API base URL for embeddings
-	EmbeddingsAPIKey   string          `mapstructure:"embeddings_api_key"`  // API key for embeddings (can reuse ai.api_key)
-	EmbeddingsModel    string          `mapstructure:"embeddings_model"`    // Embeddings model to use
-	MetadataExtraction bool            `mapstructure:"metadata_extraction"` // Extract structured metadata while indexing memories
-	MetadataModel      string          `mapstructure:"metadata_model"`      // LLM model used for metadata extraction
-	MCP                MemoryMCPConfig `mapstructure:"mcp"`                 // Optional MCP server exposing memory tools
+	Enabled            bool                    `mapstructure:"enabled"`             // Enable semantic memory
+	EmbeddingsBaseURL  string                  `mapstructure:"embeddings_base_url"` // API base URL for embeddings
+	EmbeddingsAPIKey   string                  `mapstructure:"embeddings_api_key"`  // API key for embeddings (can reuse ai.api_key)
+	EmbeddingsModel    string                  `mapstructure:"embeddings_model"`    // Embeddings model to use
+	MetadataExtraction bool                    `mapstructure:"metadata_extraction"` // Extract structured metadata while indexing memories
+	MetadataModel      string                  `mapstructure:"metadata_model"`      // LLM model used for metadata extraction
+	ExtraPaths         []MemoryExtraPathConfig `mapstructure:"extra_paths"`         // Additional named markdown roots to index (Obsidian vaults, shared exports, etc.)
+	MCP                MemoryMCPConfig         `mapstructure:"mcp"`                 // Optional MCP server exposing memory tools
+}
+
+// MemoryExtraPathConfig describes an additional markdown root to index alongside
+// the primary workspace memory. Each entry becomes a named "collection" exposed
+// in the memory_search results and memory_get tool with the prefix
+// "extra:<name>/...". Extra paths are read-only by default; writes to these
+// roots are never performed automatically.
+type MemoryExtraPathConfig struct {
+	Name     string   `mapstructure:"name"`      // Collection identifier (required, [a-z0-9-_]+)
+	Path     string   `mapstructure:"path"`      // Absolute or "~/..." path to the markdown root
+	Patterns []string `mapstructure:"patterns"`  // Glob patterns relative to path (defaults to ["**/*.md"])
+	ReadOnly *bool    `mapstructure:"read_only"` // Defaults to true; reserved for future write enablement
+	Scope    string   `mapstructure:"scope"`     // Optional human-readable scope label (e.g. "obsidian", "homelab")
 }
 
 // MemoryMCPConfig holds memory MCP server configuration

--- a/internal/memory/extra_paths.go
+++ b/internal/memory/extra_paths.go
@@ -174,9 +174,11 @@ func ParseExtraSourceLabel(source string) (collection, relativePath string, ok b
 
 // ExtraPathSources walks an extra path's configured globs and returns the
 // matched markdown sources. Hidden directories (starting with '.') and any
-// path with a hidden component are skipped. Missing roots return an empty
-// list and a nil error so callers can degrade gracefully and surface the
-// missing path through ExtraPathDiagnostics instead.
+// path with a hidden component are skipped. Symlinks (or paths beneath
+// symlinked directories) that resolve outside the collection root are
+// rejected to prevent indexing arbitrary filesystem content. Missing roots
+// return an empty list and a nil error so callers can degrade gracefully and
+// surface the missing path through ExtraPathDiagnostics instead.
 func ExtraPathSources(extra ExtraPath) ([]ManagedSource, error) {
 	info, err := os.Stat(extra.Path)
 	if err != nil {
@@ -193,6 +195,12 @@ func ExtraPathSources(extra ExtraPath) ([]ManagedSource, error) {
 	if len(patterns) == 0 {
 		patterns = []string{DefaultExtraPathPattern}
 	}
+
+	resolvedRoot, err := filepath.EvalSymlinks(extra.Path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve extra path %q: %w", extra.Path, err)
+	}
+	resolvedRootSep := resolvedRoot + string(os.PathSeparator)
 
 	matches := make(map[string]struct{})
 	walkErr := filepath.WalkDir(extra.Path, func(current string, d fs.DirEntry, walkErr error) error {
@@ -226,6 +234,18 @@ func ExtraPathSources(extra ExtraPath) ([]ManagedSource, error) {
 				return fmt.Errorf("invalid pattern %q: %w", pattern, err)
 			}
 			if ok {
+				resolvedCurrent, err := filepath.EvalSymlinks(current)
+				if err != nil {
+					// Skip entries whose targets cannot be resolved (e.g.
+					// broken symlinks) instead of aborting the entire walk.
+					return nil
+				}
+				if resolvedCurrent != resolvedRoot && !strings.HasPrefix(resolvedCurrent, resolvedRootSep) {
+					// Symlink (or symlinked-directory descendant) escapes
+					// the collection root — skip it silently to avoid
+					// surfacing arbitrary filesystem content.
+					return nil
+				}
 				matches[current] = struct{}{}
 				return nil
 			}
@@ -438,14 +458,17 @@ func (s *MemoryStore) ClearExtraSources(ctx context.Context, name string) error 
 		return fmt.Errorf("memory store is not configured")
 	}
 	if strings.TrimSpace(name) == "" {
-		_, err := s.db.ExecContext(ctx, `DELETE FROM memory_chunks WHERE source_file LIKE 'extra:%'`)
+		_, err := s.db.ExecContext(ctx, `DELETE FROM memory_chunks WHERE source_file GLOB 'extra:*'`)
 		if err != nil {
 			return fmt.Errorf("clear extra memory sources: %w", err)
 		}
 		return nil
 	}
-	prefix := ExtraSourcePrefix + name + "/"
-	_, err := s.db.ExecContext(ctx, `DELETE FROM memory_chunks WHERE source_file LIKE ? || '%'`, prefix)
+	// Use GLOB rather than LIKE so the underscore in collection names like
+	// "my_vault" is matched literally instead of as a single-character LIKE
+	// wildcard, which would otherwise also match "myXvault" prefixes.
+	prefix := ExtraSourcePrefix + name + "/*"
+	_, err := s.db.ExecContext(ctx, `DELETE FROM memory_chunks WHERE source_file GLOB ?`, prefix)
 	if err != nil {
 		return fmt.Errorf("clear extra memory source %q: %w", name, err)
 	}
@@ -482,11 +505,14 @@ func (s *MemoryStore) ExtraPathDiagnostics(ctx context.Context, extras []ExtraPa
 		}
 
 		if s != nil && s.db != nil {
-			prefix := ExtraSourcePrefix + extra.Name + "/"
+			// GLOB avoids LIKE's wildcard treatment of underscore so
+			// collections like "my_vault" don't include chunks from a
+			// hypothetical "myXvault" collection.
+			prefix := ExtraSourcePrefix + extra.Name + "/*"
 			var count int
 			if err := s.db.QueryRowContext(
 				ctx,
-				`SELECT COUNT(*) FROM memory_chunks WHERE source_file LIKE ? || '%'`,
+				`SELECT COUNT(*) FROM memory_chunks WHERE source_file GLOB ?`,
 				prefix,
 			).Scan(&count); err == nil {
 				st.ChunkCount = count

--- a/internal/memory/extra_paths.go
+++ b/internal/memory/extra_paths.go
@@ -1,0 +1,499 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// ExtraSourcePrefix is the source_file prefix used for chunks that originate
+// from a configured memory.extra_paths collection. Final source labels look
+// like "extra:<collection>/<relative-markdown-path>".
+const ExtraSourcePrefix = "extra:"
+
+// DefaultExtraPathPattern is applied when an ExtraPath specifies no patterns.
+const DefaultExtraPathPattern = "**/*.md"
+
+var (
+	extraCollectionNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+)
+
+// ExtraPath describes one additional named markdown collection to index.
+// All fields are validated and normalized via NormalizeExtraPaths.
+type ExtraPath struct {
+	Name     string
+	Path     string // resolved absolute path
+	Patterns []string
+	ReadOnly bool
+	Scope    string
+}
+
+// ExtraPathStatus reports diagnostic information about a single configured
+// extra path: whether it is reachable on disk, how many sources matched the
+// configured globs, and how many indexed chunks belong to it.
+type ExtraPathStatus struct {
+	Name        string
+	Path        string
+	Scope       string
+	ReadOnly    bool
+	Available   bool
+	Error       string
+	SourceCount int
+	ChunkCount  int
+}
+
+// HomeDirFunc resolves "~" prefixes in paths. Override in tests.
+var HomeDirFunc = os.UserHomeDir
+
+// expandHome expands a leading "~/" using the current user's home directory.
+func expandHome(path string) (string, error) {
+	if path == "~" {
+		home, err := HomeDirFunc()
+		if err != nil {
+			return "", err
+		}
+		return home, nil
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := HomeDirFunc()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, path[2:]), nil
+	}
+	return path, nil
+}
+
+// NormalizeExtraPaths validates a list of (name, path, patterns, readOnly,
+// scope) tuples and returns canonical ExtraPath entries. Paths are expanded
+// (~ prefix), made absolute, and cleaned. The returned slice is safe to use
+// for indexing.
+//
+// Names must be unique and match [a-z0-9][a-z0-9_-]*. Empty names or paths
+// are rejected.
+func NormalizeExtraPaths(raw []RawExtraPath) ([]ExtraPath, error) {
+	out := make([]ExtraPath, 0, len(raw))
+	seenNames := make(map[string]struct{}, len(raw))
+
+	for i, r := range raw {
+		name := strings.ToLower(strings.TrimSpace(r.Name))
+		if name == "" {
+			return nil, fmt.Errorf("memory.extra_paths[%d]: name is required", i)
+		}
+		if !extraCollectionNameRegexp.MatchString(name) {
+			return nil, fmt.Errorf("memory.extra_paths[%d]: invalid name %q (must match %s)", i, r.Name, extraCollectionNameRegexp.String())
+		}
+		if _, dup := seenNames[name]; dup {
+			return nil, fmt.Errorf("memory.extra_paths[%d]: duplicate name %q", i, name)
+		}
+		seenNames[name] = struct{}{}
+
+		rawPath := strings.TrimSpace(r.Path)
+		if rawPath == "" {
+			return nil, fmt.Errorf("memory.extra_paths[%q]: path is required", name)
+		}
+		expanded, err := expandHome(rawPath)
+		if err != nil {
+			return nil, fmt.Errorf("memory.extra_paths[%q]: expand home: %w", name, err)
+		}
+		abs, err := filepath.Abs(expanded)
+		if err != nil {
+			return nil, fmt.Errorf("memory.extra_paths[%q]: resolve path: %w", name, err)
+		}
+		abs = filepath.Clean(abs)
+
+		patterns := make([]string, 0, len(r.Patterns))
+		for _, p := range r.Patterns {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			patterns = append(patterns, p)
+		}
+		if len(patterns) == 0 {
+			patterns = []string{DefaultExtraPathPattern}
+		}
+
+		readOnly := true
+		if r.ReadOnly != nil {
+			readOnly = *r.ReadOnly
+		}
+
+		out = append(out, ExtraPath{
+			Name:     name,
+			Path:     abs,
+			Patterns: patterns,
+			ReadOnly: readOnly,
+			Scope:    strings.TrimSpace(r.Scope),
+		})
+	}
+
+	return out, nil
+}
+
+// RawExtraPath is the unvalidated form passed in from configuration.
+// It mirrors config.MemoryExtraPathConfig without taking a dependency on the
+// config package.
+type RawExtraPath struct {
+	Name     string
+	Path     string
+	Patterns []string
+	ReadOnly *bool
+	Scope    string
+}
+
+// SourceLabelForExtra builds the canonical source label for an indexed chunk
+// originating from the named extra collection at relativePath (forward slashes).
+func SourceLabelForExtra(collection, relativePath string) string {
+	rel := filepath.ToSlash(filepath.Clean(relativePath))
+	rel = strings.TrimPrefix(rel, "./")
+	return ExtraSourcePrefix + collection + "/" + rel
+}
+
+// ParseExtraSourceLabel parses a source label (e.g. "extra:obsidian/notes/x.md")
+// and returns the collection name and the relative path. The second return value
+// is true only when the label has the "extra:" prefix and contains both a
+// collection name and a relative path.
+func ParseExtraSourceLabel(source string) (collection, relativePath string, ok bool) {
+	if !strings.HasPrefix(source, ExtraSourcePrefix) {
+		return "", "", false
+	}
+	rest := source[len(ExtraSourcePrefix):]
+	idx := strings.Index(rest, "/")
+	if idx <= 0 || idx == len(rest)-1 {
+		return "", "", false
+	}
+	return rest[:idx], rest[idx+1:], true
+}
+
+// ExtraPathSources walks an extra path's configured globs and returns the
+// matched markdown sources. Hidden directories (starting with '.') and any
+// path with a hidden component are skipped. Missing roots return an empty
+// list and a nil error so callers can degrade gracefully and surface the
+// missing path through ExtraPathDiagnostics instead.
+func ExtraPathSources(extra ExtraPath) ([]ManagedSource, error) {
+	info, err := os.Stat(extra.Path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat extra path %q: %w", extra.Path, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("extra path %q is not a directory", extra.Path)
+	}
+
+	patterns := extra.Patterns
+	if len(patterns) == 0 {
+		patterns = []string{DefaultExtraPathPattern}
+	}
+
+	matches := make(map[string]struct{})
+	walkErr := filepath.WalkDir(extra.Path, func(current string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if errors.Is(walkErr, os.ErrNotExist) {
+				return nil
+			}
+			return walkErr
+		}
+		if current == extra.Path {
+			return nil
+		}
+		base := d.Name()
+		if strings.HasPrefix(base, ".") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(extra.Path, current)
+		if err != nil {
+			return nil
+		}
+		relSlash := filepath.ToSlash(rel)
+		for _, pattern := range patterns {
+			ok, err := matchExtraGlob(pattern, relSlash)
+			if err != nil {
+				return fmt.Errorf("invalid pattern %q: %w", pattern, err)
+			}
+			if ok {
+				matches[current] = struct{}{}
+				return nil
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	sorted := make([]string, 0, len(matches))
+	for path := range matches {
+		sorted = append(sorted, path)
+	}
+	sort.Strings(sorted)
+
+	out := make([]ManagedSource, 0, len(sorted))
+	for _, abs := range sorted {
+		rel, err := filepath.Rel(extra.Path, abs)
+		if err != nil {
+			continue
+		}
+		out = append(out, ManagedSource{
+			Path:         filepath.Clean(abs),
+			RelativePath: SourceLabelForExtra(extra.Name, rel),
+		})
+	}
+	return out, nil
+}
+
+// matchExtraGlob matches a forward-slash relative path against a glob.
+// It supports "**" as a recursive wildcard in addition to the standard
+// filepath.Match semantics.
+func matchExtraGlob(pattern, name string) (bool, error) {
+	if !strings.Contains(pattern, "**") {
+		return filepath.Match(pattern, name)
+	}
+
+	patternParts := strings.Split(pattern, "/")
+	nameParts := strings.Split(name, "/")
+	return matchSegments(patternParts, nameParts)
+}
+
+func matchSegments(pattern, name []string) (bool, error) {
+	if len(pattern) == 0 {
+		return len(name) == 0, nil
+	}
+
+	head := pattern[0]
+	if head == "**" {
+		// "**" matches zero or more path segments. Try every prefix length.
+		// Skip consecutive "**" entries.
+		rest := pattern[1:]
+		for len(rest) > 0 && rest[0] == "**" {
+			rest = rest[1:]
+		}
+		if len(rest) == 0 {
+			return true, nil
+		}
+		for i := 0; i <= len(name); i++ {
+			ok, err := matchSegments(rest, name[i:])
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	if len(name) == 0 {
+		return false, nil
+	}
+	ok, err := filepath.Match(head, name[0])
+	if err != nil || !ok {
+		return false, err
+	}
+	return matchSegments(pattern[1:], name[1:])
+}
+
+// ExtraPathByLabel returns the extra path whose collection name matches the
+// "extra:<name>/" prefix of source. The second return value is true only when
+// the source label is well-formed and the collection is registered.
+func ExtraPathByLabel(extras []ExtraPath, source string) (ExtraPath, string, bool) {
+	collection, relativePath, ok := ParseExtraSourceLabel(source)
+	if !ok {
+		return ExtraPath{}, "", false
+	}
+	for _, e := range extras {
+		if e.Name == collection {
+			return e, relativePath, true
+		}
+	}
+	return ExtraPath{}, "", false
+}
+
+// ExtraPathRelative returns the slash-relative path inside extra.Path for an
+// absolute filesystem path. Returns false when absPath is outside extra.Path
+// or its globs do not match. Hidden segments are rejected.
+func ExtraPathRelative(extra ExtraPath, absPath string) (string, bool) {
+	cleanAbs, err := filepath.Abs(absPath)
+	if err != nil {
+		return "", false
+	}
+	cleanAbs = filepath.Clean(cleanAbs)
+	rel, err := filepath.Rel(extra.Path, cleanAbs)
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.Clean(rel)
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	relSlash := filepath.ToSlash(rel)
+	for _, part := range strings.Split(relSlash, "/") {
+		if strings.HasPrefix(part, ".") {
+			return "", false
+		}
+	}
+
+	patterns := extra.Patterns
+	if len(patterns) == 0 {
+		patterns = []string{DefaultExtraPathPattern}
+	}
+	for _, pattern := range patterns {
+		ok, err := matchExtraGlob(pattern, relSlash)
+		if err != nil {
+			return "", false
+		}
+		if ok {
+			return relSlash, true
+		}
+	}
+	return "", false
+}
+
+// ResolveExtraPathFile returns the absolute filesystem path for a relative
+// markdown file inside an extra-path collection. It rejects traversal attempts
+// and symlink escapes outside the collection root. The file is not required to
+// exist; callers handle ENOENT separately.
+func ResolveExtraPathFile(extra ExtraPath, relativePath string) (string, error) {
+	clean := filepath.Clean(relativePath)
+	if filepath.IsAbs(clean) {
+		return "", fmt.Errorf("extra path source must be relative, got %q", relativePath)
+	}
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("extra path source escapes collection root: %q", relativePath)
+	}
+	for _, part := range strings.Split(filepath.ToSlash(clean), "/") {
+		if strings.HasPrefix(part, ".") {
+			return "", fmt.Errorf("extra path source has hidden segment %q", part)
+		}
+	}
+
+	full := filepath.Join(extra.Path, clean)
+	rootWithSep := extra.Path + string(os.PathSeparator)
+	if full != extra.Path && !strings.HasPrefix(full, rootWithSep) {
+		return "", fmt.Errorf("extra path source %q is outside collection %q", relativePath, extra.Name)
+	}
+
+	resolvedRoot, err := filepath.EvalSymlinks(extra.Path)
+	if err == nil {
+		resolvedFull, err := filepath.EvalSymlinks(full)
+		if err == nil {
+			resolvedRootSep := resolvedRoot + string(os.PathSeparator)
+			if resolvedFull != resolvedRoot && !strings.HasPrefix(resolvedFull, resolvedRootSep) {
+				return "", fmt.Errorf("extra path source %q resolves outside collection (symlink escape)", relativePath)
+			}
+		}
+	}
+
+	return full, nil
+}
+
+// IndexExtraPaths indexes every configured extra path. Errors for individual
+// paths are collected so a single missing/unmounted root does not abort the
+// whole pass. The returned IndexRunStats counts files indexed across all
+// extras.
+func IndexExtraPaths(ctx context.Context, extras []ExtraPath, indexer *Indexer) (IndexRunStats, []error) {
+	var (
+		stats IndexRunStats
+		errs  []error
+	)
+	if indexer == nil {
+		return stats, []error{fmt.Errorf("memory indexer is nil")}
+	}
+
+	for _, extra := range extras {
+		sources, err := ExtraPathSources(extra)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("extra path %q: %w", extra.Name, err))
+			continue
+		}
+		for _, source := range sources {
+			if err := indexer.IndexFile(ctx, source.Path, source.RelativePath); err != nil {
+				errs = append(errs, fmt.Errorf("index %s: %w", source.RelativePath, err))
+				continue
+			}
+			stats.FilesIndexed++
+		}
+	}
+	return stats, errs
+}
+
+// ClearExtraSources removes indexed chunks for the given collection name.
+// When name is empty, all extra-path chunks are removed.
+func (s *MemoryStore) ClearExtraSources(ctx context.Context, name string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("memory store is not configured")
+	}
+	if strings.TrimSpace(name) == "" {
+		_, err := s.db.ExecContext(ctx, `DELETE FROM memory_chunks WHERE source_file LIKE 'extra:%'`)
+		if err != nil {
+			return fmt.Errorf("clear extra memory sources: %w", err)
+		}
+		return nil
+	}
+	prefix := ExtraSourcePrefix + name + "/"
+	_, err := s.db.ExecContext(ctx, `DELETE FROM memory_chunks WHERE source_file LIKE ? || '%'`, prefix)
+	if err != nil {
+		return fmt.Errorf("clear extra memory source %q: %w", name, err)
+	}
+	return nil
+}
+
+// ExtraPathDiagnostics returns one ExtraPathStatus per configured extra path.
+// Missing or unmounted roots are reported with Available=false and a non-empty
+// Error so callers can surface them via `memory status` without crashing.
+func (s *MemoryStore) ExtraPathDiagnostics(ctx context.Context, extras []ExtraPath) []ExtraPathStatus {
+	out := make([]ExtraPathStatus, 0, len(extras))
+	for _, extra := range extras {
+		st := ExtraPathStatus{
+			Name:     extra.Name,
+			Path:     extra.Path,
+			Scope:    extra.Scope,
+			ReadOnly: extra.ReadOnly,
+		}
+		if info, err := os.Stat(extra.Path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				st.Error = "path does not exist"
+			} else {
+				st.Error = err.Error()
+			}
+		} else if !info.IsDir() {
+			st.Error = "path is not a directory"
+		} else {
+			st.Available = true
+			if sources, err := ExtraPathSources(extra); err != nil {
+				st.Error = err.Error()
+			} else {
+				st.SourceCount = len(sources)
+			}
+		}
+
+		if s != nil && s.db != nil {
+			prefix := ExtraSourcePrefix + extra.Name + "/"
+			var count int
+			if err := s.db.QueryRowContext(
+				ctx,
+				`SELECT COUNT(*) FROM memory_chunks WHERE source_file LIKE ? || '%'`,
+				prefix,
+			).Scan(&count); err == nil {
+				st.ChunkCount = count
+			}
+		}
+
+		out = append(out, st)
+	}
+	return out
+}

--- a/internal/memory/extra_paths_test.go
+++ b/internal/memory/extra_paths_test.go
@@ -290,6 +290,84 @@ func TestExtraPathRelativeMatchesAndFiltersHidden(t *testing.T) {
 	}
 }
 
+func TestExtraPathSourcesSkipsSymlinkEscapes(t *testing.T) {
+	outside := t.TempDir()
+	mustWrite(t, filepath.Join(outside, "secret.md"), "# secret")
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "real.md"), "# real")
+	if err := os.Symlink(filepath.Join(outside, "secret.md"), filepath.Join(root, "evil.md")); err != nil {
+		t.Skipf("symlink unsupported on this filesystem: %v", err)
+	}
+
+	extra := ExtraPath{Name: "vault", Path: root, Patterns: []string{"**/*.md"}}
+	sources, err := ExtraPathSources(extra)
+	if err != nil {
+		t.Fatalf("ExtraPathSources failed: %v", err)
+	}
+
+	got := make([]string, len(sources))
+	for i, s := range sources {
+		got[i] = s.RelativePath
+	}
+	sort.Strings(got)
+	want := []string{"extra:vault/real.md"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("symlinked file leaked into sources: got %v, want %v", got, want)
+	}
+}
+
+func TestClearAndCountExtraSourcesRespectUnderscoreNames(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	rootA := t.TempDir()
+	mustWrite(t, filepath.Join(rootA, "a.md"), "# A\n\nFirst.")
+	rootB := t.TempDir()
+	mustWrite(t, filepath.Join(rootB, "b.md"), "# B\n\nSecond.")
+
+	// Names "my_vault" and "myXvault" share a single-character difference at
+	// the underscore position; SQLite LIKE would treat `_` as a wildcard and
+	// conflate the two collections.
+	extras := []ExtraPath{
+		{Name: "my_vault", Path: rootA, Patterns: []string{"**/*.md"}, ReadOnly: true},
+		{Name: "myxvault", Path: rootB, Patterns: []string{"**/*.md"}, ReadOnly: true},
+	}
+
+	indexer := NewIndexer("", store, &stubBatchEmbedder{}, WithIndexerChunking(64, 0))
+	if _, errs := IndexExtraPaths(context.Background(), extras, indexer); len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	diag := store.ExtraPathDiagnostics(context.Background(), extras)
+	if len(diag) != 2 {
+		t.Fatalf("expected 2 diag entries, got %d", len(diag))
+	}
+	if diag[0].ChunkCount != 1 {
+		t.Fatalf("my_vault chunk count = %d, want 1 (LIKE wildcard leaking from %q?)", diag[0].ChunkCount, diag[1].Name)
+	}
+	if diag[1].ChunkCount != 1 {
+		t.Fatalf("myxvault chunk count = %d, want 1", diag[1].ChunkCount)
+	}
+
+	if err := store.ClearExtraSources(context.Background(), "my_vault"); err != nil {
+		t.Fatalf("ClearExtraSources failed: %v", err)
+	}
+
+	diag = store.ExtraPathDiagnostics(context.Background(), extras)
+	if diag[0].ChunkCount != 0 {
+		t.Fatalf("my_vault chunks after clear = %d, want 0", diag[0].ChunkCount)
+	}
+	if diag[1].ChunkCount != 1 {
+		t.Fatalf("myxvault chunks after clear = %d, want 1 (over-deletion via LIKE wildcard?)", diag[1].ChunkCount)
+	}
+}
+
 func TestMatchExtraGlob(t *testing.T) {
 	cases := []struct {
 		pattern string

--- a/internal/memory/extra_paths_test.go
+++ b/internal/memory/extra_paths_test.go
@@ -1,0 +1,317 @@
+package memory
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestNormalizeExtraPathsExpandsTildeAndDefaultsPattern(t *testing.T) {
+	home := t.TempDir()
+	prevHome := HomeDirFunc
+	HomeDirFunc = func() (string, error) { return home, nil }
+	defer func() { HomeDirFunc = prevHome }()
+
+	rw := false
+	raw := []RawExtraPath{
+		{Name: "Obsidian", Path: "~/notes", Scope: "personal"},
+		{Name: "homelab", Path: filepath.Join(home, "homelab"), Patterns: []string{"docs/*.md", "**/*.md"}, ReadOnly: &rw},
+	}
+
+	got, err := NormalizeExtraPaths(raw)
+	if err != nil {
+		t.Fatalf("NormalizeExtraPaths failed: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+
+	if got[0].Name != "obsidian" {
+		t.Fatalf("expected lowercased name, got %q", got[0].Name)
+	}
+	wantPath := filepath.Join(home, "notes")
+	if got[0].Path != wantPath {
+		t.Fatalf("home expansion failed: got %q want %q", got[0].Path, wantPath)
+	}
+	if len(got[0].Patterns) != 1 || got[0].Patterns[0] != DefaultExtraPathPattern {
+		t.Fatalf("default pattern not applied: %v", got[0].Patterns)
+	}
+	if !got[0].ReadOnly {
+		t.Fatalf("read-only must default to true")
+	}
+	if got[0].Scope != "personal" {
+		t.Fatalf("scope not preserved: %q", got[0].Scope)
+	}
+
+	if got[1].ReadOnly {
+		t.Fatalf("read-only=false override not applied")
+	}
+	if len(got[1].Patterns) != 2 {
+		t.Fatalf("explicit patterns not preserved: %v", got[1].Patterns)
+	}
+}
+
+func TestNormalizeExtraPathsRejectsBadInputs(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  []RawExtraPath
+		want string
+	}{
+		{
+			name: "empty name",
+			raw:  []RawExtraPath{{Name: "", Path: "/tmp"}},
+			want: "name is required",
+		},
+		{
+			name: "invalid name",
+			raw:  []RawExtraPath{{Name: "has space", Path: "/tmp"}},
+			want: "invalid name",
+		},
+		{
+			name: "duplicate name",
+			raw: []RawExtraPath{
+				{Name: "obsidian", Path: "/tmp/a"},
+				{Name: "obsidian", Path: "/tmp/b"},
+			},
+			want: "duplicate name",
+		},
+		{
+			name: "empty path",
+			raw:  []RawExtraPath{{Name: "vault", Path: ""}},
+			want: "path is required",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NormalizeExtraPaths(tc.raw)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestSourceLabelForExtraAndParse(t *testing.T) {
+	label := SourceLabelForExtra("obsidian", "notes/today.md")
+	if label != "extra:obsidian/notes/today.md" {
+		t.Fatalf("unexpected label %q", label)
+	}
+	collection, rel, ok := ParseExtraSourceLabel(label)
+	if !ok || collection != "obsidian" || rel != "notes/today.md" {
+		t.Fatalf("parse failed: collection=%q rel=%q ok=%v", collection, rel, ok)
+	}
+	if _, _, ok := ParseExtraSourceLabel("MEMORY.md"); ok {
+		t.Fatalf("plain source must not parse as extra")
+	}
+	if _, _, ok := ParseExtraSourceLabel("extra:onlyone"); ok {
+		t.Fatalf("source without collection/path must not parse")
+	}
+}
+
+func TestExtraPathSourcesMatchesGlobsAndSkipsHidden(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "top.md"), "# top")
+	mustWrite(t, filepath.Join(root, "notes", "a.md"), "# a")
+	mustWrite(t, filepath.Join(root, "notes", "deep", "b.md"), "# b")
+	mustWrite(t, filepath.Join(root, "notes", "ignore.txt"), "ignore")
+	mustWrite(t, filepath.Join(root, ".secret", "hidden.md"), "# hidden")
+	mustWrite(t, filepath.Join(root, "notes", ".private", "skip.md"), "# skip")
+
+	extra := ExtraPath{Name: "vault", Path: root, Patterns: []string{"**/*.md"}}
+	sources, err := ExtraPathSources(extra)
+	if err != nil {
+		t.Fatalf("ExtraPathSources failed: %v", err)
+	}
+
+	got := make([]string, len(sources))
+	for i, s := range sources {
+		got[i] = s.RelativePath
+	}
+	sort.Strings(got)
+	want := []string{
+		"extra:vault/notes/a.md",
+		"extra:vault/notes/deep/b.md",
+		"extra:vault/top.md",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("source[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestExtraPathSourcesMissingRootIsNonFatal(t *testing.T) {
+	extra := ExtraPath{Name: "missing", Path: filepath.Join(t.TempDir(), "does-not-exist"), Patterns: []string{"**/*.md"}}
+	sources, err := ExtraPathSources(extra)
+	if err != nil {
+		t.Fatalf("missing root must not error: got %v", err)
+	}
+	if len(sources) != 0 {
+		t.Fatalf("missing root must yield zero sources, got %d", len(sources))
+	}
+}
+
+func TestResolveExtraPathFileRejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "ok.md"), "# ok")
+	extra := ExtraPath{Name: "vault", Path: root, Patterns: []string{"**/*.md"}}
+
+	if _, err := ResolveExtraPathFile(extra, "ok.md"); err != nil {
+		t.Fatalf("legit path failed: %v", err)
+	}
+	if _, err := ResolveExtraPathFile(extra, "../escape.md"); err == nil {
+		t.Fatalf("expected traversal rejection")
+	}
+	if _, err := ResolveExtraPathFile(extra, "/etc/passwd"); err == nil {
+		t.Fatalf("expected absolute path rejection")
+	}
+	if _, err := ResolveExtraPathFile(extra, ".hidden/file.md"); err == nil {
+		t.Fatalf("expected hidden segment rejection")
+	}
+}
+
+func TestResolveExtraPathFileBlocksSymlinkEscape(t *testing.T) {
+	outside := t.TempDir()
+	mustWrite(t, filepath.Join(outside, "secret.md"), "# secret")
+
+	root := t.TempDir()
+	if err := os.Symlink(filepath.Join(outside, "secret.md"), filepath.Join(root, "evil.md")); err != nil {
+		t.Skipf("symlink unsupported on this filesystem: %v", err)
+	}
+
+	extra := ExtraPath{Name: "vault", Path: root, Patterns: []string{"**/*.md"}}
+	if _, err := ResolveExtraPathFile(extra, "evil.md"); err == nil {
+		t.Fatalf("expected symlink-escape rejection")
+	}
+}
+
+func TestExtraPathByLabel(t *testing.T) {
+	extras := []ExtraPath{
+		{Name: "obsidian", Path: "/tmp/o"},
+		{Name: "homelab", Path: "/tmp/h"},
+	}
+	extra, rel, ok := ExtraPathByLabel(extras, "extra:obsidian/notes/x.md")
+	if !ok || extra.Name != "obsidian" || rel != "notes/x.md" {
+		t.Fatalf("lookup failed: extra=%v rel=%q ok=%v", extra, rel, ok)
+	}
+	if _, _, ok := ExtraPathByLabel(extras, "extra:unknown/x.md"); ok {
+		t.Fatalf("unknown collection must not match")
+	}
+	if _, _, ok := ExtraPathByLabel(extras, "MEMORY.md"); ok {
+		t.Fatalf("workspace source must not match extras")
+	}
+}
+
+func TestIndexExtraPathsAndDiagnostics(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.md"), "# A\n\nFirst.")
+	mustWrite(t, filepath.Join(root, "sub", "b.md"), "# B\n\nSecond.")
+	mustWrite(t, filepath.Join(root, "ignored.txt"), "skip")
+
+	missing := filepath.Join(t.TempDir(), "missing")
+	extras := []ExtraPath{
+		{Name: "vault", Path: root, Patterns: []string{"**/*.md"}, ReadOnly: true, Scope: "personal"},
+		{Name: "missing", Path: missing, Patterns: []string{"**/*.md"}, ReadOnly: true},
+	}
+
+	indexer := NewIndexer("", store, &stubBatchEmbedder{}, WithIndexerChunking(64, 0))
+	stats, errs := IndexExtraPaths(context.Background(), extras, indexer)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if stats.FilesIndexed != 2 {
+		t.Fatalf("FilesIndexed = %d, want 2", stats.FilesIndexed)
+	}
+
+	got := countAllChunks(t, db)
+	if got != 2 {
+		t.Fatalf("chunk count = %d, want 2", got)
+	}
+	if c := countSourceChunks(t, db, "extra:vault/a.md"); c != 1 {
+		t.Fatalf("vault/a chunk = %d, want 1", c)
+	}
+	if c := countSourceChunks(t, db, "extra:vault/sub/b.md"); c != 1 {
+		t.Fatalf("vault/sub/b chunk = %d, want 1", c)
+	}
+
+	diag := store.ExtraPathDiagnostics(context.Background(), extras)
+	if len(diag) != 2 {
+		t.Fatalf("expected 2 diag entries, got %d", len(diag))
+	}
+	if !diag[0].Available || diag[0].SourceCount != 2 || diag[0].ChunkCount != 2 || diag[0].Scope != "personal" || !diag[0].ReadOnly {
+		t.Fatalf("vault diag wrong: %+v", diag[0])
+	}
+	if diag[1].Available || diag[1].Error == "" || diag[1].SourceCount != 0 || diag[1].ChunkCount != 0 {
+		t.Fatalf("missing diag wrong: %+v", diag[1])
+	}
+
+	if err := store.ClearExtraSources(context.Background(), "vault"); err != nil {
+		t.Fatalf("ClearExtraSources failed: %v", err)
+	}
+	if got := countAllChunks(t, db); got != 0 {
+		t.Fatalf("chunks after clear = %d, want 0", got)
+	}
+}
+
+func TestExtraPathRelativeMatchesAndFiltersHidden(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "x.md"), "")
+	mustWrite(t, filepath.Join(root, ".secret", "y.md"), "")
+
+	extra := ExtraPath{Name: "vault", Path: root, Patterns: []string{"**/*.md"}}
+
+	rel, ok := ExtraPathRelative(extra, filepath.Join(root, "x.md"))
+	if !ok || rel != "x.md" {
+		t.Fatalf("expected x.md, got rel=%q ok=%v", rel, ok)
+	}
+	if _, ok := ExtraPathRelative(extra, filepath.Join(root, ".secret", "y.md")); ok {
+		t.Fatalf("hidden segment must be rejected")
+	}
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	mustWrite(t, outside, "")
+	if _, ok := ExtraPathRelative(extra, outside); ok {
+		t.Fatalf("path outside extra root must not match")
+	}
+}
+
+func TestMatchExtraGlob(t *testing.T) {
+	cases := []struct {
+		pattern string
+		name    string
+		want    bool
+	}{
+		{"**/*.md", "a.md", true},
+		{"**/*.md", "x/y/z.md", true},
+		{"**/*.md", "a.txt", false},
+		{"docs/**/*.md", "docs/a.md", true},
+		{"docs/**/*.md", "docs/sub/a.md", true},
+		{"docs/**/*.md", "other/a.md", false},
+		{"*.md", "a.md", true},
+		{"*.md", "sub/a.md", false},
+	}
+	for _, tc := range cases {
+		got, err := matchExtraGlob(tc.pattern, tc.name)
+		if err != nil {
+			t.Fatalf("pattern %q: %v", tc.pattern, err)
+		}
+		if got != tc.want {
+			t.Fatalf("matchExtraGlob(%q,%q) = %v, want %v", tc.pattern, tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/tools/memory_get_tool.go
+++ b/internal/tools/memory_get_tool.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"ok-gobot/internal/memory"
 )
 
 var markdownHeaderRegexp = regexp.MustCompile(`^(#{1,6})\s+(.+?)\s*$`)
@@ -13,11 +15,24 @@ var markdownHeaderRegexp = regexp.MustCompile(`^(#{1,6})\s+(.+?)\s*$`)
 // MemoryGetTool reads markdown memory content by source and header path.
 type MemoryGetTool struct {
 	basePath string
+	extras   []memory.ExtraPath
 }
 
 // NewMemoryGetTool creates a memory_get tool.
 func NewMemoryGetTool(basePath string) *MemoryGetTool {
 	return &MemoryGetTool{basePath: basePath}
+}
+
+// WithExtraPaths returns a copy of the tool that can resolve sources from the
+// given extra-path collections. Sources prefixed with "extra:<name>/" are
+// resolved against the matching collection's root.
+func (m *MemoryGetTool) WithExtraPaths(extras []memory.ExtraPath) *MemoryGetTool {
+	if m == nil {
+		return nil
+	}
+	clone := *m
+	clone.extras = append([]memory.ExtraPath(nil), extras...)
+	return &clone
 }
 
 func (m *MemoryGetTool) Name() string {
@@ -39,7 +54,7 @@ func (m *MemoryGetTool) Execute(ctx context.Context, args ...string) (string, er
 		headerPath = strings.TrimSpace(args[1])
 	}
 
-	fullPath, err := resolvePath(m.basePath, source)
+	fullPath, err := m.resolveSource(source)
 	if err != nil {
 		return "", err
 	}
@@ -60,6 +75,20 @@ func (m *MemoryGetTool) Execute(ctx context.Context, args ...string) (string, er
 	}
 
 	return section, nil
+}
+
+// resolveSource picks the right backing root for a given source label.
+// Plain sources (e.g. "MEMORY.md", "memory/2026-04-29.md") resolve against the
+// workspace base path. Sources prefixed with "extra:<collection>/" resolve
+// against the configured collection root with traversal protection.
+func (m *MemoryGetTool) resolveSource(source string) (string, error) {
+	if extra, rel, ok := memory.ExtraPathByLabel(m.extras, source); ok {
+		return memory.ResolveExtraPathFile(extra, rel)
+	}
+	if strings.HasPrefix(source, memory.ExtraSourcePrefix) {
+		return "", fmt.Errorf("unknown extra memory collection in source %q", source)
+	}
+	return resolvePath(m.basePath, source)
 }
 
 func (m *MemoryGetTool) GetSchema() map[string]interface{} {

--- a/internal/tools/memory_tools_test.go
+++ b/internal/tools/memory_tools_test.go
@@ -75,3 +75,52 @@ func TestMemoryGetTool_PathTraversalBlocked(t *testing.T) {
 		t.Fatal("expected path traversal to fail")
 	}
 }
+
+func TestMemoryGetTool_ReadsExtraPathSource(t *testing.T) {
+	soul := t.TempDir()
+	vault := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(vault, "notes"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := "# Note\n\nVault content."
+	if err := os.WriteFile(filepath.Join(vault, "notes", "today.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	tool := NewMemoryGetTool(soul).WithExtraPaths([]memory.ExtraPath{{
+		Name:     "obsidian",
+		Path:     vault,
+		Patterns: []string{"**/*.md"},
+		ReadOnly: true,
+	}})
+
+	got, err := tool.Execute(context.Background(), "extra:obsidian/notes/today.md")
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if !strings.Contains(got, "Vault content.") {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestMemoryGetTool_RejectsTraversalInExtraSource(t *testing.T) {
+	soul := t.TempDir()
+	vault := t.TempDir()
+
+	tool := NewMemoryGetTool(soul).WithExtraPaths([]memory.ExtraPath{{
+		Name: "obsidian", Path: vault, Patterns: []string{"**/*.md"}, ReadOnly: true,
+	}})
+
+	if _, err := tool.Execute(context.Background(), "extra:obsidian/../escape.md"); err == nil {
+		t.Fatal("expected traversal rejection")
+	}
+}
+
+func TestMemoryGetTool_UnknownExtraCollectionFails(t *testing.T) {
+	soul := t.TempDir()
+
+	tool := NewMemoryGetTool(soul) // no extras configured
+	if _, err := tool.Execute(context.Background(), "extra:obsidian/notes/x.md"); err == nil {
+		t.Fatal("expected unknown collection error")
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -478,6 +478,7 @@ type ToolsConfig struct {
 	Contacts             map[string]int64 // alias -> chatID for message tool allowlist
 	CurrentChatID        int64
 	MemoryManager        *memory.MemoryManager
+	MemoryExtraPaths     []memory.ExtraPath // Additional named markdown collections exposed to memory_get
 	PatternStore         recommend.PatternStore
 	EmergencyStop        EmergencyStopProvider
 	AIClient             ai.Client               // used by frontend_verify for LLM-based visual comparison
@@ -624,7 +625,11 @@ func LoadFromConfigWithOptions(basePath string, cfg *ToolsConfig) (*Registry, er
 		// Memory tools
 		if cfg.MemoryManager != nil {
 			registry.Register(NewMemorySearchTool(cfg.MemoryManager))
-			registry.Register(NewMemoryGetTool(basePath))
+			getTool := NewMemoryGetTool(basePath)
+			if len(cfg.MemoryExtraPaths) > 0 {
+				getTool = getTool.WithExtraPaths(cfg.MemoryExtraPaths)
+			}
+			registry.Register(getTool)
 		}
 
 		// Role recommendation tool


### PR DESCRIPTION
Implements #308

## Summary

Adds a new `memory.extra_paths` configuration block so OpenClaw/QMD-style
external memory (Obsidian vaults, shared-memory exports, HomeLab docs,
NFS mounts) is indexed into the same retrieval pipeline as the workspace
`MEMORY.md` / `memory/*.md` files.

Each entry takes:

- `name` — collection identifier (`[a-z0-9][a-z0-9_-]*`, unique)
- `path` — absolute or `~/`-prefixed path; NFS/shared mounts supported
- `patterns` — globs relative to `path` (defaults to `[\"**/*.md\"]`; `**` matches any number of segments)
- `read_only` — defaults to `true`; the bot never writes to extra paths
- `scope` — optional human-readable label

Indexed chunks carry the source label `extra:<name>/<rel>` so
`memory_search` and `memory_get` results are clearly attributed to their
collection.

## Behavior

- **Workspace memory unchanged.** `MEMORY.md` + `memory/*.md` still index as before; extra paths are additive.
- **Hidden directories skipped.** Any directory or file beginning with `.` is excluded by default — no `.git`, `.obsidian` metadata, or hidden secrets get indexed.
- **Missing/unmounted roots are non-fatal.** Logged and surfaced through `ok-gobot memory status` (`[missing]` with diagnostic), bot startup continues.
- **Watcher.** Best-effort fsnotify watcher refreshes the index per extra path. NFS mounts that don't support inotify still reindex on startup and `memory index --force`.
- **Path traversal blocked.** `memory_get extra:<name>/<path>` rejects `..`, hidden segments, absolute paths, and symlink escapes outside the collection root.
- **`memory status`** now prints per-collection diagnostics (path, source/chunk counts, read-only flag, error if missing).

## Files

- `internal/memory/extra_paths.go` (+ tests) — config normalization, glob matching with `**`, source label format, `IndexExtraPaths`, `ExtraPathDiagnostics`, `ResolveExtraPathFile` with traversal/symlink protection.
- `internal/config/config.go` — `MemoryExtraPathConfig` + `ExtraPaths` slice on `MemoryConfig`.
- `internal/cli/memory.go` (+ tests) — `runMemoryIndex` indexes extras and `memory status` reports them.
- `internal/app/app.go` — startup indexing, per-extra-path filesystem watcher.
- `internal/bot/bot.go` — plumb extras into `tools.ToolsConfig`.
- `internal/tools/memory_get_tool.go` (+ tests) — `WithExtraPaths` + `extra:<name>/...` resolution.
- `internal/tools/tools.go` — register `memory_get` with extras when configured.
- `docs/MEMORY.md`, `docs/ARCHITECTURE.md` (canonical block), `config.schema.json` (regenerated), `config.example.yaml`, `README.md` — documentation.

## Testing

```bash
go fmt ./...
go vet ./...
go test ./...     # all packages pass
go build ./cmd/ok-gobot/
```

New test coverage:
- `NormalizeExtraPaths` — `~` expansion, default pattern, read-only default, invalid/duplicate names, missing path/name rejection.
- `ExtraPathSources` — glob matching, hidden directory skip, missing root non-fatal.
- `ResolveExtraPathFile` — traversal `..`, absolute path, hidden segment, symlink escape.
- `IndexExtraPaths` + `ExtraPathDiagnostics` — full index pass plus missing-mount diagnostics.
- `MemoryGetTool` — reads from extra collection, rejects unknown collection, rejects traversal in extra source.
- `memory status` CLI — reports `[ok]`/`[missing]` rows and configuration errors.
- `matchExtraGlob` — `**` recursive wildcard semantics.

## Test plan

- [ ] Add an Obsidian vault under `memory.extra_paths`, confirm `ok-gobot memory index --force` indexes the markdown files.
- [ ] Confirm `memory_search` returns `extra:<name>/...` source labels alongside workspace memory hits.
- [ ] Confirm `memory_get extra:<name>/<rel>` returns the file content (and rejects `..`).
- [ ] Confirm `ok-gobot memory status` shows `[ok]` for mounted paths and `[missing]` with a diagnostic for unmounted ones, without crashing the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `memory.extra_paths` — a new config block that lets users index external markdown roots (Obsidian vaults, NFS mounts, HomeLab docs) into the same retrieval pipeline as workspace `MEMORY.md` files. Both previous review findings have been addressed: `ClearExtraSources` and `ExtraPathDiagnostics` now use `GLOB` instead of `LIKE` to avoid SQLite's `_` wildcard matching collections with similar names, and `runMemoryIndex`'s intentional non-fatal treatment of extra-path errors is explicitly documented with a code comment explaining the parity with daemon behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic regressions found; traversal and symlink protections are solid and well-tested

Both previously flagged P1 issues (LIKE wildcard and CLI/daemon fatality inconsistency) are resolved. Traversal protection, hidden-dir skipping, symlink escape blocking, and GLOB-based collection scoping are each covered by dedicated tests. The additive-only design means existing workspace memory is unaffected.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/memory/extra_paths.go | Core implementation of external path indexing: NormalizeExtraPaths, ExtraPathSources, ResolveExtraPathFile, IndexExtraPaths, ClearExtraSources, ExtraPathDiagnostics — all well-guarded with traversal/symlink protection and GLOB (not LIKE) for correct underscore handling |
| internal/memory/extra_paths_test.go | Comprehensive tests covering normalization, glob matching, hidden-dir skipping, symlink escape, traversal rejection, and the underscore/LIKE-wildcard regression (TestClearAndCountExtraSourcesRespectUnderscoreNames) |
| internal/app/app.go | Wires extra paths into bot construction, startup indexing, and per-collection fsnotify watchers; normalizedExtraPaths() is called separately for the bot constructor and startMemoryIndexer but both calls are deterministic from the same static config |
| internal/cli/memory.go | runMemoryIndex returns extra-path errors as a separate non-fatal slice (comment explicitly documents the intentional parity with daemon behavior); memory status now prints per-collection diagnostics |
| internal/tools/memory_get_tool.go | Adds WithExtraPaths and resolveSource to dispatch extra:name/… sources through ResolveExtraPathFile with full traversal protection, falling back to workspace basePath for plain sources |
| internal/config/config.go | Adds MemoryExtraPathConfig struct and ExtraPaths slice to MemoryConfig; ReadOnly is a *bool pointer to distinguish omitted from explicit false |
| internal/bot/bot.go | Threaded memoryExtraPaths through New() signature and ToolsConfig, no logic changes beyond plumbing |
| internal/tools/tools.go | Registers memory_get with WithExtraPaths when MemoryExtraPaths is non-empty; guarded by existing MemoryManager nil-check |
| internal/cli/memory_test.go | Two new integration tests cover the full CLI status output for present/missing mounts and invalid config names |
| internal/tools/memory_tools_test.go | Three new tests validate extra-path reads, traversal rejection, and unknown-collection errors through the tool's Execute path |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(memory): address review feedback on ..."](https://github.com/befeast/ok-gobot/commit/49db09c1dfedbb113abe752b3a96fc7f52505f97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30212134)</sub>

<!-- /greptile_comment -->