### PR TITLE
feat(memory): lifecycle memory flush before compaction and job completion (#307)

### DIFF
--- a/docs/MEMORY-CONTEXT-PIPELINE.md
+++ b/docs/MEMORY-CONTEXT-PIPELINE.md
@@ -436,15 +436,52 @@ redundancy.
 
 The `/compact` command:
 1. Loads all v2 transcript messages for the session
-2. Calls the AI to summarize the conversation
-3. Clears the old messages from `session_messages_v2`
-4. Inserts a single assistant message with the compacted summary
-5. Updates the compaction counter
+2. Runs a **lifecycle memory flush** (see 7.5) before any messages are removed
+3. Calls the AI to summarize the conversation
+4. Clears the old messages from `session_messages_v2`
+5. Inserts a single assistant message with the compacted summary
+6. Updates the compaction counter
 
 The result is reported to the user:
 ```
 Tokens saved: 12000 → 800 (11200 saved)
 ```
+
+### 7.5 Lifecycle Memory Flush
+
+The `LifecycleFlusher` (`internal/agent/lifecycle_memory.go`) is a bounded
+memory-preservation hook attached to the points where context is most likely to
+be lost:
+
+| Trigger                       | Flush kind        |
+|-------------------------------|-------------------|
+| Pre-`/compact` (this section) | `pre-compact`     |
+| Successful long role job      | `job-success`     |
+| Failed role job               | `job-failure`     |
+| Timed-out role job            | `job-timeout`     |
+| Cancelled role job            | `job-cancelled`   |
+
+Each flush appends a **draft section** to today's daily note (under
+`memory/<YYYY-MM-DD>.md`) with:
+
+- the lifecycle kind and timestamp,
+- source IDs (`session`, `job`, `run`, `role`) for traceability,
+- a bounded `summary` and optional `detail` line,
+- artifact references for completed jobs,
+- a `> draft pending review` marker so a human reviewer can promote or discard.
+
+**Write policy (v1):**
+
+- Drafts go to the daily note **only**. The flusher never silently writes to
+  `MEMORY.md`. `RequestDurableUpdate` returns `ErrDurableMemoryNeedsApproval`
+  so durable promotions must go through the existing admin approval flow.
+- Untrusted tool output is preserved as a marked draft, not as durable memory.
+- Flush failure is logged and surfaced as a warning but never blocks
+  compaction or the job's recorded outcome (so emergency compaction can always
+  proceed).
+- In-process **dedup** suppresses repeat flushes for the same lifecycle state:
+  the key is `(kind, session/job ID, message-count for pre-compact)`. A real
+  retry after a write error is allowed once the underlying error clears.
 
 ---
 
@@ -513,6 +550,7 @@ Complete flow for a Telegram DM message:
 | `internal/bootstrap/scaffold.go` | Create default bootstrap directory structure |
 | `internal/agent/tool_agent.go` | Agent tool loop, fallback handling, AgentResponse |
 | `internal/agent/memory.go` | Daily notes read/write, MEMORY.md access |
+| `internal/agent/lifecycle_memory.go` | Lifecycle memory flush (pre-compact, job outcomes) with dedup + write policy |
 | `internal/agent/compactor.go` | Context compaction via AI summarization |
 | `internal/agent/tokens.go` | Token counting, model context limits |
 | `internal/bot/hub_handler.go` | Request orchestration, history loading, persistence |
@@ -534,7 +572,7 @@ simpler (single-channel Telegram, no multi-surface routing).
 | Bootstrap files in prompt | SOUL, USER, AGENTS, MEMORY, TOOLS, IDENTITY, HEARTBEAT, daily today | SOUL, IDENTITY, USER, TOOLS, AGENTS, HEARTBEAT, MEMORY, daily today + yesterday |
 | Daily notes | Today only | Today + yesterday |
 | Session history | Full multi-turn | Full multi-turn (120 messages) |
-| Compaction | Implemented | Logic exists, command not wired |
+| Compaction | Implemented | Implemented; `/compact` runs a lifecycle memory flush before replacing transcript history |
 | Semantic search | Via tool call | Via tool call |
 | Channels | Multi-channel (Telegram, Discord, etc.) | Telegram only |
 | Honest failures | Clear error messages | Clear error messages (IsFallback guard) |
@@ -552,7 +590,9 @@ simpler (single-channel Telegram, no multi-surface routing).
 
 3. **No MEMORY.md auto-curation** — MEMORY.md must be manually edited (via `file`
    tool or direct edit). There is no automatic summarization or promotion from
-   daily notes to long-term memory.
+   daily notes to long-term memory. The lifecycle memory flush stages drafts in
+   the daily note but explicitly refuses durable MEMORY.md updates in v1; admin
+   approval is required to promote a draft.
 
 4. **No automatic compaction trigger** — `/compact` works but must be invoked
    manually. There is no automatic trigger when context approaches the limit.

