### PR TITLE
feat(memory): session transcript memory and LCM-like search (#309)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -351,7 +351,7 @@ func (a *App) Start(ctx context.Context) error {
 		log.Printf("⚠️ [memory] extra paths config error: %v", err)
 		memoryExtras = nil
 	}
-	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.config.Browser, a.config.STT, a.scheduler, a.memoryManager, memoryExtras, a.config.Contacts)
+	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.config.Browser, a.config.STT, a.scheduler, a.memoryManager, memoryExtras, a.config.Memory.Sessions.Enabled, a.config.Contacts)
 	if err != nil {
 		return fmt.Errorf("failed to create bot: %w", err)
 	}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -74,7 +74,7 @@ type AIConfig struct {
 }
 
 // New creates a new bot instance
-func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, browserCfg config.BrowserConfig, sttCfg config.STTConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager, memoryExtraPaths []memory.ExtraPath, contacts map[string]int64) (*Bot, error) {
+func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, browserCfg config.BrowserConfig, sttCfg config.STTConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager, memoryExtraPaths []memory.ExtraPath, sessionMemoryEnabled bool, contacts map[string]int64) (*Bot, error) {
 	pref := telebot.Settings{
 		Token:  token,
 		Poller: &telebot.LongPoller{Timeout: 10 * time.Second},
@@ -105,6 +105,15 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		SkillVersionSaveFunc: func(path string) error {
 			return bootstrap.SaveSkillVersion(path, bootstrap.DefaultMaxVersions)
 		},
+	}
+	// Wire optional session memory tools (off by default; opt-in via
+	// memory.sessions.enabled). LoadFromConfigWithOptions only registers
+	// session_search/session_get when all three deps + the flag are set.
+	if sessionMemoryEnabled && memoryManager != nil {
+		toolsConfig.SessionMemoryEnabled = true
+		toolsConfig.MemoryStore = memoryManager.Store()
+		toolsConfig.MemoryEmbedder = memoryManager.Embedder()
+		toolsConfig.SessionTranscriptsDB = store.DB()
 	}
 	toolRegistry, _ := tools.LoadFromConfigWithOptions(personality.BasePath, toolsConfig)
 

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -289,7 +289,7 @@ fingerprint), and matched header so callers can expand the original span.`,
 
 			for i, snippet := range hits {
 				fmt.Fprintf(out, "%d. %s  (score=%.3f)\n", i+1, memory.FormatSnippetCitation(snippet), snippet.Score)
-				preview := summarizeForCLI(snippet.Text, 240)
+				preview := memory.ClipForOutput(snippet.Text, 240)
 				fmt.Fprintf(out, "   %s\n\n", preview)
 			}
 			return nil
@@ -388,7 +388,7 @@ Without --around the most recent (1 + 2*span) messages are shown.`,
 				}
 				clean := memory.SanitizeMessageContent(msg.Content)
 				fmt.Fprintf(out, "%s msg %d [%s] @ %s\n", marker, msg.ID, msg.Role, msg.CreatedAt)
-				fmt.Fprintf(out, "  %s\n\n", summarizeForCLI(clean, 800))
+				fmt.Fprintf(out, "  %s\n\n", memory.ClipForOutput(clean, 800))
 			}
 			return nil
 		},
@@ -398,12 +398,4 @@ Without --around the most recent (1 + 2*span) messages are shown.`,
 	cmd.Flags().IntVar(&span, "span", 2, "messages to show before/after the anchor")
 	cmd.Flags().IntVar(&limit, "limit", 0, "hard cap on messages to show (0 = no cap)")
 	return cmd
-}
-
-func summarizeForCLI(text string, max int) string {
-	text = strings.TrimSpace(text)
-	if max <= 0 || len(text) <= max {
-		return text
-	}
-	return text[:max] + "…"
 }

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -8,17 +8,21 @@ import (
 	"github.com/spf13/cobra"
 
 	"ok-gobot/internal/config"
+	"ok-gobot/internal/memory"
 	"ok-gobot/internal/storage"
 )
 
 func newSessionsCommand(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sessions",
-		Short: "List and fork conversation sessions",
+		Short: "List, fork, search, and inspect conversation sessions",
 	}
 
 	cmd.AddCommand(newSessionsListCommand(cfg))
 	cmd.AddCommand(newSessionsForkCommand(cfg))
+	cmd.AddCommand(newSessionsIndexCommand(cfg))
+	cmd.AddCommand(newSessionsSearchCommand(cfg))
+	cmd.AddCommand(newSessionsShowCommand(cfg))
 
 	return cmd
 }
@@ -117,4 +121,289 @@ Use 'ok-gobot sessions list' to find available session keys.`,
 		},
 	}
 	return cmd
