### PR TITLE
feat(memory): curation drafts for daily-note promotion (#310)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -104,6 +104,14 @@ memory:
     max_snippets: 5       # Maximum snippets injected
     max_chars: 2000       # Maximum total chars of injected memory
     history_turns: 3      # Recent turns blended into the recall query
+  # Curation drafts: turn daily notes into auditable durable-memory promotions.
+  # Drafts never modify MEMORY.md on their own; admins must explicitly approve
+  # apply via `ok-gobot memory curate apply <id> --yes` or the Telegram
+  # /memory_curate apply <id> yes command.
+  curation:
+    enabled: false       # Optional scheduled curation suggestions; never auto-applies (default false)
+    schedule: ""         # Cron expression for the suggestion run; ignored when disabled
+    days: 7              # Daily-note window scanned per suggestion run
 
 # Multi-Agent Configuration (optional)
 # Configure multiple agents with different personalities, models, and tool restrictions

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -157,6 +157,46 @@ The bot also starts debounced filesystem watchers for the workspace memory
 sources and for each extra path. Changes update the `memory_chunks` index;
 deleted files remove their chunks.
 
+### Curation Drafts (manual promotion)
+
+Daily notes accumulate quickly. To turn them into durable, audited promotions
+without ever silently rewriting `MEMORY.md`, use:
+
+```bash
+ok-gobot memory curate --since 2026-04-15 --until 2026-04-21
+```
+
+This scans `<soul>/memory/*.md` in the date range and writes a draft under
+`<soul>/memory/drafts/<id>.{md,json}`. It does **not** modify `MEMORY.md`.
+
+The draft groups extracted candidates by section (durable user preferences,
+project decisions, infrastructure facts, todos/follow-ups, stale/conflicting
+facts), keeps a source link to the original daily note line, and runs a safety
+audit that flags credentials, destructive shell snippets, low-confidence
+candidates, and conflicts where the same fact appears with different values.
+
+To apply a draft to `MEMORY.md` you must explicitly confirm:
+
+```bash
+ok-gobot memory curate apply <id> --yes
+```
+
+Apply is blocked automatically if the audit reports any error-severity finding.
+Other actions:
+
+- `ok-gobot memory curate list` — list drafts
+- `ok-gobot memory curate show <id>` — render the draft and audit
+- `ok-gobot memory curate reject <id> [--notes ...]` — keep on disk, mark rejected
+- `ok-gobot memory curate delete <id>` — remove the draft files
+
+In Telegram the same flow is exposed to the admin via `/memory_curate`.
+The `apply` subcommand requires the literal `yes` token as confirmation.
+
+The optional scheduled suggestion mode is **disabled by default**. Set
+`memory.curation.enabled: true` and a cron expression in `memory.curation.schedule`
+to have the bot generate draft suggestions on a cadence. The scheduled mode
+never auto-applies — admin approval is always required for `MEMORY.md` writes.
+
 ### Agent Tool Commands
 
 The active agent tools are:

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -113,6 +113,10 @@ func (b *Bot) registerExtraHandlers() {
 	b.api.Handle("/active_memory", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleActiveMemoryCommand(c)
 	}))
+
+	b.api.Handle("/memory_curate", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
+		return b.handleMemoryCurateCommand(c)
+	}))
 }
 
 // handleWhoamiCommand shows sender info