--- a/internal/agent/lifecycle_memory.go
+++ b/internal/agent/lifecycle_memory.go
@@ -1,0 +1,231 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FlushKind identifies a lifecycle moment that triggered a memory flush.
+type FlushKind string
+
+const (
+	// FlushKindPreCompact runs before /compact (or any preflight compaction)
+	// replaces transcript history with summaries.
+	FlushKindPreCompact FlushKind = "pre-compact"
+	// FlushKindJobSuccess runs after a successful long role/runtime job.
+	FlushKindJobSuccess FlushKind = "job-success"
+	// FlushKindJobFailure runs after a failed job to preserve diagnostics.
+	FlushKindJobFailure FlushKind = "job-failure"
+	// FlushKindJobTimeout runs after a timed-out job.
+	FlushKindJobTimeout FlushKind = "job-timeout"
+	// FlushKindJobCancelled runs after a cancelled job.
+	FlushKindJobCancelled FlushKind = "job-cancelled"
+)
+
+// FlushRecord describes one bounded lifecycle memory flush opportunity. Fields
+// are intentionally small: this is a guarded preservation hook, not a free-form
+// memory write. Source IDs (JobID, SessionKey, RunID) are included for
+// traceability so the daily-note draft can be tied back to its origin.
+type FlushRecord struct {
+	Kind       FlushKind
+	JobID      string
+	SessionKey string
+	RunID      string
+	RoleName   string
+	// MessageCount is the transcript size at the time of a pre-compact flush.
+	// Combined with SessionKey it forms the dedup key for that compaction.
+	MessageCount int
+	Summary      string
+	Detail       string
+	Artifacts    []string
+}
+
+// FlushResult is the outcome of one Flush call. A skipped flush is NOT an
+// error: the caller (compaction, job lifecycle) should continue regardless so
+// emergency compaction is never blocked indefinitely.
+type FlushResult struct {
+	Skipped  bool
+	Reason   string
+	Path     string
+	DedupKey string
+	Body     string
+}
+
+// ErrDurableMemoryNeedsApproval is returned when a caller asks the lifecycle
+// flusher to silently mutate MEMORY.md. v1 forbids this: durable updates must
+// be staged into a daily-note draft and then promoted by an admin.
+var ErrDurableMemoryNeedsApproval = errors.New("durable MEMORY.md updates require explicit admin approval (v1)")
+
+// LifecycleFlusher writes bounded, deduplicated memory drafts at session/job
+// lifecycle moments. By default it appends a draft section to today's daily
+// note via the underlying *Memory; it never silently rewrites MEMORY.md.
+type LifecycleFlusher struct {
+	mem *Memory
+	now func() time.Time
+
+	mu   sync.Mutex
+	done map[string]bool
+}
+
+// NewLifecycleFlusher creates a flusher that writes drafts via mem. mem may be
+// nil — in that case Flush returns a Skipped result rather than an error so a
+// missing memory configuration never blocks compaction or job completion.
+func NewLifecycleFlusher(mem *Memory) *LifecycleFlusher {
+	return &LifecycleFlusher{
+		mem:  mem,
+		now:  time.Now,
+		done: make(map[string]bool),
+	}
+}
+
+// SetClock overrides the time source. Used by tests.
+func (f *LifecycleFlusher) SetClock(now func() time.Time) {
+	if f == nil || now == nil {
+		return
+	}
+	f.now = now
+}
+
+// dedupKey returns the stable key used to suppress duplicate flushes for the
+// same compaction or job state.
+func dedupKey(rec FlushRecord) string {
+	switch rec.Kind {
+	case FlushKindPreCompact:
+		return fmt.Sprintf("pre-compact|%s|%d", rec.SessionKey, rec.MessageCount)
+	default:
+		key := rec.JobID
+		if key == "" {
+			key = rec.SessionKey
+		}
+		return fmt.Sprintf("%s|%s", string(rec.Kind), key)
+	}
+}
+
+// Flush writes a bounded lifecycle draft and returns a FlushResult. It never
+// blocks the caller: a nil flusher, nil memory, or write error all surface as
+// either an error result or a Skipped result, but the caller may continue.
+//
+// Dedup: repeat calls with the same (kind, source-id, message-count) are
+// suppressed in-process so a retry of the same compaction or job state does
+// not produce duplicate drafts.
+func (f *LifecycleFlusher) Flush(rec FlushRecord) (FlushResult, error) {
+	if f == nil {
+		return FlushResult{Skipped: true, Reason: "lifecycle flusher not configured"}, nil
+	}
+	if rec.Kind == "" {
+		return FlushResult{Skipped: true, Reason: "flush kind is empty"}, nil
+	}
+
+	key := dedupKey(rec)
+	f.mu.Lock()
+	if f.done[key] {
+		f.mu.Unlock()
+		return FlushResult{Skipped: true, Reason: "already flushed for this lifecycle state", DedupKey: key}, nil
+	}
+	// Reserve the key before writing so concurrent calls dedup even if the
+	// write below fails. The clear-on-error path below releases the slot so
+	// a real retry can succeed once the underlying problem is fixed.
+	f.done[key] = true
+	f.mu.Unlock()
+
+	if f.mem == nil {
+		return FlushResult{Skipped: true, Reason: "memory writer not configured", DedupKey: key}, nil
+	}
+
+	body := formatFlushBody(rec, f.clock())
+	if err := f.mem.appendToTodayRaw(body); err != nil {
+		// Release the dedup slot so a follow-up retry can proceed once the
+		// underlying write problem (disk full, perms) is resolved.
+		f.mu.Lock()
+		delete(f.done, key)
+		f.mu.Unlock()
+		return FlushResult{DedupKey: key, Body: body}, fmt.Errorf("lifecycle memory flush: %w", err)
+	}
+
+	note, _ := f.mem.GetTodayNote()
+	path := ""
+	if note != nil {
+		path = note.Path
+	}
+	return FlushResult{DedupKey: key, Body: body, Path: path}, nil
+}
+
+// RequestDurableUpdate is the v1 guard for direct MEMORY.md writes. It always
+// refuses: durable promotions must go through the admin-approval flow, not
+// through automatic lifecycle flushes.
+func (f *LifecycleFlusher) RequestDurableUpdate(rec FlushRecord) (FlushResult, error) {
+	return FlushResult{
+		Skipped:  true,
+		Reason:   "durable memory write requires admin approval — staged as daily-note draft instead",
+		DedupKey: dedupKey(rec),
+	}, ErrDurableMemoryNeedsApproval
+}
+
+// Reset clears the in-process dedup table. Tests use this to re-exercise the
+// same lifecycle moment without spinning up a fresh flusher.
+func (f *LifecycleFlusher) Reset() {
+	if f == nil {
+		return
+	}
+	f.mu.Lock()
+	f.done = make(map[string]bool)
+	f.mu.Unlock()
+}
+
+func (f *LifecycleFlusher) clock() time.Time {
+	if f.now == nil {
+		return time.Now()
+	}
+	return f.now()
+}
+
+// formatFlushBody renders a draft section for today's daily note. Output is
+// intentionally simple markdown: a header that flags this as a lifecycle
+// draft (so a human reviewer can promote or discard), a kind tag, source IDs
+// for traceability, and the bounded summary/detail.
+func formatFlushBody(rec FlushRecord, ts time.Time) string {
+	var sb strings.Builder
+	sb.WriteString("\n\n## Lifecycle memory draft (")
+	sb.WriteString(string(rec.Kind))
+	sb.WriteString(" • ")
+	sb.WriteString(ts.Format("15:04"))
+	sb.WriteString(")\n")
+	sb.WriteString("> draft pending review — promote to MEMORY.md only with admin approval\n")
+
+	if rec.SessionKey != "" {
+		fmt.Fprintf(&sb, "- session: `%s`\n", rec.SessionKey)
+	}
+	if rec.JobID != "" {
+		fmt.Fprintf(&sb, "- job: `%s`\n", rec.JobID)
+	}
+	if rec.RunID != "" {
+		fmt.Fprintf(&sb, "- run: `%s`\n", rec.RunID)
+	}
+	if rec.RoleName != "" {
+		fmt.Fprintf(&sb, "- role: `%s`\n", rec.RoleName)
+	}
+	if rec.Kind == FlushKindPreCompact && rec.MessageCount > 0 {
+		fmt.Fprintf(&sb, "- transcript size: %d messages\n", rec.MessageCount)
+	}
+	if rec.Summary != "" {
+		fmt.Fprintf(&sb, "- summary: %s\n", strings.TrimSpace(rec.Summary))
+	}
+	if rec.Detail != "" {
+		fmt.Fprintf(&sb, "- detail: %s\n", strings.TrimSpace(rec.Detail))
+	}
+	if len(rec.Artifacts) > 0 {
+		sb.WriteString("- artifacts:\n")
+		for _, a := range rec.Artifacts {
+			a = strings.TrimSpace(a)
+			if a == "" {
+				continue
+			}
+			fmt.Fprintf(&sb, "  - %s\n", a)
+		}
+	}
+
+	return sb.String()
+}