+}
+
+// --- sessions index ---
+
+func newSessionsIndexCommand(cfg *config.Config) *cobra.Command {
+	var (
+		sessionKey    string
+		includeGroups bool
+		maxMessages   int
+		clear         bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "index",
+		Short: "Index past session transcripts into the memory search index",
+		Long: `Index past session transcripts into the memory search index so they can be
+retrieved alongside workspace and daily memory. Indexing is opt-in: it stores
+sanitized user/assistant turns and is disabled by default for privacy.
+
+Group sessions are skipped unless --include-groups is given. Use --key to
+reindex a specific session, or --clear to drop all indexed transcript
+chunks before reindexing.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cfg.Memory.Enabled {
+				return fmt.Errorf("memory.enabled is false; enable memory before indexing sessions")
+			}
+
+			store, memStore, err := openMemoryStore(cfg)
+			if err != nil {
+				return err
+			}
+			defer store.Close() //nolint:errcheck
+
+			ctx := cmd.Context()
+
+			if clear {
+				if sessionKey != "" {
+					if err := memStore.ClearSessionChunksForKey(ctx, sessionKey); err != nil {
+						return fmt.Errorf("clear session chunks: %w", err)
+					}
+				} else if err := memStore.ClearSessionChunks(ctx); err != nil {
+					return fmt.Errorf("clear session chunks: %w", err)
+				}
+			}
+
+			apiKey := cfg.Memory.EmbeddingsAPIKey
+			if apiKey == "" {
+				apiKey = cfg.AI.APIKey
+			}
+			embedder := memory.NewEmbeddingClient(
+				cfg.Memory.EmbeddingsBaseURL,
+				apiKey,
+				cfg.Memory.EmbeddingsModel,
+			)
+
+			source := memory.NewSQLiteSessionTranscriptSource(store.DB())
+			indexer := memory.NewSessionIndexer(memStore, embedder, source)
+
+			cap := maxMessages
+			if cap == 0 {
+				cap = cfg.Memory.Sessions.MaxMessagesPerSession
+			}
+			opts := memory.SessionIndexOptions{
+				IncludeGroups:         includeGroups || cfg.Memory.Sessions.IncludeGroups,
+				MaxMessagesPerSession: cap,
+			}
+			if sessionKey != "" {
+				opts.OnlyKeys = []string{sessionKey}
+			}
+
+			stats, err := indexer.IndexSessions(ctx, opts)
+			if err != nil {
+				return fmt.Errorf("index sessions: %w", err)
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Sessions considered: %d\n", stats.SessionsConsidered)
+			fmt.Fprintf(out, "Sessions indexed:    %d\n", stats.SessionsIndexed)
+			fmt.Fprintf(out, "Sessions skipped:    %d\n", stats.SessionsSkipped)
+			fmt.Fprintf(out, "Messages indexed:    %d\n", stats.MessagesIndexed)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&sessionKey, "key", "", "index only the given session key")
+	cmd.Flags().BoolVar(&includeGroups, "include-groups", false, "index group-keyed sessions (off by default for privacy)")
+	cmd.Flags().IntVar(&maxMessages, "max-messages", 0, "limit messages per session (0 = config default)")
+	cmd.Flags().BoolVar(&clear, "clear", false, "remove existing session chunks before indexing")
+	return cmd
+}
+
+// --- sessions search ---
+
+func newSessionsSearchCommand(cfg *config.Config) *cobra.Command {
+	var (
+		topK    int
+		expand  bool
+		sources []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search indexed memory across selected sources",
+		Long: `Search indexed memory across selected sources (workspace, daily, sessions, extra).
+
+Default sources are session transcripts. Use --source repeatedly to broaden
+the search:
+
+  ok-gobot sessions search "kotlin retry" --source session
+  ok-gobot sessions search "alice" --source session --source workspace
+
+The output identifies each result by source type, source key (e.g. session
+fingerprint), and matched header so callers can expand the original span.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := strings.Join(args, " ")
+			if strings.TrimSpace(query) == "" {
+				return fmt.Errorf("query must not be empty")
+			}
+			if !cfg.Memory.Enabled {
+				return fmt.Errorf("memory.enabled is false; enable memory before searching")
+			}
+
+			store, memStore, err := openMemoryStore(cfg)
+			if err != nil {
+				return err
+			}
+			defer store.Close() //nolint:errcheck
+
+			ctx := cmd.Context()
+			searcher, err := memory.NewSearcher(ctx, memStore.DB())
+			if err != nil {
+				return fmt.Errorf("open searcher: %w", err)
+			}
+
+			apiKey := cfg.Memory.EmbeddingsAPIKey
+			if apiKey == "" {
+				apiKey = cfg.AI.APIKey
+			}
+			embedder := memory.NewEmbeddingClient(
+				cfg.Memory.EmbeddingsBaseURL,
+				apiKey,
+				cfg.Memory.EmbeddingsModel,
+			)
+			embedding, err := embedder.GetEmbedding(ctx, query)
+			if err != nil {
+				return fmt.Errorf("embed query: %w", err)
+			}
+
+			selected := memory.NormalizeSourceTypes(sources)
+			if len(selected) == 0 {
+				selected = []memory.SourceType{memory.SourceSession}
+			}
+
+			hits := searcher.Search(embedding, memory.SearchOptions{
+				TopK:         topK,
+				ExpandBranch: expand,
+				Sources:      selected,
+			})
+
+			out := cmd.OutOrStdout()
+			if len(hits) == 0 {
+				fmt.Fprintln(out, "No matches.")
+				return nil
+			}
+
+			for i, snippet := range hits {
+				fmt.Fprintf(out, "%d. %s  (score=%.3f)\n", i+1, memory.FormatSnippetCitation(snippet), snippet.Score)
+				preview := summarizeForCLI(snippet.Text, 240)
+				fmt.Fprintf(out, "   %s\n\n", preview)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&topK, "limit", memory.DefaultSearchTopK, "maximum results")
+	cmd.Flags().BoolVar(&expand, "expand", false, "expand each match to the full branch (all chunks of the same message/section)")
+	cmd.Flags().StringSliceVar(&sources, "source", nil, "limit to source types: workspace, daily, session, extra (repeatable)")
+	return cmd
+}
+
+// --- sessions show ---
+
+func newSessionsShowCommand(cfg *config.Config) *cobra.Command {
+	var (
+		around int64
+		span   int
+		limit  int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "show <session-key>",
+		Short: "Show a span of messages around a search hit",
+		Long: `Show a span of messages from a session transcript without loading the full
+history. Pair with 'sessions search' to expand around a matched message:
+
+  ok-gobot sessions search "alice" --source session
+  ok-gobot sessions show agent:default:telegram:dm:42 --around 102 --span 3
+
+Without --around the most recent (1 + 2*span) messages are shown.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessionKey := strings.TrimSpace(args[0])
+			if sessionKey == "" {
+				return fmt.Errorf("session key must not be empty")
+			}
+
+			store, err := storage.New(cfg.StoragePath)
+			if err != nil {
+				return fmt.Errorf("open storage: %w", err)
+			}
+			defer store.Close() //nolint:errcheck
+
+			source := memory.NewSQLiteSessionTranscriptSource(store.DB())
+			ctx := cmd.Context()
+			result, err := memory.LoadSessionSpan(ctx, source, sessionKey, around, span)
+			if err != nil {
+				return fmt.Errorf("load span: %w", err)
+			}
+			if len(result.Messages) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No messages.")
+				return nil
+			}
+
+			messages := result.Messages
+			if limit > 0 && limit < len(messages) {
+				// Centre the window on the anchor when one is provided.
+				if around > 0 {
+					anchorIdx := -1
+					for i, m := range messages {
+						if m.ID == around {
+							anchorIdx = i
+							break
+						}
+					}
+					if anchorIdx >= 0 {
+						start := anchorIdx - limit/2
+						if start < 0 {
+							start = 0
+						}
+						end := start + limit
+						if end > len(messages) {
+							end = len(messages)
+							start = end - limit
+							if start < 0 {
+								start = 0
+							}
+						}
+						messages = messages[start:end]
+					} else {
+						messages = messages[len(messages)-limit:]
+					}
+				} else {
+					messages = messages[len(messages)-limit:]
+				}
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Session: %s (fingerprint=%s)\n", sessionKey, memory.SessionKeyFingerprint(sessionKey))
+			fmt.Fprintf(out, "Messages: %d\n\n", len(messages))
+			for _, msg := range messages {
+				marker := " "
+				if msg.ID == around {
+					marker = ">"
+				}
+				clean := memory.SanitizeMessageContent(msg.Content)
+				fmt.Fprintf(out, "%s msg %d [%s] @ %s\n", marker, msg.ID, msg.Role, msg.CreatedAt)
+				fmt.Fprintf(out, "  %s\n\n", summarizeForCLI(clean, 800))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().Int64Var(&around, "around", 0, "anchor message id to centre the window on")
+	cmd.Flags().IntVar(&span, "span", 2, "messages to show before/after the anchor")
+	cmd.Flags().IntVar(&limit, "limit", 0, "hard cap on messages to show (0 = no cap)")
+	return cmd
+}
+
+func summarizeForCLI(text string, max int) string {
+	text = strings.TrimSpace(text)
+	if max <= 0 || len(text) <= max {
+		return text
+	}
+	return text[:max] + "…"
 }

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/storage"
+)
+
+func TestSessionsIndexRequiresMemoryEnabled(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+	cfg.Memory.Enabled = false
+
+	cmd := newSessionsCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"index"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "memory.enabled is false") {
+		t.Fatalf("expected memory.enabled error, got %v", err)
+	}
+}
+
+func TestSessionsShowReturnsSpanAroundAnchor(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+
+	sessionKey := "agent:default:telegram:dm:42"
+	if err := store.UpsertSessionV2(&storage.SessionV2{SessionKey: sessionKey, AgentID: "default"}); err != nil {
+		t.Fatalf("UpsertSessionV2: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		if err := store.SaveSessionMessageV2(sessionKey, role, "message body for turn", "run-1"); err != nil {
+			t.Fatalf("SaveSessionMessageV2: %v", err)
+		}
+	}
+
+	// fetch ids to find the third message id
+	msgs, err := store.GetSessionMessagesV2(sessionKey, 100)
+	if err != nil {
+		t.Fatalf("GetSessionMessagesV2: %v", err)
+	}
+	if len(msgs) < 5 {
+		t.Fatalf("expected 5 messages, got %d", len(msgs))
+	}
+	anchor := msgs[2].ID
+
+	cmd := newSessionsCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"show", sessionKey,
+		"--around", strString(anchor),
+		"--span", "1",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "fingerprint=") {
+		t.Errorf("expected fingerprint label, got: %q", output)
+	}
+	if !strings.Contains(output, "Messages: 3") {
+		t.Errorf("expected 3 messages in span, got: %q", output)
+	}
+	// Ensure the anchor row uses the highlight marker.
+	if !strings.Contains(output, "> msg "+strString(anchor)) {
+		t.Errorf("expected anchor marker, got: %q", output)
+	}
+}
+
+func strString(n int64) string {
+	return strconv.FormatInt(n, 10)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,6 +217,7 @@ type MemoryConfig struct {
 	ExtraPaths         []MemoryExtraPathConfig `mapstructure:"extra_paths"`         // Additional named markdown roots to index (Obsidian vaults, shared exports, etc.)
 	MCP                MemoryMCPConfig         `mapstructure:"mcp"`                 // Optional MCP server exposing memory tools
 	Active             ActiveMemoryConfig      `mapstructure:"active"`              // Pre-reply Active Memory recall (DM only)
+	Sessions           SessionMemoryConfig     `mapstructure:"sessions"`            // Session transcript indexing (off by default)
 }
 
 // ActiveMemoryConfig configures the pre-reply Active Memory recall step.
@@ -241,6 +242,16 @@ type MemoryExtraPathConfig struct {
 	Patterns []string `mapstructure:"patterns"`  // Glob patterns relative to path (defaults to ["**/*.md"])
 	ReadOnly *bool    `mapstructure:"read_only"` // Defaults to true; reserved for future write enablement
 	Scope    string   `mapstructure:"scope"`     // Optional human-readable scope label (e.g. "obsidian", "homelab")
+}
+
+// SessionMemoryConfig controls indexing of past session transcripts as a
+// retrieval source. Transcript memory is disabled by default for privacy:
+// it stores user-supplied text in the search index and must be opted into
+// explicitly. Group sessions are excluded unless include_groups is true.
+type SessionMemoryConfig struct {
+	Enabled               bool `mapstructure:"enabled"`                  // Enable indexing past session transcripts (default false)
+	IncludeGroups         bool `mapstructure:"include_groups"`           // Index group-keyed sessions too (default false)
+	MaxMessagesPerSession int  `mapstructure:"max_messages_per_session"` // Cap on messages indexed per session (0 = unlimited)
 }
 
 // Memory prompt mode constants. The mode controls what the bootstrap loader
@@ -369,6 +380,9 @@ func Load() (*Config, error) {
 	v.SetDefault("memory.active.max_snippets", 5)
 	v.SetDefault("memory.active.max_chars", 2000)
 	v.SetDefault("memory.active.history_turns", 3)
+	v.SetDefault("memory.sessions.enabled", false)
+	v.SetDefault("memory.sessions.include_groups", false)
+	v.SetDefault("memory.sessions.max_messages_per_session", 0)
 	v.SetDefault("control.enabled", false)
 	v.SetDefault("control.port", 8787)
 	v.SetDefault("control.token", "")
@@ -489,6 +503,9 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("memory.active.max_snippets", 5)
 	v.SetDefault("memory.active.max_chars", 2000)
 	v.SetDefault("memory.active.history_turns", 3)
+	v.SetDefault("memory.sessions.enabled", false)
+	v.SetDefault("memory.sessions.include_groups", false)
+	v.SetDefault("memory.sessions.max_messages_per_session", 0)
 	v.SetDefault("control.enabled", false)
 	v.SetDefault("control.port", 8787)
 	v.SetDefault("control.token", "")

--- a/internal/memory/manager.go
+++ b/internal/memory/manager.go
@@ -48,6 +48,24 @@ func NewMemoryManager(client EmbeddingQueryClient, store *MemoryStore, opts ...M
 	return manager
 }
 
+// Store returns the manager's underlying memory store, or nil if unset.
+// Exposed so callers (e.g. tool registries) can share the same connection
+// without re-opening the database.
+func (m *MemoryManager) Store() *MemoryStore {
+	if m == nil {
+		return nil
+	}
+	return m.store
+}
+
+// Embedder returns the manager's embedding query client, or nil if unset.
+func (m *MemoryManager) Embedder() EmbeddingQueryClient {
+	if m == nil {
+		return nil
+	}
+	return m.client
+}
+
 // Search searches indexed markdown chunks with hybrid lexical and semantic ranking.
 func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
 	if m == nil || m.store == nil {

--- a/internal/memory/search.go
+++ b/internal/memory/search.go
@@ -22,10 +22,18 @@ const (
 
 // MemorySnippet is a ranked memory match returned from semantic search.
 type MemorySnippet struct {
-	File       string  `json:"file"`
-	HeaderPath string  `json:"header_path"`
-	Text       string  `json:"text"`
-	Score      float32 `json:"score"`
+	File       string     `json:"file"`
+	HeaderPath string     `json:"header_path"`
+	Text       string     `json:"text"`
+	Score      float32    `json:"score"`
+	SourceType SourceType `json:"source_type,omitempty"`
+	// SessionKey is set when SourceType is SourceSession; it carries the
+	// canonical session key parsed from the chunk's source_file.
+	SessionKey string `json:"session_key,omitempty"`
+	// Ordinal is the per-branch chunk ordinal copied from the underlying
+	// chunk index. For session chunks it carries the chunk index within the
+	// originating session message.
+	Ordinal int `json:"ordinal,omitempty"`
 }
 
 // SearchOptions configures per-query filtering and result count.
@@ -33,6 +41,9 @@ type SearchOptions struct {
 	Threshold    float32
 	TopK         int
 	ExpandBranch bool // When true, expand results to include all chunks from matching branches.
+	// Sources, when non-empty, restricts results to chunks whose derived
+	// SourceType is in the list. An empty list searches every source.
+	Sources []SourceType
 }
 
 // Searcher keeps memory chunk embeddings in RAM and performs cosine search in Go.
@@ -49,6 +60,25 @@ type indexedChunk struct {
 	Ordinal    int
 	Text       string
 	Embedding  []float32 // Pre-normalized for fast cosine dot products.
+	SourceType SourceType
+	SessionKey string
+}
+
+func sourceFilterSet(sources []SourceType) map[SourceType]struct{} {
+	if len(sources) == 0 {
+		return nil
+	}
+	allowed := make(map[SourceType]struct{}, len(sources))
+	for _, source := range sources {
+		if source == "" {
+			continue
+		}
+		allowed[source] = struct{}{}
+	}
+	if len(allowed) == 0 {
+		return nil
+	}
+	return allowed
 }
 
 type memoryChunkColumns struct {
@@ -129,8 +159,15 @@ func (s *Searcher) Search(queryEmbedding []float32, opts SearchOptions) []Memory
 		return nil
 	}
 
+	allowed := sourceFilterSet(opts.Sources)
+
 	best := make([]MemorySnippet, 0, topK)
 	for _, chunk := range s.chunks {
+		if allowed != nil {
+			if _, ok := allowed[chunk.SourceType]; !ok {
+				continue
+			}
+		}
 		score := dotProduct(query, chunk.Embedding)
 		if score < threshold {
 			continue
@@ -141,6 +178,9 @@ func (s *Searcher) Search(queryEmbedding []float32, opts SearchOptions) []Memory
 			HeaderPath: chunk.HeaderPath,
 			Text:       chunk.Text,
 			Score:      score,
+			SourceType: chunk.SourceType,
+			SessionKey: chunk.SessionKey,
+			Ordinal:    chunk.Ordinal,
 		}
 
 		if len(best) < topK {
@@ -193,10 +233,20 @@ func (s *Searcher) expandBranches(hits []MemorySnippet) []MemorySnippet {
 
 	expanded := make([]MemorySnippet, 0, len(orderedKeys))
 	for _, key := range orderedKeys {
-		var parts []orderedText
+		var (
+			parts      []orderedText
+			sourceType SourceType
+			sessionKey string
+		)
 		for _, chunk := range s.chunks {
 			if chunk.File == key.file && chunk.HeaderPath == key.headerPath {
 				parts = append(parts, orderedText{ordinal: chunk.Ordinal, text: chunk.Text})
+				if sourceType == "" {
+					sourceType = chunk.SourceType
+				}
+				if sessionKey == "" {
+					sessionKey = chunk.SessionKey
+				}
 			}
 		}
 
@@ -214,6 +264,8 @@ func (s *Searcher) expandBranches(hits []MemorySnippet) []MemorySnippet {
 			HeaderPath: key.headerPath,
 			Text:       strings.Join(texts, "\n\n"),
 			Score:      bestScores[key],
+			SourceType: sourceType,
+			SessionKey: sessionKey,
 		})
 	}
 
@@ -297,12 +349,20 @@ func loadChunksIntoRAM(ctx context.Context, db *sql.DB) ([]indexedChunk, int, er
 			continue
 		}
 
+		fileValue := file.String
+		sourceType := DeriveSourceType(fileValue)
+		sessionKey := ""
+		if sourceType == SourceSession {
+			sessionKey, _ = SessionKeyFromSourceFile(fileValue)
+		}
 		chunks = append(chunks, indexedChunk{
-			File:       file.String,
+			File:       fileValue,
 			HeaderPath: headerPath.String,
 			Ordinal:    ordinal,
 			Text:       text.String,
 			Embedding:  normalized,
+			SourceType: sourceType,
+			SessionKey: sessionKey,
 		})
 	}
 

--- a/internal/memory/sessions.go
+++ b/internal/memory/sessions.go
@@ -1,0 +1,527 @@
+package memory
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"ok-gobot/internal/redact"
+	"ok-gobot/internal/sanitize"
+)
+
+// SessionMessage is one row of a stored session transcript that the indexer
+// consumes. It mirrors the shape of storage.SessionMessageV2 but lives in
+// the memory package to keep the dependency direction one-way.
+type SessionMessage struct {
+	ID         int64
+	SessionKey string
+	Role       string
+	Content    string
+	RunID      string
+	CreatedAt  string
+}
+
+// SessionTranscriptSource enumerates the sessions that should be indexed.
+// Implementations are typically backed by storage.Store.
+type SessionTranscriptSource interface {
+	// ListSessionKeysForIndexing returns canonical session keys eligible
+	// for transcript indexing. Privacy filtering (e.g. group sessions)
+	// is applied by the indexer, not by the source.
+	ListSessionKeysForIndexing(ctx context.Context) ([]string, error)
+	// LoadSessionMessages returns transcript messages for sessionKey in
+	// chronological order.
+	LoadSessionMessages(ctx context.Context, sessionKey string) ([]SessionMessage, error)
+}
+
+// SessionIndexOptions configures session transcript indexing behavior.
+type SessionIndexOptions struct {
+	// IncludeGroups, when true, indexes group-keyed sessions. By default
+	// only DM and main sessions are indexed for privacy.
+	IncludeGroups bool
+	// MaxMessagesPerSession limits how many messages from a session are
+	// indexed. 0 means no limit. The most recent N are kept.
+	MaxMessagesPerSession int
+	// OnlyKeys, when non-empty, restricts indexing to the listed session
+	// keys. Useful for ad-hoc reindexing of a single session.
+	OnlyKeys []string
+}
+
+// SessionIndexStats describes a single index pass over session transcripts.
+type SessionIndexStats struct {
+	SessionsConsidered int
+	SessionsIndexed    int
+	SessionsSkipped    int
+	MessagesIndexed    int
+}
+
+// SessionRoleHeader is the exact regular expression that matches a session
+// chunk's header_path. It is exposed so that callers (e.g. the CLI) can
+// parse search results back into (message_id, role) pairs.
+var SessionRoleHeader = regexp.MustCompile(`^msg\s+(\d+)\s+\[([^\]]+)\]$`)
+
+// SessionRoles enumerates the roles that are eligible for indexing. Other
+// roles (system, tool, etc.) are skipped because they are either machine-
+// generated or contain prompt scaffolding rather than user-meaningful turns.
+var SessionRoles = map[string]struct{}{
+	"user":      {},
+	"assistant": {},
+}
+
+// IsGroupSessionKey reports whether sessionKey targets a shared group chat.
+// Group sessions hold messages from multiple users and are excluded from
+// the default index for privacy.
+func IsGroupSessionKey(sessionKey string) bool {
+	return strings.Contains(sessionKey, ":telegram:group:")
+}
+
+// SanitizeMessageContent prepares raw message content for indexing.
+// It strips control characters and redacts well-known secrets, but keeps
+// the textual meaning intact so semantic search remains useful.
+func SanitizeMessageContent(content string) string {
+	if content == "" {
+		return ""
+	}
+	content = sanitize.StripControlChars(content)
+	content = redact.Redact(content)
+	return strings.TrimSpace(content)
+}
+
+// SessionChunkHeader returns the canonical header_path for a session chunk.
+// Pairing message_id and role makes it possible to reconstruct the original
+// span on demand and to display search hits as `msg <id> [<role>]`.
+func SessionChunkHeader(messageID int64, role string) string {
+	return fmt.Sprintf("msg %d [%s]", messageID, strings.ToLower(strings.TrimSpace(role)))
+}
+
+// ParseSessionChunkHeader extracts the message id and role from a header
+// previously produced by SessionChunkHeader.
+func ParseSessionChunkHeader(header string) (messageID int64, role string, ok bool) {
+	matches := SessionRoleHeader.FindStringSubmatch(strings.TrimSpace(header))
+	if len(matches) != 3 {
+		return 0, "", false
+	}
+	id, err := strconv.ParseInt(matches[1], 10, 64)
+	if err != nil {
+		return 0, "", false
+	}
+	return id, matches[2], true
+}
+
+// SessionIndexer persists session transcript chunks into memory_chunks.
+// It shares the underlying embedding pipeline with the file-based Indexer
+// but reads from a SessionTranscriptSource instead of the filesystem.
+type SessionIndexer struct {
+	store    *MemoryStore
+	embedder EmbeddingBatchClient
+	source   SessionTranscriptSource
+
+	chunkTokens  int
+	chunkOverlap int
+	batchSize    int
+}
+
+// NewSessionIndexer constructs a SessionIndexer. The chunker reuses the
+// same word-level chunking as the file indexer to keep retrieval behavior
+// consistent across source types.
+func NewSessionIndexer(store *MemoryStore, embedder EmbeddingBatchClient, source SessionTranscriptSource, opts ...IndexerOption) *SessionIndexer {
+	idx := &SessionIndexer{
+		store:        store,
+		embedder:     embedder,
+		source:       source,
+		chunkTokens:  defaultChunkTokenLimit,
+		chunkOverlap: defaultChunkTokenOverlap,
+		batchSize:    defaultEmbeddingBatchSize,
+	}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		stub := &Indexer{
+			batchSize:    idx.batchSize,
+			chunkTokens:  idx.chunkTokens,
+			chunkOverlap: idx.chunkOverlap,
+		}
+		opt(stub)
+		idx.batchSize = stub.batchSize
+		idx.chunkTokens = stub.chunkTokens
+		idx.chunkOverlap = stub.chunkOverlap
+	}
+	if idx.chunkOverlap >= idx.chunkTokens {
+		idx.chunkOverlap = 0
+	}
+	return idx
+}
+
+// IndexSessions runs a single indexing pass according to opts. Sessions
+// excluded by privacy rules contribute to SessionsSkipped but never produce
+// chunks.
+func (s *SessionIndexer) IndexSessions(ctx context.Context, opts SessionIndexOptions) (SessionIndexStats, error) {
+	if s == nil || s.store == nil || s.embedder == nil || s.source == nil {
+		return SessionIndexStats{}, fmt.Errorf("session indexer is not fully configured")
+	}
+
+	keys := opts.OnlyKeys
+	if len(keys) == 0 {
+		listed, err := s.source.ListSessionKeysForIndexing(ctx)
+		if err != nil {
+			return SessionIndexStats{}, fmt.Errorf("list session keys: %w", err)
+		}
+		keys = listed
+	}
+
+	stats := SessionIndexStats{}
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		stats.SessionsConsidered++
+		if !opts.IncludeGroups && IsGroupSessionKey(key) {
+			stats.SessionsSkipped++
+			continue
+		}
+
+		messages, err := s.source.LoadSessionMessages(ctx, key)
+		if err != nil {
+			return stats, fmt.Errorf("load messages for %s: %w", key, err)
+		}
+		if opts.MaxMessagesPerSession > 0 && len(messages) > opts.MaxMessagesPerSession {
+			messages = messages[len(messages)-opts.MaxMessagesPerSession:]
+		}
+
+		messagesIndexed, err := s.indexSession(ctx, key, messages)
+		if err != nil {
+			return stats, err
+		}
+		if messagesIndexed > 0 {
+			stats.SessionsIndexed++
+			stats.MessagesIndexed += messagesIndexed
+		} else {
+			stats.SessionsSkipped++
+		}
+	}
+	return stats, nil
+}
+
+// indexSession upserts every eligible message of a single session.
+func (s *SessionIndexer) indexSession(ctx context.Context, sessionKey string, messages []SessionMessage) (int, error) {
+	sourceFile := SessionSourceFile(sessionKey)
+
+	existing, err := s.loadExistingHeaders(ctx, sourceFile)
+	if err != nil {
+		return 0, err
+	}
+
+	type pending struct {
+		header  string
+		ordinal int
+		content string
+		hash    string
+	}
+
+	var (
+		toEmbed   []pending
+		seenKeys  = make(map[chunkKey]struct{})
+		processed int
+	)
+
+	for _, msg := range messages {
+		if _, ok := SessionRoles[strings.ToLower(strings.TrimSpace(msg.Role))]; !ok {
+			continue
+		}
+		clean := SanitizeMessageContent(msg.Content)
+		if clean == "" {
+			continue
+		}
+		header := SessionChunkHeader(msg.ID, msg.Role)
+		pieces := splitChunkText(clean, s.chunkTokens, s.chunkOverlap)
+		if len(pieces) == 0 {
+			continue
+		}
+		processed++
+		for ordinal, piece := range pieces {
+			text := strings.TrimSpace(piece)
+			if text == "" {
+				continue
+			}
+			key := chunkKey{headerPath: header, ordinal: ordinal}
+			seenKeys[key] = struct{}{}
+			hash := hashChunkContent(text)
+			if prev, ok := existing[key]; ok && prev == hash {
+				continue
+			}
+			toEmbed = append(toEmbed, pending{
+				header:  header,
+				ordinal: ordinal,
+				content: text,
+				hash:    hash,
+			})
+		}
+	}
+
+	// Anything in `existing` that we did not see is now stale.
+	stale := make(map[chunkKey]string)
+	for k, v := range existing {
+		if _, ok := seenKeys[k]; !ok {
+			stale[k] = v
+		}
+	}
+
+	if len(toEmbed) == 0 && len(stale) == 0 {
+		return processed, nil
+	}
+
+	embeddings := make([][]float32, 0, len(toEmbed))
+	if len(toEmbed) > 0 {
+		texts := make([]string, len(toEmbed))
+		for i, p := range toEmbed {
+			texts[i] = p.content
+		}
+		for start := 0; start < len(texts); start += s.batchSize {
+			end := start + s.batchSize
+			if end > len(texts) {
+				end = len(texts)
+			}
+			batch, err := s.embedder.GetEmbeddings(ctx, texts[start:end])
+			if err != nil {
+				return processed, fmt.Errorf("embed session batch: %w", err)
+			}
+			if len(batch) != end-start {
+				return processed, fmt.Errorf("embedding count mismatch for session: got %d want %d", len(batch), end-start)
+			}
+			embeddings = append(embeddings, batch...)
+		}
+	}
+
+	tx, err := s.store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return processed, fmt.Errorf("begin session index tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	for i, p := range toEmbed {
+		blob, err := encodeEmbedding(embeddings[i])
+		if err != nil {
+			return processed, fmt.Errorf("encode session embedding: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO memory_chunks (
+				source_file, header_path, chunk_ordinal, content, content_hash, embedding, indexed_at
+			) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+			ON CONFLICT(source_file, header_path, chunk_ordinal) DO UPDATE SET
+				content = excluded.content,
+				content_hash = excluded.content_hash,
+				embedding = excluded.embedding,
+				indexed_at = CURRENT_TIMESTAMP
+		`, sourceFile, p.header, p.ordinal, p.content, p.hash, blob); err != nil {
+			return processed, fmt.Errorf("upsert session chunk: %w", err)
+		}
+	}
+
+	for key := range stale {
+		if _, err := tx.ExecContext(
+			ctx,
+			`DELETE FROM memory_chunks WHERE source_file = ? AND header_path = ? AND chunk_ordinal = ?`,
+			sourceFile, key.headerPath, key.ordinal,
+		); err != nil {
+			return processed, fmt.Errorf("delete stale session chunk: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return processed, fmt.Errorf("commit session index tx: %w", err)
+	}
+	return processed, nil
+}
+
+func (s *SessionIndexer) loadExistingHeaders(ctx context.Context, sourceFile string) (map[chunkKey]string, error) {
+	rows, err := s.store.db.QueryContext(
+		ctx,
+		`SELECT header_path, chunk_ordinal, content_hash FROM memory_chunks WHERE source_file = ?`,
+		sourceFile,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query existing session chunks: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[chunkKey]string)
+	for rows.Next() {
+		var (
+			header  string
+			ordinal int
+			hash    string
+		)
+		if err := rows.Scan(&header, &ordinal, &hash); err != nil {
+			return nil, err
+		}
+		out[chunkKey{headerPath: header, ordinal: ordinal}] = hash
+	}
+	return out, rows.Err()
+}
+
+// ClearSessionChunks removes every indexed transcript chunk. Useful when
+// disabling session memory and wanting a clean slate.
+func (s *MemoryStore) ClearSessionChunks(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("memory store is not configured")
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM memory_chunks WHERE source_file LIKE ?`, SessionSourceFilePrefix+"%")
+	if err != nil {
+		return fmt.Errorf("clear session chunks: %w", err)
+	}
+	return nil
+}
+
+// ClearSessionChunksForKey removes indexed transcript chunks for a single
+// session, e.g. when the user invokes /new and wants the session forgotten.
+func (s *MemoryStore) ClearSessionChunksForKey(ctx context.Context, sessionKey string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("memory store is not configured")
+	}
+	if strings.TrimSpace(sessionKey) == "" {
+		return fmt.Errorf("session key is empty")
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM memory_chunks WHERE source_file = ?`, SessionSourceFile(sessionKey))
+	return err
+}
+
+// SessionSpan is a contiguous slice of session messages returned when
+// expanding a search hit back into full transcript context.
+type SessionSpan struct {
+	SessionKey string
+	Anchor     int64
+	Messages   []SessionMessage
+}
+
+// LoadSessionSpan returns up to (1+2*span) messages centered on anchorID
+// from the given session. If anchorID is 0 the most recent span+1 messages
+// are returned. Sources implementing this method should sort messages by
+// id ascending.
+func LoadSessionSpan(ctx context.Context, source SessionTranscriptSource, sessionKey string, anchorID int64, span int) (SessionSpan, error) {
+	if source == nil {
+		return SessionSpan{}, fmt.Errorf("session source is nil")
+	}
+	msgs, err := source.LoadSessionMessages(ctx, sessionKey)
+	if err != nil {
+		return SessionSpan{}, fmt.Errorf("load messages: %w", err)
+	}
+	if span < 0 {
+		span = 0
+	}
+	if anchorID <= 0 || len(msgs) == 0 {
+		// Tail-most slice when no anchor is provided.
+		size := span*2 + 1
+		if size <= 0 || size > len(msgs) {
+			size = len(msgs)
+		}
+		return SessionSpan{
+			SessionKey: sessionKey,
+			Messages:   msgs[len(msgs)-size:],
+		}, nil
+	}
+	idx := -1
+	for i, m := range msgs {
+		if m.ID == anchorID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return SessionSpan{SessionKey: sessionKey, Anchor: anchorID}, nil
+	}
+	start := idx - span
+	if start < 0 {
+		start = 0
+	}
+	end := idx + span + 1
+	if end > len(msgs) {
+		end = len(msgs)
+	}
+	return SessionSpan{
+		SessionKey: sessionKey,
+		Anchor:     anchorID,
+		Messages:   msgs[start:end],
+	}, nil
+}
+
+// FormatSnippetCitation renders a one-line citation describing a memory
+// snippet. The citation always identifies the source type, and for session
+// snippets it includes the session key fingerprint and message id so users
+// can locate the original turn without exposing raw transcript content.
+func FormatSnippetCitation(snippet MemorySnippet) string {
+	source := snippet.SourceType
+	if source == "" {
+		source = DeriveSourceType(snippet.File)
+	}
+	switch source {
+	case SourceSession:
+		key := snippet.SessionKey
+		if key == "" {
+			key, _ = SessionKeyFromSourceFile(snippet.File)
+		}
+		fingerprint := SessionKeyFingerprint(key)
+		msgID, role, ok := ParseSessionChunkHeader(snippet.HeaderPath)
+		if ok {
+			return fmt.Sprintf("[session %s] msg %d [%s]", fingerprint, msgID, role)
+		}
+		return fmt.Sprintf("[session %s] %s", fingerprint, snippet.HeaderPath)
+	case SourceWorkspace:
+		return fmt.Sprintf("[workspace] %s :: %s", snippet.File, snippet.HeaderPath)
+	case SourceDaily:
+		return fmt.Sprintf("[daily] %s :: %s", snippet.File, snippet.HeaderPath)
+	default:
+		return fmt.Sprintf("[%s] %s :: %s", source, snippet.File, snippet.HeaderPath)
+	}
+}
+
+// SessionKeyFingerprint returns a short, deterministic identifier suitable
+// for displaying a session key in logs or telegram output without exposing
+// the full per-user identifier.
+func SessionKeyFingerprint(sessionKey string) string {
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(sessionKey))
+	return hex.EncodeToString(sum[:4])
+}
+
+// ListSessionKeys returns every session_key that currently has at least one
+// indexed chunk. Useful for diagnostics and reindex flows.
+func (s *MemoryStore) ListSessionKeys(ctx context.Context) ([]string, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("memory store is not configured")
+	}
+	rows, err := s.db.QueryContext(
+		ctx,
+		`SELECT DISTINCT source_file FROM memory_chunks WHERE source_file LIKE ? ORDER BY source_file ASC`,
+		SessionSourceFilePrefix+"%",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list session source files: %w", err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var sourceFile string
+		if err := rows.Scan(&sourceFile); err != nil {
+			return nil, err
+		}
+		key, ok := SessionKeyFromSourceFile(sourceFile)
+		if !ok {
+			continue
+		}
+		out = append(out, key)
+	}
+	return out, rows.Err()
+}
+
+// Compile-time assertion that *sql.DB satisfies the queries we rely on.
+var _ = (*sql.DB)(nil)