@@ -180,6 +184,7 @@ func (b *Bot) handleCommandsCommand(c telebot.Context) error {
 		{"jobs", "List recent durable jobs"},
 		{"job", "Show job details"},
 		{"job_cancel", "Cancel a durable job (admin)"},
+		{"memory_curate", "Curate daily notes into auditable durable-memory drafts (admin)"},
 		{"activate", "Activate bot in group"},
 		{"standby", "Set standby mode in group"},
 		{"pair", "Pair with bot using code"},

--- a/internal/bot/memory_curate.go
+++ b/internal/bot/memory_curate.go
@@ -1,0 +1,258 @@
+package bot
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/memory/curate"
+)
+
+// handleMemoryCurateCommand routes /memory_curate subcommands. Most actions
+// require admin privileges because they generate or apply changes that
+// eventually land in MEMORY.md.
+//
+// Subcommands:
+//
+//	/memory_curate                 — usage
+//	/memory_curate draft [N]       — draft from the last N days (default 7)
+//	/memory_curate range YYYY-MM-DD YYYY-MM-DD
+//	/memory_curate list
+//	/memory_curate show <id>
+//	/memory_curate apply <id> yes  — admin only, requires the literal "yes"
+//	/memory_curate reject <id> [notes]
+//	/memory_curate delete <id>
+func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
+	args := strings.Fields(strings.TrimSpace(c.Message().Payload))
+	if len(args) == 0 {
+		return c.Send(memoryCurateUsage(), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+	}
+
+	soul := b.memory.BasePath
+	if soul == "" {
+		return c.Send("❌ Memory base path not configured.")
+	}
+	store := curate.NewDraftStore(soul)
+	isAdmin := b.authManager.IsAdmin(c.Sender().ID)
+
+	switch strings.ToLower(args[0]) {
+	case "draft":
+		if !isAdmin {
+			return c.Send("🔒 /memory_curate draft is admin-only.")
+		}
+		days := 7
+		if len(args) >= 2 {
+			if n, err := parseDaysArg(args[1]); err == nil {
+				days = n
+			}
+		}
+		until := time.Now().UTC()
+		since := until.AddDate(0, 0, -(days - 1))
+		return runBotCurateDraft(c, soul, since, until)
+
+	case "range":
+		if !isAdmin {
+			return c.Send("🔒 /memory_curate range is admin-only.")
+		}
+		if len(args) < 3 {
+			return c.Send("Usage: `/memory_curate range YYYY-MM-DD YYYY-MM-DD`",
+				&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+		}
+		since, err := curate.ParseDate(args[1])
+		if err != nil {
+			return c.Send(fmt.Sprintf("❌ %v", err))
+		}
+		until, err := curate.ParseDate(args[2])
+		if err != nil {
+			return c.Send(fmt.Sprintf("❌ %v", err))
+		}
+		return runBotCurateDraft(c, soul, since, until)
+
+	case "list":
+		summaries, err := store.List()
+		if err != nil {
+			return c.Send(fmt.Sprintf("❌ Failed to list drafts: %v", err))
+		}
+		if len(summaries) == 0 {
+			return c.Send("No curation drafts found.")
+		}
+		var sb strings.Builder
+		sb.WriteString("*Curation drafts:*\n\n")
+		for _, s := range summaries {
+			fmt.Fprintf(&sb, "`%s` [%s] %s→%s — %d cand, %d conflicts\n",
+				s.ID, s.Status, s.Since, s.Until, s.Candidates, s.Conflicts)
+		}
+		return c.Send(sb.String(), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+
+	case "show":
+		if len(args) < 2 {
+			return c.Send("Usage: `/memory_curate show <id>`", &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+		}
+		d, err := store.Load(args[1])
+		if err != nil {
+			return c.Send(fmt.Sprintf("❌ %v", err))
+		}
+		audit := curate.AuditDraft(d)
+		body := curate.RenderDraftMarkdown(d, audit)
+		return sendChunked(c, body)
+
+	case "apply":
+		if !isAdmin {
+			return c.Send("🔒 /memory_curate apply is admin-only.")
+		}
+		if len(args) < 3 || strings.ToLower(args[2]) != "yes" {
+			return c.Send("Usage: `/memory_curate apply <id> yes`\n\n"+
+				"The literal `yes` is required as explicit confirmation that you want "+
+				"to modify MEMORY.md.",
+				&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+		}
+		label := senderLabel(c)
+		d, audit, err := curate.Apply(soul, store, args[1], curate.ApplyOptions{
+			Approved:   true,
+			AdminLabel: label,
+		})
+		switch {
+		case errors.Is(err, curate.ErrAuditBlocked):
+			var sb strings.Builder
+			sb.WriteString("❌ Apply blocked by audit. Findings:\n")
+			for _, f := range audit.Findings {
+				if f.Severity == curate.AuditError {
+					fmt.Fprintf(&sb, "- %s\n", f.String())
+				}
+			}
+			return c.Send(sb.String())
+		case errors.Is(err, curate.ErrEmptyDraft):
+			return c.Send("ℹ️ Nothing to promote: draft has no candidates.")
+		case errors.Is(err, curate.ErrAlreadyApplied):
+			return c.Send("ℹ️ Draft was already applied.")
+		case err != nil:
+			return c.Send(fmt.Sprintf("❌ %v", err))
+		}
+		return c.Send(fmt.Sprintf("✅ Applied draft `%s` to MEMORY.md.", d.ID),
+			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+
+	case "reject":
+		if !isAdmin {
+			return c.Send("🔒 /memory_curate reject is admin-only.")
+		}
+		if len(args) < 2 {
+			return c.Send("Usage: `/memory_curate reject <id> [notes]`",
+				&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+		}
+		notes := ""
+		if len(args) > 2 {
+			notes = strings.Join(args[2:], " ")
+		}
+		d, err := store.SetStatus(args[1], curate.StatusRejected, notes)
+		if err != nil {
+			return c.Send(fmt.Sprintf("❌ %v", err))
+		}
+		return c.Send(fmt.Sprintf("Draft `%s` rejected. Use `/memory_curate delete %s` to remove from disk.",
+			d.ID, d.ID), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+
+	case "delete":
+		if !isAdmin {
+			return c.Send("🔒 /memory_curate delete is admin-only.")
+		}
+		if len(args) < 2 {
+			return c.Send("Usage: `/memory_curate delete <id>`",
+				&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+		}
+		if err := store.Delete(args[1]); err != nil {
+			return c.Send(fmt.Sprintf("❌ %v", err))
+		}
+		return c.Send(fmt.Sprintf("Draft `%s` deleted.", args[1]),
+			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+
+	default:
+		return c.Send(memoryCurateUsage(), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+	}
+}
+
+func memoryCurateUsage() string {
+	return "*Memory curation*\n\n" +
+		"`/memory_curate draft [days]` — draft from last N days (default 7, admin)\n" +
+		"`/memory_curate range YYYY-MM-DD YYYY-MM-DD` — draft from a date range (admin)\n" +
+		"`/memory_curate list` — list drafts\n" +
+		"`/memory_curate show <id>` — show full draft + audit\n" +
+		"`/memory_curate apply <id> yes` — apply to MEMORY.md (admin, explicit confirm)\n" +
+		"`/memory_curate reject <id> [notes]` — reject but keep on disk (admin)\n" +
+		"`/memory_curate delete <id>` — remove from disk (admin)\n"
+}
+
+func runBotCurateDraft(c telebot.Context, soul string, since, until time.Time) error {
+	curator := curate.NewCurator(soul)
+	draft, err := curator.CurateRange(since, until)
+	if err != nil {
+		return c.Send(fmt.Sprintf("❌ %v", err))
+	}
+	store := curate.NewDraftStore(soul)
+	if err := store.Save(draft); err != nil {
+		return c.Send(fmt.Sprintf("❌ Failed to save draft: %v", err))
+	}
+	if draft.IsEmpty() {
+		return c.Send(fmt.Sprintf("ℹ️ Draft `%s` has no useful candidates from %s → %s.",
+			draft.ID, draft.Since, draft.Until),
+			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+	}
+	audit := curate.AuditDraft(draft)
+	body := curate.RenderDraftMarkdown(draft, audit)
+	if err := sendChunked(c, body); err != nil {
+		return err
+	}
+	return c.Send(fmt.Sprintf("Apply with `/memory_curate apply %s yes` (admin).", draft.ID),
+		&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+}
+
+// parseDaysArg accepts "7" or "7d" and returns the integer day count, clamped
+// to a reasonable window so the command cannot accidentally scan years of
+// history.
+func parseDaysArg(s string) (int, error) {
+	s = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(s)), "d")
+	var n int
+	if _, err := fmt.Sscanf(s, "%d", &n); err != nil {
+		return 0, err
+	}
+	if n < 1 {
+		n = 1
+	}
+	if n > 90 {
+		n = 90
+	}
+	return n, nil
+}
+
+// sendChunked sends a long body to Telegram, splitting on chunk boundaries to
+// stay under the per-message limit.
+func sendChunked(c telebot.Context, body string) error {
+	const limit = 3500
+	for len(body) > limit {
+		// Try to break on a newline within the last 200 chars of the limit.
+		cut := limit
+		if idx := strings.LastIndex(body[:limit], "\n"); idx > limit-300 {
+			cut = idx
+		}
+		if err := c.Send(body[:cut]); err != nil {
+			return err
+		}
+		body = body[cut:]
+	}
+	if strings.TrimSpace(body) != "" {
+		return c.Send(body)
+	}
+	return nil
+}
+
+func senderLabel(c telebot.Context) string {
+	s := c.Sender()
+	if s == nil {
+		return "telegram"
+	}
+	if s.Username != "" {
+		return "@" + s.Username
+	}
+	return fmt.Sprintf("tg:%d", s.ID)
+}

--- a/internal/bot/memory_curate.go
+++ b/internal/bot/memory_curate.go
@@ -11,9 +11,10 @@ import (
 	"ok-gobot/internal/memory/curate"
 )
 
-// handleMemoryCurateCommand routes /memory_curate subcommands. Most actions
-// require admin privileges because they generate or apply changes that
-// eventually land in MEMORY.md.
+// handleMemoryCurateCommand routes /memory_curate subcommands. All actions are
+// admin-only: drafts can contain extracted private notes and even raw
+// secret-like strings the audit blocked from apply, so non-admin reads must
+// not be possible either.
 //
 // Subcommands:
 //
@@ -35,28 +36,27 @@ func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 	if soul == "" {
 		return c.Send("❌ Memory base path not configured.")
 	}
+	if !b.authManager.IsAdmin(c.Sender().ID) {
+		return c.Send("🔒 /memory_curate is admin-only.")
+	}
 	store := curate.NewDraftStore(soul)
-	isAdmin := b.authManager.IsAdmin(c.Sender().ID)
 
 	switch strings.ToLower(args[0]) {
 	case "draft":
-		if !isAdmin {
-			return c.Send("🔒 /memory_curate draft is admin-only.")
-		}
 		days := 7
 		if len(args) >= 2 {
 			if n, err := parseDaysArg(args[1]); err == nil {
 				days = n
 			}
 		}
-		until := time.Now().UTC()
+		// Daily-note files are written from local time elsewhere in the bot,
+		// so the default window must be in local time too — otherwise on
+		// non-UTC hosts the scan misses today's note around UTC midnight.
+		until := time.Now()
 		since := until.AddDate(0, 0, -(days - 1))
 		return runBotCurateDraft(c, soul, since, until)
 
 	case "range":
-		if !isAdmin {
-			return c.Send("🔒 /memory_curate range is admin-only.")
-		}
 		if len(args) < 3 {
 			return c.Send("Usage: `/memory_curate range YYYY-MM-DD YYYY-MM-DD`",
 				&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
@@ -91,6 +91,9 @@ func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 		if len(args) < 2 {
 			return c.Send("Usage: `/memory_curate show <id>`", &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 		}
+		if err := curate.ValidateDraftID(args[1]); err != nil {
+			return c.Send(fmt.Sprintf("❌ %v", err))
+		}
 		d, err := store.Load(args[1])
 		if err != nil {
 			return c.Send(fmt.Sprintf("❌ %v", err))
@@ -100,9 +103,6 @@ func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 		return sendChunked(c, body)
 
 	case "apply":
-		if !isAdmin {
-			return c.Send("🔒 /memory_curate apply is admin-only.")
-		}
 		if len(args) < 3 || strings.ToLower(args[2]) != "yes" {
 			return c.Send("Usage: `/memory_curate apply <id> yes`\n\n"+
 				"The literal `yes` is required as explicit confirmation that you want "+
@@ -135,9 +135,6 @@ func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 
 	case "reject":
-		if !isAdmin {
-			return c.Send("🔒 /memory_curate reject is admin-only.")
-		}
 		if len(args) < 2 {
 			return c.Send("Usage: `/memory_curate reject <id> [notes]`",
 				&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
@@ -154,9 +151,6 @@ func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 			d.ID, d.ID), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 
 	case "delete":
-		if !isAdmin {
-			return c.Send("🔒 /memory_curate delete is admin-only.")
-		}
 		if len(args) < 2 {
 			return c.Send("Usage: `/memory_curate delete <id>`",
 				&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})

--- a/internal/bot/memory_curate_test.go
+++ b/internal/bot/memory_curate_test.go
@@ -1,0 +1,51 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseDaysArg(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"7", 7, false},
+		{"7d", 7, false},
+		{"  14d ", 14, false},
+		{"0", 1, false},    // clamped up to minimum 1
+		{"500", 90, false}, // clamped down to max 90
+		{"abc", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := parseDaysArg(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseDaysArg(%q): expected error, got %d", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseDaysArg(%q): unexpected error %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseDaysArg(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMemoryCurateUsage_DescribesAllSubcommands(t *testing.T) {
+	usage := memoryCurateUsage()
+	for _, want := range []string{"draft", "range", "list", "show", "apply", "reject", "delete"} {
+		if !strings.Contains(usage, want) {
+			t.Errorf("usage missing subcommand %q:\n%s", want, usage)
+		}
+	}
+	// The literal `yes` confirmation token must be documented so admins know
+	// it is required.
+	if !strings.Contains(usage, "yes") {
+		t.Error("usage should mention the explicit `yes` confirmation token")
+	}
+}

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"ok-gobot/internal/config"
 	"ok-gobot/internal/memory"
+	"ok-gobot/internal/memory/curate"
 	"ok-gobot/internal/storage"
 )
 
@@ -18,6 +21,7 @@ func newMemoryCommand(cfg *config.Config) *cobra.Command {
 	}
 	cmd.AddCommand(newMemoryStatusCommand(cfg))
 	cmd.AddCommand(newMemoryIndexCommand(cfg))
+	cmd.AddCommand(newMemoryCurateCommand(cfg))
 	return cmd
 }
 
@@ -131,6 +135,262 @@ func openMemoryStore(cfg *config.Config) (*storage.Store, *memory.MemoryStore, e
 		return nil, nil, fmt.Errorf("open memory store: %w", err)
 	}
 	return store, memStore, nil
+}
+
+// newMemoryCurateCommand creates the `memory curate` subcommand tree.
+//
+// `memory curate --since <date> --until <date>` produces a draft promotion
+// from daily notes; it never writes to MEMORY.md by itself. The draft is
+// stored under <soul>/memory/drafts/ for inspection. Apply requires `--yes`
+// for explicit admin approval and a clean audit. Reject keeps the draft for
+// inspection; delete removes it.
+func newMemoryCurateCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "curate",
+		Short: "Curate daily notes into auditable durable-memory promotion drafts",
+		Long: "Memory curation reads daily notes from <soul>/memory/*.md and produces " +
+			"a draft promotion. Drafts are inspected and audited before any change to " +
+			"MEMORY.md. Apply requires explicit admin approval (--yes). Use `list`, " +
+			"`show`, `apply`, `reject`, and `delete` subcommands to manage drafts.",
+	}
+	cmd.AddCommand(newMemoryCurateDraftCommand(cfg))
+	cmd.AddCommand(newMemoryCurateListCommand(cfg))
+	cmd.AddCommand(newMemoryCurateShowCommand(cfg))
+	cmd.AddCommand(newMemoryCurateApplyCommand(cfg))
+	cmd.AddCommand(newMemoryCurateRejectCommand(cfg))
+	cmd.AddCommand(newMemoryCurateDeleteCommand(cfg))
+	// The bare `memory curate --since X --until Y` flow is the most common
+	// entry point; mirror it on the parent command so users do not have to
+	// type `curate draft`.
+	addCurateRangeFlags(cmd, true)
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return runMemoryCurateDraft(cmd, cfg)
+	}
+	return cmd
+}
+
+func addCurateRangeFlags(cmd *cobra.Command, optional bool) {
+	cmd.Flags().String("since", "", "Inclusive start date YYYY-MM-DD")
+	cmd.Flags().String("until", "", "Inclusive end date YYYY-MM-DD")
+	cmd.Flags().Bool("apply", false, "After producing the draft, apply it (requires --yes)")
+	cmd.Flags().Bool("yes", false, "Confirm apply without prompt; required to write MEMORY.md")
+	if !optional {
+		_ = cmd.MarkFlagRequired("since")
+		_ = cmd.MarkFlagRequired("until")
+	}
+}
+
+func newMemoryCurateDraftCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "draft",
+		Short: "Generate a curation draft from the given date range",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMemoryCurateDraft(cmd, cfg)
+		},
+	}
+	addCurateRangeFlags(cmd, false)
+	return cmd
+}
+
+func runMemoryCurateDraft(cmd *cobra.Command, cfg *config.Config) error {
+	soul := cfg.GetSoulPath()
+	if soul == "" {
+		return fmt.Errorf("soul path is empty; configure soul_path in your config")
+	}
+
+	since, _ := cmd.Flags().GetString("since")
+	until, _ := cmd.Flags().GetString("until")
+	apply, _ := cmd.Flags().GetBool("apply")
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	if since == "" || until == "" {
+		return fmt.Errorf("--since and --until are required (YYYY-MM-DD)")
+	}
+	sinceDate, err := curate.ParseDate(since)
+	if err != nil {
+		return err
+	}
+	untilDate, err := curate.ParseDate(until)
+	if err != nil {
+		return err
+	}
+
+	curator := curate.NewCurator(soul)
+	draft, err := curator.CurateRange(sinceDate, untilDate)
+	if err != nil {
+		return err
+	}
+
+	store := curate.NewDraftStore(soul)
+	if err := store.Save(draft); err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	report := curate.AuditDraft(draft)
+
+	fmt.Fprintf(out, "Draft saved: %s\n", draft.ID)
+	fmt.Fprintln(out, curate.RenderDraftSummary(draft))
+	if draft.IsEmpty() {
+		fmt.Fprintln(out, "No useful candidates extracted from the daily notes in this range.")
+		return nil
+	}
+	for _, f := range report.Findings {
+		fmt.Fprintf(out, "audit: %s\n", f.String())
+	}
+
+	if !apply {
+		fmt.Fprintf(out, "\nReview with: ok-gobot memory curate show %s\n", draft.ID)
+		fmt.Fprintf(out, "Apply with:  ok-gobot memory curate apply %s --yes\n", draft.ID)
+		return nil
+	}
+	if !yes {
+		return fmt.Errorf("--apply requires --yes for explicit admin confirmation; refusing to modify MEMORY.md")
+	}
+	return runMemoryCurateApply(cmd, cfg, draft.ID, true)
+}
+
+func newMemoryCurateListCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List existing curation drafts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			soul := cfg.GetSoulPath()
+			if soul == "" {
+				return fmt.Errorf("soul path is empty")
+			}
+			store := curate.NewDraftStore(soul)
+			summaries, err := store.List()
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			if len(summaries) == 0 {
+				fmt.Fprintln(out, "No drafts found.")
+				return nil
+			}
+			for _, s := range summaries {
+				fmt.Fprintf(out, "%s [%s] %s→%s — %d candidate(s), %d conflict(s) — %s\n",
+					s.ID, s.Status, s.Since, s.Until, s.Candidates, s.Conflicts,
+					s.CreatedAt.UTC().Format("2006-01-02 15:04:05Z"))
+			}
+			return nil
+		},
+	}
+}
+
+func newMemoryCurateShowCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <draft-id>",
+		Short: "Show the rendered draft including audit findings",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			soul := cfg.GetSoulPath()
+			store := curate.NewDraftStore(soul)
+			d, err := store.Load(strings.TrimSpace(args[0]))
+			if err != nil {
+				return err
+			}
+			audit := curate.AuditDraft(d)
+			fmt.Fprint(cmd.OutOrStdout(), curate.RenderDraftMarkdown(d, audit))
+			return nil
+		},
+	}
+}
+
+func newMemoryCurateApplyCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "apply <draft-id>",
+		Short: "Apply a draft to MEMORY.md (requires --yes for explicit confirmation)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			yes, _ := cmd.Flags().GetBool("yes")
+			return runMemoryCurateApply(cmd, cfg, strings.TrimSpace(args[0]), yes)
+		},
+	}
+	cmd.Flags().Bool("yes", false, "Confirm the apply; required to modify MEMORY.md")
+	return cmd
+}
+
+func runMemoryCurateApply(cmd *cobra.Command, cfg *config.Config, draftID string, approved bool) error {
+	soul := cfg.GetSoulPath()
+	if soul == "" {
+		return fmt.Errorf("soul path is empty")
+	}
+	store := curate.NewDraftStore(soul)
+	d, audit, err := curate.Apply(soul, store, draftID, curate.ApplyOptions{
+		Approved:   approved,
+		AdminLabel: "cli",
+	})
+	out := cmd.OutOrStdout()
+	if err != nil {
+		switch {
+		case errors.Is(err, curate.ErrApprovalRequired):
+			fmt.Fprintln(out, "❌ Apply blocked: explicit confirmation required (pass --yes).")
+			return err
+		case errors.Is(err, curate.ErrAuditBlocked):
+			fmt.Fprintln(out, "❌ Apply blocked: audit findings need to be addressed first:")
+			for _, f := range audit.Findings {
+				if f.Severity == curate.AuditError {
+					fmt.Fprintf(out, "  - %s\n", f.String())
+				}
+			}
+			return err
+		case errors.Is(err, curate.ErrEmptyDraft):
+			fmt.Fprintln(out, "ℹ️ Nothing to promote: draft has no candidates.")
+			return err
+		case errors.Is(err, curate.ErrAlreadyApplied):
+			fmt.Fprintln(out, "ℹ️ Draft was already applied.")
+			return err
+		}
+		return err
+	}
+	fmt.Fprintf(out, "✅ Applied draft %s to MEMORY.md\n", d.ID)
+	for _, f := range audit.Findings {
+		if f.Severity == curate.AuditWarning {
+			fmt.Fprintf(out, "  warning: %s\n", f.String())
+		}
+	}
+	return nil
+}
+
+func newMemoryCurateRejectCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reject <draft-id>",
+		Short: "Mark a draft rejected (kept on disk for inspection)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			soul := cfg.GetSoulPath()
+			store := curate.NewDraftStore(soul)
+			notes, _ := cmd.Flags().GetString("notes")
+			d, err := store.SetStatus(strings.TrimSpace(args[0]), curate.StatusRejected, notes)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Draft %s rejected (still on disk; remove with `memory curate delete %s`).\n", d.ID, d.ID)
+			return nil
+		},
+	}
+	cmd.Flags().String("notes", "", "Optional reviewer notes recorded with the rejection")
+	return cmd
+}
+
+func newMemoryCurateDeleteCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <draft-id>",
+		Short: "Permanently delete a draft from disk",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			soul := cfg.GetSoulPath()
+			store := curate.NewDraftStore(soul)
+			id := strings.TrimSpace(args[0])
+			if err := store.Delete(id); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Draft %s deleted.\n", id)
+			return nil
+		},
+	}
 }
 
 // runMemoryIndex indexes the managed sources and any configured extra paths.

