### PR TITLE
feat(memory): retrieval-first memory prompt mode (#306)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -60,6 +60,13 @@ tts:
 # Memory configuration (optional)
 memory:
   enabled: false
+  # Memory prompt mode controls how memory is injected into the system prompt:
+  #   eager           — MEMORY.md + today's + yesterday's daily notes are inlined (default)
+  #   retrieval_first — only MEMORY.md is inlined; daily notes are fetched on demand via memory_search
+  #   startup_recent  — MEMORY.md + today's note are inlined; older notes are fetched on demand
+  # retrieval_first is recommended once memory.enabled=true and the index is populated, because
+  # daily notes can otherwise grow the system prompt without bound.
+  mode: "eager"
   embeddings_base_url: "https://api.openai.com/v1"
   embeddings_api_key: ""  # Can reuse ai.api_key
   embeddings_model: "text-embedding-3-small"

--- a/config.schema.json
+++ b/config.schema.json
@@ -373,6 +373,17 @@
             "type": "object"
           },
           "type": "array"
+        },
+        "mode": {
+          "default": "eager",
+          "description": "Memory prompt mode. eager: inline MEMORY.md + today's and yesterday's daily notes (current default). retrieval_first: inline MEMORY.md only; daily notes are reachable via memory_search/memory_get. startup_recent: inline MEMORY.md + today's daily note only.",
+          "enum": [
+            "",
+            "eager",
+            "retrieval_first",
+            "startup_recent"
+          ],
+          "type": "string"
         }
       },
       "type": "object"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -417,6 +417,12 @@ single source of truth for configuration keys, types, defaults, and descriptions
           "default": false,
           "description": "Enable semantic memory index and tools."
         },