--- a/internal/memory/sessions.go
+++ b/internal/memory/sessions.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"ok-gobot/internal/redact"
 	"ok-gobot/internal/sanitize"
@@ -478,6 +479,26 @@ func FormatSnippetCitation(snippet MemorySnippet) string {
 	default:
 		return fmt.Sprintf("[%s] %s :: %s", source, snippet.File, snippet.HeaderPath)
 	}
+}
+
+// ClipForOutput trims text and truncates it on a UTF-8 rune boundary so the
+// returned string never contains an invalid byte sequence. An ellipsis is
+// appended when the input was clipped. max is interpreted as a byte budget;
+// the function will not exceed it.
+func ClipForOutput(text string, max int) string {
+	text = strings.TrimSpace(text)
+	if max <= 0 || len(text) <= max {
+		return text
+	}
+	cut := 0
+	for cut < max {
+		_, size := utf8.DecodeRuneInString(text[cut:])
+		if cut+size > max {
+			break
+		}
+		cut += size
+	}
+	return text[:cut] + "…"
 }
 
 // SessionKeyFingerprint returns a short, deterministic identifier suitable

--- a/internal/memory/sessions_storage.go
+++ b/internal/memory/sessions_storage.go
@@ -1,0 +1,81 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// SQLiteSessionTranscriptSource wraps a *sql.DB that backs the storage.Store
+// and exposes its session transcript tables to the memory indexer. It avoids
+// importing the storage package so the dependency direction stays
+// memory ← cli/app, not memory ↔ storage.
+type SQLiteSessionTranscriptSource struct {
+	db *sql.DB
+}
+
+// NewSQLiteSessionTranscriptSource constructs a transcript source backed by db.
+func NewSQLiteSessionTranscriptSource(db *sql.DB) *SQLiteSessionTranscriptSource {
+	return &SQLiteSessionTranscriptSource{db: db}
+}
+
+// ListSessionKeysForIndexing returns canonical session_keys present in
+// sessions_v2 that have at least one indexable message. The list is not
+// privacy-filtered; callers (typically the indexer) decide whether to skip
+// group sessions.
+func (s *SQLiteSessionTranscriptSource) ListSessionKeysForIndexing(ctx context.Context) ([]string, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("session transcript source is not configured")
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT DISTINCT session_key
+		FROM session_messages_v2
+		WHERE TRIM(content) <> ''
+		  AND role IN ('user', 'assistant')
+		ORDER BY session_key ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list session keys: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, rows.Err()
+}
+
+// LoadSessionMessages returns the transcript for sessionKey ordered by
+// (created_at ASC, id ASC). System and tool roles are excluded; only user
+// and assistant turns are returned.
+func (s *SQLiteSessionTranscriptSource) LoadSessionMessages(ctx context.Context, sessionKey string) ([]SessionMessage, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("session transcript source is not configured")
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, session_key, role, content, COALESCE(run_id, ''), created_at
+		FROM session_messages_v2
+		WHERE session_key = ?
+		  AND role IN ('user', 'assistant')
+		ORDER BY created_at ASC, id ASC
+	`, sessionKey)
+	if err != nil {
+		return nil, fmt.Errorf("load session messages: %w", err)
+	}
+	defer rows.Close()
+
+	var msgs []SessionMessage
+	for rows.Next() {
+		var m SessionMessage
+		if err := rows.Scan(&m.ID, &m.SessionKey, &m.Role, &m.Content, &m.RunID, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs, rows.Err()
+}

--- a/internal/memory/sessions_test.go
+++ b/internal/memory/sessions_test.go
@@ -4,9 +4,37 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	_ "github.com/mattn/go-sqlite3"
 )
+
+func TestClipForOutputRespectsRuneBoundary(t *testing.T) {
+	// Each rocket is 4 bytes; max=10 means we can fit 2 runes (8 bytes) +
+	// ellipsis. The cut must never land mid-codepoint.
+	in := strings.Repeat("🚀", 5)
+	got := ClipForOutput(in, 10)
+	if !utf8.ValidString(got) {
+		t.Fatalf("ClipForOutput produced invalid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected ellipsis suffix, got %q", got)
+	}
+	// Strip the ellipsis and confirm only whole runes remain.
+	body := strings.TrimSuffix(got, "…")
+	if len(body) != 8 {
+		t.Errorf("expected 2 emojis (8 bytes) before ellipsis, got %d bytes: %q", len(body), body)
+	}
+}
+
+func TestClipForOutputBelowLimitReturnsInput(t *testing.T) {
+	if got := ClipForOutput("hello", 100); got != "hello" {
+		t.Errorf("short input mutated: %q", got)
+	}
+	if got := ClipForOutput("  hello  ", 100); got != "hello" {
+		t.Errorf("expected trim, got %q", got)
+	}
+}
 
 type stubSessionSource struct {
 	keys     []string

--- a/internal/memory/sessions_test.go
+++ b/internal/memory/sessions_test.go
@@ -1,0 +1,382 @@
+package memory
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type stubSessionSource struct {
+	keys     []string
+	messages map[string][]SessionMessage
+}
+
+func (s *stubSessionSource) ListSessionKeysForIndexing(_ context.Context) ([]string, error) {
+	return append([]string(nil), s.keys...), nil
+}
+
+func (s *stubSessionSource) LoadSessionMessages(_ context.Context, sessionKey string) ([]SessionMessage, error) {
+	msgs := s.messages[sessionKey]
+	out := make([]SessionMessage, len(msgs))
+	copy(out, msgs)
+	return out, nil
+}
+
+func newStubSessionSource(keys ...string) *stubSessionSource {
+	return &stubSessionSource{
+		keys:     keys,
+		messages: make(map[string][]SessionMessage),
+	}
+}
+
+func TestIsGroupSessionKey(t *testing.T) {
+	cases := map[string]bool{
+		"agent:default:main":                        false,
+		"agent:default:telegram:dm:42":              false,
+		"agent:default:telegram:group:101":          true,
+		"agent:default:telegram:group:101:thread:7": true,
+		"agent:default:subagent:run-1":              false,
+	}
+	for key, want := range cases {
+		if got := IsGroupSessionKey(key); got != want {
+			t.Errorf("IsGroupSessionKey(%q) = %v, want %v", key, got, want)
+		}
+	}
+}
+
+func TestSanitizeMessageContentRedactsSecretsAndStripsControlChars(t *testing.T) {
+	raw := "remember sk-secretAPIKEYvalue1234567890\x07 ok? `Bearer abc.def.ghi`"
+	clean := SanitizeMessageContent(raw)
+	if strings.Contains(clean, "sk-secretAPIKEYvalue1234567890") {
+		t.Fatalf("expected api key to be redacted, got: %q", clean)
+	}
+	if strings.Contains(clean, "\x07") {
+		t.Fatalf("expected control characters to be stripped, got: %q", clean)
+	}
+	if strings.Contains(clean, "Bearer abc.def.ghi") {
+		t.Fatalf("expected bearer token to be redacted, got: %q", clean)
+	}
+}
+
+func TestSessionChunkHeaderRoundTrip(t *testing.T) {
+	header := SessionChunkHeader(42, "User")
+	if header != "msg 42 [user]" {
+		t.Fatalf("unexpected header: %q", header)
+	}
+	id, role, ok := ParseSessionChunkHeader(header)
+	if !ok || id != 42 || role != "user" {
+		t.Fatalf("ParseSessionChunkHeader = (%d, %q, %v)", id, role, ok)
+	}
+	if _, _, ok := ParseSessionChunkHeader("garbage"); ok {
+		t.Fatalf("expected ParseSessionChunkHeader to fail on bad input")
+	}
+}
+
+func TestDeriveSourceTypeAndSessionFile(t *testing.T) {
+	if got := DeriveSourceType("MEMORY.md"); got != SourceWorkspace {
+		t.Errorf("workspace: got %q", got)
+	}
+	if got := DeriveSourceType("memory/2026-04-29.md"); got != SourceDaily {
+		t.Errorf("daily: got %q", got)
+	}
+	if got := DeriveSourceType("notes/random.md"); got != SourceExtra {
+		t.Errorf("extra: got %q", got)
+	}
+	source := SessionSourceFile("agent:default:telegram:dm:1")
+	if !strings.HasPrefix(source, SessionSourceFilePrefix) {
+		t.Fatalf("session source file missing prefix: %q", source)
+	}
+	if got := DeriveSourceType(source); got != SourceSession {
+		t.Errorf("session: got %q", got)
+	}
+	got, ok := SessionKeyFromSourceFile(source)
+	if !ok || got != "agent:default:telegram:dm:1" {
+		t.Errorf("SessionKeyFromSourceFile = (%q, %v)", got, ok)
+	}
+}
+
+func TestNormalizeSourceTypes(t *testing.T) {
+	got := NormalizeSourceTypes([]string{"workspace", "Workspace", "Sessions", "memory", "garbage", ""})
+	want := []SourceType{SourceWorkspace, SourceSession}
+	if len(got) != len(want) {
+		t.Fatalf("normalized = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("normalized[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if got := NormalizeSourceTypes(nil); got != nil {
+		t.Errorf("nil input should return nil, got %v", got)
+	}
+}
+
+func TestSessionIndexerSkipsGroupSessionsByDefault(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	dmKey := "agent:default:telegram:dm:1"
+	groupKey := "agent:default:telegram:group:99"
+	source := newStubSessionSource(dmKey, groupKey)
+	source.messages[dmKey] = []SessionMessage{
+		{ID: 1, SessionKey: dmKey, Role: "user", Content: "hello"},
+		{ID: 2, SessionKey: dmKey, Role: "assistant", Content: "hi there"},
+	}
+	source.messages[groupKey] = []SessionMessage{
+		{ID: 3, SessionKey: groupKey, Role: "user", Content: "do not index me"},
+	}
+
+	embedder := &stubBatchEmbedder{}
+	indexer := NewSessionIndexer(store, embedder, source, WithIndexerChunking(64, 0))
+	stats, err := indexer.IndexSessions(context.Background(), SessionIndexOptions{})
+	if err != nil {
+		t.Fatalf("IndexSessions failed: %v", err)
+	}
+
+	if stats.SessionsIndexed != 1 {
+		t.Errorf("SessionsIndexed = %d, want 1", stats.SessionsIndexed)
+	}
+	if stats.SessionsSkipped < 1 {
+		t.Errorf("expected group session to be skipped, stats=%+v", stats)
+	}
+
+	if count := countSourceChunks(t, db, SessionSourceFile(dmKey)); count == 0 {
+		t.Fatalf("expected dm session chunks, got %d", count)
+	}
+	if count := countSourceChunks(t, db, SessionSourceFile(groupKey)); count != 0 {
+		t.Fatalf("group session must not be indexed by default, got %d", count)
+	}
+}
+
+func TestSessionIndexerIncludesGroupsWhenAllowed(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	groupKey := "agent:default:telegram:group:99"
+	source := newStubSessionSource(groupKey)
+	source.messages[groupKey] = []SessionMessage{
+		{ID: 1, SessionKey: groupKey, Role: "user", Content: "shared question"},
+		{ID: 2, SessionKey: groupKey, Role: "assistant", Content: "shared answer"},
+	}
+
+	embedder := &stubBatchEmbedder{}
+	indexer := NewSessionIndexer(store, embedder, source, WithIndexerChunking(64, 0))
+	stats, err := indexer.IndexSessions(context.Background(), SessionIndexOptions{IncludeGroups: true})
+	if err != nil {
+		t.Fatalf("IndexSessions failed: %v", err)
+	}
+	if stats.SessionsIndexed != 1 {
+		t.Errorf("SessionsIndexed = %d, want 1", stats.SessionsIndexed)
+	}
+	if count := countSourceChunks(t, db, SessionSourceFile(groupKey)); count != 2 {
+		t.Fatalf("group session chunks = %d, want 2", count)
+	}
+}
+
+func TestSessionIndexerSanitizesContentBeforeIndexing(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	dmKey := "agent:default:telegram:dm:7"
+	source := newStubSessionSource(dmKey)
+	source.messages[dmKey] = []SessionMessage{
+		{ID: 1, SessionKey: dmKey, Role: "user", Content: "use sk-supersecretvalue1234567890 to login"},
+	}
+
+	embedder := &stubBatchEmbedder{}
+	indexer := NewSessionIndexer(store, embedder, source, WithIndexerChunking(64, 0))
+	if _, err := indexer.IndexSessions(context.Background(), SessionIndexOptions{}); err != nil {
+		t.Fatalf("IndexSessions failed: %v", err)
+	}
+
+	rows, err := db.Query(`SELECT content FROM memory_chunks WHERE source_file = ?`, SessionSourceFile(dmKey))
+	if err != nil {
+		t.Fatalf("query stored chunks: %v", err)
+	}
+	defer rows.Close()
+
+	var stored []string
+	for rows.Next() {
+		var c string
+		if err := rows.Scan(&c); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		stored = append(stored, c)
+	}
+	if len(stored) == 0 {
+		t.Fatalf("no chunks stored")
+	}
+	for _, content := range stored {
+		if strings.Contains(content, "sk-supersecretvalue1234567890") {
+			t.Errorf("indexed chunk leaked secret: %q", content)
+		}
+	}
+}
+
+func TestSessionIndexerAppliesPerSessionLimit(t *testing.T) {
+	db := openIndexerTestDB(t)
+	defer db.Close() //nolint:errcheck
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	dmKey := "agent:default:telegram:dm:9"
+	source := newStubSessionSource(dmKey)
+	for i := 0; i < 6; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		source.messages[dmKey] = append(source.messages[dmKey], SessionMessage{
+			ID:         int64(i + 1),
+			SessionKey: dmKey,
+			Role:       role,
+			Content:    "msg-" + strings.Repeat("x", 8),
+		})
+	}
+
+	embedder := &stubBatchEmbedder{}
+	indexer := NewSessionIndexer(store, embedder, source, WithIndexerChunking(64, 0))
+	if _, err := indexer.IndexSessions(context.Background(), SessionIndexOptions{MaxMessagesPerSession: 3}); err != nil {
+		t.Fatalf("IndexSessions failed: %v", err)
+	}
+
+	got := countSourceChunks(t, db, SessionSourceFile(dmKey))
+	if got != 3 {
+		t.Fatalf("chunks under message cap = %d, want 3", got)
+	}
+}
+
+func TestLoadSessionSpanCentersOnAnchor(t *testing.T) {
+	dmKey := "agent:default:telegram:dm:1"
+	source := newStubSessionSource(dmKey)
+	for i := 0; i < 5; i++ {
+		source.messages[dmKey] = append(source.messages[dmKey], SessionMessage{
+			ID:         int64(i + 1),
+			SessionKey: dmKey,
+			Role:       "user",
+			Content:    "m",
+		})
+	}
+
+	span, err := LoadSessionSpan(context.Background(), source, dmKey, 3, 1)
+	if err != nil {
+		t.Fatalf("LoadSessionSpan: %v", err)
+	}
+	if len(span.Messages) != 3 {
+		t.Fatalf("len(span) = %d, want 3", len(span.Messages))
+	}
+	if span.Messages[0].ID != 2 || span.Messages[2].ID != 4 {
+		t.Fatalf("expected messages [2,3,4], got %v", spanIDs(span.Messages))
+	}
+}
+
+func TestLoadSessionSpanFallsBackToTail(t *testing.T) {
+	dmKey := "agent:default:telegram:dm:1"
+	source := newStubSessionSource(dmKey)
+	for i := 0; i < 4; i++ {
+		source.messages[dmKey] = append(source.messages[dmKey], SessionMessage{
+			ID: int64(i + 1), SessionKey: dmKey, Role: "user", Content: "m",
+		})
+	}
+
+	span, err := LoadSessionSpan(context.Background(), source, dmKey, 0, 1)
+	if err != nil {
+		t.Fatalf("LoadSessionSpan: %v", err)
+	}
+	want := []int64{2, 3, 4}
+	got := spanIDs(span.Messages)
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestFormatSnippetCitationIdentifiesSessionsByFingerprint(t *testing.T) {
+	sessionKey := "agent:default:telegram:dm:1"
+	hit := MemorySnippet{
+		File:       SessionSourceFile(sessionKey),
+		HeaderPath: "msg 12 [user]",
+		Score:      0.81,
+		SourceType: SourceSession,
+		SessionKey: sessionKey,
+	}
+	citation := FormatSnippetCitation(hit)
+	if !strings.Contains(citation, "[session ") {
+		t.Errorf("missing session prefix: %q", citation)
+	}
+	if !strings.Contains(citation, SessionKeyFingerprint(sessionKey)) {
+		t.Errorf("missing session fingerprint: %q", citation)
+	}
+	if !strings.Contains(citation, "msg 12 [user]") {
+		t.Errorf("missing message identifier: %q", citation)
+	}
+	// Workspace citation does not leak fingerprint.
+	workspace := MemorySnippet{File: "MEMORY.md", HeaderPath: "Topics > Goals", SourceType: SourceWorkspace}
+	if cite := FormatSnippetCitation(workspace); !strings.HasPrefix(cite, "[workspace]") {
+		t.Errorf("workspace citation = %q", cite)
+	}
+}
+
+func TestSearcherSourceFilterRestrictsResults(t *testing.T) {
+	db := newMemoryChunksTestDBWithOrdinal(t)
+
+	insertChunkWithOrdinal(t, db, "MEMORY.md", "root", 0, "workspace fact", []float32{1, 0, 0})
+	insertChunkWithOrdinal(t, db, "memory/2026-04-29.md", "root", 0, "daily fact", []float32{0.99, 0, 0})
+	insertChunkWithOrdinal(t, db, SessionSourceFile("k1"), "msg 1 [user]", 0, "session fact", []float32{0.98, 0, 0})
+
+	searcher, err := NewSearcher(context.Background(), db)
+	if err != nil {
+		t.Fatalf("NewSearcher: %v", err)
+	}
+
+	all := searcher.Search([]float32{1, 0, 0}, SearchOptions{Threshold: 0.5})
+	if len(all) != 3 {
+		t.Fatalf("expected 3 hits without filter, got %d", len(all))
+	}
+
+	sessionsOnly := searcher.Search([]float32{1, 0, 0}, SearchOptions{
+		Threshold: 0.5,
+		Sources:   []SourceType{SourceSession},
+	})
+	if len(sessionsOnly) != 1 {
+		t.Fatalf("expected 1 session-only hit, got %d", len(sessionsOnly))
+	}
+	if sessionsOnly[0].SourceType != SourceSession {
+		t.Fatalf("hit source = %q, want %q", sessionsOnly[0].SourceType, SourceSession)
+	}
+	if sessionsOnly[0].SessionKey != "k1" {
+		t.Fatalf("hit session key = %q, want k1", sessionsOnly[0].SessionKey)
+	}
+}
+
+func spanIDs(msgs []SessionMessage) []int64 {
+	out := make([]int64, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.ID
+	}
+	return out
+}

--- a/internal/memory/sources.go
+++ b/internal/memory/sources.go
@@ -1,0 +1,109 @@
+package memory
+
+import (
+	"strings"
+)
+
+// SourceType identifies which retrieval bucket a memory chunk belongs to.
+// Source types let the searcher filter results to a specific subset
+// (workspace, daily, sessions, extra) without changing the underlying
+// chunk storage.
+type SourceType string
+
+const (
+	// SourceWorkspace is the durable curated MEMORY.md file at the soul root.
+	SourceWorkspace SourceType = "workspace"
+	// SourceDaily covers daily notes under memory/<date>.md.
+	SourceDaily SourceType = "daily"
+	// SourceSession covers indexed transcript chunks from past sessions.
+	SourceSession SourceType = "session"
+	// SourceExtra covers configured extra paths outside the canonical layout.
+	SourceExtra SourceType = "extra"
+)
+
+// SessionSourceFilePrefix is the source_file prefix used for indexed session
+// transcript chunks. The remainder of the source_file is the canonical
+// session key as produced by the session package.
+const SessionSourceFilePrefix = "session://"
+
+// SessionSourceFile returns the canonical source_file value for a transcript
+// chunk belonging to sessionKey.
+func SessionSourceFile(sessionKey string) string {
+	return SessionSourceFilePrefix + sessionKey
+}
+
+// SessionKeyFromSourceFile extracts the session key embedded in a session
+// transcript source_file. Returns ("", false) when sourceFile does not
+// represent a session.
+func SessionKeyFromSourceFile(sourceFile string) (string, bool) {
+	if !strings.HasPrefix(sourceFile, SessionSourceFilePrefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(sourceFile, SessionSourceFilePrefix), true
+}
+
+// DeriveSourceType returns the canonical SourceType for a stored chunk's
+// source_file value. The derivation is intentionally string-based so that
+// the underlying memory_chunks schema does not need a separate column for
+// source classification.
+func DeriveSourceType(sourceFile string) SourceType {
+	sourceFile = strings.TrimSpace(sourceFile)
+	if sourceFile == "" {
+		return SourceExtra
+	}
+	if strings.HasPrefix(sourceFile, SessionSourceFilePrefix) {
+		return SourceSession
+	}
+	if sourceFile == "MEMORY.md" {
+		return SourceWorkspace
+	}
+	if strings.HasPrefix(sourceFile, "memory/") && strings.Count(sourceFile, "/") == 1 {
+		return SourceDaily
+	}
+	return SourceExtra
+}
+
+// NormalizeSourceTypes returns a deduplicated, lower-cased list of source
+// types. Unknown values are dropped so callers can pass user input directly.
+// An empty input returns nil, which the searcher treats as "all sources".
+func NormalizeSourceTypes(values []string) []SourceType {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[SourceType]struct{}, len(values))
+	out := make([]SourceType, 0, len(values))
+	for _, raw := range values {
+		v := strings.TrimSpace(strings.ToLower(raw))
+		if v == "" {
+			continue
+		}
+		var st SourceType
+		switch v {
+		case string(SourceWorkspace), "memory":
+			st = SourceWorkspace
+		case string(SourceDaily), "notes":
+			st = SourceDaily
+		case string(SourceSession), "sessions", "transcript", "transcripts":
+			st = SourceSession
+		case string(SourceExtra), "extras", "external":
+			st = SourceExtra
+		default:
+			continue
+		}
+		if _, ok := seen[st]; ok {
+			continue
+		}
+		seen[st] = struct{}{}
+		out = append(out, st)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// AllSourceTypes returns the full list of supported source types. The order
+// is stable so callers can rely on it for help text and CLI flags.
+func AllSourceTypes() []SourceType {
+	return []SourceType{SourceWorkspace, SourceDaily, SourceSession, SourceExtra}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -60,6 +60,15 @@ func NewMemoryStore(db *sql.DB) (*MemoryStore, error) {
 	return store, nil
 }
 
+// DB returns the underlying *sql.DB. Exposed for callers that need to
+// share the connection with the searcher and session indexer.
+func (s *MemoryStore) DB() *sql.DB {
+	if s == nil {
+		return nil
+	}
+	return s.db
+}
+
 // migrate creates/updates memory index tables.
 func (s *MemoryStore) migrate() error {
 	if err := s.ensureLegacyMemoriesTable(); err != nil {

--- a/internal/tools/session_search_tool.go
+++ b/internal/tools/session_search_tool.go
@@ -1,0 +1,202 @@
+package tools
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"ok-gobot/internal/memory"
+)
+
+// SessionSearchTool performs semantic search restricted to indexed session
+// transcripts. It is a thin wrapper around memory.Searcher that defaults
+// the source filter to "session" and includes session metadata in the
+// rendered output.
+type SessionSearchTool struct {
+	embedder *memory.EmbeddingClient
+	store    *memory.MemoryStore
+	source   memory.SessionTranscriptSource
+}
+
+// NewSessionSearchTool wires the agent-facing /session_search tool.
+// Any of the dependencies may be nil — Execute returns a clear error in
+// that case rather than panicking, which keeps the tool registry safe to
+// expose even when session memory is disabled.
+func NewSessionSearchTool(embedder *memory.EmbeddingClient, store *memory.MemoryStore, db *sql.DB) *SessionSearchTool {
+	var source memory.SessionTranscriptSource
+	if db != nil {
+		source = memory.NewSQLiteSessionTranscriptSource(db)
+	}
+	return &SessionSearchTool{
+		embedder: embedder,
+		store:    store,
+		source:   source,
+	}
+}
+
+func (t *SessionSearchTool) Name() string { return "session_search" }
+
+func (t *SessionSearchTool) Description() string {
+	return "Search past session transcripts by meaning. Returns top matches with session fingerprint and message id; pair with session_get to read the surrounding span."
+}
+
+func (t *SessionSearchTool) Execute(ctx context.Context, args ...string) (string, error) {
+	if t == nil || t.store == nil || t.embedder == nil {
+		return "", fmt.Errorf("session memory is not configured")
+	}
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return "", fmt.Errorf("usage: session_search <query> [limit]")
+	}
+
+	query := strings.TrimSpace(args[0])
+	limit := memory.DefaultSearchTopK
+	if len(args) > 1 {
+		if n, err := strconv.Atoi(strings.TrimSpace(args[1])); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	embedding, err := t.embedder.GetEmbedding(ctx, query)
+	if err != nil {
+		return "", fmt.Errorf("embed query: %w", err)
+	}
+
+	searcher, err := memory.NewSearcher(ctx, t.store.DB())
+	if err != nil {
+		return "", fmt.Errorf("open searcher: %w", err)
+	}
+
+	hits := searcher.Search(embedding, memory.SearchOptions{
+		TopK:    limit,
+		Sources: []memory.SourceType{memory.SourceSession},
+	})
+	if len(hits) == 0 {
+		return "No matching session transcripts.", nil
+	}
+
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("Found %d session transcript snippet(s):\n\n", len(hits)))
+	for i, hit := range hits {
+		out.WriteString(fmt.Sprintf("%d. %s  (score=%.3f)\n", i+1, memory.FormatSnippetCitation(hit), hit.Score))
+		out.WriteString(fmt.Sprintf("   %s\n\n", clipForOutput(hit.Text, 320)))
+	}
+	out.WriteString("Use session_get with the matching session key + message id to read the surrounding span.")
+	return out.String(), nil
+}
+
+func (t *SessionSearchTool) GetSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"query": map[string]interface{}{
+				"type":        "string",
+				"description": "Natural-language query to search past session transcripts",
+			},
+			"limit": map[string]interface{}{
+				"type":        "integer",
+				"description": "Maximum number of session snippets to return (default 5)",
+			},
+		},
+		"required": []string{"query"},
+	}
+}
+
+// SessionGetTool reads a span of messages from a single session transcript
+// without loading the full history. It complements session_search.
+type SessionGetTool struct {
+	source memory.SessionTranscriptSource
+}
+
+// NewSessionGetTool builds a session_get tool backed by db. When db is nil
+// the tool reports a clear configuration error instead of panicking.
+func NewSessionGetTool(db *sql.DB) *SessionGetTool {
+	var source memory.SessionTranscriptSource
+	if db != nil {
+		source = memory.NewSQLiteSessionTranscriptSource(db)
+	}
+	return &SessionGetTool{source: source}
+}
+
+func (t *SessionGetTool) Name() string { return "session_get" }
+
+func (t *SessionGetTool) Description() string {
+	return "Read a span of messages from a session transcript around an anchor message id. Use session_search to discover candidate session keys and message ids first."
+}
+
+func (t *SessionGetTool) Execute(ctx context.Context, args ...string) (string, error) {
+	if t == nil || t.source == nil {
+		return "", fmt.Errorf("session transcript source is not configured")
+	}
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return "", fmt.Errorf("usage: session_get <session-key> [message-id] [span]")
+	}
+	sessionKey := strings.TrimSpace(args[0])
+	var anchor int64
+	if len(args) > 1 {
+		if n, err := strconv.ParseInt(strings.TrimSpace(args[1]), 10, 64); err == nil {
+			anchor = n
+		}
+	}
+	span := 2
+	if len(args) > 2 {
+		if n, err := strconv.Atoi(strings.TrimSpace(args[2])); err == nil && n >= 0 {
+			span = n
+		}
+	}
+
+	result, err := memory.LoadSessionSpan(ctx, t.source, sessionKey, anchor, span)
+	if err != nil {
+		return "", fmt.Errorf("load session span: %w", err)
+	}
+	if len(result.Messages) == 0 {
+		return "No messages found.", nil
+	}
+
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf("Session: %s (fingerprint=%s)\n", sessionKey, memory.SessionKeyFingerprint(sessionKey)))
+	if anchor > 0 {
+		out.WriteString(fmt.Sprintf("Anchor: msg %d, span ±%d\n", anchor, span))
+	}
+	out.WriteString(fmt.Sprintf("Messages: %d\n\n", len(result.Messages)))
+	for _, msg := range result.Messages {
+		marker := " "
+		if msg.ID == anchor {
+			marker = ">"
+		}
+		clean := memory.SanitizeMessageContent(msg.Content)
+		out.WriteString(fmt.Sprintf("%s msg %d [%s] @ %s\n", marker, msg.ID, msg.Role, msg.CreatedAt))
+		out.WriteString(fmt.Sprintf("  %s\n\n", clipForOutput(clean, 800)))
+	}
+	return out.String(), nil
+}
+
+func (t *SessionGetTool) GetSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"session_key": map[string]interface{}{
+				"type":        "string",
+				"description": "Canonical session key (e.g. agent:default:telegram:dm:42)",
+			},
+			"message_id": map[string]interface{}{
+				"type":        "integer",
+				"description": "Anchor message id; the surrounding window is centered on it",
+			},
+			"span": map[string]interface{}{
+				"type":        "integer",
+				"description": "Number of messages before and after the anchor (default 2)",
+			},
+		},
+		"required": []string{"session_key"},
+	}
+}
+
+func clipForOutput(text string, max int) string {
+	text = strings.TrimSpace(text)
+	if max <= 0 || len(text) <= max {
+		return text
+	}
+	return text[:max] + "…"
+}

--- a/internal/tools/session_search_tool.go
+++ b/internal/tools/session_search_tool.go
@@ -15,7 +15,7 @@ import (
 // the source filter to "session" and includes session metadata in the
 // rendered output.
 type SessionSearchTool struct {
-	embedder *memory.EmbeddingClient
+	embedder memory.EmbeddingQueryClient
 	store    *memory.MemoryStore
 	source   memory.SessionTranscriptSource
 }
@@ -24,7 +24,7 @@ type SessionSearchTool struct {
 // Any of the dependencies may be nil — Execute returns a clear error in
 // that case rather than panicking, which keeps the tool registry safe to
 // expose even when session memory is disabled.
-func NewSessionSearchTool(embedder *memory.EmbeddingClient, store *memory.MemoryStore, db *sql.DB) *SessionSearchTool {
+func NewSessionSearchTool(embedder memory.EmbeddingQueryClient, store *memory.MemoryStore, db *sql.DB) *SessionSearchTool {
 	var source memory.SessionTranscriptSource
 	if db != nil {
 		source = memory.NewSQLiteSessionTranscriptSource(db)
@@ -39,7 +39,7 @@ func NewSessionSearchTool(embedder *memory.EmbeddingClient, store *memory.Memory
 func (t *SessionSearchTool) Name() string { return "session_search" }
 
 func (t *SessionSearchTool) Description() string {
-	return "Search past session transcripts by meaning. Returns top matches with session fingerprint and message id; pair with session_get to read the surrounding span."
+	return "Search past session transcripts by meaning. Returns matches with the canonical session key and message id; pair with session_get to read the surrounding span."
 }
 
 func (t *SessionSearchTool) Execute(ctx context.Context, args ...string) (string, error) {
@@ -57,7 +57,29 @@ func (t *SessionSearchTool) Execute(ctx context.Context, args ...string) (string
 			limit = n
 		}
 	}
+	return t.run(ctx, query, limit)
+}
 
+// ExecuteJSON implements JSONExecutor so the tool-calling agent passes
+// named parameters directly without going through positional adaptation.
+func (t *SessionSearchTool) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
+	if t == nil || t.store == nil || t.embedder == nil {
+		return "", fmt.Errorf("session memory is not configured")
+	}
+	query := strings.TrimSpace(params["query"])
+	if query == "" {
+		return "", fmt.Errorf("'query' is required")
+	}
+	limit := memory.DefaultSearchTopK
+	if raw := strings.TrimSpace(params["limit"]); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	return t.run(ctx, query, limit)
+}
+
+func (t *SessionSearchTool) run(ctx context.Context, query string, limit int) (string, error) {
 	embedding, err := t.embedder.GetEmbedding(ctx, query)
 	if err != nil {
 		return "", fmt.Errorf("embed query: %w", err)
@@ -80,9 +102,20 @@ func (t *SessionSearchTool) Execute(ctx context.Context, args ...string) (string
 	out.WriteString(fmt.Sprintf("Found %d session transcript snippet(s):\n\n", len(hits)))
 	for i, hit := range hits {
 		out.WriteString(fmt.Sprintf("%d. %s  (score=%.3f)\n", i+1, memory.FormatSnippetCitation(hit), hit.Score))
-		out.WriteString(fmt.Sprintf("   %s\n\n", clipForOutput(hit.Text, 320)))
+		// Expose the canonical session key and message id so the agent can
+		// pass them to session_get. The fingerprint citation alone is a
+		// one-way hash and cannot be used to address the source session.
+		if hit.SessionKey != "" {
+			msgID, role, ok := memory.ParseSessionChunkHeader(hit.HeaderPath)
+			if ok {
+				out.WriteString(fmt.Sprintf("   session_key=%s  message_id=%d  role=%s\n", hit.SessionKey, msgID, role))
+			} else {
+				out.WriteString(fmt.Sprintf("   session_key=%s\n", hit.SessionKey))
+			}
+		}
+		out.WriteString(fmt.Sprintf("   %s\n\n", memory.ClipForOutput(hit.Text, 320)))
 	}
-	out.WriteString("Use session_get with the matching session key + message id to read the surrounding span.")
+	out.WriteString("Use session_get with session_key (and optional message_id) to read the surrounding span.")
 	return out.String(), nil
 }
 
@@ -145,7 +178,36 @@ func (t *SessionGetTool) Execute(ctx context.Context, args ...string) (string, e
 			span = n
 		}
 	}
+	return t.run(ctx, sessionKey, anchor, span)
+}
 
+// ExecuteJSON implements JSONExecutor so message_id and span are read by
+// name, not by Go map iteration order. Without this, the generic positional
+// fallback can swap fields when the model supplies both numeric values.
+func (t *SessionGetTool) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
+	if t == nil || t.source == nil {
+		return "", fmt.Errorf("session transcript source is not configured")
+	}
+	sessionKey := strings.TrimSpace(params["session_key"])
+	if sessionKey == "" {
+		return "", fmt.Errorf("'session_key' is required")
+	}
+	var anchor int64
+	if raw := strings.TrimSpace(params["message_id"]); raw != "" {
+		if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			anchor = n
+		}
+	}
+	span := 2
+	if raw := strings.TrimSpace(params["span"]); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n >= 0 {
+			span = n
+		}
+	}
+	return t.run(ctx, sessionKey, anchor, span)
+}
+
+func (t *SessionGetTool) run(ctx context.Context, sessionKey string, anchor int64, span int) (string, error) {
 	result, err := memory.LoadSessionSpan(ctx, t.source, sessionKey, anchor, span)
 	if err != nil {
 		return "", fmt.Errorf("load session span: %w", err)
@@ -167,7 +229,7 @@ func (t *SessionGetTool) Execute(ctx context.Context, args ...string) (string, e
 		}
 		clean := memory.SanitizeMessageContent(msg.Content)
 		out.WriteString(fmt.Sprintf("%s msg %d [%s] @ %s\n", marker, msg.ID, msg.Role, msg.CreatedAt))
-		out.WriteString(fmt.Sprintf("  %s\n\n", clipForOutput(clean, 800)))
+		out.WriteString(fmt.Sprintf("  %s\n\n", memory.ClipForOutput(clean, 800)))
 	}
 	return out.String(), nil
 }
@@ -191,12 +253,4 @@ func (t *SessionGetTool) GetSchema() map[string]interface{} {
 		},
 		"required": []string{"session_key"},
 	}
-}
-
-func clipForOutput(text string, max int) string {
-	text = strings.TrimSpace(text)
-	if max <= 0 || len(text) <= max {
-		return text
-	}
-	return text[:max] + "…"
 }

--- a/internal/tools/session_search_tool_test.go
+++ b/internal/tools/session_search_tool_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestSessionGetToolUnconfiguredReturnsError(t *testing.T) {
+	tool := NewSessionGetTool(nil)
+	if _, err := tool.Execute(context.Background(), "agent:default:telegram:dm:1"); err == nil {
+		t.Fatal("expected error when source is not configured")
+	}
+}
+
+func TestSessionSearchToolUnconfiguredReturnsError(t *testing.T) {
+	tool := NewSessionSearchTool(nil, nil, nil)
+	if _, err := tool.Execute(context.Background(), "anything"); err == nil {
+		t.Fatal("expected error when session memory is not configured")
+	}
+}
+
+func TestSessionGetToolFormatsSpan(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec(`
+		CREATE TABLE session_messages_v2 (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_key TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT NOT NULL,
+			run_id TEXT DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	const sessionKey = "agent:default:telegram:dm:7"
+	for _, msg := range []struct{ role, content string }{
+		{"user", "hello there"},
+		{"assistant", "hi! how can I help?"},
+		{"user", "remember sk-abcdefghij1234567890 token"},
+		{"assistant", "noted privately"},
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO session_messages_v2 (session_key, role, content) VALUES (?, ?, ?)`,
+			sessionKey, msg.role, msg.content,
+		); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	tool := NewSessionGetTool(db)
+	out, err := tool.Execute(context.Background(), sessionKey, "3", "1")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "fingerprint=") {
+		t.Errorf("missing fingerprint header: %q", out)
+	}
+	if strings.Contains(out, "sk-abcdefghij1234567890") {
+		t.Errorf("session_get leaked secret: %q", out)
+	}
+	if !strings.Contains(out, "> msg 3") {
+		t.Errorf("anchor marker missing: %q", out)
+	}
+}

--- a/internal/tools/session_search_tool_test.go
+++ b/internal/tools/session_search_tool_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -71,5 +72,108 @@ func TestSessionGetToolFormatsSpan(t *testing.T) {
 	}
 	if !strings.Contains(out, "> msg 3") {
 		t.Errorf("anchor marker missing: %q", out)
+	}
+}
+
+// TestSessionGetToolExecuteJSONReadsByName ensures named arguments are
+// honored regardless of map iteration order, so message_id and span are
+// never swapped.
+func TestSessionGetToolExecuteJSONReadsByName(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec(`
+		CREATE TABLE session_messages_v2 (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_key TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT NOT NULL,
+			run_id TEXT DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	const sessionKey = "agent:default:telegram:dm:9"
+	for _, msg := range []struct{ role, content string }{
+		{"user", "first"},
+		{"assistant", "second"},
+		{"user", "third"},
+		{"assistant", "fourth"},
+		{"user", "fifth"},
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO session_messages_v2 (session_key, role, content) VALUES (?, ?, ?)`,
+			sessionKey, msg.role, msg.content,
+		); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	tool := NewSessionGetTool(db)
+	out, err := tool.ExecuteJSON(context.Background(), map[string]string{
+		"session_key": sessionKey,
+		"message_id":  "3",
+		"span":        "1",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteJSON: %v", err)
+	}
+	if !strings.Contains(out, "Anchor: msg 3") {
+		t.Errorf("anchor not honoured by name: %q", out)
+	}
+	if !strings.Contains(out, "> msg 3") {
+		t.Errorf("anchor marker missing: %q", out)
+	}
+	// span=1 around msg 3 → 3 messages (2,3,4); never 5.
+	if strings.Contains(out, "msg 5") {
+		t.Errorf("span=1 leaked far-away message: %q", out)
+	}
+}
+
+// TestSessionGetToolClipsOnRuneBoundary ensures multi-byte content does
+// not get sliced mid-codepoint, which previously produced invalid UTF-8.
+func TestSessionGetToolClipsOnRuneBoundary(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec(`
+		CREATE TABLE session_messages_v2 (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_key TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT NOT NULL,
+			run_id TEXT DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	const sessionKey = "agent:default:telegram:dm:11"
+	// Each "🚀" is a 4-byte UTF-8 sequence; 250 of them = 1000 bytes,
+	// which is over the 800-byte session_get clip threshold.
+	emojiBlob := strings.Repeat("🚀", 250)
+	if _, err := db.Exec(
+		`INSERT INTO session_messages_v2 (session_key, role, content) VALUES (?, ?, ?)`,
+		sessionKey, "user", emojiBlob,
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	tool := NewSessionGetTool(db)
+	out, err := tool.Execute(context.Background(), sessionKey)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !utf8.ValidString(out) {
+		t.Fatalf("session_get produced invalid UTF-8: %q", out)
 	}
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -479,11 +479,11 @@ type ToolsConfig struct {
 	Contacts             map[string]int64 // alias -> chatID for message tool allowlist
 	CurrentChatID        int64
 	MemoryManager        *memory.MemoryManager
-	MemoryExtraPaths     []memory.ExtraPath      // Additional named markdown collections exposed to memory_get
-	MemoryStore          *memory.MemoryStore     // shared sqlite-backed memory index
-	MemoryEmbedder       *memory.EmbeddingClient // used by session_search to embed queries
-	SessionMemoryEnabled bool                    // when true, session_search/session_get are registered
-	SessionTranscriptsDB *sql.DB                 // sqlite DB providing access to session_messages_v2
+	MemoryExtraPaths     []memory.ExtraPath          // Additional named markdown collections exposed to memory_get
+	MemoryStore          *memory.MemoryStore         // shared sqlite-backed memory index
+	MemoryEmbedder       memory.EmbeddingQueryClient // used by session_search to embed queries
+	SessionMemoryEnabled bool                        // when true, session_search/session_get are registered
+	SessionTranscriptsDB *sql.DB                     // sqlite DB providing access to session_messages_v2
 	PatternStore         recommend.PatternStore
 	EmergencyStop        EmergencyStopProvider
 	AIClient             ai.Client               // used by frontend_verify for LLM-based visual comparison

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -478,7 +479,11 @@ type ToolsConfig struct {
 	Contacts             map[string]int64 // alias -> chatID for message tool allowlist
 	CurrentChatID        int64
 	MemoryManager        *memory.MemoryManager
-	MemoryExtraPaths     []memory.ExtraPath // Additional named markdown collections exposed to memory_get
+	MemoryExtraPaths     []memory.ExtraPath      // Additional named markdown collections exposed to memory_get
+	MemoryStore          *memory.MemoryStore     // shared sqlite-backed memory index
+	MemoryEmbedder       *memory.EmbeddingClient // used by session_search to embed queries
+	SessionMemoryEnabled bool                    // when true, session_search/session_get are registered
+	SessionTranscriptsDB *sql.DB                 // sqlite DB providing access to session_messages_v2
 	PatternStore         recommend.PatternStore
 	EmergencyStop        EmergencyStopProvider
 	AIClient             ai.Client               // used by frontend_verify for LLM-based visual comparison
@@ -630,6 +635,16 @@ func LoadFromConfigWithOptions(basePath string, cfg *ToolsConfig) (*Registry, er
 				getTool = getTool.WithExtraPaths(cfg.MemoryExtraPaths)
 			}
 			registry.Register(getTool)
+		}
+
+		// Session memory tools (off by default; opt-in via cfg.SessionMemoryEnabled).
+		if cfg.SessionMemoryEnabled {
+			if cfg.MemoryStore != nil && cfg.MemoryEmbedder != nil {
+				registry.Register(NewSessionSearchTool(cfg.MemoryEmbedder, cfg.MemoryStore, cfg.SessionTranscriptsDB))
+			}
+			if cfg.SessionTranscriptsDB != nil {
+				registry.Register(NewSessionGetTool(cfg.SessionTranscriptsDB))
+			}
 		}
 
 		// Role recommendation tool


### PR DESCRIPTION
Implements #309

## Summary
Adds an opt-in session transcript memory source so past conversations are
searchable without replaying entire transcripts. Indexed transcript chunks
share the existing `memory_chunks` table but are tagged via a `session://`
source_file prefix and a derived `SourceType`, keeping them logically separate
from durable workspace and daily memory.

## Changes

- **Source-aware searcher** (`internal/memory/search.go`, `sources.go`): every
  chunk now carries a derived `SourceType` (`workspace`, `daily`, `session`,
  `extra`) and snippets surface the source type, session key, and ordinal.
  `SearchOptions.Sources` filters results to a subset.
- **Session indexer** (`internal/memory/sessions.go`,
  `internal/memory/sessions_storage.go`): walks `session_messages_v2`,
  redacts secrets via `internal/redact`, strips control characters, and
  upserts chunks under `session://<session_key>`. Group-keyed sessions are
  skipped unless `IncludeGroups=true`.
- **Span expansion**: `LoadSessionSpan` returns N messages around an anchor
  message id, so a search hit can be expanded without loading the full
  transcript.
- **Config** (`internal/config/config.go`): new `memory.sessions` block —
  `enabled`, `include_groups`, `max_messages_per_session`. Disabled by
  default for privacy.
- **CLI** (`internal/cli/sessions.go`): `ok-gobot sessions index`,
  `sessions search`, and `sessions show` for admin use.
- **Agent tools** (`internal/tools/session_search_tool.go`):
  `session_search` and `session_get` are wired into `ToolsConfig` and
  registered only when the operator opts in.

## Privacy

- Session memory is **disabled by default**; operators must set
  `memory.sessions.enabled: true`.
- Group sessions (`agent:*:telegram:group:*`) are excluded unless
  `include_groups` is also true.
- Indexed content is sanitized (`redact.Redact` + `sanitize.StripControlChars`).
- Search citations use a short SHA-256 fingerprint of the session key, so
  log output never leaks raw `:dm:<userId>` identifiers.
- Durable `MEMORY.md` is untouched — session memory is *evidence*, not
  curated truth.

## Testing

- `go fmt ./...`, `go vet ./...`, `go build ./cmd/ok-gobot/` — clean.
- `go test ./...` — all packages pass.
- New tests cover privacy scoping, secret redaction in indexed content,
  search-result formatting (source type + session fingerprint), source
  filtering, span expansion around an anchor, and CLI behavior when memory
  is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an opt-in session transcript memory source (`memory.sessions.enabled`) that indexes past `session_messages_v2` rows into the shared `memory_chunks` table under a `session://` prefix, together with CLI admin commands (`sessions index/search/show`) and agent-facing tools (`session_search`, `session_get`).

- **P1 (security):** `session_search` performs an unscoped vector search across all indexed sessions and outputs the raw `session_key` (e.g. `agent:default:telegram:dm:99`) for every match. `session_get` accepts any key with no ownership check. In a multi-user bot a user's query can surface another user's session key, which the agent can then pass to `session_get` to retrieve that user's private transcript. Both tools receive the full `store.DB()` (set in `bot.go`) with no per-user filter; scoping lookups to the current caller's session key is needed before this feature is safe for multi-tenant deployments.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is for multi-user bots; the session tools have no per-user authorization and can leak private conversation content across users once session memory is enabled.

One P1 security finding (cross-user session access) caps the score at 4; the severity and breadth of potential data leakage in any multi-tenant deployment warrants pulling the score down to 3.

internal/tools/session_search_tool.go — unscoped search and unrestricted session_get; internal/bot/bot.go — passes full store.DB() with no per-user context to tool config.

<details open><summary><h3>Security Review</h3></summary>

- **Cross-user session data leak** (`internal/tools/session_search_tool.go`): `session_search` returns raw session keys for every matched session regardless of the requesting user's identity, and `session_get` accepts any session key without an authorization check. In a multi-user bot this allows User A to retrieve User B's private conversation transcript.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tools/session_search_tool.go | New agent-facing tools for session search and span retrieval; cross-user session access is possible since neither tool scopes results to the current user's session key. |
| internal/memory/sessions.go | Core session indexer, span loader, and citation helpers; sanitization pipeline (redact + control-char strip) and UTF-8-safe ClipForOutput are correctly implemented. |
| internal/memory/sessions_storage.go | SQLite-backed transcript source; correctly filters to user/assistant roles and orders by created_at ASC, id ASC. |
| internal/memory/sources.go | Source type derivation and normalization helpers; all cases are string-based and well-tested. |
| internal/memory/search.go | Adds SourceType/SessionKey fields to MemorySnippet and source-filter set logic; source filter correctly gates chunks in the hot search loop. |
| internal/memory/store.go | Adds DB() accessor for sharing the connection with session tools; nil-safe. |
| internal/cli/sessions.go | Adds index/search/show sub-commands; uses FormatSnippetCitation (fingerprint-only) for CLI output, which is correct. |
| internal/config/config.go | Adds SessionMemoryConfig with correct defaults (all false/0); duplicate SetDefault blocks in Load and LoadFrom are consistent with the existing pattern. |
| internal/bot/bot.go | Wires session tool deps into ToolsConfig; passes store.DB() (full DB) to SessionTranscriptsDB with no per-user scoping. |
| internal/tools/tools.go | Adds four new ToolsConfig fields and conditional tool registration behind SessionMemoryEnabled guard; registration logic is correct. |
| internal/memory/manager.go | Adds Store() and Embedder() accessors; both are nil-safe. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/tools/session_search_tool.go`, line 1963-1977 ([link](https://github.com/befeast/ok-gobot/blob/6e91f9b8e77457ce03d9add9a837454aa37cbf4e/internal/tools/session_search_tool.go#L1963-L1977)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Cross-user session key exposure enables unauthorized data access**

   In a multi-user bot (e.g., a single agent serving many Telegram DMs), all users' sessions are indexed together. `session_search` runs an unscoped vector search across **all** indexed sessions and writes the raw `session_key` (e.g., `agent:default:telegram:dm:99`) to the output for every match. When User A's query happens to hit a chunk from User B's private session, the agent receives User B's canonical session key and can immediately call `session_get` to retrieve and present User B's conversation to User A — no authorization check exists at any layer.

   `session_get` receives the full `store.DB()` containing every user's transcripts (set unconditionally in `bot.go:38`) and calls `LoadSessionSpan` with whatever key the model provides. There is no check that the requested session key belongs to the current conversation.

   The minimal fix is to scope search results and `session_get` lookups to the current session key. The tools would need the caller's session key injected at construction time (from `bot.go` where it is available) so that `Search` can filter by a prefix or exact key, and `session_get` can reject keys that do not match.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tools/session_search_tool.go
   Line: 1963-1977

   Comment:
   **Cross-user session key exposure enables unauthorized data access**

   In a multi-user bot (e.g., a single agent serving many Telegram DMs), all users' sessions are indexed together. `session_search` runs an unscoped vector search across **all** indexed sessions and writes the raw `session_key` (e.g., `agent:default:telegram:dm:99`) to the output for every match. When User A's query happens to hit a chunk from User B's private session, the agent receives User B's canonical session key and can immediately call `session_get` to retrieve and present User B's conversation to User A — no authorization check exists at any layer.

   `session_get` receives the full `store.DB()` containing every user's transcripts (set unconditionally in `bot.go:38`) and calls `LoadSessionSpan` with whatever key the model provides. There is no check that the requested session key belongs to the current conversation.

   The minimal fix is to scope search results and `session_get` lookups to the current session key. The tools would need the caller's session key injected at construction time (from `bot.go` where it is available) so that `Search` can filter by a prefix or exact key, and `session_get` can reject keys that do not match.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/tools/session_search_tool.go
Line: 1963-1977

Comment:
**Cross-user session key exposure enables unauthorized data access**

In a multi-user bot (e.g., a single agent serving many Telegram DMs), all users' sessions are indexed together. `session_search` runs an unscoped vector search across **all** indexed sessions and writes the raw `session_key` (e.g., `agent:default:telegram:dm:99`) to the output for every match. When User A's query happens to hit a chunk from User B's private session, the agent receives User B's canonical session key and can immediately call `session_get` to retrieve and present User B's conversation to User A — no authorization check exists at any layer.

`session_get` receives the full `store.DB()` containing every user's transcripts (set unconditionally in `bot.go:38`) and calls `LoadSessionSpan` with whatever key the model provides. There is no check that the requested session key belongs to the current conversation.

The minimal fix is to scope search results and `session_get` lookups to the current session key. The tools would need the caller's session key injected at construction time (from `bot.go` where it is available) so that `Search` can filter by a prefix or exact key, and `session_get` can reject keys that do not match.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(memory): address PR review on sessio..."](https://github.com/befeast/ok-gobot/commit/6e91f9b8e77457ce03d9add9a837454aa37cbf4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30241276)</sub>

<!-- /greptile_comment -->