--- a/internal/cli/memory_curate_test.go
+++ b/internal/cli/memory_curate_test.go
@@ -1,0 +1,169 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/config"
+)
+
+func newCurateTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	soul := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(soul, "memory"), 0o755); err != nil {
+		t.Fatalf("mkdir memory: %v", err)
+	}
+	return &config.Config{SoulPath: soul}
+}
+
+func writeNote(t *testing.T, soul, date, body string) {
+	t.Helper()
+	path := filepath.Join(soul, "memory", date+".md")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write note %s: %v", date, err)
+	}
+}
+
+func runCmd(t *testing.T, cfg *config.Config, args ...string) (string, error) {
+	t.Helper()
+	cmd := newMemoryCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func extractDraftID(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "Draft saved: ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "Draft saved: "))
+		}
+	}
+	t.Fatalf("could not find draft id in output:\n%s", out)
+	return ""
+}
+
+func TestMemoryCurateDraft_CreatesDraftWithoutWriting(t *testing.T) {
+	cfg := newCurateTestConfig(t)
+	writeNote(t, cfg.SoulPath, "2026-04-15", "# Memory: 2026-04-15\n\n- preference: dark mode for everything\n")
+	out, err := runCmd(t, cfg, "curate", "--since", "2026-04-15", "--until", "2026-04-15")
+	if err != nil {
+		t.Fatalf("execute: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Draft saved:") {
+		t.Errorf("expected 'Draft saved:' in output: %s", out)
+	}
+	if _, err := os.Stat(filepath.Join(cfg.SoulPath, "MEMORY.md")); !os.IsNotExist(err) {
+		t.Fatalf("MEMORY.md must NOT be created by `curate draft`: %v", err)
+	}
+}
+
+func TestMemoryCurate_NoOpWhenNoNotes(t *testing.T) {
+	cfg := newCurateTestConfig(t)
+	out, err := runCmd(t, cfg, "curate", "--since", "2026-04-15", "--until", "2026-04-16")
+	if err != nil {
+		t.Fatalf("execute: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "No useful candidates") {
+		t.Errorf("expected 'No useful candidates' in output: %s", out)
+	}
+}
+
+func TestMemoryCurate_ApplyRequiresYes(t *testing.T) {
+	cfg := newCurateTestConfig(t)
+	writeNote(t, cfg.SoulPath, "2026-04-15", "# Memory: 2026-04-15\n\n- decision: ship via Docker\n")
+	out, err := runCmd(t, cfg, "curate", "--since", "2026-04-15", "--until", "2026-04-15")
+	if err != nil {
+		t.Fatalf("draft: %v\n%s", err, out)
+	}
+	id := extractDraftID(t, out)
+
+	// Apply without --yes must fail and must not write MEMORY.md.
+	out2, err2 := runCmd(t, cfg, "curate", "apply", id)
+	if err2 == nil {
+		t.Fatalf("expected error applying without --yes:\n%s", out2)
+	}
+	if _, statErr := os.Stat(filepath.Join(cfg.SoulPath, "MEMORY.md")); !os.IsNotExist(statErr) {
+		t.Fatal("MEMORY.md should not exist before approval")
+	}
+
+	// Apply with --yes succeeds and writes the curated block to MEMORY.md.
+	out3, err3 := runCmd(t, cfg, "curate", "apply", id, "--yes")
+	if err3 != nil {
+		t.Fatalf("apply --yes: %v\n%s", err3, out3)
+	}
+	if !strings.Contains(out3, "Applied draft") {
+		t.Errorf("expected confirmation in output: %s", out3)
+	}
+	body, err := os.ReadFile(filepath.Join(cfg.SoulPath, "MEMORY.md"))
+	if err != nil {
+		t.Fatalf("read MEMORY.md: %v", err)
+	}
+	if !strings.Contains(string(body), id) {
+		t.Errorf("expected MEMORY.md to contain draft id %s; got:\n%s", id, body)
+	}
+}
+
+func TestMemoryCurate_RejectKeepsDraftForInspection(t *testing.T) {
+	cfg := newCurateTestConfig(t)
+	writeNote(t, cfg.SoulPath, "2026-04-15", "# Memory: 2026-04-15\n\n- preference: dark mode\n")
+	out, err := runCmd(t, cfg, "curate", "--since", "2026-04-15", "--until", "2026-04-15")
+	if err != nil {
+		t.Fatalf("draft: %v\n%s", err, out)
+	}
+	id := extractDraftID(t, out)
+
+	rejectOut, err := runCmd(t, cfg, "curate", "reject", id, "--notes", "noise")
+	if err != nil {
+		t.Fatalf("reject: %v\n%s", err, rejectOut)
+	}
+	// Draft files should still exist after rejection.
+	if _, err := os.Stat(filepath.Join(cfg.SoulPath, "memory", "drafts", id+".json")); err != nil {
+		t.Fatalf("expected rejected draft to be retained on disk: %v", err)
+	}
+	showOut, err := runCmd(t, cfg, "curate", "show", id)
+	if err != nil {
+		t.Fatalf("show: %v\n%s", err, showOut)
+	}
+	if !strings.Contains(showOut, "rejected") {
+		t.Errorf("expected status rejected in show output: %s", showOut)
+	}
+
+	// Delete must remove both files.
+	delOut, err := runCmd(t, cfg, "curate", "delete", id)
+	if err != nil {
+		t.Fatalf("delete: %v\n%s", err, delOut)
+	}
+	if _, err := os.Stat(filepath.Join(cfg.SoulPath, "memory", "drafts", id+".json")); !os.IsNotExist(err) {
+		t.Fatal("delete should remove the json file")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.SoulPath, "memory", "drafts", id+".md")); !os.IsNotExist(err) {
+		t.Fatal("delete should remove the markdown file")
+	}
+}
+
+func TestMemoryCurate_AuditBlocksSecretCandidates(t *testing.T) {
+	cfg := newCurateTestConfig(t)
+	writeNote(t, cfg.SoulPath, "2026-04-15", "# Memory: 2026-04-15\n\n- infra: api_key = sk-leakedvalue\n")
+	out, err := runCmd(t, cfg, "curate", "--since", "2026-04-15", "--until", "2026-04-15")
+	if err != nil {
+		t.Fatalf("draft: %v\n%s", err, out)
+	}
+	id := extractDraftID(t, out)
+	applyOut, err := runCmd(t, cfg, "curate", "apply", id, "--yes")
+	if err == nil {
+		t.Fatalf("expected audit to block apply, got success:\n%s", applyOut)
+	}
+	if !strings.Contains(applyOut, "Apply blocked") {
+		t.Errorf("expected 'Apply blocked' in output: %s", applyOut)
+	}
+	if _, statErr := os.Stat(filepath.Join(cfg.SoulPath, "MEMORY.md")); !os.IsNotExist(statErr) {
+		t.Fatal("MEMORY.md must not be created when audit blocks apply")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -218,6 +218,7 @@ type MemoryConfig struct {
 	MCP                MemoryMCPConfig         `mapstructure:"mcp"`                 // Optional MCP server exposing memory tools
 	Active             ActiveMemoryConfig      `mapstructure:"active"`              // Pre-reply Active Memory recall (DM only)
 	Sessions           SessionMemoryConfig     `mapstructure:"sessions"`            // Session transcript indexing (off by default)
+	Curation           MemoryCurationConfig    `mapstructure:"curation"`            // Optional scheduled curation suggestions (disabled by default)
 }
 
 // ActiveMemoryConfig configures the pre-reply Active Memory recall step.
@@ -295,6 +296,15 @@ func IsValidMemoryMode(mode string) bool {
 	default:
 		return false
 	}
+}
+
+// MemoryCurationConfig configures the optional scheduled curation suggestion
+// loop. The suggestion mode never modifies MEMORY.md; it only generates a
+// draft for admin review on the configured cadence. Default: disabled.
+type MemoryCurationConfig struct {
+	Enabled  bool   `mapstructure:"enabled"`  // When true, a scheduled job creates curation drafts on the configured cadence (default false)
+	Schedule string `mapstructure:"schedule"` // Optional cron expression; ignored when Enabled is false
+	Days     int    `mapstructure:"days"`     // Daily-note window for each suggestion run (default 7)
 }
 
 // MemoryMCPConfig holds memory MCP server configuration
@@ -383,6 +393,9 @@ func Load() (*Config, error) {
 	v.SetDefault("memory.sessions.enabled", false)
 	v.SetDefault("memory.sessions.include_groups", false)
 	v.SetDefault("memory.sessions.max_messages_per_session", 0)
+	v.SetDefault("memory.curation.enabled", false)
+	v.SetDefault("memory.curation.schedule", "")
+	v.SetDefault("memory.curation.days", 7)
 	v.SetDefault("control.enabled", false)
 	v.SetDefault("control.port", 8787)
 	v.SetDefault("control.token", "")
@@ -506,6 +519,9 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("memory.sessions.enabled", false)
 	v.SetDefault("memory.sessions.include_groups", false)
 	v.SetDefault("memory.sessions.max_messages_per_session", 0)
+	v.SetDefault("memory.curation.enabled", false)
+	v.SetDefault("memory.curation.schedule", "")
+	v.SetDefault("memory.curation.days", 7)
 	v.SetDefault("control.enabled", false)
 	v.SetDefault("control.port", 8787)
 	v.SetDefault("control.token", "")
@@ -712,6 +728,9 @@ func (c *Config) Save() error {
 	v.Set("memory.active.max_snippets", c.Memory.Active.MaxSnippets)
 	v.Set("memory.active.max_chars", c.Memory.Active.MaxChars)
 	v.Set("memory.active.history_turns", c.Memory.Active.HistoryTurns)
+	v.Set("memory.curation.enabled", c.Memory.Curation.Enabled)
+	v.Set("memory.curation.schedule", c.Memory.Curation.Schedule)
+	v.Set("memory.curation.days", c.Memory.Curation.Days)
 	v.Set("storage_path", c.StoragePath)
 	v.Set("soul_path", c.SoulPath)
 	v.Set("roles_path", c.RolesPath)

--- a/internal/memory/curate/apply.go
+++ b/internal/memory/curate/apply.go
@@ -1,0 +1,108 @@
+package curate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrApprovalRequired is returned by Apply when the caller did not explicitly
+// confirm. This makes "apply without confirmation" a hard error rather than a
+// silent default.
+var ErrApprovalRequired = errors.New("curate: explicit admin approval required to modify MEMORY.md")
+
+// ErrAuditBlocked is returned by Apply when the safety audit reported errors
+// that block promotion.
+var ErrAuditBlocked = errors.New("curate: audit findings block apply")
+
+// ErrEmptyDraft is returned by Apply when the draft has nothing worth
+// promoting. Callers should treat this as a no-op rather than a failure.
+var ErrEmptyDraft = errors.New("curate: draft has no candidates worth promoting")
+
+// ErrAlreadyApplied is returned when a draft has already been applied; callers
+// must explicitly create a fresh draft to promote new facts.
+var ErrAlreadyApplied = errors.New("curate: draft already applied")
+
+// ApplyOptions controls Apply behavior.
+type ApplyOptions struct {
+	// Approved must be true. This makes the approval explicit and is the
+	// gate that prevents callers from accidentally promoting a draft.
+	Approved bool
+	// AdminLabel records who approved the change (e.g. telegram username
+	// or "cli"). Stored on the draft for audit history.
+	AdminLabel string
+}
+
+// Apply writes the draft's promotions into MEMORY.md after the safety audit
+// passes and the caller has set Approved=true. It is the only function in the
+// curate package that mutates MEMORY.md.
+func Apply(soulPath string, store *DraftStore, draftID string, opts ApplyOptions) (*Draft, AuditReport, error) {
+	if soulPath == "" {
+		return nil, AuditReport{}, fmt.Errorf("curate apply: soul path is empty")
+	}
+	if store == nil {
+		return nil, AuditReport{}, fmt.Errorf("curate apply: draft store is nil")
+	}
+	if draftID == "" {
+		return nil, AuditReport{}, fmt.Errorf("curate apply: draft id is empty")
+	}
+
+	d, err := store.Load(draftID)
+	if err != nil {
+		return nil, AuditReport{}, err
+	}
+	if d.Status == StatusApplied {
+		return d, AuditReport{}, ErrAlreadyApplied
+	}
+
+	audit := AuditDraft(d)
+	if d.IsEmpty() {
+		return d, audit, ErrEmptyDraft
+	}
+	if audit.HasErrors() {
+		return d, audit, ErrAuditBlocked
+	}
+	if !opts.Approved {
+		return d, audit, ErrApprovalRequired
+	}
+
+	memoryPath := filepath.Join(soulPath, "MEMORY.md")
+	if err := os.MkdirAll(filepath.Dir(memoryPath), 0o755); err != nil {
+		return d, audit, fmt.Errorf("ensure soul path: %w", err)
+	}
+	block := RenderApplyBlock(d)
+	if err := appendToFile(memoryPath, block); err != nil {
+		return d, audit, fmt.Errorf("append to MEMORY.md: %w", err)
+	}
+
+	d.Status = StatusApplied
+	notes := "applied"
+	if opts.AdminLabel != "" {
+		notes = "applied by " + opts.AdminLabel
+	}
+	d.Notes = notes
+	if err := store.Save(d); err != nil {
+		return d, audit, fmt.Errorf("save updated draft: %w", err)
+	}
+	return d, audit, nil
+}
+
+// appendToFile creates the file if missing and appends the block. The file is
+// always read-modify-rewrite so we can guarantee a leading newline.
+func appendToFile(path, block string) error {
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	final := string(existing)
+	if final != "" && !endsWithNewline(final) {
+		final += "\n"
+	}
+	final += block
+	return os.WriteFile(path, []byte(final), 0o644)
+}
+
+func endsWithNewline(s string) bool {
+	return len(s) > 0 && s[len(s)-1] == '\n'
+}

--- a/internal/memory/curate/audit.go
+++ b/internal/memory/curate/audit.go
@@ -1,0 +1,140 @@
+package curate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// AuditSeverity indicates how serious an audit finding is. Errors block apply;
+// warnings are surfaced for reviewer attention but do not block.
+type AuditSeverity string
+
+const (
+	AuditError   AuditSeverity = "error"
+	AuditWarning AuditSeverity = "warning"
+	AuditInfo    AuditSeverity = "info"
+)
+
+// AuditFinding is a single observation about a draft.
+type AuditFinding struct {
+	Severity    AuditSeverity
+	CandidateID string // empty when the finding is about the draft as a whole
+	Message     string
+}
+
+// String renders the finding for CLI / Telegram display.
+func (f AuditFinding) String() string {
+	if f.CandidateID != "" {
+		return fmt.Sprintf("[%s] %s: %s", f.Severity, f.CandidateID, f.Message)
+	}
+	return fmt.Sprintf("[%s] %s", f.Severity, f.Message)
+}
+
+// AuditReport is the result of running the safety audit over a draft.
+type AuditReport struct {
+	Findings []AuditFinding
+}
+
+// HasErrors reports whether any finding is severe enough to block apply.
+func (r AuditReport) HasErrors() bool {
+	for _, f := range r.Findings {
+		if f.Severity == AuditError {
+			return true
+		}
+	}
+	return false
+}
+
+// secretPatterns flags candidates that look like leaked secrets. Matches are
+// deliberately conservative — false positives are surfaced as warnings, not
+// errors, and the apply gate is the admin's explicit confirmation.
+var secretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\b(api[_-]?key|secret|token|password|passwd|pwd)\b\s*[:=]`),
+	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),                   // AWS access key
+	regexp.MustCompile(`ghp_[A-Za-z0-9]{20,}`),               // GitHub personal access token
+	regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),       // Slack token
+	regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----`), // PEM block
+}
+
+// destructivePatterns flags candidates that look like raw shell commands that
+// would be unsafe to surface as durable memory.
+var destructivePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\brm\s+-rf\b`),
+	regexp.MustCompile(`\bDROP\s+(TABLE|DATABASE)\b`),
+	regexp.MustCompile(`\bdelete\s+from\b`),
+	regexp.MustCompile(`>\s*/dev/`),
+}
+
+// AuditDraft runs the safety audit over a draft. It does not mutate the
+// draft; the caller decides whether to apply, reject, or edit and re-audit.
+func AuditDraft(d *Draft) AuditReport {
+	if d == nil {
+		return AuditReport{Findings: []AuditFinding{{
+			Severity: AuditError,
+			Message:  "draft is nil",
+		}}}
+	}
+
+	var findings []AuditFinding
+
+	if d.SourceCount == 0 {
+		findings = append(findings, AuditFinding{
+			Severity: AuditInfo,
+			Message:  "no daily notes found in the requested range",
+		})
+	}
+
+	if d.IsEmpty() {
+		findings = append(findings, AuditFinding{
+			Severity: AuditInfo,
+			Message:  "draft has no candidates worth promoting",
+		})
+		// No further per-candidate checks possible.
+		return AuditReport{Findings: findings}
+	}
+
+	for _, c := range d.Candidates {
+		text := c.Text
+		// Conflict marker → warning so reviewer must read it.
+		if len(c.Conflicts) > 0 {
+			findings = append(findings, AuditFinding{
+				Severity:    AuditWarning,
+				CandidateID: c.ID,
+				Message:     fmt.Sprintf("conflicting values across notes (peers: %s)", strings.Join(c.Conflicts, ", ")),
+			})
+		}
+		// Secret leakage → block apply.
+		for _, re := range secretPatterns {
+			if re.MatchString(text) {
+				findings = append(findings, AuditFinding{
+					Severity:    AuditError,
+					CandidateID: c.ID,
+					Message:     "candidate looks like it contains a credential or secret",
+				})
+				break
+			}
+		}
+		// Destructive shell snippets → block apply.
+		for _, re := range destructivePatterns {
+			if re.MatchString(text) {
+				findings = append(findings, AuditFinding{
+					Severity:    AuditError,
+					CandidateID: c.ID,
+					Message:     "candidate contains a destructive shell snippet; do not promote raw commands",
+				})
+				break
+			}
+		}
+		// Very low confidence → warn so reviewer is forced to consider it.
+		if c.Confidence > 0 && c.Confidence < 0.5 {
+			findings = append(findings, AuditFinding{
+				Severity:    AuditInfo,
+				CandidateID: c.ID,
+				Message:     fmt.Sprintf("low extraction confidence (%.2f); review carefully", c.Confidence),
+			})
+		}
+	}
+
+	return AuditReport{Findings: findings}
+}

--- a/internal/memory/curate/curate.go
+++ b/internal/memory/curate/curate.go
@@ -1,0 +1,303 @@
+// Package curate turns raw daily memory notes into auditable durable-memory
+// promotion drafts. Drafts never modify MEMORY.md on their own; they are
+// inspected, audited, and only applied with explicit admin approval.
+package curate
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Section identifies the bucket a candidate fact belongs to.
+type Section string
+
+const (
+	SectionPreference   Section = "preferences"
+	SectionDecision     Section = "decisions"
+	SectionInfra        Section = "infra"
+	SectionTodo         Section = "todos"
+	SectionStale        Section = "stale"
+	SectionMisc         Section = "misc"
+	SectionUncategoried Section = "uncategorized"
+)
+
+// SectionTitle returns a human-readable title for the section.
+func SectionTitle(s Section) string {
+	switch s {
+	case SectionPreference:
+		return "Durable user preferences"
+	case SectionDecision:
+		return "Project decisions"
+	case SectionInfra:
+		return "Infrastructure facts"
+	case SectionTodo:
+		return "Todos / follow-ups"
+	case SectionStale:
+		return "Stale or conflicting facts"
+	case SectionMisc:
+		return "Miscellaneous candidates"
+	default:
+		return "Uncategorized"
+	}
+}
+
+// AllSections lists sections in the canonical render order. SectionStale and
+// SectionTodo always render even if empty so reviewers see a complete picture.
+func AllSections() []Section {
+	return []Section{
+		SectionPreference,
+		SectionDecision,
+		SectionInfra,
+		SectionTodo,
+		SectionStale,
+		SectionMisc,
+	}
+}
+
+// Source records where a candidate originated within the daily notes.
+type Source struct {
+	Date string // YYYY-MM-DD of the daily note file
+	Path string // relative path under soul, e.g. memory/2026-04-15.md
+	Line int    // line number in the note (1-based)
+}
+
+// String renders a source reference suitable for the draft markdown.
+func (s Source) String() string {
+	if s.Line > 0 {
+		return fmt.Sprintf("%s:L%d", s.Path, s.Line)
+	}
+	return s.Path
+}
+
+// Candidate is a single fact extracted from daily notes that may be promoted.
+type Candidate struct {
+	ID         string  // stable id within a draft
+	Section    Section // categorized bucket
+	Text       string  // the extracted fact
+	Sources    []Source
+	Conflicts  []string // ids of other candidates that disagree
+	Confidence float64  // 0.0..1.0; lower means more uncertain
+}
+
+// Status is the lifecycle state of a draft.
+type Status string
+
+const (
+	StatusPending  Status = "pending"
+	StatusApproved Status = "approved"
+	StatusRejected Status = "rejected"
+	StatusApplied  Status = "applied"
+)
+
+// Draft is a single curation pass over a date range.
+type Draft struct {
+	ID          string
+	CreatedAt   time.Time
+	Since       string // YYYY-MM-DD
+	Until       string // YYYY-MM-DD inclusive
+	SourceCount int    // number of daily notes scanned
+	Candidates  []Candidate
+	Status      Status
+	Notes       string // free-form notes about why a status was set
+}
+
+// IsEmpty reports whether the draft has no candidates worth promoting.
+func (d *Draft) IsEmpty() bool {
+	if d == nil {
+		return true
+	}
+	for _, c := range d.Candidates {
+		if strings.TrimSpace(c.Text) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+// CandidatesBySection groups candidates by section in canonical render order.
+func (d *Draft) CandidatesBySection() map[Section][]Candidate {
+	out := make(map[Section][]Candidate)
+	if d == nil {
+		return out
+	}
+	for _, c := range d.Candidates {
+		out[c.Section] = append(out[c.Section], c)
+	}
+	for s := range out {
+		sort.SliceStable(out[s], func(i, j int) bool {
+			return out[s][i].ID < out[s][j].ID
+		})
+	}
+	return out
+}
+
+// HasConflicts reports whether any candidate is marked as conflicting.
+func (d *Draft) HasConflicts() bool {
+	if d == nil {
+		return false
+	}
+	for _, c := range d.Candidates {
+		if len(c.Conflicts) > 0 || c.Section == SectionStale {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyLine inspects a candidate text and returns the best-fit section plus
+// a confidence score. Heuristic-only — no AI is required.
+func classifyLine(text string) (Section, float64) {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if lower == "" {
+		return SectionUncategoried, 0
+	}
+
+	// Highest-priority explicit prefixes.
+	switch {
+	case strings.HasPrefix(lower, "preference:") || strings.HasPrefix(lower, "pref:"):
+		return SectionPreference, 0.9
+	case strings.HasPrefix(lower, "decision:") || strings.HasPrefix(lower, "decided:"):
+		return SectionDecision, 0.9
+	case strings.HasPrefix(lower, "infra:") || strings.HasPrefix(lower, "infrastructure:"):
+		return SectionInfra, 0.9
+	case strings.HasPrefix(lower, "todo:") || strings.HasPrefix(lower, "todo "):
+		return SectionTodo, 0.9
+	case strings.HasPrefix(lower, "follow-up:") || strings.HasPrefix(lower, "followup:"):
+		return SectionTodo, 0.85
+	}
+
+	// Keyword-based fallback (lower confidence).
+	switch {
+	case containsAny(lower, "i prefer ", "i like ", "i don't like ", "i don't want ", "preferred "):
+		return SectionPreference, 0.65
+	case containsAny(lower, "decided ", "we agreed", "we will use", "we'll use", "going to use", "switching to "):
+		return SectionDecision, 0.6
+	case containsAny(lower, "deploy", "kubernetes", "k8s", "docker ", "postgres", "redis", "host:", "endpoint", "port "):
+		return SectionInfra, 0.55
+	case containsAny(lower, "todo ", "todo:", "fixme", "follow up", "follow-up", "remember to "):
+		return SectionTodo, 0.6
+	}
+
+	return SectionMisc, 0.3
+}
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		if strings.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// candidateKeyRegexp captures the leading "<key>:" portion of a candidate so we
+// can detect when the same key appears with different values in different
+// notes.
+var candidateKeyRegexp = regexp.MustCompile(`^\s*([\w][\w \-]{0,40}):\s*(.+)$`)
+
+// candidateIsRegexp captures "X is Y" / "X = Y" / "X are Y" patterns where the
+// subject acts as the conflict key.
+var candidateIsRegexp = regexp.MustCompile(`(?i)^\s*([\w][\w \-]{1,60}?)\s+(?:is|are|=)\s+(.+?)\s*$`)
+
+// classificationPrefixes are recognized leading tags that classify a note;
+// they are not the conflict key themselves. Stripped before key extraction.
+var classificationPrefixes = []string{
+	"preference",
+	"pref",
+	"decision",
+	"decided",
+	"infra",
+	"infrastructure",
+	"todo",
+	"follow-up",
+	"followup",
+}
+
+// stripClassificationPrefix removes a leading "preference: ", "decision: ",
+// etc. so conflict detection can compare the underlying fact.
+func stripClassificationPrefix(text string) string {
+	trimmed := strings.TrimSpace(text)
+	lower := strings.ToLower(trimmed)
+	for _, p := range classificationPrefixes {
+		if strings.HasPrefix(lower, p+":") {
+			return strings.TrimSpace(trimmed[len(p)+1:])
+		}
+	}
+	return trimmed
+}
+
+// candidateKey extracts a normalized "key" from a candidate when the text uses
+// a "key: value" or "key is value" shape. Returns empty when no key is
+// recognizable. Classification prefixes are stripped first so two notes
+// labeled "decision: X is Y" / "decision: X is Z" share the same key X.
+func candidateKey(text string) (key, value string) {
+	stripped := stripClassificationPrefix(text)
+
+	if m := candidateKeyRegexp.FindStringSubmatch(stripped); len(m) == 3 {
+		rawKey := strings.ToLower(strings.TrimSpace(m[1]))
+		rawVal := strings.TrimSpace(m[2])
+		// Skip if the "key" turned out to be a leftover classification tag.
+		for _, p := range classificationPrefixes {
+			if rawKey == p {
+				return "", ""
+			}
+		}
+		return rawKey, rawVal
+	}
+	if m := candidateIsRegexp.FindStringSubmatch(stripped); len(m) == 3 {
+		return strings.ToLower(strings.TrimSpace(m[1])), strings.TrimSpace(m[2])
+	}
+	return "", ""
+}
+
+// detectConflicts marks candidates that share a key but disagree on the value.
+// Updates the candidates in place.
+func detectConflicts(cands []Candidate) {
+	type entry struct {
+		idx   int
+		value string
+	}
+	groups := map[string][]entry{}
+	for i, c := range cands {
+		k, v := candidateKey(c.Text)
+		if k == "" || v == "" {
+			continue
+		}
+		groups[k] = append(groups[k], entry{idx: i, value: strings.ToLower(v)})
+	}
+	for _, group := range groups {
+		if len(group) < 2 {
+			continue
+		}
+		// All-same value → not a conflict.
+		first := group[0].value
+		allSame := true
+		for _, e := range group[1:] {
+			if e.value != first {
+				allSame = false
+				break
+			}
+		}
+		if allSame {
+			continue
+		}
+		ids := make([]string, 0, len(group))
+		for _, e := range group {
+			ids = append(ids, cands[e.idx].ID)
+		}
+		for _, e := range group {
+			peers := make([]string, 0, len(ids)-1)
+			for _, id := range ids {
+				if id == cands[e.idx].ID {
+					continue
+				}
+				peers = append(peers, id)
+			}
+			cands[e.idx].Conflicts = append(cands[e.idx].Conflicts, peers...)
+			cands[e.idx].Section = SectionStale
+		}
+	}
+}

--- a/internal/memory/curate/curate_test.go
+++ b/internal/memory/curate/curate_test.go
@@ -1,0 +1,332 @@
+package curate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func makeSoulWithNotes(t *testing.T, notes map[string]string) string {
+	t.Helper()
+	soul := t.TempDir()
+	memoryDir := filepath.Join(soul, "memory")
+	if err := os.MkdirAll(memoryDir, 0o755); err != nil {
+		t.Fatalf("mkdir memory dir: %v", err)
+	}
+	for date, body := range notes {
+		path := filepath.Join(memoryDir, date+".md")
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write daily note %s: %v", date, err)
+		}
+	}
+	return soul
+}
+
+func mustParseDate(t *testing.T, s string) time.Time {
+	t.Helper()
+	d, err := ParseDate(s)
+	if err != nil {
+		t.Fatalf("parse date %s: %v", s, err)
+	}
+	return d
+}
+
+func fixedClock(now time.Time) func() time.Time {
+	return func() time.Time { return now }
+}
+
+func TestCurateRange_ExtractsCandidatesAndCategorizes(t *testing.T) {
+	notes := map[string]string{
+		"2026-04-15": "# Memory: 2026-04-15\n\n" +
+			"## 09:00\n" +
+			"- preference: prefers tea over coffee\n" +
+			"- decision: deploy via Docker on Hetzner\n" +
+			"- todo: write integration tests for memory curation\n" +
+			"- I prefer using Postgres for everything\n",
+		"2026-04-16": "# Memory: 2026-04-16\n\n" +
+			"## Quick Note (12:34)\n" +
+			"infra: Postgres host db.internal:5432\n",
+	}
+	soul := makeSoulWithNotes(t, notes)
+
+	c := &Curator{SoulPath: soul, Now: fixedClock(time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC))}
+	draft, err := c.CurateRange(mustParseDate(t, "2026-04-15"), mustParseDate(t, "2026-04-16"))
+	if err != nil {
+		t.Fatalf("CurateRange: %v", err)
+	}
+	if draft.SourceCount != 2 {
+		t.Errorf("SourceCount = %d, want 2", draft.SourceCount)
+	}
+	if draft.IsEmpty() {
+		t.Fatal("draft unexpectedly empty")
+	}
+	grouped := draft.CandidatesBySection()
+	if len(grouped[SectionPreference]) == 0 {
+		t.Error("expected at least one preference candidate")
+	}
+	if len(grouped[SectionDecision]) == 0 {
+		t.Error("expected at least one decision candidate")
+	}
+	if len(grouped[SectionTodo]) == 0 {
+		t.Error("expected at least one todo candidate")
+	}
+	if len(grouped[SectionInfra]) == 0 {
+		t.Error("expected at least one infra candidate")
+	}
+
+	// Each candidate must include a source reference back to the daily note.
+	for _, c := range draft.Candidates {
+		if len(c.Sources) == 0 {
+			t.Errorf("candidate %s has no sources", c.ID)
+			continue
+		}
+		src := c.Sources[0]
+		if !strings.HasPrefix(src.Path, "memory/") {
+			t.Errorf("candidate %s source path %q does not start with memory/", c.ID, src.Path)
+		}
+		if src.Line <= 0 {
+			t.Errorf("candidate %s missing line reference", c.ID)
+		}
+	}
+}
+
+func TestCurateRange_EmptyWhenNoNotes(t *testing.T) {
+	soul := makeSoulWithNotes(t, nil)
+	c := &Curator{SoulPath: soul, Now: fixedClock(time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC))}
+	draft, err := c.CurateRange(mustParseDate(t, "2026-04-15"), mustParseDate(t, "2026-04-16"))
+	if err != nil {
+		t.Fatalf("CurateRange: %v", err)
+	}
+	if !draft.IsEmpty() {
+		t.Errorf("expected empty draft, got %d candidates", len(draft.Candidates))
+	}
+	if draft.SourceCount != 0 {
+		t.Errorf("SourceCount = %d, want 0", draft.SourceCount)
+	}
+}
+
+func TestCurateRange_RejectsInvertedRange(t *testing.T) {
+	c := &Curator{SoulPath: t.TempDir()}
+	_, err := c.CurateRange(mustParseDate(t, "2026-04-16"), mustParseDate(t, "2026-04-15"))
+	if err == nil {
+		t.Fatal("expected error for inverted range")
+	}
+}
+
+func TestCurateRange_DetectsConflicts(t *testing.T) {
+	notes := map[string]string{
+		"2026-04-10": "# Memory: 2026-04-10\n\n- decision: target language is Go\n",
+		"2026-04-11": "# Memory: 2026-04-11\n\n- decision: target language is Rust\n",
+	}
+	soul := makeSoulWithNotes(t, notes)
+	c := &Curator{SoulPath: soul, Now: fixedClock(time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC))}
+	draft, err := c.CurateRange(mustParseDate(t, "2026-04-10"), mustParseDate(t, "2026-04-11"))
+	if err != nil {
+		t.Fatalf("CurateRange: %v", err)
+	}
+	if !draft.HasConflicts() {
+		t.Fatalf("expected draft.HasConflicts(); got candidates: %#v", draft.Candidates)
+	}
+	// Conflicting candidates should be moved to the stale/conflicting bucket.
+	stale := draft.CandidatesBySection()[SectionStale]
+	if len(stale) < 2 {
+		t.Errorf("expected at least 2 stale candidates from a conflict; got %d", len(stale))
+	}
+}
+
+func TestAuditDraft_NoOpWhenEmpty(t *testing.T) {
+	soul := makeSoulWithNotes(t, nil)
+	c := &Curator{SoulPath: soul, Now: fixedClock(time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC))}
+	draft, err := c.CurateRange(mustParseDate(t, "2026-04-15"), mustParseDate(t, "2026-04-16"))
+	if err != nil {
+		t.Fatalf("CurateRange: %v", err)
+	}
+	report := AuditDraft(draft)
+	if report.HasErrors() {
+		t.Errorf("expected no audit errors for empty draft; got %v", report.Findings)
+	}
+	hasInfo := false
+	for _, f := range report.Findings {
+		if f.Severity == AuditInfo {
+			hasInfo = true
+			break
+		}
+	}
+	if !hasInfo {
+		t.Error("expected at least one info finding for empty draft")
+	}
+}
+
+func TestAuditDraft_FlagsSecrets(t *testing.T) {
+	notes := map[string]string{
+		"2026-04-15": "# Memory: 2026-04-15\n\n- infra: api_key = sk-abcdefghijklmno\n",
+	}
+	soul := makeSoulWithNotes(t, notes)
+	c := &Curator{SoulPath: soul, Now: fixedClock(time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC))}
+	draft, err := c.CurateRange(mustParseDate(t, "2026-04-15"), mustParseDate(t, "2026-04-15"))
+	if err != nil {
+		t.Fatalf("CurateRange: %v", err)
+	}
+	report := AuditDraft(draft)
+	if !report.HasErrors() {
+		t.Errorf("expected audit error for credential pattern; got %v", report.Findings)
+	}
+}
+
+func TestAuditDraft_FlagsDestructiveSnippets(t *testing.T) {
+	notes := map[string]string{
+		"2026-04-15": "# Memory: 2026-04-15\n\n- decision: use rm -rf node_modules to reset\n",
+	}
+	soul := makeSoulWithNotes(t, notes)
+	c := &Curator{SoulPath: soul, Now: fixedClock(time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC))}
+	draft, err := c.CurateRange(mustParseDate(t, "2026-04-15"), mustParseDate(t, "2026-04-15"))
+	if err != nil {
+		t.Fatalf("CurateRange: %v", err)
+	}
+	report := AuditDraft(draft)
+	if !report.HasErrors() {
+		t.Errorf("expected audit error for destructive snippet; got %v", report.Findings)
+	}
+}
+
+func TestApply_RequiresExplicitApproval(t *testing.T) {
+	notes := map[string]string{
+		"2026-04-15": "# Memory: 2026-04-15\n\n- decision: ship via Docker\n",
+	}
+	soul := makeSoulWithNotes(t, notes)
+	c := &Curator{SoulPath: soul, Now: fixedClock(time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC))}
+	draft, err := c.CurateRange(mustParseDate(t, "2026-04-15"), mustParseDate(t, "2026-04-15"))
+	if err != nil {
+		t.Fatalf("CurateRange: %v", err)
+	}
+	store := NewDraftStore(soul)
+	if err := store.Save(draft); err != nil {
+		t.Fatalf("save draft: %v", err)
+	}
+
+	// Approval not granted → must error and must NOT touch MEMORY.md.
+	if _, _, err := Apply(soul, store, draft.ID, ApplyOptions{Approved: false}); !errors.Is(err, ErrApprovalRequired) {
+		t.Fatalf("Apply(Approved=false) err = %v, want ErrApprovalRequired", err)
+	}
+	if _, err := os.Stat(filepath.Join(soul, "MEMORY.md")); !os.IsNotExist(err) {
+		t.Fatalf("MEMORY.md should not exist before approval: %v", err)
+	}
+
+	// Approval granted → MEMORY.md is updated, status flips to applied.
+	d, _, err := Apply(soul, store, draft.ID, ApplyOptions{Approved: true, AdminLabel: "test-admin"})
+	if err != nil {
+		t.Fatalf("Apply(Approved=true): %v", err)
+	}
+	if d.Status != StatusApplied {
+		t.Errorf("status after apply = %s, want %s", d.Status, StatusApplied)
+	}
+	memoryBytes, err := os.ReadFile(filepath.Join(soul, "MEMORY.md"))
+	if err != nil {
+		t.Fatalf("read MEMORY.md after apply: %v", err)
+	}
+	if !strings.Contains(string(memoryBytes), draft.ID) {
+		t.Errorf("expected MEMORY.md to contain draft id %s; got:\n%s", draft.ID, memoryBytes)
+	}
+
+	// A second apply must fail — drafts cannot be applied twice.
+	if _, _, err := Apply(soul, store, draft.ID, ApplyOptions{Approved: true}); !errors.Is(err, ErrAlreadyApplied) {
+		t.Errorf("second Apply err = %v, want ErrAlreadyApplied", err)
+	}
+}
+
+func TestApply_BlockedByAuditErrors(t *testing.T) {
+	notes := map[string]string{
+		"2026-04-15": "# Memory: 2026-04-15\n\n- infra: api_key = sk-deadbeef0000\n",
+	}
+	soul := makeSoulWithNotes(t, notes)
+	c := &Curator{SoulPath: soul, Now: fixedClock(time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC))}
+	draft, err := c.CurateRange(mustParseDate(t, "2026-04-15"), mustParseDate(t, "2026-04-15"))
+	if err != nil {
+		t.Fatalf("CurateRange: %v", err)
+	}
+	store := NewDraftStore(soul)
+	if err := store.Save(draft); err != nil {
+		t.Fatalf("save draft: %v", err)
+	}
+
+	// Even with explicit approval, the audit must block apply when secrets
+	// are detected — defense in depth.
+	if _, _, err := Apply(soul, store, draft.ID, ApplyOptions{Approved: true}); !errors.Is(err, ErrAuditBlocked) {
+		t.Fatalf("Apply err = %v, want ErrAuditBlocked", err)
+	}
+	if _, err := os.Stat(filepath.Join(soul, "MEMORY.md")); !os.IsNotExist(err) {
+		t.Fatal("MEMORY.md should not be created when audit blocks apply")
+	}
+}
+
+func TestApply_NoOpWhenEmpty(t *testing.T) {
+	soul := makeSoulWithNotes(t, nil)
+	c := &Curator{SoulPath: soul, Now: fixedClock(time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC))}
+	draft, err := c.CurateRange(mustParseDate(t, "2026-04-15"), mustParseDate(t, "2026-04-16"))
+	if err != nil {
+		t.Fatalf("CurateRange: %v", err)
+	}
+	store := NewDraftStore(soul)
+	if err := store.Save(draft); err != nil {
+		t.Fatalf("save draft: %v", err)
+	}
+	if _, _, err := Apply(soul, store, draft.ID, ApplyOptions{Approved: true}); !errors.Is(err, ErrEmptyDraft) {
+		t.Fatalf("Apply(empty draft) err = %v, want ErrEmptyDraft", err)
+	}
+	if _, err := os.Stat(filepath.Join(soul, "MEMORY.md")); !os.IsNotExist(err) {
+		t.Fatal("MEMORY.md should not be created for an empty draft")
+	}
+}
+
+func TestDraftStore_PersistAndList(t *testing.T) {
+	notes := map[string]string{
+		"2026-04-15": "# Memory: 2026-04-15\n\n- preference: dark mode for everything\n",
+	}
+	soul := makeSoulWithNotes(t, notes)
+	c := &Curator{SoulPath: soul, Now: fixedClock(time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC))}
+	d1, err := c.CurateRange(mustParseDate(t, "2026-04-15"), mustParseDate(t, "2026-04-15"))
+	if err != nil {
+		t.Fatalf("curate: %v", err)
+	}
+	store := NewDraftStore(soul)
+	if err := store.Save(d1); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := store.Load(d1.ID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.Status != StatusPending {
+		t.Errorf("loaded status = %s, want %s", loaded.Status, StatusPending)
+	}
+	summaries, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("summaries = %d, want 1", len(summaries))
+	}
+
+	// Reject keeps the draft for inspection.
+	if _, err := store.SetStatus(d1.ID, StatusRejected, "noise"); err != nil {
+		t.Fatalf("set status: %v", err)
+	}
+	loaded2, err := store.Load(d1.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if loaded2.Status != StatusRejected {
+		t.Errorf("status = %s, want rejected", loaded2.Status)
+	}
+
+	// Explicit Delete removes both files.
+	if err := store.Delete(d1.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := store.Load(d1.ID); err == nil {
+		t.Fatal("expected error loading deleted draft")
+	}
+}

--- a/internal/memory/curate/curator.go
+++ b/internal/memory/curate/curator.go
@@ -1,0 +1,201 @@
+package curate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Curator scans daily notes under SoulPath/memory and builds curation drafts.
+// It does not call any LLM — extraction is heuristic so the v1 promotion loop
+// is fully reproducible from the local filesystem.
+type Curator struct {
+	// SoulPath is the soul root (the directory that contains memory/).
+	SoulPath string
+	// Now returns the wall-clock time. Tests inject a fixed clock.
+	Now func() time.Time
+}
+
+// NewCurator returns a Curator rooted at soulPath.
+func NewCurator(soulPath string) *Curator {
+	return &Curator{
+		SoulPath: soulPath,
+		Now:      time.Now,
+	}
+}
+
+// CurateRange reads daily notes between since and until (inclusive) and
+// returns a draft with extracted candidate facts. If no useful candidates
+// are found the draft is still returned with an empty candidate list so the
+// caller can render a "nothing to promote" message.
+func (c *Curator) CurateRange(since, until time.Time) (*Draft, error) {
+	if c.SoulPath == "" {
+		return nil, fmt.Errorf("curator: soul path is empty")
+	}
+	if since.After(until) {
+		return nil, fmt.Errorf("curator: --since (%s) is after --until (%s)", formatDate(since), formatDate(until))
+	}
+
+	now := time.Now
+	if c.Now != nil {
+		now = c.Now
+	}
+	current := now()
+
+	memoryDir := filepath.Join(c.SoulPath, "memory")
+	dates := datesBetween(since, until)
+
+	draft := &Draft{
+		ID:        generateDraftID(current),
+		CreatedAt: current,
+		Since:     formatDate(since),
+		Until:     formatDate(until),
+		Status:    StatusPending,
+	}
+
+	for _, date := range dates {
+		path := filepath.Join(memoryDir, date+".md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read daily note %s: %w", path, err)
+		}
+		draft.SourceCount++
+
+		relPath := filepath.ToSlash(filepath.Join("memory", date+".md"))
+		extractCandidates(string(data), date, relPath, draft)
+	}
+
+	detectConflicts(draft.Candidates)
+	return draft, nil
+}
+
+// extractCandidates parses a single daily-note body, appending recognized
+// candidate facts to the draft.
+func extractCandidates(body, date, relPath string, draft *Draft) {
+	if body == "" {
+		return
+	}
+	lines := strings.Split(body, "\n")
+	for i, raw := range lines {
+		text := strings.TrimSpace(raw)
+		if text == "" {
+			continue
+		}
+		// Skip headers — they are structure, not candidates.
+		if strings.HasPrefix(text, "#") {
+			continue
+		}
+		// Strip common bullet prefixes.
+		stripped := strings.TrimSpace(strings.TrimLeft(text, "-*•+ \t"))
+		if stripped == "" || stripped == "---" {
+			continue
+		}
+		// Skip lines that are clearly headers / metadata (timestamps).
+		if isTimestampHeader(stripped) {
+			continue
+		}
+		// Drop overly long lines — they are usually prose, not facts.
+		if len(stripped) > 300 {
+			continue
+		}
+
+		section, conf := classifyLine(stripped)
+		// Drop low-signal lines that didn't trigger any keyword.
+		if section == SectionUncategoried || (section == SectionMisc && conf < 0.3) {
+			continue
+		}
+
+		cand := Candidate{
+			ID:         candidateID(date, i+1),
+			Section:    section,
+			Text:       cleanText(stripped),
+			Confidence: conf,
+			Sources: []Source{{
+				Date: date,
+				Path: relPath,
+				Line: i + 1,
+			}},
+		}
+		draft.Candidates = append(draft.Candidates, cand)
+	}
+}
+
+// isTimestampHeader matches "12:34" or "Quick Note (12:34)" style markers that
+// the rest of the bot writes via Memory.AppendQuickNoteToToday.
+func isTimestampHeader(s string) bool {
+	if len(s) >= 5 && s[2] == ':' && isAllDigits(s[:2]) && isAllDigits(s[3:5]) {
+		// "12:34" possibly followed by trailing text.
+		return true
+	}
+	if strings.HasPrefix(strings.ToLower(s), "quick note (") {
+		return true
+	}
+	return false
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// cleanText normalizes whitespace and trailing punctuation so candidates render
+// consistently in the draft markdown.
+func cleanText(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimRight(s, ".")
+	s = strings.Join(strings.Fields(s), " ")
+	return s
+}
+
+func candidateID(date string, line int) string {
+	return fmt.Sprintf("%s-%04d", strings.ReplaceAll(date, "-", ""), line)
+}
+
+func generateDraftID(now time.Time) string {
+	stamp := now.UTC().Format("20060102-150405")
+	h := sha256.Sum256([]byte(stamp + fmt.Sprint(now.UnixNano())))
+	return fmt.Sprintf("%s-%s", stamp, hex.EncodeToString(h[:3]))
+}
+
+func datesBetween(start, end time.Time) []string {
+	start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC)
+	end = time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, time.UTC)
+	var out []string
+	for d := start; !d.After(end); d = d.AddDate(0, 0, 1) {
+		out = append(out, d.Format("2006-01-02"))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func formatDate(t time.Time) string {
+	return t.Format("2006-01-02")
+}
+
+// ParseDate parses a YYYY-MM-DD string into a UTC time.
+func ParseDate(s string) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, fmt.Errorf("date is empty")
+	}
+	t, err := time.ParseInLocation("2006-01-02", s, time.UTC)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse date %q: %w", s, err)
+	}
+	return t, nil
+}

--- a/internal/memory/curate/render.go
+++ b/internal/memory/curate/render.go
@@ -1,0 +1,111 @@
+package curate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RenderDraftMarkdown produces a human-readable rendering of a draft and its
+// audit findings. Used both for on-disk inspection files and Telegram replies.
+func RenderDraftMarkdown(d *Draft, audit AuditReport) string {
+	if d == nil {
+		return ""
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# Curation Draft %s\n\n", d.ID)
+	fmt.Fprintf(&sb, "- Status: `%s`\n", d.Status)
+	fmt.Fprintf(&sb, "- Created: %s\n", d.CreatedAt.UTC().Format("2006-01-02 15:04:05Z"))
+	fmt.Fprintf(&sb, "- Range: %s → %s\n", d.Since, d.Until)
+	fmt.Fprintf(&sb, "- Daily notes scanned: %d\n", d.SourceCount)
+	fmt.Fprintf(&sb, "- Candidates: %d\n", len(d.Candidates))
+	if d.Notes != "" {
+		fmt.Fprintf(&sb, "- Reviewer notes: %s\n", d.Notes)
+	}
+	sb.WriteString("\n")
+
+	if d.IsEmpty() {
+		sb.WriteString("_No useful candidates were extracted from the daily notes in this range._\n")
+	} else {
+		grouped := d.CandidatesBySection()
+		for _, section := range AllSections() {
+			cands := grouped[section]
+			if len(cands) == 0 && section != SectionStale && section != SectionTodo {
+				continue
+			}
+			fmt.Fprintf(&sb, "## %s\n\n", SectionTitle(section))
+			if len(cands) == 0 {
+				sb.WriteString("_(none)_\n\n")
+				continue
+			}
+			for _, c := range cands {
+				fmt.Fprintf(&sb, "- **%s** (%s, conf %.2f)\n", c.Text, c.ID, c.Confidence)
+				for _, src := range c.Sources {
+					fmt.Fprintf(&sb, "  - source: `%s`\n", src.String())
+				}
+				if len(c.Conflicts) > 0 {
+					fmt.Fprintf(&sb, "  - ⚠️ conflicts with: %s\n", strings.Join(c.Conflicts, ", "))
+				}
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	if len(audit.Findings) > 0 {
+		sb.WriteString("## Audit findings\n\n")
+		for _, f := range audit.Findings {
+			fmt.Fprintf(&sb, "- %s\n", f.String())
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("---\n")
+	sb.WriteString("Apply with `ok-gobot memory curate apply " + d.ID + " --yes` (admin) or reject with `ok-gobot memory curate reject " + d.ID + "`.\n")
+
+	return sb.String()
+}
+
+// RenderDraftSummary produces a short summary suitable for Telegram messages
+// and CLI list output.
+func RenderDraftSummary(d *Draft) string {
+	if d == nil {
+		return ""
+	}
+	conflicts := 0
+	for _, c := range d.Candidates {
+		if len(c.Conflicts) > 0 {
+			conflicts++
+		}
+	}
+	return fmt.Sprintf("%s [%s] %s→%s — %d candidate(s), %d conflict(s)",
+		d.ID, d.Status, d.Since, d.Until, len(d.Candidates), conflicts)
+}
+
+// RenderApplyBlock formats the markdown block that gets appended to MEMORY.md
+// when a draft is applied. The block is bracketed with a unique header so it
+// can be located later if the admin wants to revert the change manually.
+func RenderApplyBlock(d *Draft) string {
+	if d == nil {
+		return ""
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "\n## Curated promotion %s\n\n", d.ID)
+	fmt.Fprintf(&sb, "_Promoted from daily notes %s → %s on %s._\n\n",
+		d.Since, d.Until, d.CreatedAt.UTC().Format("2006-01-02"))
+	grouped := d.CandidatesBySection()
+	for _, section := range AllSections() {
+		cands := grouped[section]
+		if len(cands) == 0 {
+			continue
+		}
+		fmt.Fprintf(&sb, "### %s\n\n", SectionTitle(section))
+		for _, c := range cands {
+			sources := make([]string, 0, len(c.Sources))
+			for _, src := range c.Sources {
+				sources = append(sources, src.String())
+			}
+			fmt.Fprintf(&sb, "- %s _(source: %s)_\n", c.Text, strings.Join(sources, ", "))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}

--- a/internal/memory/curate/store.go
+++ b/internal/memory/curate/store.go
@@ -1,0 +1,170 @@
+package curate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DraftStore persists drafts to disk under SoulPath/memory/drafts/.
+// Each draft lives in two side-by-side files:
+//
+//   - <id>.md   — human-readable rendering for inspection
+//   - <id>.json — structured form used by the CLI/bot to load and apply
+//
+// Rejected drafts are kept on disk by default so admins can re-read them; they
+// must be deleted explicitly via DeleteDraft.
+type DraftStore struct {
+	// SoulPath is the soul root (the directory that contains memory/).
+	SoulPath string
+}
+
+// NewDraftStore returns a DraftStore rooted at soulPath.
+func NewDraftStore(soulPath string) *DraftStore {
+	return &DraftStore{SoulPath: soulPath}
+}
+
+func (s *DraftStore) draftsDir() string {
+	return filepath.Join(s.SoulPath, "memory", "drafts")
+}
+
+func (s *DraftStore) jsonPath(id string) string {
+	return filepath.Join(s.draftsDir(), id+".json")
+}
+
+func (s *DraftStore) markdownPath(id string) string {
+	return filepath.Join(s.draftsDir(), id+".md")
+}
+
+// Save writes a draft to disk in both JSON and markdown form. Existing files
+// are overwritten so callers can update status by re-saving.
+func (s *DraftStore) Save(d *Draft) error {
+	if s.SoulPath == "" {
+		return fmt.Errorf("draft store: soul path is empty")
+	}
+	if d == nil || d.ID == "" {
+		return fmt.Errorf("draft store: draft missing id")
+	}
+	if err := os.MkdirAll(s.draftsDir(), 0o755); err != nil {
+		return fmt.Errorf("create drafts dir: %w", err)
+	}
+	jsonBytes, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal draft: %w", err)
+	}
+	if err := os.WriteFile(s.jsonPath(d.ID), jsonBytes, 0o644); err != nil {
+		return fmt.Errorf("write draft json: %w", err)
+	}
+	rendered := RenderDraftMarkdown(d, AuditDraft(d))
+	if err := os.WriteFile(s.markdownPath(d.ID), []byte(rendered), 0o644); err != nil {
+		return fmt.Errorf("write draft markdown: %w", err)
+	}
+	return nil
+}
+
+// Load returns the draft with the given id.
+func (s *DraftStore) Load(id string) (*Draft, error) {
+	if id == "" {
+		return nil, fmt.Errorf("draft store: id is empty")
+	}
+	data, err := os.ReadFile(s.jsonPath(id))
+	if err != nil {
+		return nil, fmt.Errorf("read draft %s: %w", id, err)
+	}
+	var d Draft
+	if err := json.Unmarshal(data, &d); err != nil {
+		return nil, fmt.Errorf("parse draft %s: %w", id, err)
+	}
+	return &d, nil
+}
+
+// DraftSummary is a lightweight description used by CLI/bot listings.
+type DraftSummary struct {
+	ID         string
+	Status     Status
+	Since      string
+	Until      string
+	Candidates int
+	Conflicts  int
+	CreatedAt  time.Time
+}
+
+// List returns drafts on disk sorted newest-first.
+func (s *DraftStore) List() ([]DraftSummary, error) {
+	dir := s.draftsDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read drafts dir: %w", err)
+	}
+
+	var summaries []DraftSummary
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		d, err := s.Load(id)
+		if err != nil {
+			continue
+		}
+		conflicts := 0
+		for _, c := range d.Candidates {
+			if len(c.Conflicts) > 0 {
+				conflicts++
+			}
+		}
+		summaries = append(summaries, DraftSummary{
+			ID:         d.ID,
+			Status:     d.Status,
+			Since:      d.Since,
+			Until:      d.Until,
+			Candidates: len(d.Candidates),
+			Conflicts:  conflicts,
+			CreatedAt:  d.CreatedAt,
+		})
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].CreatedAt.After(summaries[j].CreatedAt)
+	})
+	return summaries, nil
+}
+
+// Delete removes a draft from disk. Callers must opt in explicitly; rejected
+// drafts are kept by default so admins can re-read them.
+func (s *DraftStore) Delete(id string) error {
+	if id == "" {
+		return fmt.Errorf("draft store: id is empty")
+	}
+	for _, p := range []string{s.jsonPath(id), s.markdownPath(id)} {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("delete %s: %w", p, err)
+		}
+	}
+	return nil
+}
+
+// SetStatus updates a draft's status and re-saves it.
+func (s *DraftStore) SetStatus(id string, status Status, notes string) (*Draft, error) {
+	d, err := s.Load(id)
+	if err != nil {
+		return nil, err
+	}
+	d.Status = status
+	if notes != "" {
+		d.Notes = notes
+	}
+	if err := s.Save(d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}

--- a/internal/memory/curate/store.go
+++ b/internal/memory/curate/store.go
@@ -5,10 +5,30 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
 )
+
+// draftIDRegexp matches the exact format produced by generateDraftID:
+// "YYYYMMDD-HHMMSS-<6 hex chars>". Unsanitized IDs would otherwise be joined
+// straight into filesystem paths, so any caller-supplied value must be
+// validated before being used to build a draft path.
+var draftIDRegexp = regexp.MustCompile(`^\d{8}-\d{6}-[0-9a-f]{6}$`)
+
+// ValidateDraftID returns nil iff id matches the canonical draft ID format.
+// Exposed so handlers can fail fast (and uniformly) before calling store ops
+// that would otherwise turn a bad id into a path traversal.
+func ValidateDraftID(id string) error {
+	if id == "" {
+		return fmt.Errorf("draft store: id is empty")
+	}
+	if !draftIDRegexp.MatchString(id) {
+		return fmt.Errorf("draft store: invalid draft id %q", id)
+	}
+	return nil
+}
 
 // DraftStore persists drafts to disk under SoulPath/memory/drafts/.
 // Each draft lives in two side-by-side files:
@@ -46,8 +66,11 @@ func (s *DraftStore) Save(d *Draft) error {
 	if s.SoulPath == "" {
 		return fmt.Errorf("draft store: soul path is empty")
 	}
-	if d == nil || d.ID == "" {
+	if d == nil {
 		return fmt.Errorf("draft store: draft missing id")
+	}
+	if err := ValidateDraftID(d.ID); err != nil {
+		return err
 	}
 	if err := os.MkdirAll(s.draftsDir(), 0o755); err != nil {
 		return fmt.Errorf("create drafts dir: %w", err)
@@ -68,8 +91,8 @@ func (s *DraftStore) Save(d *Draft) error {
 
 // Load returns the draft with the given id.
 func (s *DraftStore) Load(id string) (*Draft, error) {
-	if id == "" {
-		return nil, fmt.Errorf("draft store: id is empty")
+	if err := ValidateDraftID(id); err != nil {
+		return nil, err
 	}
 	data, err := os.ReadFile(s.jsonPath(id))
 	if err != nil {
@@ -142,8 +165,8 @@ func (s *DraftStore) List() ([]DraftSummary, error) {
 // Delete removes a draft from disk. Callers must opt in explicitly; rejected
 // drafts are kept by default so admins can re-read them.
 func (s *DraftStore) Delete(id string) error {
-	if id == "" {
-		return fmt.Errorf("draft store: id is empty")
+	if err := ValidateDraftID(id); err != nil {
+		return err
 	}
 	for _, p := range []string{s.jsonPath(id), s.markdownPath(id)} {
 		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {


### PR DESCRIPTION
Implements #310

## Changes

Adds a v1 memory-curation loop that turns raw daily notes (`<soul>/memory/*.md`)
into auditable durable-memory promotion drafts. Drafts never modify
`MEMORY.md` on their own — explicit admin approval is required, and the
safety audit blocks apply when error-severity findings are present.

### New `internal/memory/curate` package

- **Curator** scans daily notes in a `--since`/`--until` window and extracts
  candidate facts via heuristics (no LLM calls), categorizing each into:
  durable user preferences, project decisions, infrastructure facts,
  todos/follow-ups, stale/conflicting facts, miscellaneous.
- **Conflict detection** flags candidates that share a key but disagree
  across notes (e.g. `decision: target language is Go` vs. `... is Rust`)
  and routes them to the stale/conflicting bucket.
- **Audit** flags secret-like patterns (api keys, AWS/GitHub/Slack tokens,
  PEM blocks), destructive shell snippets (`rm -rf`, `DROP TABLE`),
  conflicting candidates, and low-confidence extractions.
- **DraftStore** persists drafts to `<soul>/memory/drafts/<id>.{json,md}`
  for inspection. Rejected drafts are kept on disk; deletion is explicit.
- **Apply** is the only function that mutates `MEMORY.md`. It returns
  `ErrApprovalRequired`, `ErrAuditBlocked`, `ErrEmptyDraft`, or
  `ErrAlreadyApplied` to make every gate explicit.

### CLI subcommand `ok-gobot memory curate`

- `memory curate --since YYYY-MM-DD --until YYYY-MM-DD` — produce a draft;
  never writes `MEMORY.md`.
- `memory curate apply <id> --yes` — explicit-confirmation apply.
- `memory curate {list|show|reject|delete}` — manage existing drafts.

### Telegram admin command `/memory_curate`

Mirrors the CLI: `draft [days]`, `range YYYY-MM-DD YYYY-MM-DD`, `list`,
`show <id>`, `apply <id> yes` (literal `yes` required), `reject <id>`,
`delete <id>`. Admin-only for any action that creates or applies a draft.

### Optional scheduled suggestion mode (default off)

New `memory.curation` config block:
- `enabled: false` (default)
- `schedule: ""` (cron expression; ignored when disabled)
- `days: 7` (window per suggestion run)

## Testing

- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass, including the new
  `ok-gobot/internal/memory/curate` and curate-specific tests in
  `internal/cli` and `internal/bot`.
- `go build ./cmd/ok-gobot/` — clean.

Tests cover draft generation, conflict marking, audit rejection (secrets +
destructive snippets), the explicit-approval gate, no-op behavior when there
are no useful candidates, and the persist/list/reject/delete lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `memory curate` subsystem that extracts candidate facts from daily notes into auditable drafts, with explicit admin-approval gates and a heuristic safety audit before any write to `MEMORY.md`. The previously-flagged path-traversal concern is addressed via `ValidateDraftID` enforced in all store methods, and the Telegram `show` handler now validates IDs early.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 quality improvements with no blocking correctness or security issues.

No P0 or P1 findings. The four P2 items (case-insensitive destructive-pattern gaps, missing soul-path guards in three CLI commands, a constant name typo, and silent skipping of corrupt draft files) are all quality improvements rather than present defects.

internal/memory/curate/audit.go (destructive pattern case sensitivity) and internal/cli/memory.go (missing soul-path guards in show/reject/delete)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/memory/curate/audit.go | Safety audit for secret and destructive-command detection; inconsistent case sensitivity across destructive SQL patterns |
| internal/memory/curate/store.go | DraftStore with ID validation fixing previously flagged path traversal; List() silently skips unloadable entries |
| internal/memory/curate/apply.go | Apply function with explicit approval gate and audit checks; non-atomic MEMORY.md write order previously flagged |
| internal/memory/curate/curator.go | Heuristic daily-note scanner; correct date-range iteration, injectable clock for tests, no LLM calls |
| internal/memory/curate/curate.go | Core types, classification, and conflict detection; minor typo in SectionUncategoried constant name |
| internal/bot/memory_curate.go | Telegram handler with admin guard applied to all subcommands; uses store-layer ValidateDraftID for all path-bearing operations |
| internal/cli/memory.go | CLI subcommand tree for memory curate; show, reject, and delete subcommands are missing the soul-path-empty guard that list, apply, and draft have |
| internal/memory/curate/render.go | Markdown rendering for drafts and MEMORY.md apply blocks; straightforward, no issues |
| internal/config/config.go | Adds MemoryCurationConfig struct and sets defaults in both Load and LoadFrom; defaults applied in Save too |
| internal/memory/curate/curate_test.go | Comprehensive unit tests for extraction, conflict detection, audit, apply guards, and store lifecycle |
| internal/cli/memory_curate_test.go | Integration-style CLI tests covering draft creation, apply gate, reject/delete lifecycle, and audit blocking |
| internal/bot/memory_curate_test.go | Unit tests for parseDaysArg and usage-string completeness |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/memory/curate/audit.go
Line: 1114-1119

Comment:
**Inconsistent case sensitivity in destructive SQL patterns**

`DROP TABLE`/`DATABASE` uses uppercase-only matching while `delete from` uses lowercase-only, so neither catches the opposite casing. A note containing `drop table users` or `DELETE FROM orders` would slip past the audit without triggering the block.

```suggestion
var destructivePatterns = []*regexp.Regexp{
	regexp.MustCompile(`(?i)\brm\s+-rf\b`),
	regexp.MustCompile(`(?i)\bDROP\s+(TABLE|DATABASE)\b`),
	regexp.MustCompile(`(?i)\bdelete\s+from\b`),
	regexp.MustCompile(`>\s*/dev/`),
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/cli/memory.go
Line: 583-600

Comment:
**Missing soul-path guard in `show`, `reject`, and `delete` commands**

`newMemoryCurateShowCommand`, `newMemoryCurateRejectCommand`, and `newMemoryCurateDeleteCommand` all skip the `soul == ""` check that the `list`, `apply`, and `draft` commands perform. When `SoulPath` is empty the store constructs paths relative to the working directory, producing confusing `no such file or directory` errors rather than the clear `"soul path is empty"` message.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/memory/curate/curate.go
Line: 1222

Comment:
**Typo in constant name: `SectionUncategoried`**

The constant is missing the `z` — should be `SectionUncategorized`. The string value `"uncategorized"` is correct so there is no runtime impact, but the exported name is part of the public API.

```suggestion
	SectionUncategorized Section = "uncategorized"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/memory/curate/store.go
Line: 2300-2311

Comment:
**Silent swallow of load errors in `List()`**

When `s.Load(id)` fails (e.g. a truncated or corrupted JSON file), the entry is silently skipped. A partially-written draft from a previous `Save` failure would disappear from listings with no indication to the user.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(memory): harden curation draft handl..."](https://github.com/befeast/ok-gobot/commit/bafb5b599e0a6091159fd24ef81c16316034acf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30247590)</sub>

<!-- /greptile_comment -->