--- a/internal/agent/lifecycle_memory_test.go
+++ b/internal/agent/lifecycle_memory_test.go
@@ -1,0 +1,289 @@
+package agent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestFlusher(t *testing.T) (*LifecycleFlusher, string) {
+	t.Helper()
+	root := t.TempDir()
+	mem := NewMemory(root)
+	f := NewLifecycleFlusher(mem)
+	f.SetClock(func() time.Time { return time.Date(2026, 4, 29, 10, 30, 0, 0, time.UTC) })
+	return f, root
+}
+
+func todayNotePath(root string) string {
+	date := time.Now().Format("2006-01-02")
+	return filepath.Join(root, "memory", date+".md")
+}
+
+func readTodayNote(t *testing.T, root string) string {
+	t.Helper()
+	data, err := os.ReadFile(todayNotePath(root))
+	if err != nil {
+		t.Fatalf("read today note: %v", err)
+	}
+	return string(data)
+}
+
+func TestLifecycleFlush_PreCompactWritesDraft(t *testing.T) {
+	f, root := newTestFlusher(t)
+
+	res, err := f.Flush(FlushRecord{
+		Kind:         FlushKindPreCompact,
+		SessionKey:   "chat:42",
+		MessageCount: 120,
+		Summary:      "open todos: ship feature X, retire old auth",
+	})
+	if err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if res.Skipped {
+		t.Fatalf("expected write, got skip: %s", res.Reason)
+	}
+	if res.Path == "" || res.Path != todayNotePath(root) {
+		t.Fatalf("unexpected path: %q", res.Path)
+	}
+
+	body := readTodayNote(t, root)
+	if !strings.Contains(body, "Lifecycle memory draft (pre-compact") {
+		t.Fatalf("daily note missing pre-compact header:\n%s", body)
+	}
+	if !strings.Contains(body, "session: `chat:42`") {
+		t.Fatalf("daily note missing session id:\n%s", body)
+	}
+	if !strings.Contains(body, "transcript size: 120 messages") {
+		t.Fatalf("daily note missing message count:\n%s", body)
+	}
+	if !strings.Contains(body, "draft pending review") {
+		t.Fatalf("draft missing review-required marker:\n%s", body)
+	}
+}
+
+func TestLifecycleFlush_JobSuccessIncludesArtifacts(t *testing.T) {
+	f, root := newTestFlusher(t)
+
+	res, err := f.Flush(FlushRecord{
+		Kind:      FlushKindJobSuccess,
+		JobID:     "job-1",
+		RoleName:  "researcher",
+		Summary:   "compiled latest pipeline metrics",
+		Artifacts: []string{"reports/2026-04/metrics.md", "reports/2026-04/plot.png"},
+	})
+	if err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if res.Skipped {
+		t.Fatalf("expected write, got skip: %s", res.Reason)
+	}
+
+	body := readTodayNote(t, root)
+	if !strings.Contains(body, "Lifecycle memory draft (job-success") {
+		t.Fatalf("missing job-success header:\n%s", body)
+	}
+	if !strings.Contains(body, "job: `job-1`") {
+		t.Fatalf("missing job id:\n%s", body)
+	}
+	if !strings.Contains(body, "role: `researcher`") {
+		t.Fatalf("missing role name:\n%s", body)
+	}
+	if !strings.Contains(body, "reports/2026-04/metrics.md") {
+		t.Fatalf("missing artifact path:\n%s", body)
+	}
+}
+
+func TestLifecycleFlush_TimeoutAndFailurePreserveDetail(t *testing.T) {
+	cases := []struct {
+		name string
+		kind FlushKind
+		want string
+	}{
+		{"timeout", FlushKindJobTimeout, "job-timeout"},
+		{"failure", FlushKindJobFailure, "job-failure"},
+		{"cancelled", FlushKindJobCancelled, "job-cancelled"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, root := newTestFlusher(t)
+			res, err := f.Flush(FlushRecord{
+				Kind:    tc.kind,
+				JobID:   "job-x",
+				Summary: "background scrape",
+				Detail:  "context deadline exceeded after 5m",
+			})
+			if err != nil {
+				t.Fatalf("Flush() error = %v", err)
+			}
+			if res.Skipped {
+				t.Fatalf("expected write, got skip: %s", res.Reason)
+			}
+			body := readTodayNote(t, root)
+			if !strings.Contains(body, tc.want) {
+				t.Fatalf("missing kind tag %q in:\n%s", tc.want, body)
+			}
+			if !strings.Contains(body, "context deadline exceeded after 5m") {
+				t.Fatalf("missing diagnostic detail in:\n%s", body)
+			}
+		})
+	}
+}
+
+func TestLifecycleFlush_DeduplicatesSameState(t *testing.T) {
+	f, root := newTestFlusher(t)
+
+	rec := FlushRecord{
+		Kind:         FlushKindPreCompact,
+		SessionKey:   "chat:99",
+		MessageCount: 50,
+		Summary:      "first call",
+	}
+	first, err := f.Flush(rec)
+	if err != nil {
+		t.Fatalf("first Flush() error = %v", err)
+	}
+	if first.Skipped {
+		t.Fatalf("first call unexpectedly skipped: %s", first.Reason)
+	}
+
+	rec.Summary = "second call (should be ignored)"
+	second, err := f.Flush(rec)
+	if err != nil {
+		t.Fatalf("second Flush() error = %v", err)
+	}
+	if !second.Skipped {
+		t.Fatalf("expected duplicate flush to skip, got body=%q", second.Body)
+	}
+	if second.DedupKey != first.DedupKey {
+		t.Fatalf("dedup keys diverged: first=%q second=%q", first.DedupKey, second.DedupKey)
+	}
+
+	body := readTodayNote(t, root)
+	if strings.Count(body, "Lifecycle memory draft (pre-compact") != 1 {
+		t.Fatalf("expected exactly one draft section, got:\n%s", body)
+	}
+	if strings.Contains(body, "second call (should be ignored)") {
+		t.Fatalf("second flush leaked into note:\n%s", body)
+	}
+
+	// A different message count is a different compaction state — should write.
+	third, err := f.Flush(FlushRecord{
+		Kind:         FlushKindPreCompact,
+		SessionKey:   "chat:99",
+		MessageCount: 80,
+		Summary:      "later compaction",
+	})
+	if err != nil {
+		t.Fatalf("third Flush() error = %v", err)
+	}
+	if third.Skipped {
+		t.Fatalf("expected new state to write, got skip: %s", third.Reason)
+	}
+}
+
+func TestLifecycleFlush_DedupAcrossJobKinds(t *testing.T) {
+	f, _ := newTestFlusher(t)
+
+	if _, err := f.Flush(FlushRecord{Kind: FlushKindJobSuccess, JobID: "job-7"}); err != nil {
+		t.Fatalf("success flush error = %v", err)
+	}
+	// A failure for the same job should still be allowed: the kind differs,
+	// so the lifecycle state is distinct.
+	res, err := f.Flush(FlushRecord{Kind: FlushKindJobFailure, JobID: "job-7"})
+	if err != nil {
+		t.Fatalf("failure flush error = %v", err)
+	}
+	if res.Skipped {
+		t.Fatalf("expected failure flush to write despite earlier success, got skip: %s", res.Reason)
+	}
+}
+
+func TestLifecycleFlush_DurableMemoryRefusedInV1(t *testing.T) {
+	f, _ := newTestFlusher(t)
+
+	res, err := f.RequestDurableUpdate(FlushRecord{
+		Kind:    FlushKindJobSuccess,
+		JobID:   "job-9",
+		Summary: "durable note candidate",
+	})
+	if !errors.Is(err, ErrDurableMemoryNeedsApproval) {
+		t.Fatalf("expected ErrDurableMemoryNeedsApproval, got %v", err)
+	}
+	if !res.Skipped {
+		t.Fatalf("expected skipped result, got %#v", res)
+	}
+	if !strings.Contains(res.Reason, "admin approval") {
+		t.Fatalf("reason should mention admin approval: %q", res.Reason)
+	}
+}
+
+func TestLifecycleFlush_NilFlusherSafe(t *testing.T) {
+	var f *LifecycleFlusher
+	res, err := f.Flush(FlushRecord{Kind: FlushKindJobSuccess, JobID: "job-1"})
+	if err != nil {
+		t.Fatalf("nil flusher Flush() error = %v", err)
+	}
+	if !res.Skipped {
+		t.Fatalf("expected skip on nil flusher, got %#v", res)
+	}
+}
+
+func TestLifecycleFlush_NilMemorySkipsWithoutError(t *testing.T) {
+	f := NewLifecycleFlusher(nil)
+	f.SetClock(func() time.Time { return time.Date(2026, 4, 29, 10, 30, 0, 0, time.UTC) })
+	res, err := f.Flush(FlushRecord{Kind: FlushKindJobSuccess, JobID: "job-1"})
+	if err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if !res.Skipped {
+		t.Fatalf("expected skip when memory is nil, got %#v", res)
+	}
+	if res.Reason == "" {
+		t.Fatalf("expected reason explaining skip")
+	}
+}
+
+func TestLifecycleFlush_WriteFailureClearsDedupForRetry(t *testing.T) {
+	root := t.TempDir()
+	mem := NewMemory(root)
+
+	// Pre-create a directory at the today-note path so the file write fails
+	// (open returns EISDIR or similar). This simulates a transient I/O issue.
+	memDir := filepath.Join(root, "memory")
+	if err := os.MkdirAll(memDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	date := time.Now().Format("2006-01-02")
+	conflict := filepath.Join(memDir, date+".md")
+	if err := os.MkdirAll(conflict, 0o755); err != nil {
+		t.Fatalf("create conflicting dir: %v", err)
+	}
+
+	f := NewLifecycleFlusher(mem)
+	f.SetClock(func() time.Time { return time.Date(2026, 4, 29, 10, 30, 0, 0, time.UTC) })
+
+	rec := FlushRecord{Kind: FlushKindJobSuccess, JobID: "job-z"}
+	if _, err := f.Flush(rec); err == nil {
+		t.Fatalf("expected write error from path conflict, got nil")
+	}
+
+	// Replace the conflicting directory with a writable file location so the
+	// retry can succeed; flush must not be permanently dedup-blocked.
+	if err := os.RemoveAll(conflict); err != nil {
+		t.Fatalf("remove conflict: %v", err)
+	}
+
+	res, err := f.Flush(rec)
+	if err != nil {
+		t.Fatalf("retry Flush() error = %v", err)
+	}
+	if res.Skipped {
+		t.Fatalf("retry unexpectedly skipped: %s", res.Reason)
+	}
+}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -36,6 +36,7 @@ type Bot struct {
 	toolRegistry     *tools.Registry
 	safety           *agent.Safety
 	memory           *agent.Memory
+	lifecycleFlush   *agent.LifecycleFlusher
 	authManager      *AuthManager
 	groupManager     *GroupManager
 	approvalManager  *ApprovalManager
@@ -120,6 +121,7 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 	if personality != nil {
 		memoryBasePath = personality.BasePath
 	}
+	botMemory := agent.NewMemory(memoryBasePath)
 
 	b := &Bot{
 		api:              api,
@@ -131,7 +133,8 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		agentRegistry:    agentRegistry,
 		toolRegistry:     toolRegistry,
 		safety:           agent.NewSafety(),
-		memory:           agent.NewMemory(memoryBasePath),
+		memory:           botMemory,
+		lifecycleFlush:   agent.NewLifecycleFlusher(botMemory),
 		authManager:      authManager,
 		groupManager:     groupManager,
 		approvalManager:  NewApprovalManager(api),

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -364,6 +364,21 @@ func (b *Bot) handleCompactCommand(c telebot.Context) error {
 
 	_ = c.Send("🌳 Compacting conversation into context tree...")
 
+	// Lifecycle memory flush BEFORE the transcript is replaced. Failure must
+	// not block compaction (acceptance criteria: "Flush failure does not
+	// block emergency compaction forever; it produces a clear warning").
+	if flushRes, flushErr := b.lifecycleFlush.Flush(agent.FlushRecord{
+		Kind:         agent.FlushKindPreCompact,
+		SessionKey:   sk,
+		MessageCount: len(msgs),
+		Summary:      fmt.Sprintf("about to compact %d messages from session %s", len(msgs), sk),
+	}); flushErr != nil {
+		log.Printf("[lifecycle] pre-compact memory flush failed (continuing): %v", flushErr)
+		_ = c.Send(fmt.Sprintf("⚠️ Pre-compact memory flush failed: %v (continuing with compaction)", flushErr))
+	} else if flushRes.Skipped && flushRes.Reason != "" && flushRes.Reason != "already flushed for this lifecycle state" {
+		log.Printf("[lifecycle] pre-compact memory flush skipped: %s", flushRes.Reason)
+	}
+
 	tc := agent.NewTreeCompactor(b.ai, b.getEffectiveModel(c.Chat().ID))
 	treeResult, err := b.compactToTree(context.Background(), tc, sk, msgs)
 	if err != nil {

--- a/internal/bot/lifecycle_flush_test.go
+++ b/internal/bot/lifecycle_flush_test.go
@@ -95,6 +95,55 @@ func TestRunLifecycleJobFlush_CancelKind(t *testing.T) {
 	}
 }
 
+func TestRunLifecycleJobFlush_TimeoutDetailPrefersContextErr(t *testing.T) {
+	// When ctx has expired but runErr describes an unrelated downstream
+	// failure (e.g. the runner returned the side-effect of a cancelled
+	// I/O), the recorded Detail should reflect the context cause that
+	// drove the kind classification, not the misleading runErr.
+	flusher, root := newFlushFixture(t)
+	job := &storage.Job{JobID: "job-timeout-detail"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(2 * time.Millisecond)
+
+	runErr := errors.New("redis: connection refused")
+	runLifecycleJobFlush(ctx, flusher, job, "researcher", runtime.JobRunResult{}, runErr)
+
+	body := readFlushDailyNote(t, root)
+	if !strings.Contains(body, "job-timeout") {
+		t.Fatalf("expected job-timeout kind in:\n%s", body)
+	}
+	if !strings.Contains(body, "context deadline exceeded") {
+		t.Fatalf("expected context-derived detail, got:\n%s", body)
+	}
+	if strings.Contains(body, "redis: connection refused") {
+		t.Fatalf("did not expect misleading runErr in timeout detail:\n%s", body)
+	}
+}
+
+func TestRunLifecycleJobFlush_CancelDetailPrefersContextErr(t *testing.T) {
+	flusher, root := newFlushFixture(t)
+	job := &storage.Job{JobID: "job-cancel-detail"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	runErr := errors.New("upstream rpc: deadline propagated as failure")
+	runLifecycleJobFlush(ctx, flusher, job, "", runtime.JobRunResult{}, runErr)
+
+	body := readFlushDailyNote(t, root)
+	if !strings.Contains(body, "job-cancelled") {
+		t.Fatalf("expected job-cancelled kind in:\n%s", body)
+	}
+	if !strings.Contains(body, "context canceled") {
+		t.Fatalf("expected context-derived detail, got:\n%s", body)
+	}
+	if strings.Contains(body, "upstream rpc") {
+		t.Fatalf("did not expect misleading runErr in cancel detail:\n%s", body)
+	}
+}
+
 func TestRunLifecycleJobFlush_GenericFailure(t *testing.T) {
 	flusher, root := newFlushFixture(t)
 	job := &storage.Job{JobID: "job-4"}

--- a/internal/bot/lifecycle_flush_test.go
+++ b/internal/bot/lifecycle_flush_test.go
@@ -1,0 +1,140 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/runtime"
+	"ok-gobot/internal/storage"
+)
+
+func newFlushFixture(t *testing.T) (*agent.LifecycleFlusher, string) {
+	t.Helper()
+	root := t.TempDir()
+	mem := agent.NewMemory(root)
+	flusher := agent.NewLifecycleFlusher(mem)
+	flusher.SetClock(func() time.Time { return time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC) })
+	return flusher, root
+}
+
+func readFlushDailyNote(t *testing.T, root string) string {
+	t.Helper()
+	date := time.Now().Format("2006-01-02")
+	data, err := os.ReadFile(filepath.Join(root, "memory", date+".md"))
+	if err != nil {
+		t.Fatalf("read daily note: %v", err)
+	}
+	return string(data)
+}
+
+func TestRunLifecycleJobFlush_SuccessIncludesArtifacts(t *testing.T) {
+	flusher, root := newFlushFixture(t)
+	job := &storage.Job{JobID: "job-1", SessionKey: "chat:7"}
+	result := runtime.JobRunResult{
+		Summary: "scrape complete",
+		Artifacts: []runtime.JobArtifactSpec{
+			{Name: "report.md", URI: "file:///tmp/report.md"},
+			{Name: "summary.txt"},
+		},
+	}
+
+	runLifecycleJobFlush(context.Background(), flusher, job, "researcher", result, nil)
+
+	body := readFlushDailyNote(t, root)
+	if !strings.Contains(body, "job-success") {
+		t.Fatalf("expected job-success header in:\n%s", body)
+	}
+	if !strings.Contains(body, "role: `researcher`") {
+		t.Fatalf("missing role tag:\n%s", body)
+	}
+	if !strings.Contains(body, "report.md (file:///tmp/report.md)") {
+		t.Fatalf("missing artifact entry:\n%s", body)
+	}
+	if !strings.Contains(body, "summary.txt") {
+		t.Fatalf("missing un-URI artifact:\n%s", body)
+	}
+}
+
+func TestRunLifecycleJobFlush_TimeoutKindFromContextDeadline(t *testing.T) {
+	flusher, root := newFlushFixture(t)
+	job := &storage.Job{JobID: "job-2"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(2 * time.Millisecond)
+
+	runLifecycleJobFlush(ctx, flusher, job, "researcher", runtime.JobRunResult{Summary: "partial"}, ctx.Err())
+
+	body := readFlushDailyNote(t, root)
+	if !strings.Contains(body, "job-timeout") {
+		t.Fatalf("expected job-timeout kind in:\n%s", body)
+	}
+	if !strings.Contains(body, "context deadline exceeded") {
+		t.Fatalf("expected timeout detail in:\n%s", body)
+	}
+}
+
+func TestRunLifecycleJobFlush_CancelKind(t *testing.T) {
+	flusher, root := newFlushFixture(t)
+	job := &storage.Job{JobID: "job-3"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	runLifecycleJobFlush(ctx, flusher, job, "", runtime.JobRunResult{}, ctx.Err())
+
+	body := readFlushDailyNote(t, root)
+	if !strings.Contains(body, "job-cancelled") {
+		t.Fatalf("expected job-cancelled kind in:\n%s", body)
+	}
+}
+
+func TestRunLifecycleJobFlush_GenericFailure(t *testing.T) {
+	flusher, root := newFlushFixture(t)
+	job := &storage.Job{JobID: "job-4"}
+
+	runLifecycleJobFlush(context.Background(), flusher, job, "", runtime.JobRunResult{}, errors.New("boom"))
+
+	body := readFlushDailyNote(t, root)
+	if !strings.Contains(body, "job-failure") {
+		t.Fatalf("expected job-failure kind in:\n%s", body)
+	}
+	if !strings.Contains(body, "boom") {
+		t.Fatalf("expected failure detail in:\n%s", body)
+	}
+}
+
+func TestRunLifecycleJobFlush_DedupSameJobOutcome(t *testing.T) {
+	flusher, root := newFlushFixture(t)
+	job := &storage.Job{JobID: "job-5"}
+	result := runtime.JobRunResult{Summary: "first"}
+
+	runLifecycleJobFlush(context.Background(), flusher, job, "", result, nil)
+	// Second call with the same job and same kind should be deduped.
+	runLifecycleJobFlush(context.Background(), flusher, job, "", runtime.JobRunResult{Summary: "second"}, nil)
+
+	body := readFlushDailyNote(t, root)
+	if strings.Count(body, "Lifecycle memory draft (job-success") != 1 {
+		t.Fatalf("expected exactly one job-success draft, got:\n%s", body)
+	}
+	if strings.Contains(body, "second") {
+		t.Fatalf("dedup leaked second flush content into note:\n%s", body)
+	}
+}
+
+func TestRunLifecycleJobFlush_NilFlusherIsSafe(t *testing.T) {
+	// Must not panic when the bot has no lifecycle flusher (e.g. tests
+	// that build a partial *Bot without wiring memory).
+	runLifecycleJobFlush(context.Background(), nil, &storage.Job{JobID: "job-6"}, "", runtime.JobRunResult{}, nil)
+}
+
+func TestRunLifecycleJobFlush_NilJobIsSafe(t *testing.T) {
+	flusher, _ := newFlushFixture(t)
+	runLifecycleJobFlush(context.Background(), flusher, nil, "", runtime.JobRunResult{}, nil)
+}

--- a/internal/bot/role_commands.go
+++ b/internal/bot/role_commands.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"gopkg.in/telebot.v4"
 
+	"ok-gobot/internal/agent"
 	"ok-gobot/internal/role"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
@@ -153,19 +155,26 @@ func (b *Bot) handleRoleRunCommand(c telebot.Context) error {
 	}
 
 	js := runtime.NewJobService(b.store)
+	flusher := b.lifecycleFlush
+	roleName := m.Name
 	job, err := js.StartDetached(context.Background(), runtime.JobSpec{
 		Kind:        "role",
 		Worker:      m.Worker,
 		Description: fmt.Sprintf("role:%s", m.Name),
+		RoleName:    m.Name,
 		Timeout:     5 * time.Minute,
-	}, func(ctx context.Context, job *storage.Job, svc *runtime.JobService) (runtime.JobRunResult, error) {
+	}, func(ctx context.Context, job *storage.Job, svc *runtime.JobService) (result runtime.JobRunResult, runErr error) {
+		defer func() {
+			runLifecycleJobFlush(ctx, flusher, job, roleName, result, runErr)
+		}()
 		prompt := m.Prompt
 		if input != "" {
 			prompt = prompt + "\n\nUser input: " + input
 		}
-		return runtime.JobRunResult{
+		result = runtime.JobRunResult{
 			Summary: fmt.Sprintf("role %q executed (prompt length: %d chars)", m.Name, len(prompt)),
-		}, nil
+		}
+		return result, nil
 	})
 	if err != nil {
 		return c.Send(fmt.Sprintf("Failed to start role job: %v", err))
@@ -314,6 +323,51 @@ func jobStatusIcon(status string) string {
 		return "⏰"
 	default:
 		return "🧾"
+	}
+}
+
+// runLifecycleJobFlush stages a bounded memory draft for the job's terminal
+// state. Called from the deferred path of a role-job runner so success,
+// failure, timeout, and cancellation each leave a traceable note. Flush errors
+// are logged but never propagated: a memory-write failure must not corrupt the
+// job's recorded outcome.
+func runLifecycleJobFlush(ctx context.Context, flusher *agent.LifecycleFlusher, job *storage.Job, roleName string, result runtime.JobRunResult, runErr error) {
+	if flusher == nil || job == nil {
+		return
+	}
+
+	rec := agent.FlushRecord{
+		JobID:      job.JobID,
+		SessionKey: job.SessionKey,
+		RoleName:   roleName,
+		Summary:    strings.TrimSpace(result.Summary),
+	}
+	for _, a := range result.Artifacts {
+		entry := strings.TrimSpace(a.Name)
+		if a.URI != "" {
+			entry = fmt.Sprintf("%s (%s)", entry, a.URI)
+		}
+		if entry != "" {
+			rec.Artifacts = append(rec.Artifacts, entry)
+		}
+	}
+
+	switch {
+	case runErr == nil:
+		rec.Kind = agent.FlushKindJobSuccess
+	case errors.Is(runErr, context.DeadlineExceeded) || (ctx != nil && errors.Is(ctx.Err(), context.DeadlineExceeded)):
+		rec.Kind = agent.FlushKindJobTimeout
+		rec.Detail = runErr.Error()
+	case errors.Is(runErr, context.Canceled) || (ctx != nil && errors.Is(ctx.Err(), context.Canceled)):
+		rec.Kind = agent.FlushKindJobCancelled
+		rec.Detail = runErr.Error()
+	default:
+		rec.Kind = agent.FlushKindJobFailure
+		rec.Detail = runErr.Error()
+	}
+
+	if _, err := flusher.Flush(rec); err != nil {
+		log.Printf("[lifecycle] job %s memory flush failed: %v", job.JobID, err)
 	}
 }
 

--- a/internal/bot/role_commands.go
+++ b/internal/bot/role_commands.go
@@ -357,10 +357,18 @@ func runLifecycleJobFlush(ctx context.Context, flusher *agent.LifecycleFlusher, 
 		rec.Kind = agent.FlushKindJobSuccess
 	case errors.Is(runErr, context.DeadlineExceeded) || (ctx != nil && errors.Is(ctx.Err(), context.DeadlineExceeded)):
 		rec.Kind = agent.FlushKindJobTimeout
-		rec.Detail = runErr.Error()
+		if errors.Is(runErr, context.DeadlineExceeded) {
+			rec.Detail = runErr.Error()
+		} else {
+			rec.Detail = ctx.Err().Error()
+		}
 	case errors.Is(runErr, context.Canceled) || (ctx != nil && errors.Is(ctx.Err(), context.Canceled)):
 		rec.Kind = agent.FlushKindJobCancelled
-		rec.Detail = runErr.Error()
+		if errors.Is(runErr, context.Canceled) {
+			rec.Detail = runErr.Error()
+		} else {
+			rec.Detail = ctx.Err().Error()
+		}
 	default:
 		rec.Kind = agent.FlushKindJobFailure
 		rec.Detail = runErr.Error()


### PR DESCRIPTION
Implements #307

## Changes

Add a guarded, deduplicated lifecycle memory-flush hook so durable facts get a bounded chance to be preserved at the points where context is most likely to be lost:

- **Before `/compact` replaces transcript history** (`internal/bot/commands.go`): `handleCompactCommand` calls `lifecycleFlush.Flush(...)` with `FlushKindPreCompact` before invoking `compactToTree`. Flush failure logs a warning and surfaces a Telegram message but never blocks emergency compaction.
- **After role-job completion** (`internal/bot/role_commands.go`): the `/role_run` `JobRunner` uses a deferred `runLifecycleJobFlush` that classifies the terminal state from `(runErr, ctx.Err())` into `job-success` / `job-failure` / `job-timeout` / `job-cancelled`, attaching artifact references and diagnostic detail.

The hook itself lives in a new `internal/agent/lifecycle_memory.go`:

- `LifecycleFlusher` writes a draft section to today's daily note via the existing `agent.Memory`, with source IDs (`session`, `job`, `run`, `role`), a bounded summary/detail, and a `> draft pending review` marker.
- In-process dedup keyed by `(kind, session/job ID, message-count for pre-compact)` suppresses repeat flushes for the same lifecycle state. A real retry after a write error releases the slot so the operator can recover.
- `RequestDurableUpdate` returns `ErrDurableMemoryNeedsApproval` so silent `MEMORY.md` rewrites are explicitly refused in v1; durable promotions stay admin-gated.
- Nil-safe (`var f *LifecycleFlusher; f.Flush(...)` returns a Skipped result rather than panicking) so existing `Bot{}` test fixtures don't need updates.

`docs/MEMORY-CONTEXT-PIPELINE.md` gains a new section 7.5 documenting the trigger points, draft format, and write policy.

## Testing

- `go fmt ./...`, `go vet ./...`, `go build ./cmd/ok-gobot/` — clean.
- `go test ./...` — all green after rebase onto `origin/main` (`d55dd5e..aed6873` merged in).
- New tests in `internal/agent/lifecycle_memory_test.go`: pre-compact write, job-success with artifacts, timeout/failure/cancel detail preservation, dedup per state, dedup independence across job kinds, durable-write refusal, nil-flusher safety, nil-memory skip, write-failure clearing the dedup slot for retry.
- New tests in `internal/bot/lifecycle_flush_test.go`: helper-level coverage for success-with-artifacts, timeout, cancel, generic failure, dedup, nil-flusher, nil-job.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a guarded `LifecycleFlusher` that appends bounded draft sections to the daily note at two lifecycle points — before `/compact` replaces transcript history and after a role-job reaches a terminal state — while explicitly refusing silent `MEMORY.md` writes. The implementation addresses the previously flagged misleading `Detail` field by preferring `ctx.Err().Error()` when the flush kind is derived from context cancellation/timeout rather than `runErr`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic bugs found, all edge cases from prior review are addressed with tests.

All files reviewed cleanly; the previously flagged misleading-Detail issue is fixed and covered by two new test cases. Nil-safety, dedup, write-failure retry, and durable-write refusal are all well-tested. No P0 or P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/agent/lifecycle_memory.go | New LifecycleFlusher with dedup, nil-safety, and write-failure retry; logic is sound and the previous misleading-Detail issue has been fixed in this file's consumers |
| internal/bot/role_commands.go | Adds deferred runLifecycleJobFlush with correct kind/detail classification; timeout and cancel detail now prefer ctx.Err() over unrelated runErr as addressed from previous review |
| internal/bot/commands.go | Pre-compact flush added before transcript replacement; flush failures are non-blocking and surfaced as warnings as intended |
| internal/bot/bot.go | Shares botMemory instance between b.memory and b.lifecycleFlush — clean refactor, no issues |
| internal/agent/lifecycle_memory_test.go | Comprehensive unit tests covering write, dedup, nil-safety, durable-write refusal, and write-failure retry; all edge cases from the spec are covered |
| internal/bot/lifecycle_flush_test.go | Bot-level helper tests including the new timeout/cancel detail-preference cases that verify the fix for the previously flagged issue |
| docs/MEMORY-CONTEXT-PIPELINE.md | Documentation updated with section 7.5 accurately describing trigger points, draft format, write policy, and dedup semantics |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(memory): prefer ctx.Err() detail whe..."](https://github.com/befeast/ok-gobot/commit/dae19f483f87ea9f7e8ac3697f972960f570aed6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30235737)</sub>

<!-- /greptile_comment -->