+        "mode": {
+          "type": "string",
+          "default": "eager",
+          "enum": ["", "eager", "retrieval_first", "startup_recent"],
+          "description": "Memory prompt mode. eager: inline MEMORY.md + today's and yesterday's daily notes (current default). retrieval_first: inline MEMORY.md only; daily notes are reachable via memory_search/memory_get. startup_recent: inline MEMORY.md + today's daily note only."
+        },
         "embeddings_base_url": {
           "type": "string",
           "default": "https://api.openai.com/v1",

--- a/docs/MEMORY-CONTEXT-PIPELINE.md
+++ b/docs/MEMORY-CONTEXT-PIPELINE.md
@@ -25,10 +25,11 @@ Telegram message
 │     explicit job ID + lifecycle status      │
 ├─────────────────────────────────────────────┤
 │  1. SYSTEM PROMPT ASSEMBLY                  │
-│     Bootstrap files → SystemPrompt()        │
+│     Bootstrap files → SystemPromptForMode() │
 │     SOUL + IDENTITY + USER + TOOLS +        │
 │     AGENTS + HEARTBEAT + MEMORY.md +        │
-│     daily notes (today + yesterday)         │
+│     daily notes per memory.mode             │
+│     (eager / retrieval_first / startup_recent) │
 ├─────────────────────────────────────────────┤
 │  2. CONVERSATION HISTORY                    │
 │     session_messages_v2 → last 120 msgs     │
@@ -66,10 +67,12 @@ directory (default `~/ok-gobot-soul/`) and assembles them into a single system p
 | `AGENTS.md` | Agent protocol, multi-step workflow rules | `## AGENT PROTOCOL` |
 | `HEARTBEAT.md` | Periodic check checklist, context warnings | `## HEARTBEAT` |
 | `MEMORY.md` | Long-term memory (facts, decisions, history) | `## LONG-TERM MEMORY` |
-| `memory/YYYY-MM-DD.md` (today) | Today's conversation log | `## DAILY MEMORY: YYYY-MM-DD` |
-| `memory/YYYY-MM-DD.md` (yesterday) | Yesterday's conversation log | `## DAILY MEMORY: YYYY-MM-DD` |
+| `memory/YYYY-MM-DD.md` (today) | Today's conversation log — gated by `memory.mode` | `## DAILY MEMORY: YYYY-MM-DD` |
+| `memory/YYYY-MM-DD.md` (yesterday) | Yesterday's conversation log — gated by `memory.mode` | `## DAILY MEMORY: YYYY-MM-DD` |
 
-All files are optional — missing files are silently skipped.
+All files are optional — missing files are silently skipped. Whether the
+two daily-note rows above are inlined depends on `memory.mode` — see
+[Memory Prompt Modes](#25-memory-prompt-modes-injection-vs-retrieval).
 
 ### 2.2 File Size Limit
 
@@ -108,6 +111,46 @@ with additional runtime sections:
 | `full` | Everything above — used for normal requests |
 | `minimal` | IDENTITY + SOUL only — used for lightweight operations |
 | `none` | Single identity line ("You are Name Emoji.") |
+
+### 2.5 Memory Prompt Modes (Injection vs. Retrieval)
+
+Identity files (SOUL, IDENTITY, USER, TOOLS, AGENTS, HEARTBEAT, MEMORY.md)
+are always inlined when prompt mode is `full`. The `memory.mode` config key
+only governs whether daily notes (`memory/YYYY-MM-DD.md`) are inlined or
+treated as retrieval-only sources reachable via `memory_search` /
+`memory_get`.
+
+| `memory.mode`     | MEMORY.md | Today's daily | Yesterday's daily | Older daily | When to use |
+| ----------------- | :-------: | :-----------: | :---------------: | :---------: | ----------- |
+| `eager` (default) |     ✅    |       ✅       |          ✅        |  retrieval  | Backward compatible. Small or low-volume daily notes. |
+| `retrieval_first` |     ✅    |       ⚪       |          ⚪        |  retrieval  | Recommended once `memory.enabled: true`. Avoids unbounded prompt growth. |
+| `startup_recent`  |     ✅    |       ✅       |          ⚪        |  retrieval  | Fresh sessions / `/new` workflows where the most recent context is high-value but older days are not. |
+
+When `memory_search` is registered, the `## Memory` block emits mode-specific
+instructions:
+
+- **eager**: "call memory_search first" guidance (legacy behavior).
+- **retrieval_first**: explicit "daily notes are NOT inlined — search and
+  cite source paths"; lists known retrieval-only `memory/<date>.md` paths so
+  the agent can call `memory_get` directly.
+- **startup_recent**: highlights that today is inlined, older days are
+  retrieval-only; same source-listing as retrieval_first.
+
+Why not just delete `MEMORY.md` from the prompt? It carries stable
+identity-shaped context (preferences, ongoing constraints, "remember to do
+X" rules) that is too foundational to depend on retrieval discipline.
+Keeping it in the prompt while ejecting daily notes hits the ratio that
+matters: stable context stays free, log-shaped context becomes searchable.
+
+> Pair `retrieval_first` with **Active Memory** (issue #305). Without
+> proactive injection, retrieval relies entirely on the model remembering to
+> call `memory_search` before answering — that's an unreliable contract for
+> anything load-bearing. Active Memory closes the gap by deterministically
+> surfacing relevant chunks before the model decides to ask.
+
+`/context` reflects the active mode and lists which daily notes are
+inlined vs. retrieval-only; `/status` shows a compact `🧠 Memory: mode=… ·
+tools=on|off` line.
 
 ---
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -23,6 +23,7 @@ Add the following to your `~/.ok-gobot/config.yaml`:
 ```yaml
 memory:
   enabled: true
+  mode: "eager"        # eager | retrieval_first | startup_recent
   embeddings_base_url: "https://api.openai.com/v1"
   embeddings_api_key: ""  # Leave empty to reuse ai.api_key
   embeddings_model: "text-embedding-3-small"
@@ -48,6 +49,8 @@ memory:
 ### Configuration Options
 
 - **enabled**: Set to `true` to enable semantic memory
+- **mode**: How memory is injected into the system prompt — see
+  [Memory prompt modes](#memory-prompt-modes) below.
 - **embeddings_base_url**: API endpoint for embeddings (OpenAI-compatible)
 - **embeddings_api_key**: API key for embeddings (if empty, reuses `ai.api_key`)
 - **embeddings_model**: Embedding model to use (default: `text-embedding-3-small`)
@@ -90,6 +93,36 @@ Behavior:
 - **Path-traversal protection.** `memory_get extra:<name>/<path>` validates
   that the resolved path stays inside the configured collection root and
   rejects symlink escapes.
+
+### Memory prompt modes
+
+The bootstrap loader always inlines stable identity context — `SOUL.md`,
+`IDENTITY.md`, `USER.md`, `TOOLS.md`, `AGENTS.md`, `HEARTBEAT.md` — regardless
+of mode. `memory.mode` only controls whether `MEMORY.md` and the per-day
+files in `memory/<date>.md` are inlined into the prompt or kept as
+retrieval-only sources reachable through `memory_search` / `memory_get`.
+
+| Mode              | MEMORY.md | Today's daily note | Yesterday's daily note | Older notes |
+| ----------------- | :-------: | :----------------: | :--------------------: | :---------: |
+| `eager` (default) |     ✅    |          ✅         |            ✅           |  retrieval  |
+| `retrieval_first` |     ✅    |          ⚪         |            ⚪           |  retrieval  |
+| `startup_recent`  |     ✅    |          ✅         |            ⚪           |  retrieval  |
+
+`retrieval_first` is the recommended mode once `memory.enabled: true` and the
+markdown index is populated. Daily notes can grow without bound; in
+retrieval_first mode the agent is instructed to call `memory_search` /
+`memory_get` and cite source paths instead of relying on an inflated system
+prompt. The `## Memory` section of the system prompt also advertises which
+daily notes are reachable only via retrieval, so the agent has a
+deterministic starting point for `memory_get`.
+
+> Practical guidance: pair `retrieval_first` with Active Memory (issue #305)
+> for best results. Without proactive memory injection, the model is the only
+> safety net for remembering to search before answering.
+
+`/context` reports the active mode plus which notes are inlined vs.
+retrieval-only. `/status` shows a one-line summary
+(`🧠 Memory: mode=… · tools=on|off`).
 
 ### Supported Embedding Providers
 

--- a/internal/agent/personality_test.go
+++ b/internal/agent/personality_test.go
@@ -151,3 +151,82 @@ func TestBuildSystemPrompt_OrdersSkillsAfterAgentsAndMentionsMemoryTools(t *test
 		t.Fatalf("prompt should instruct proactive use of memory_get")
 	}
 }
+
+func TestBuildSystemPrompt_RetrievalFirstSkipsDailyNotes(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(&staticTool{name: "memory_search", desc: "Search memory"})
+	registry.Register(&staticTool{name: "memory_get", desc: "Get memory"})
+
+	personality := &Personality{
+		Files: map[string]string{
+			"SOUL.md":              "SOUL_SECTION",
+			"IDENTITY.md":          "IDENTITY_SECTION",
+			"MEMORY.md":            "STABLE_MEMORY_LINE",
+			"memory/2026-04-29.md": "TODAY_DAILY_LINE",
+			"memory/2026-04-28.md": "YESTERDAY_DAILY_LINE",
+		},
+	}
+
+	agent := NewToolCallingAgent(nil, registry, personality)
+	agent.SetMemoryMode("retrieval_first")
+	prompt := agent.buildSystemPrompt()
+
+	if !strings.Contains(prompt, "STABLE_MEMORY_LINE") {
+		t.Fatalf("retrieval_first must keep MEMORY.md inlined")
+	}
+	if strings.Contains(prompt, "TODAY_DAILY_LINE") || strings.Contains(prompt, "YESTERDAY_DAILY_LINE") {
+		t.Fatalf("retrieval_first must NOT inline daily-note bodies")
+	}
+	if !strings.Contains(prompt, "Memory mode: retrieval_first.") {
+		t.Fatalf("retrieval_first prompt should advertise its mode")
+	}
+}
+
+func TestBuildSystemPrompt_StartupRecentInlinesOnlyToday(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(&staticTool{name: "memory_search", desc: "Search memory"})
+
+	personality := &Personality{
+		Files: map[string]string{
+			"IDENTITY.md": "IDENTITY_SECTION",
+			"MEMORY.md":   "STABLE_MEMORY_LINE",
+			"memory/" + time.Now().Format("2006-01-02") + ".md":                   "TODAY_DAILY_LINE",
+			"memory/" + time.Now().AddDate(0, 0, -1).Format("2006-01-02") + ".md": "YESTERDAY_DAILY_LINE",
+		},
+	}
+
+	agent := NewToolCallingAgent(nil, registry, personality)
+	agent.SetMemoryMode("startup_recent")
+	prompt := agent.buildSystemPrompt()
+
+	if !strings.Contains(prompt, "TODAY_DAILY_LINE") {
+		t.Fatalf("startup_recent must inline today's daily note")
+	}
+	if strings.Contains(prompt, "YESTERDAY_DAILY_LINE") {
+		t.Fatalf("startup_recent must NOT inline yesterday's daily note")
+	}
+}
+
+func TestBuildSystemPrompt_DefaultMemoryModeIsEager(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(&staticTool{name: "memory_search", desc: "Search memory"})
+
+	personality := &Personality{
+		Files: map[string]string{
+			"IDENTITY.md": "IDENTITY_SECTION",
+			"MEMORY.md":   "STABLE_MEMORY_LINE",
+			"memory/" + time.Now().Format("2006-01-02") + ".md":                   "TODAY_DAILY_LINE",
+			"memory/" + time.Now().AddDate(0, 0, -1).Format("2006-01-02") + ".md": "YESTERDAY_DAILY_LINE",
+		},
+	}
+
+	// Leave MemoryMode empty — must default to eager (today + yesterday inlined).
+	agent := NewToolCallingAgent(nil, registry, personality)
+	prompt := agent.buildSystemPrompt()
+
+	for _, want := range []string{"STABLE_MEMORY_LINE", "TODAY_DAILY_LINE", "YESTERDAY_DAILY_LINE", "Memory mode: eager."} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("default eager prompt missing %q", want)
+		}
+	}
+}

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -26,6 +26,9 @@ type AIResolverConfig struct {
 	DefaultThinking string
 	DefaultClient   ai.Client
 	ModelAliases    map[string]string
+	// MemoryMode controls how memory is injected into the system prompt.
+	// Recognized values: "eager" (default), "retrieval_first", "startup_recent".
+	MemoryMode string
 }
 
 // RunResolver resolves session parameters into agent run components.
@@ -80,6 +83,9 @@ func (r *RunResolver) Resolve(chatID int64, overrides *RunOverrides, job *delega
 	ta.SetModelAliases(aliases)
 	if thinkLevel != "" {
 		ta.SetThinkLevel(thinkLevel)
+	}
+	if r.AIConfig.MemoryMode != "" {
+		ta.SetMemoryMode(r.AIConfig.MemoryMode)
 	}
 	ta.SetHookRunner(NewHookRunner(r.HooksDir))
 

--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -48,6 +48,7 @@ type ToolCallingAgent struct {
 	modelAliases  map[string]string
 	ThinkLevel    string      // "off", "low", "medium", "high" — controls extended thinking
 	PromptMode    string      // "full", "minimal", "none" — controls system prompt verbosity
+	MemoryMode    string      // "eager" (default), "retrieval_first", or "startup_recent" — controls daily-note injection
 	MaxToolCalls  int         // max number of tool executions allowed for this run (0 = default/unlimited)
 	contextMode   ContextMode // chat vs job context assembly strategy
 	model         string      // model name for token budget calculation
@@ -118,6 +119,13 @@ func (a *ToolCallingAgent) SetThinkLevel(level string) {
 // SetPromptMode sets the prompt verbosity mode ("full", "minimal", "none")
 func (a *ToolCallingAgent) SetPromptMode(mode string) {
 	a.PromptMode = mode
+}
+
+// SetMemoryMode sets the memory prompt mode. Recognized values:
+// "eager" (default), "retrieval_first", "startup_recent". Invalid or empty
+// values fall back to eager during prompt assembly.
+func (a *ToolCallingAgent) SetMemoryMode(mode string) {
+	a.MemoryMode = mode
 }
 
 // SetMaxToolCalls sets the per-run tool-call budget.
@@ -597,6 +605,7 @@ func (a *ToolCallingAgent) buildSystemPrompt() string {
 	return bootstrap.BuildPrompt(a.personality.Loader(), a.tools, bootstrap.PromptOptions{
 		Mode:         a.PromptMode,
 		ThinkLevel:   a.ThinkLevel,
+		MemoryMode:   a.MemoryMode,
 		ModelAliases: a.modelAliases,
 	})
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -343,6 +343,7 @@ func (a *App) Start(ctx context.Context) error {
 		ModelAliases:    a.config.ModelAliases,
 		DefaultThinking: a.config.AI.DefaultThinking,
 		Routing:         a.config.AI.Routing,
+		MemoryMode:      config.NormalizeMemoryMode(a.config.Memory.Mode),
 	}
 	memoryExtras, err := a.normalizedExtraPaths()
 	if err != nil {

--- a/internal/bootstrap/loader.go
+++ b/internal/bootstrap/loader.go
@@ -19,6 +19,14 @@ const (
 	maxFileChars = 32000
 )
 
+// Memory prompt mode names. Mirror the values defined in
+// internal/config so callers can reference them without importing config.
+const (
+	MemoryModeEager          = "eager"
+	MemoryModeRetrievalFirst = "retrieval_first"
+	MemoryModeStartupRecent  = "startup_recent"
+)
+
 var managedFiles = []string{
 	"SOUL.md",
 	"IDENTITY.md",
@@ -141,11 +149,29 @@ func (l *Loader) loadFiles() error {
 	return nil
 }
 
-// SystemPrompt builds the markdown bootstrap prompt.
+// SystemPrompt builds the markdown bootstrap prompt using the eager memory
+// mode (the original behavior: MEMORY.md plus today's and yesterday's daily
+// notes are inlined). Equivalent to SystemPromptForMode(MemoryModeEager).
 func (l *Loader) SystemPrompt() string {
+	return l.SystemPromptForMode(MemoryModeEager)
+}
+
+// SystemPromptForMode builds the markdown bootstrap prompt with memory
+// injection controlled by mode:
+//   - "eager": MEMORY.md + today's + yesterday's daily notes (current default).
+//   - "retrieval_first": MEMORY.md only; daily notes are reachable via
+//     memory_search/memory_get instead of being inlined.
+//   - "startup_recent": MEMORY.md + today's daily note only; yesterday's note
+//     is reachable via retrieval.
+//
+// Identity/personality files (SOUL, IDENTITY, USER, TOOLS, AGENTS, HEARTBEAT)
+// are always loaded so the bot retains stable bootstrap context regardless
+// of mode.
+func (l *Loader) SystemPromptForMode(mode string) string {
 	if l == nil {
 		return ""
 	}
+	mode = normalizeMode(mode)
 
 	var prompt strings.Builder
 
@@ -192,9 +218,7 @@ func (l *Loader) SystemPrompt() string {
 		prompt.WriteString("\n\n")
 	}
 
-	today := l.currentTime().Format("2006-01-02")
-	yesterday := l.currentTime().AddDate(0, 0, -1).Format("2006-01-02")
-	for _, date := range []string{today, yesterday} {
+	for _, date := range l.dailyNoteCandidatesForMode(mode) {
 		key := "memory/" + date + ".md"
 		if note, ok := l.Files[key]; ok {
 			prompt.WriteString("## DAILY MEMORY: ")
@@ -206,6 +230,83 @@ func (l *Loader) SystemPrompt() string {
 	}
 
 	return prompt.String()
+}
+
+// DailyNoteDatesForMode returns the date keys (YYYY-MM-DD) that should be
+// inlined into the system prompt for the given mode. Retrieval_first mode
+// returns no inline daily notes; startup_recent returns today only; eager
+// (default) returns today and yesterday.
+//
+// Only dates whose corresponding memory/<date>.md exists on disk are
+// returned, so the result reflects what will actually appear in the prompt.
+func (l *Loader) DailyNoteDatesForMode(mode string) []string {
+	if l == nil {
+		return nil
+	}
+	candidates := l.dailyNoteCandidatesForMode(mode)
+	out := make([]string, 0, len(candidates))
+	for _, d := range candidates {
+		if _, ok := l.Files["memory/"+d+".md"]; ok {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func (l *Loader) dailyNoteCandidatesForMode(mode string) []string {
+	switch normalizeMode(mode) {
+	case MemoryModeRetrievalFirst:
+		return nil
+	case MemoryModeStartupRecent:
+		return []string{l.currentTime().Format("2006-01-02")}
+	default:
+		today := l.currentTime().Format("2006-01-02")
+		yesterday := l.currentTime().AddDate(0, 0, -1).Format("2006-01-02")
+		return []string{today, yesterday}
+	}
+}
+
+// DailyNoteSourcesForMode returns the relative source paths of daily notes
+// the loader has on disk that are NOT inlined under the given mode. These
+// are the files an agent should reach for via memory_search/memory_get.
+func (l *Loader) DailyNoteSourcesForMode(mode string) []string {
+	if l == nil {
+		return nil
+	}
+	inline := map[string]struct{}{}
+	for _, d := range l.dailyNoteCandidatesForMode(mode) {
+		inline["memory/"+d+".md"] = struct{}{}
+	}
+	var out []string
+	for name := range l.Files {
+		if !strings.HasPrefix(name, "memory/") {
+			continue
+		}
+		if _, ok := inline[name]; ok {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// NormalizeMemoryMode normalizes a memory mode string to a canonical value.
+// Empty or unknown values fall back to MemoryModeEager so the loader keeps
+// its original behavior when configuration is absent.
+func NormalizeMemoryMode(mode string) string {
+	return normalizeMode(mode)
+}
+
+func normalizeMode(mode string) string {
+	switch strings.TrimSpace(strings.ToLower(mode)) {
+	case MemoryModeRetrievalFirst:
+		return MemoryModeRetrievalFirst
+	case MemoryModeStartupRecent:
+		return MemoryModeStartupRecent
+	default:
+		return MemoryModeEager
+	}
 }
 
 // MinimalPrompt builds the minimal IDENTITY+SOUL bootstrap prompt.

--- a/internal/bootstrap/loader_test.go
+++ b/internal/bootstrap/loader_test.go
@@ -106,6 +106,7 @@ func TestBuildPromptPreservesFullPromptSections(t *testing.T) {
 		"If you have nothing meaningful to add (e.g. heartbeat poll with no issues, acknowledgment-only situations), reply with exactly: SILENT_REPLY\n" +
 		"The system will suppress this and send nothing to the user.\n\n" +
 		"## Memory\n\n" +
+		"Memory mode: eager.\n" +
 		"Before answering anything about prior work, decisions, dates, people, preferences, or todos:\n" +
 		"call memory_search first, then use the results to inform your answer.\n\n" +
 		"## Reply Tags\n\n" +

--- a/internal/bootstrap/memory_mode_test.go
+++ b/internal/bootstrap/memory_mode_test.go
@@ -1,0 +1,290 @@
+package bootstrap
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"ok-gobot/internal/tools"
+)
+
+// fixtureLoader builds a loader populated with all canonical bootstrap files
+// plus today's, yesterday's, and an older daily note. The clock is frozen at
+// 2026-03-03 so tests can assert exact date strings.
+func fixtureLoader(t *testing.T) (*Loader, time.Time) {
+	t.Helper()
+
+	frozen := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
+	basePath := t.TempDir()
+
+	writeTestFile(t, filepath.Join(basePath, "IDENTITY.md"), "# Identity\nName: TestBot\nEmoji: 🤖")
+	writeTestFile(t, filepath.Join(basePath, "SOUL.md"), "Soul line")
+	writeTestFile(t, filepath.Join(basePath, "USER.md"), "User line")
+	writeTestFile(t, filepath.Join(basePath, "AGENTS.md"), "Agents line")
+	writeTestFile(t, filepath.Join(basePath, "TOOLS.md"), "Tools line")
+	writeTestFile(t, filepath.Join(basePath, "HEARTBEAT.md"), "Heartbeat line")
+	writeTestFile(t, filepath.Join(basePath, "MEMORY.md"), "Memory line")
+	writeTestFile(t, filepath.Join(basePath, "memory", "2026-03-03.md"), "Today line")
+	writeTestFile(t, filepath.Join(basePath, "memory", "2026-03-02.md"), "Yesterday line")
+	writeTestFile(t, filepath.Join(basePath, "memory", "2026-02-15.md"), "Older line")
+
+	loader, err := newLoader(basePath, func() time.Time { return frozen })
+	if err != nil {
+		t.Fatalf("newLoader() error = %v", err)
+	}
+	return loader, frozen
+}
+
+func TestSystemPromptForMode_Eager_InlinesTodayAndYesterday(t *testing.T) {
+	loader, _ := fixtureLoader(t)
+	got := loader.SystemPromptForMode(MemoryModeEager)
+
+	if !strings.Contains(got, "Today line") {
+		t.Errorf("eager mode should inline today's daily note")
+	}
+	if !strings.Contains(got, "Yesterday line") {
+		t.Errorf("eager mode should inline yesterday's daily note")
+	}
+	if !strings.Contains(got, "Memory line") {
+		t.Errorf("eager mode should inline MEMORY.md")
+	}
+	if strings.Contains(got, "Older line") {
+		t.Errorf("eager mode must not inline notes older than yesterday")
+	}
+}
+
+func TestSystemPromptForMode_RetrievalFirst_OmitsAllDailyNotes(t *testing.T) {
+	loader, _ := fixtureLoader(t)
+	got := loader.SystemPromptForMode(MemoryModeRetrievalFirst)
+
+	if !strings.Contains(got, "Memory line") {
+		t.Errorf("retrieval_first must keep MEMORY.md so identity context survives")
+	}
+	for _, banned := range []string{"Today line", "Yesterday line", "Older line", "## DAILY MEMORY:"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("retrieval_first prompt unexpectedly contains %q", banned)
+		}
+	}
+}
+
+func TestSystemPromptForMode_StartupRecent_InlinesOnlyToday(t *testing.T) {
+	loader, _ := fixtureLoader(t)
+	got := loader.SystemPromptForMode(MemoryModeStartupRecent)
+
+	if !strings.Contains(got, "Memory line") {
+		t.Errorf("startup_recent must keep MEMORY.md inlined")
+	}
+	if !strings.Contains(got, "Today line") {
+		t.Errorf("startup_recent must inline today's daily note")
+	}
+	if strings.Contains(got, "Yesterday line") {
+		t.Errorf("startup_recent must NOT inline yesterday's note (retrieval-only)")
+	}
+	if strings.Contains(got, "Older line") {
+		t.Errorf("startup_recent must NOT inline older notes")
+	}
+}
+
+func TestDailyNoteSourcesForMode_ReportsRetrievalOnlyNotes(t *testing.T) {
+	// Loader only tracks today + yesterday in Files (older notes live on disk
+	// but are reached via the memory index, not the bootstrap loader).
+	loader, _ := fixtureLoader(t)
+
+	cases := []struct {
+		mode string
+		want []string
+	}{
+		{MemoryModeEager, nil},
+		{MemoryModeRetrievalFirst, []string{"memory/2026-03-02.md", "memory/2026-03-03.md"}},
+		{MemoryModeStartupRecent, []string{"memory/2026-03-02.md"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.mode, func(t *testing.T) {
+			got := loader.DailyNoteSourcesForMode(tc.mode)
+			if len(got) != len(tc.want) {
+				t.Fatalf("mode=%s: got %v, want %v", tc.mode, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("mode=%s: got[%d]=%s want %s", tc.mode, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDailyNoteDatesForMode_OnlyReturnsExistingDates(t *testing.T) {
+	loader, _ := fixtureLoader(t)
+
+	if got := loader.DailyNoteDatesForMode(MemoryModeRetrievalFirst); len(got) != 0 {
+		t.Errorf("retrieval_first must inline no daily notes, got %v", got)
+	}
+	if got := loader.DailyNoteDatesForMode(MemoryModeStartupRecent); len(got) != 1 || got[0] != "2026-03-03" {
+		t.Errorf("startup_recent dates = %v, want [2026-03-03]", got)
+	}
+	got := loader.DailyNoteDatesForMode(MemoryModeEager)
+	if len(got) != 2 || got[0] != "2026-03-03" || got[1] != "2026-03-02" {
+		t.Errorf("eager dates = %v, want [2026-03-03 2026-03-02]", got)
+	}
+}
+
+func TestDailyNoteDatesForMode_MissingFilesAreSkipped(t *testing.T) {
+	frozen := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
+	basePath := t.TempDir()
+	writeTestFile(t, filepath.Join(basePath, "IDENTITY.md"), "Name: T")
+	writeTestFile(t, filepath.Join(basePath, "memory", "2026-03-02.md"), "Y")
+
+	loader, err := newLoader(basePath, func() time.Time { return frozen })
+	if err != nil {
+		t.Fatalf("newLoader() error = %v", err)
+	}
+
+	got := loader.DailyNoteDatesForMode(MemoryModeEager)
+	if len(got) != 1 || got[0] != "2026-03-02" {
+		t.Errorf("eager dates with only yesterday file = %v, want [2026-03-02]", got)
+	}
+}
+
+func TestNormalizeMemoryMode(t *testing.T) {
+	cases := map[string]string{
+		"":                     MemoryModeEager,
+		"eager":                MemoryModeEager,
+		"EAGER":                MemoryModeEager,
+		"  retrieval_first  ":  MemoryModeRetrievalFirst,
+		"startup_recent":       MemoryModeStartupRecent,
+		"unknown-future-value": MemoryModeEager,
+	}
+	for in, want := range cases {
+		if got := NormalizeMemoryMode(in); got != want {
+			t.Errorf("NormalizeMemoryMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildPrompt_RetrievalFirstMemorySection(t *testing.T) {
+	loader, _ := fixtureLoader(t)
+	registry := tools.NewRegistry()
+	registry.Register(testTool{name: "memory_search", desc: "search"})
+	registry.Register(testTool{name: "memory_get", desc: "get"})
+
+	got := BuildPrompt(loader, registry, PromptOptions{
+		Mode:       "full",
+		MemoryMode: MemoryModeRetrievalFirst,
+		Now: func() time.Time {
+			return time.Date(2026, time.March, 3, 9, 0, 0, 0, time.UTC)
+		},
+	})
+
+	for _, banned := range []string{"Today line", "Yesterday line", "Older line"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("retrieval_first prompt unexpectedly contained %q", banned)
+		}
+	}
+	for _, want := range []string{
+		"Memory mode: retrieval_first.",
+		"Daily notes (memory/YYYY-MM-DD.md) are NOT inlined",
+		"call memory_get with the exact source + header_path",
+		"Cite source paths",
+		"Available retrieval-only daily notes:",
+		"memory/2026-03-02.md",
+		"memory/2026-03-03.md",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("retrieval_first prompt missing expected fragment %q", want)
+		}
+	}
+}
+
+func TestBuildPrompt_StartupRecentMemorySection(t *testing.T) {
+	loader, _ := fixtureLoader(t)
+	registry := tools.NewRegistry()
+	registry.Register(testTool{name: "memory_search", desc: "search"})
+
+	got := BuildPrompt(loader, registry, PromptOptions{
+		Mode:       "full",
+		MemoryMode: MemoryModeStartupRecent,
+		Now: func() time.Time {
+			return time.Date(2026, time.March, 3, 9, 0, 0, 0, time.UTC)
+		},
+	})
+
+	if !strings.Contains(got, "Today line") {
+		t.Errorf("startup_recent must inline today's daily note")
+	}
+	if strings.Contains(got, "Yesterday line") {
+		t.Errorf("startup_recent must NOT inline yesterday's daily note")
+	}
+	for _, want := range []string{
+		"Memory mode: startup_recent.",
+		"Today's daily note is inlined above",
+		"Available retrieval-only daily notes:",
+		"memory/2026-03-02.md",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("startup_recent prompt missing expected fragment %q", want)
+		}
+	}
+}
+
+func TestBuildPrompt_DailyNotesNotDuplicatedInBothPromptAndRetrievalHint(t *testing.T) {
+	loader, _ := fixtureLoader(t)
+	registry := tools.NewRegistry()
+	registry.Register(testTool{name: "memory_search", desc: "search"})
+
+	cases := []string{MemoryModeEager, MemoryModeRetrievalFirst, MemoryModeStartupRecent}
+	for _, mode := range cases {
+		t.Run(mode, func(t *testing.T) {
+			got := BuildPrompt(loader, registry, PromptOptions{
+				Mode:       "full",
+				MemoryMode: mode,
+				Now: func() time.Time {
+					return time.Date(2026, time.March, 3, 9, 0, 0, 0, time.UTC)
+				},
+			})
+
+			inlined := loader.DailyNoteDatesForMode(mode)
+			retrievalOnly := loader.DailyNoteSourcesForMode(mode)
+			for _, date := range inlined {
+				key := "memory/" + date + ".md"
+				for _, src := range retrievalOnly {
+					if src == key {
+						t.Fatalf("mode %s: %s appears in BOTH inlined and retrieval-only sets", mode, key)
+					}
+				}
+			}
+
+			// Sanity: prompt only carries each daily note's content once.
+			if mode == MemoryModeEager {
+				if c := strings.Count(got, "Today line"); c != 1 {
+					t.Errorf("eager: 'Today line' appears %d times, want 1", c)
+				}
+				if c := strings.Count(got, "Yesterday line"); c != 1 {
+					t.Errorf("eager: 'Yesterday line' appears %d times, want 1", c)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildPrompt_EagerStillEmitsLegacyMemoryGuidance(t *testing.T) {
+	loader, _ := fixtureLoader(t)
+	registry := tools.NewRegistry()
+	registry.Register(testTool{name: "memory_search", desc: "search"})
+
+	got := BuildPrompt(loader, registry, PromptOptions{
+		Mode:       "full",
+		MemoryMode: "", // empty -> eager
+		Now: func() time.Time {
+			return time.Date(2026, time.March, 3, 9, 0, 0, 0, time.UTC)
+		},
+	})
+
+	if !strings.Contains(got, "Memory mode: eager.") {
+		t.Errorf("default mode should emit eager memory section")
+	}
+	if !strings.Contains(got, "Today line") || !strings.Contains(got, "Yesterday line") {
+		t.Errorf("eager prompt must inline both today and yesterday for backward compatibility")
+	}
+}

--- a/internal/bootstrap/prompt.go
+++ b/internal/bootstrap/prompt.go
@@ -13,6 +13,7 @@ import (
 type PromptOptions struct {
 	Mode         string
 	ThinkLevel   string
+	MemoryMode   string // "eager" (default), "retrieval_first", or "startup_recent"
 	ModelAliases map[string]string
 	Now          func() time.Time
 }
@@ -25,6 +26,7 @@ func BuildPrompt(loader *Loader, registry *tools.Registry, opts PromptOptions) s
 	if mode == "" {
 		mode = "full"
 	}
+	memoryMode := normalizeMode(opts.MemoryMode)
 
 	switch mode {
 	case "none":
@@ -33,7 +35,7 @@ func BuildPrompt(loader *Loader, registry *tools.Registry, opts PromptOptions) s
 	case "minimal":
 		prompt.WriteString(loader.MinimalPrompt())
 	default:
-		prompt.WriteString(loader.SystemPrompt())
+		prompt.WriteString(loader.SystemPromptForMode(memoryMode))
 
 		skillsSummary := loader.SkillsSummary()
 		if skillsSummary != "" {
@@ -72,13 +74,8 @@ func BuildPrompt(loader *Loader, registry *tools.Registry, opts PromptOptions) s
 
 		if registry != nil {
 			if _, hasMemorySearch := registry.Get("memory_search"); hasMemorySearch {
-				prompt.WriteString("## Memory\n\n")
-				prompt.WriteString("Before answering anything about prior work, decisions, dates, people, preferences, or todos:\n")
-				prompt.WriteString("call memory_search first, then use the results to inform your answer.\n")
-				if _, hasMemoryGet := registry.Get("memory_get"); hasMemoryGet {
-					prompt.WriteString("If needed, call memory_get with source + header_path for exact context.\n")
-				}
-				prompt.WriteString("\n")
+				_, hasMemoryGet := registry.Get("memory_get")
+				prompt.WriteString(buildMemorySection(memoryMode, loader, hasMemoryGet))
 			}
 		}
 
@@ -115,4 +112,70 @@ func BuildPrompt(loader *Loader, registry *tools.Registry, opts PromptOptions) s
 		runtime.GOOS, runtime.GOARCH, now().Format("2006-01-02")))
 
 	return prompt.String()
+}
+
+// buildMemorySection emits the "## Memory" guidance block. The text is
+// mode-aware so the agent gets clear direction about whether to rely on
+// inlined daily notes or to retrieve them on demand.
+func buildMemorySection(memoryMode string, loader *Loader, hasMemoryGet bool) string {
+	var b strings.Builder
+	b.WriteString("## Memory\n\n")
+
+	switch memoryMode {
+	case MemoryModeRetrievalFirst:
+		b.WriteString("Memory mode: retrieval_first.\n")
+		b.WriteString("Daily notes (memory/YYYY-MM-DD.md) are NOT inlined in this prompt — search for them.\n")
+		b.WriteString("Before answering anything about prior work, decisions, dates, people, preferences, or todos:\n")
+		b.WriteString("1. Call memory_search with a focused query.\n")
+		if hasMemoryGet {
+			b.WriteString("2. If a result looks relevant, call memory_get with the exact source + header_path for full context.\n")
+		}
+		b.WriteString("Cite source paths (e.g. memory/2026-04-29.md) when you use retrieved content so the user can verify.\n")
+		if loader != nil {
+			if hint := dailyNoteHint(loader, MemoryModeRetrievalFirst); hint != "" {
+				b.WriteString(hint)
+			}
+		}
+	case MemoryModeStartupRecent:
+		b.WriteString("Memory mode: startup_recent.\n")
+		b.WriteString("Today's daily note is inlined above; older notes are NOT — search for them.\n")
+		b.WriteString("Before answering questions that span beyond today, call memory_search and cite source paths.\n")
+		if hasMemoryGet {
+			b.WriteString("Use memory_get with source + header_path for exact context when needed.\n")
+		}
+		if loader != nil {
+			if hint := dailyNoteHint(loader, MemoryModeStartupRecent); hint != "" {
+				b.WriteString(hint)
+			}
+		}
+	default:
+		b.WriteString("Memory mode: eager.\n")
+		b.WriteString("Before answering anything about prior work, decisions, dates, people, preferences, or todos:\n")
+		b.WriteString("call memory_search first, then use the results to inform your answer.\n")
+		if hasMemoryGet {
+			b.WriteString("If needed, call memory_get with source + header_path for exact context.\n")
+		}
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// dailyNoteHint surfaces the names of daily notes the loader has on disk but
+// did NOT inline in the system prompt. Listing them helps the agent pick a
+// targeted memory_get call without first having to discover the filename.
+func dailyNoteHint(loader *Loader, memoryMode string) string {
+	sources := loader.DailyNoteSourcesForMode(memoryMode)
+	if len(sources) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Available retrieval-only daily notes: ")
+	for i, s := range sources {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(s)
+	}
+	b.WriteString(".\n")
+	return b.String()
 }

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -68,6 +68,7 @@ type AIConfig struct {
 	ModelAliases    map[string]string
 	DefaultThinking string                    // Default thinking level when no session override is set
 	Routing         config.ModelRoutingConfig // Per-task-type model routing
+	MemoryMode      string                    // Memory prompt mode: "eager", "retrieval_first", "startup_recent"
 }
 
 // New creates a new bot instance
@@ -189,6 +190,7 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 			DefaultThinking: aiCfg.DefaultThinking,
 			DefaultClient:   aiClient,
 			ModelAliases:    aiCfg.ModelAliases,
+			MemoryMode:      aiCfg.MemoryMode,
 		},
 		ToolRegistry: toolRegistry,
 		Scheduler:    scheduler,

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/telebot.v4"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/bootstrap"
 	"ok-gobot/internal/storage"
 	"ok-gobot/internal/tools"
 )
@@ -283,8 +284,34 @@ func (b *Bot) handleContextCommand(c telebot.Context) error {
 	toolCount := len(b.toolRegistry.List())
 	sb.WriteString(fmt.Sprintf("• Tools: %d registered\n", toolCount))
 
-	// Memory
-	sb.WriteString("• Daily memory: today + yesterday notes\n")
+	// Memory mode + indexed daily notes
+	memoryMode := bootstrap.NormalizeMemoryMode(b.aiConfig.MemoryMode)
+	sb.WriteString(fmt.Sprintf("• Memory mode: `%s` — %s\n", memoryMode, memoryModeBlurb(memoryMode)))
+	if loader := b.personality.Loader(); loader != nil {
+		inline := loader.DailyNoteDatesForMode(memoryMode)
+		if len(inline) > 0 {
+			sb.WriteString(fmt.Sprintf("• Inlined daily notes: %s\n", strings.Join(inline, ", ")))
+		} else {
+			sb.WriteString("• Inlined daily notes: none (retrieval-first)\n")
+		}
+		retrievalOnly := loader.DailyNoteSourcesForMode(memoryMode)
+		if len(retrievalOnly) > 0 {
+			sb.WriteString(fmt.Sprintf("• Retrieval-only daily notes: %s\n", strings.Join(retrievalOnly, ", ")))
+		}
+	}
+	memoryEnabled := false
+	if _, ok := b.toolRegistry.Get("memory_search"); ok {
+		memoryEnabled = true
+	}
+	if memoryEnabled {
+		sb.WriteString("• Active memory tools: `memory_search`")
+		if _, ok := b.toolRegistry.Get("memory_get"); ok {
+			sb.WriteString(", `memory_get`")
+		}
+		sb.WriteString("\n")
+	} else {
+		sb.WriteString("• Active memory tools: none (memory.enabled=false)\n")
+	}
 
 	// Session info
 	sb.WriteString(fmt.Sprintf("\n*Session:*\n"))
@@ -303,6 +330,18 @@ func (b *Bot) handleContextCommand(c telebot.Context) error {
 	}
 
 	return c.Send(sb.String(), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+}
+
+// memoryModeBlurb returns a short, human-friendly description of a memory mode.
+func memoryModeBlurb(mode string) string {
+	switch mode {
+	case bootstrap.MemoryModeRetrievalFirst:
+		return "MEMORY.md inlined; daily notes via memory_search"
+	case bootstrap.MemoryModeStartupRecent:
+		return "MEMORY.md + today inlined; older notes via memory_search"
+	default:
+		return "MEMORY.md + today + yesterday inlined"
+	}
 }
 
 // handleCompactCommand manually compacts session context using the D0/D1/D2

--- a/internal/bot/status.go
+++ b/internal/bot/status.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/telebot.v4"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/bootstrap"
 	"ok-gobot/internal/tools"
 	"ok-gobot/internal/version"
 )
@@ -80,6 +81,13 @@ func (b *Bot) buildStatusString(chatID int64) string {
 	}
 	queueDepth := b.debouncer.GetPendingCount()
 	sb.WriteString(fmt.Sprintf("⚙️ Think: %s · 🪢 Queue: %s (depth %d)\n", thinkLevel, queueMode, queueDepth))
+
+	memoryMode := bootstrap.NormalizeMemoryMode(b.aiConfig.MemoryMode)
+	memoryToolStatus := "off"
+	if _, ok := b.toolRegistry.Get("memory_search"); ok {
+		memoryToolStatus = "on"
+	}
+	sb.WriteString(fmt.Sprintf("🧠 Memory: mode=`%s` · tools=%s\n", memoryMode, memoryToolStatus))
 
 	// Estop state
 	estopEnabled, err := b.store.IsEmergencyStopEnabled()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -208,6 +208,7 @@ type STTConfig struct {
 // MemoryConfig holds semantic memory configuration
 type MemoryConfig struct {
 	Enabled            bool                    `mapstructure:"enabled"`             // Enable semantic memory
+	Mode               string                  `mapstructure:"mode"`                // Prompt assembly mode: "eager" (default), "retrieval_first", or "startup_recent"
 	EmbeddingsBaseURL  string                  `mapstructure:"embeddings_base_url"` // API base URL for embeddings
 	EmbeddingsAPIKey   string                  `mapstructure:"embeddings_api_key"`  // API key for embeddings (can reuse ai.api_key)
 	EmbeddingsModel    string                  `mapstructure:"embeddings_model"`    // Embeddings model to use
@@ -228,6 +229,49 @@ type MemoryExtraPathConfig struct {
 	Patterns []string `mapstructure:"patterns"`  // Glob patterns relative to path (defaults to ["**/*.md"])
 	ReadOnly *bool    `mapstructure:"read_only"` // Defaults to true; reserved for future write enablement
 	Scope    string   `mapstructure:"scope"`     // Optional human-readable scope label (e.g. "obsidian", "homelab")
+}
+
+// Memory prompt mode constants. The mode controls what the bootstrap loader
+// pulls into the system prompt and what guidance the agent receives about
+// memory_search / memory_get usage.
+const (
+	// MemoryModeEager loads MEMORY.md and today's + yesterday's daily notes
+	// into the system prompt. Original ok-gobot behavior; preserved as the
+	// default for backward compatibility.
+	MemoryModeEager = "eager"
+	// MemoryModeRetrievalFirst keeps MEMORY.md in the prompt for compact
+	// long-term context but omits daily notes. Pairs with strong instructions
+	// to call memory_search / memory_get and cite source paths.
+	MemoryModeRetrievalFirst = "retrieval_first"
+	// MemoryModeStartupRecent loads MEMORY.md plus today's daily note (only)
+	// for a session-start one-shot bootstrap. Yesterday's note is reachable
+	// via retrieval but not eagerly injected.
+	MemoryModeStartupRecent = "startup_recent"
+)
+
+// NormalizeMemoryMode returns the normalized mode name. Empty input falls
+// back to MemoryModeEager.
+func NormalizeMemoryMode(mode string) string {
+	switch strings.TrimSpace(strings.ToLower(mode)) {
+	case "", MemoryModeEager:
+		return MemoryModeEager
+	case MemoryModeRetrievalFirst:
+		return MemoryModeRetrievalFirst
+	case MemoryModeStartupRecent:
+		return MemoryModeStartupRecent
+	default:
+		return mode
+	}
+}
+
+// IsValidMemoryMode reports whether mode is a recognized memory prompt mode.
+func IsValidMemoryMode(mode string) bool {
+	switch mode {
+	case MemoryModeEager, MemoryModeRetrievalFirst, MemoryModeStartupRecent:
+		return true
+	default:
+		return false
+	}
 }
 
 // MemoryMCPConfig holds memory MCP server configuration
@@ -297,6 +341,7 @@ func Load() (*Config, error) {
 	v.SetDefault("stt.api_key", "")
 	v.SetDefault("stt.confidence_threshold", 0.6)
 	v.SetDefault("memory.enabled", false)
+	v.SetDefault("memory.mode", MemoryModeEager)
 	v.SetDefault("memory.embeddings_base_url", "https://api.openai.com/v1")
 	v.SetDefault("memory.embeddings_api_key", "")
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
@@ -411,6 +456,7 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("stt.api_key", "")
 	v.SetDefault("stt.confidence_threshold", 0.6)
 	v.SetDefault("memory.enabled", false)
+	v.SetDefault("memory.mode", MemoryModeEager)
 	v.SetDefault("memory.embeddings_base_url", "https://api.openai.com/v1")
 	v.SetDefault("memory.embeddings_api_key", "")
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
@@ -547,6 +593,11 @@ func (c *Config) Validate() error {
 	validDMScope := map[string]bool{"main": true, "per_user": true}
 	if c.Session.DMScope != "" && !validDMScope[c.Session.DMScope] {
 		return fmt.Errorf("invalid session.dm_scope: %s (must be 'main' or 'per_user')", c.Session.DMScope)
+	}
+
+	// Validate memory prompt mode
+	if c.Memory.Mode != "" && !IsValidMemoryMode(c.Memory.Mode) {
+		return fmt.Errorf("invalid memory.mode: %q (must be 'eager', 'retrieval_first', or 'startup_recent')", c.Memory.Mode)
 	}
 
 	// Validate TTS provider

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -596,7 +596,7 @@ func (c *Config) Validate() error {
 	}
 
 	// Validate memory prompt mode
-	if c.Memory.Mode != "" && !IsValidMemoryMode(c.Memory.Mode) {
+	if c.Memory.Mode != "" && !IsValidMemoryMode(NormalizeMemoryMode(c.Memory.Mode)) {
 		return fmt.Errorf("invalid memory.mode: %q (must be 'eager', 'retrieval_first', or 'startup_recent')", c.Memory.Mode)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -416,3 +416,91 @@ agents:
 		t.Errorf("expected 2 allowed_tools, got %d", len(agent.AllowedTools))
 	}
 }
+
+func TestLoadFromMemoryModeDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+  provider: "openrouter"
+storage_path: "/tmp/test.db"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if cfg.Memory.Mode != MemoryModeEager {
+		t.Errorf("memory.mode default = %q, want %q", cfg.Memory.Mode, MemoryModeEager)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestLoadFromMemoryModeRetrievalFirst(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+  provider: "openrouter"
+storage_path: "/tmp/test.db"
+memory:
+  mode: "retrieval_first"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if cfg.Memory.Mode != MemoryModeRetrievalFirst {
+		t.Errorf("memory.mode = %q, want %q", cfg.Memory.Mode, MemoryModeRetrievalFirst)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestValidateRejectsUnknownMemoryMode(t *testing.T) {
+	cfg := &Config{
+		Telegram:    TelegramConfig{Token: "t"},
+		AI:          AIConfig{APIKey: "k", Model: "m", Provider: "openrouter"},
+		Auth:        AuthConfig{Mode: "open"},
+		Memory:      MemoryConfig{Mode: "wholly-invented"},
+		StoragePath: "/tmp/x",
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatalf("Validate must reject unknown memory.mode")
+	}
+}
+
+func TestNormalizeMemoryMode(t *testing.T) {
+	cases := map[string]string{
+		"":                   MemoryModeEager,
+		"eager":              MemoryModeEager,
+		"EAGER":              MemoryModeEager,
+		"  retrieval_first ": MemoryModeRetrievalFirst,
+		"startup_recent":     MemoryModeStartupRecent,
+	}
+	for in, want := range cases {
+		if got := NormalizeMemoryMode(in); got != want {
+			t.Errorf("NormalizeMemoryMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := NormalizeMemoryMode("???"); got != "???" {
+		t.Errorf("unknown values should be returned verbatim so Validate can reject them, got %q", got)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -487,6 +487,21 @@ func TestValidateRejectsUnknownMemoryMode(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsCaseVariantMemoryMode(t *testing.T) {
+	for _, mode := range []string{"EAGER", "Eager", "Retrieval_First", "  startup_recent "} {
+		cfg := &Config{
+			Telegram:    TelegramConfig{Token: "t"},
+			AI:          AIConfig{APIKey: "k", Model: "m", Provider: "openrouter"},
+			Auth:        AuthConfig{Mode: "open"},
+			Memory:      MemoryConfig{Mode: mode},
+			StoragePath: "/tmp/x",
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate(memory.mode=%q) unexpected error: %v", mode, err)
+		}
+	}
+}
+
 func TestNormalizeMemoryMode(t *testing.T) {
 	cases := map[string]string{
 		"":                   MemoryModeEager,


### PR DESCRIPTION
Implements #306

## Summary

Adds a `memory.mode` config knob with three values controlling how memory is injected into the system prompt:

- `eager` (default) — preserves the original behavior: `MEMORY.md` + today's + yesterday's daily notes are all inlined.
- `retrieval_first` — keeps `MEMORY.md` for stable identity context, but drops daily notes from the prompt and instructs the agent to use `memory_search` / `memory_get` with explicit source-path citations.
- `startup_recent` — inlines `MEMORY.md` + today's daily note only; older days move to retrieval.

Identity/personality files (`SOUL.md`, `IDENTITY.md`, `USER.md`, `TOOLS.md`, `AGENTS.md`, `HEARTBEAT.md`) are **always** loaded so the bot retains stable bootstrap context regardless of mode.

## Changes

- `internal/config`: new `MemoryConfig.Mode`, mode constants, `NormalizeMemoryMode`, `IsValidMemoryMode`, validation.
- `internal/bootstrap`: `SystemPromptForMode(mode)` selects which daily notes to inline; new `DailyNoteDatesForMode` / `DailyNoteSourcesForMode` helpers expose retrieval-only daily notes for prompt and UI use. `BuildPrompt` emits a mode-specific `## Memory` section listing retrieval-only sources so the agent has a deterministic `memory_get` target.
- `internal/agent`: `ToolCallingAgent.MemoryMode` flows from `RunResolver.AIConfig.MemoryMode` → `SetMemoryMode` → `BuildPrompt` `PromptOptions`.
- `internal/bot`: `AIConfig.MemoryMode` is the single transport into `RunResolver`. `/context` reports the active mode plus inlined vs. retrieval-only daily notes; `/status` adds a one-line `🧠 Memory: mode=… · tools=on|off` summary.
- `internal/app`: pulls `memory.mode` from config and feeds it through `bot.AIConfig`.
- Config: `config.example.yaml` + `docs/ARCHITECTURE.md` (canonical schema source) updated; `config.schema.json` regenerated.
- Docs: `docs/MEMORY.md` and `docs/MEMORY-CONTEXT-PIPELINE.md` gain a Memory Prompt Modes section with the injection-vs-retrieval table and the recommendation to pair `retrieval_first` with Active Memory (#305).

## Acceptance criteria

- ✅ Default mode is `eager` for backward compat; recommended `retrieval_first` documented for users with `memory.enabled: true`.
- ✅ Stable bootstrap context (`SOUL`/`IDENTITY`/`USER`/etc. + `MEMORY.md`) is always loaded.
- ✅ Older decisions are answerable through retrieval (`memory_search` + `memory_get`); the prompt block lists retrieval-only daily-note paths so verbose/debug consumers can see what's available.
- ✅ `/context` shows mode, inlined daily notes, retrieval-only daily notes, active memory tools.
- ✅ Tests cover prompt assembly in all three modes and assert daily notes never appear in both the inlined block and the retrieval-only hint.

## Testing

```
go fmt ./...
go vet ./...
go test ./...    # all packages green
go build ./cmd/ok-gobot/
```

New tests:
- `internal/bootstrap/memory_mode_test.go` — eager / retrieval_first / startup_recent prompt assembly, retrieval-only listings, normalize, no-duplication invariant.
- `internal/agent/personality_test.go` — `ToolCallingAgent.SetMemoryMode` propagates correctly through `BuildPrompt`.
- `internal/config/config_test.go` — default/explicit `memory.mode` loading, `Validate` rejects unknown values, `NormalizeMemoryMode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `memory.mode` config knob (`eager` / `retrieval_first` / `startup_recent`) that controls whether daily notes are inlined into the system prompt or left as retrieval-only sources. The implementation threads the mode through config → app → bot → resolver → agent → bootstrap cleanly, with good backward-compatibility defaults and thorough test coverage across all three modes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — well-tested, backward-compatible, and no logic defects found.

No P0 or P1 issues found. The previously flagged Validate/NormalizeMemoryMode inconsistency has been correctly resolved. The two NormalizeMemoryMode implementations (config vs bootstrap) have intentionally different unknown-value semantics, which is both documented and tested. All three modes are covered by frozen-clock unit tests with a no-duplication invariant.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Adds MemoryConfig.Mode field, mode constants, NormalizeMemoryMode (returns verbatim unknown for Validate to catch), IsValidMemoryMode, and SetDefault for both Load/LoadFrom; validation correctly normalizes before checking. |
| internal/bootstrap/loader.go | Adds SystemPromptForMode, DailyNoteDatesForMode, DailyNoteSourcesForMode; normalizeMode always falls back to eager for unknowns (safe runtime default); loadFiles still only loads today/yesterday so Sources only reflects those two files. |
| internal/bootstrap/prompt.go | Replaces monolithic memory section with mode-aware buildMemorySection; memory guidance block is still only emitted when memory_search is registered, which correctly gates retrieval_first instructions behind tool availability. |
| internal/bootstrap/memory_mode_test.go | New test file with frozen-clock fixture covering all three modes, Sources/Dates helpers, normalize, no-duplication invariant; well-structured and thorough. |
| internal/agent/tool_agent.go | Adds MemoryMode field and SetMemoryMode; passes value through to BuildPrompt PromptOptions cleanly. |
| internal/bot/commands.go | /context command augmented with mode, inlined/retrieval-only daily note lists, and tool availability; uses bootstrap.NormalizeMemoryMode which falls back to eager for unknowns. |
| internal/agent/resolver.go | Threads MemoryMode from AIResolverConfig into SetMemoryMode; the non-empty guard means a fully-normalized empty value (which never occurs post-app.go normalization) would harmlessly skip the call. |
| internal/bot/status.go | Adds compact 🧠 Memory line to /status output showing mode and tool availability. |
| internal/app/app.go | Pulls memory.mode from config, normalizes via config.NormalizeMemoryMode, and feeds into AIConfig; single entry point into the agent pipeline. |
| internal/config/config_test.go | New tests cover default loading, explicit retrieval_first loading, rejection of unknown modes, acceptance of case-variant modes, and normalize behavior including verbatim-passthrough for unknowns. |
| internal/agent/personality_test.go | New tests verify retrieval_first excludes all daily notes, startup_recent inlines only today, and default (empty) mode is eager. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(config): normalize memory.mode befor..."](https://github.com/befeast/ok-gobot/commit/ecb97a2a64b2daa8898c86e84f95963d0ef57b9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30220977)</sub>

<!-- /greptile_comment -->