### PR TITLE
feat(memory): add optional QMD backend

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -2,8 +2,9 @@
 
 > Current architecture note: memory v2 is markdown-first. `MEMORY.md` and
 > `memory/*.md` are the source of truth; SQLite stores an embedding index over
-> those files. Legacy record-style commands such as `memory save/list/forget`
-> are deprecated.
+> those files. QMD can be configured as an optional read-only search backend for
+> advanced local-first search, but it is never required. Legacy record-style
+> commands such as `memory save/list/forget` are deprecated.
 
 The semantic memory system allows the bot to store and recall information using vector embeddings for similarity search. This enables long-term memory beyond the conversation context window.
 
@@ -13,6 +14,7 @@ The semantic memory system allows the bot to store and recall information using 
 - **Vector Embeddings**: Uses OpenAI-compatible embedding APIs
 - **SQLite Storage**: Memories stored in the same database as conversations
 - **Cosine Similarity**: Efficient similarity computation in Go
+- **Optional QMD Backend**: Read-only integration with a pre-existing QMD index for BM25/vector/hybrid search
 - **Category Organization**: Tag memories with categories
 - **Simple Tool Interface**: Easy-to-use commands via the memory tool
 
@@ -24,6 +26,7 @@ Add the following to your `~/.ok-gobot/config.yaml`:
 memory:
   enabled: true
   mode: "eager"        # eager | retrieval_first | startup_recent
+  backend: "builtin"        # builtin, qmd, or auto
   embeddings_base_url: "https://api.openai.com/v1"
   embeddings_api_key: ""  # Leave empty to reuse ai.api_key
   embeddings_model: "text-embedding-3-small"
@@ -38,6 +41,18 @@ memory:
     - name: "homelab"
       path: "/mnt/shared/memory/homelab"
       patterns: ["docs/**/*.md", "runbooks/**/*.md"]
+  qmd:
+    binary_path: "qmd"
+    index: "index"
+    index_path: ""          # Optional explicit QMD SQLite index path
+    search_mode: "search"   # search, vsearch, or query
+    timeout: "10s"
+    fallback_cooldown: "1m"
+    collections:
+      workspace: ""          # QMD collection rooted at the soul/workspace directory
+      daily_notes: ""        # QMD collection rooted at memory/
+      session_transcripts: "" # QMD collection rooted at exported session transcripts
+      extra_paths: []         # Additional pre-existing QMD collection names
   mcp:
     enabled: false
     host: "127.0.0.1"
@@ -51,12 +66,18 @@ memory:
 - **enabled**: Set to `true` to enable semantic memory
 - **mode**: How memory is injected into the system prompt — see
   [Memory prompt modes](#memory-prompt-modes) below.
+- **backend**: `builtin` uses ok-gobot SQLite embeddings; `qmd` prefers QMD with built-in fallback; `auto` behaves like `qmd` but is intended for local profiles that may not always have QMD installed
 - **embeddings_base_url**: API endpoint for embeddings (OpenAI-compatible)
 - **embeddings_api_key**: API key for embeddings (if empty, reuses `ai.api_key`)
 - **embeddings_model**: Embedding model to use (default: `text-embedding-3-small`)
 - **metadata_extraction**: When `true`, extracts structured metadata (`people/topics/action_items/type`) during indexing
 - **metadata_model**: Lightweight LLM model used for metadata extraction (default: `haiku`)
 - **extra_paths**: Additional named markdown roots to index (Obsidian vaults, shared-memory exports). See "External markdown collections" below.
+- **qmd.binary_path**: QMD CLI path. QMD is optional; missing binaries fall back to the built-in backend.
+- **qmd.index / qmd.index_path**: Select the QMD index. `index_path` maps to QMD's `INDEX_PATH` and avoids relying on `~/.cache/qmd/<index>.sqlite`.
+- **qmd.search_mode**: `search` is BM25 and the safe default. `vsearch` and `query` can use QMD's local embedding/reranking models and should only be enabled after you have intentionally prepared those models with QMD.
+- **qmd.fallback_cooldown**: How long ok-gobot suppresses QMD retries after a failure before trying QMD again.
+- **qmd.collections**: Names of pre-existing QMD collections. ok-gobot v1 does not create, update, embed, or delete QMD collections.
 - **mcp.enabled**: Enable optional MCP server exposing `memory_search`, `memory_get`, `memory_capture`
 - **mcp.host / mcp.port / mcp.endpoint**: MCP bind/interface settings (`127.0.0.1` by default for local-only access)
 - **mcp.allow_writes**: Must be explicitly `true` to allow `memory_capture` writes
@@ -140,6 +161,17 @@ Inspect the persisted index:
 ok-gobot memory status
 ```
 
+Include backend diagnostics, including QMD binary, configured collections,
+index/update state, embedding readiness, and last error:
+
+```bash
+ok-gobot memory status --deep
+```
+
+`memory status --deep` intentionally does not run `qmd status`. QMD 2.1.0's
+status command can initialize local model tooling. ok-gobot instead uses the
+stable read-only contract `qmd --version` and QMD SQLite index metadata.
+
 Force a rebuild of the managed markdown sources:
 
 ```bash
@@ -196,6 +228,63 @@ The optional scheduled suggestion mode is **disabled by default**. Set
 `memory.curation.enabled: true` and a cron expression in `memory.curation.schedule`
 to have the bot generate draft suggestions on a cadence. The scheduled mode
 never auto-applies — admin approval is always required for `MEMORY.md` writes.
+
+When `memory.backend: qmd`, ok-gobot still maintains the built-in SQLite index so
+fallback remains available. QMD failures are cached for `qmd.fallback_cooldown`
+to avoid retry storms; during that window searches use the built-in backend.
+
+## Built-in vs QMD
+
+Use the built-in backend when:
+
+- You want ok-gobot to run with no Node/Bun/QMD installation.
+- Your memory sources are `MEMORY.md` and `memory/*.md`.
+- OpenAI-compatible embeddings are acceptable.
+- You want the simplest operational path.
+
+Use QMD when:
+
+- You already maintain a QMD index and want BM25, vector search, hybrid query, reranking, or query expansion.
+- You want local-first search over additional markdown collections.
+- You are prepared to manage QMD updates and embeddings yourself.
+
+QMD v1 integration is read-only from ok-gobot's perspective. Create and maintain
+collections with QMD directly, for example:
+
+```bash
+qmd collection add ~/ok-gobot-soul --name ok-workspace
+qmd collection add ~/ok-gobot-soul/memory --name ok-daily
+qmd update
+qmd embed
+```
+
+Then reference those collection names:
+
+```yaml
+memory:
+  enabled: true
+  backend: "qmd"
+  qmd:
+    search_mode: "search"
+    collections:
+      workspace: "ok-workspace"
+      daily_notes: "ok-daily"
+      session_transcripts: "ok-sessions"
+      extra_paths:
+        - "project-docs"
+```
+
+QMD search results are normalized to sources that `memory_get` can read when the
+collection is rooted at the expected location:
+
+- `workspace` results become `MEMORY.md` or another path relative to the soul directory.
+- `daily_notes` results become `memory/<file>.md`.
+- `session_transcripts` results become `sessions/<file>.md`.
+- `extra_paths` results use the QMD collection-relative path; keep those paths under the soul directory if you need `memory_get` to read them.
+
+To use QMD's heavier model-backed behavior, explicitly set `search_mode: "query"`
+or `search_mode: "vsearch"` after configuring QMD. ok-gobot does not download
+QMD models itself and defaults to `search` to avoid triggering model setup.
 
 ### Agent Tool Commands
 
@@ -276,12 +365,18 @@ Deletes the memory with the specified ID.
    - Binary encoding of float32 vectors
 
 3. **MemoryManager** (`internal/memory/manager.go`)
-   - Coordinates embedding client and store
-   - Provides high-level Remember/Recall interface
+   - Selects the configured backend
+   - Falls back from QMD to built-in SQLite when QMD is missing or unhealthy
+   - Provides high-level Remember/Recall compatibility aliases
 
-4. **MemoryTool** (`internal/tools/memory_tool.go`)
+4. **QMDBackend** (`internal/memory/qmd.go`)
+   - Calls the `qmd` CLI read-only using `--json`
+   - Parses QMD citations into `memory_get`-compatible source paths when possible
+   - Reads QMD SQLite metadata for deep diagnostics without running `qmd status`
+
+5. **Memory Tools** (`internal/tools/memory_search_tool.go`, `internal/tools/memory_get_tool.go`)
    - Tool interface for agent use
-   - Parses commands and delegates to manager
+   - Delegates search to the selected manager backend
 
 ### Database Schema
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -280,6 +280,7 @@ func (a *App) Start(ctx context.Context) error {
 			log.Printf("⚠️ Failed to initialize memory store: %v", err)
 		} else {
 			var options []memory.MemoryManagerOption
+			builtinBackend := memory.NewBuiltinBackend(embClient, memStore)
 
 			if a.config.Memory.MetadataExtraction {
 				metadataModel := strings.TrimSpace(a.config.Memory.MetadataModel)
@@ -304,6 +305,14 @@ func (a *App) Start(ctx context.Context) error {
 					options = append(options, memory.WithMetadataExtractor(memory.NewLLMMetadataExtractor(metadataClient)))
 					log.Printf("🧠 Memory metadata extraction enabled (model: %s)", metadataModel)
 				}
+			}
+
+			backendName := strings.ToLower(strings.TrimSpace(a.config.Memory.Backend))
+			if backendName == "qmd" || backendName == "auto" {
+				qmdBackend := memory.NewQMDBackend(appQMDConfig(a.config.Memory.QMD))
+				cooldown := parseDurationOrDefault(a.config.Memory.QMD.FallbackCooldown, time.Minute)
+				options = append(options, memory.WithBackend(memory.NewFallbackBackend(qmdBackend, builtinBackend, cooldown)))
+				log.Printf("🧠 QMD memory backend configured (mode=%s, fallback=builtin)", a.config.Memory.QMD.SearchMode)
 			}
 
 			a.memoryManager = memory.NewMemoryManager(embClient, memStore, options...)
@@ -499,6 +508,34 @@ func (a *App) startBootstrapWatcher(name string, personality *agent.Personality)
 
 	a.bootstraps = append(a.bootstraps, watcher)
 	a.bootstrapSeen[personality.BasePath] = struct{}{}
+}
+
+func appQMDConfig(cfg config.MemoryQMDConfig) memory.QMDConfig {
+	return memory.QMDConfig{
+		BinaryPath: cfg.BinaryPath,
+		Index:      cfg.Index,
+		IndexPath:  cfg.IndexPath,
+		SearchMode: cfg.SearchMode,
+		Timeout:    parseDurationOrDefault(cfg.Timeout, memory.DefaultQMDTimeout),
+		Collections: memory.QMDCollections{
+			Workspace:          cfg.Collections.Workspace,
+			DailyNotes:         cfg.Collections.DailyNotes,
+			SessionTranscripts: cfg.Collections.SessionTranscripts,
+			ExtraPaths:         cfg.Collections.ExtraPaths,
+		},
+	}
+}
+
+func parseDurationOrDefault(value string, fallback time.Duration) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil || duration <= 0 {
+		return fallback
+	}
+	return duration
 }
 
 func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *memory.MemoryStore, embedder memory.EmbeddingBatchClient) {

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -26,7 +27,8 @@ func newMemoryCommand(cfg *config.Config) *cobra.Command {
 }
 
 func newMemoryStatusCommand(cfg *config.Config) *cobra.Command {
-	return &cobra.Command{
+	var deep bool
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show memory index status",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -43,6 +45,7 @@ func newMemoryStatusCommand(cfg *config.Config) *cobra.Command {
 
 			out := cmd.OutOrStdout()
 			fmt.Fprintf(out, "Memory enabled: %v\n", status.Enabled)
+			fmt.Fprintf(out, "Backend: %s\n", memoryBackendName(cfg))
 			fmt.Fprintf(out, "Root: %s\n", status.RootPath)
 			fmt.Fprintf(out, "Sources: %d\n", status.SourceCount)
 			fmt.Fprintf(out, "Chunks: %d\n", status.ChunkCount)
@@ -55,26 +58,28 @@ func newMemoryStatusCommand(cfg *config.Config) *cobra.Command {
 			extras, err := extraPathsFromConfig(cfg)
 			if err != nil {
 				fmt.Fprintf(out, "Extra paths: configuration error: %v\n", err)
-				return nil
-			}
-			if len(extras) == 0 {
-				return nil
-			}
-			fmt.Fprintf(out, "Extra paths (%d):\n", len(extras))
-			for _, diag := range memStore.ExtraPathDiagnostics(cmd.Context(), extras) {
-				state := "ok"
-				if !diag.Available {
-					state = "missing"
+			} else if len(extras) > 0 {
+				fmt.Fprintf(out, "Extra paths (%d):\n", len(extras))
+				for _, diag := range memStore.ExtraPathDiagnostics(cmd.Context(), extras) {
+					state := "ok"
+					if !diag.Available {
+						state = "missing"
+					}
+					fmt.Fprintf(out, "  - %s [%s] path=%s sources=%d chunks=%d read_only=%v\n",
+						diag.Name, state, diag.Path, diag.SourceCount, diag.ChunkCount, diag.ReadOnly)
+					if diag.Error != "" {
+						fmt.Fprintf(out, "    error: %s\n", diag.Error)
+					}
 				}
-				fmt.Fprintf(out, "  - %s [%s] path=%s sources=%d chunks=%d read_only=%v\n",
-					diag.Name, state, diag.Path, diag.SourceCount, diag.ChunkCount, diag.ReadOnly)
-				if diag.Error != "" {
-					fmt.Fprintf(out, "    error: %s\n", diag.Error)
-				}
+			}
+			if deep {
+				printDeepMemoryStatus(cmd.Context(), out, cfg)
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&deep, "deep", false, "include backend diagnostics such as QMD binary, collections, and embedding readiness")
+	return cmd
 }
 
 func newMemoryIndexCommand(cfg *config.Config) *cobra.Command {
@@ -443,4 +448,102 @@ func extraPathsFromConfig(cfg *config.Config) ([]memory.ExtraPath, error) {
 		})
 	}
 	return memory.NormalizeExtraPaths(raw)
+}
+
+type memoryStatusWriter interface {
+	Write(p []byte) (n int, err error)
+}
+
+func printDeepMemoryStatus(ctx context.Context, out memoryStatusWriter, cfg *config.Config) {
+	qmd := memory.NewQMDBackend(cliQMDConfig(cfg.Memory.QMD))
+	d := qmd.Diagnostics(ctx)
+
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Deep diagnostics:")
+	fmt.Fprintln(out, "Built-in backend:")
+	fmt.Fprintln(out, "  Type: SQLite + OpenAI-compatible embeddings")
+	fmt.Fprintf(out, "  Embeddings model: %s\n", cfg.Memory.EmbeddingsModel)
+	fmt.Fprintf(out, "  Embeddings base URL: %s\n", cfg.Memory.EmbeddingsBaseURL)
+
+	fmt.Fprintln(out, "QMD backend:")
+	fmt.Fprintf(out, "  Configured: %v\n", memoryBackendName(cfg) == "qmd" || memoryBackendName(cfg) == "auto")
+	fmt.Fprintf(out, "  Contract: %s\n", d.StableContract)
+	fmt.Fprintf(out, "  Model-safe status: %s\n", d.ModelSafeStatus)
+	fmt.Fprintf(out, "  Binary: %s\n", d.BinaryPath)
+	fmt.Fprintf(out, "  Binary found: %v\n", d.BinaryFound)
+	if d.Version != "" {
+		fmt.Fprintf(out, "  Version: %s\n", d.Version)
+	}
+	fmt.Fprintf(out, "  Search mode: %s\n", d.SearchMode)
+	fmt.Fprintf(out, "  Index: %s\n", d.IndexName)
+	fmt.Fprintf(out, "  Index path: %s\n", d.IndexPath)
+	fmt.Fprintf(out, "  Index exists: %v\n", d.IndexExists)
+	fmt.Fprintf(out, "  Update state: %s\n", d.UpdateState)
+	fmt.Fprintf(out, "  Embedding ready: %v\n", d.EmbeddingReady)
+	fmt.Fprintf(out, "  Vector index: %v\n", d.HasVectorIndex)
+	fmt.Fprintf(out, "  Pending embeddings: %d\n", d.NeedsEmbedding)
+	fmt.Fprintf(out, "  Total documents: %d\n", d.TotalDocuments)
+	if len(d.Collections) == 0 {
+		fmt.Fprintln(out, "  Collections: none")
+	} else {
+		fmt.Fprintln(out, "  Collections:")
+		for _, col := range d.Collections {
+			state := "missing"
+			if col.Present {
+				state = "present"
+			}
+			fmt.Fprintf(out, "    - %s (%s): %s", col.Name, col.Role, state)
+			if col.Documents > 0 {
+				fmt.Fprintf(out, ", documents=%d", col.Documents)
+			}
+			if col.Pattern != "" {
+				fmt.Fprintf(out, ", pattern=%s", col.Pattern)
+			}
+			fmt.Fprintln(out)
+		}
+	}
+	if d.LastError != "" {
+		fmt.Fprintf(out, "  Last error: %s\n", d.LastError)
+	} else {
+		fmt.Fprintln(out, "  Last error: none")
+	}
+}
+
+func memoryBackendName(cfg *config.Config) string {
+	if cfg == nil {
+		return "builtin"
+	}
+	name := strings.ToLower(strings.TrimSpace(cfg.Memory.Backend))
+	if name == "" {
+		return "builtin"
+	}
+	return name
+}
+
+func cliQMDConfig(cfg config.MemoryQMDConfig) memory.QMDConfig {
+	return memory.QMDConfig{
+		BinaryPath: cfg.BinaryPath,
+		Index:      cfg.Index,
+		IndexPath:  cfg.IndexPath,
+		SearchMode: cfg.SearchMode,
+		Timeout:    cliDurationOrDefault(cfg.Timeout, memory.DefaultQMDTimeout),
+		Collections: memory.QMDCollections{
+			Workspace:          cfg.Collections.Workspace,
+			DailyNotes:         cfg.Collections.DailyNotes,
+			SessionTranscripts: cfg.Collections.SessionTranscripts,
+			ExtraPaths:         cfg.Collections.ExtraPaths,
+		},
+	}
+}
+
+func cliDurationOrDefault(value string, fallback time.Duration) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil || duration <= 0 {
+		return fallback
+	}
+	return duration
 }

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -63,6 +63,36 @@ func TestMemoryIndexRequiresMemoryEnabled(t *testing.T) {
 	}
 }
 
+func TestMemoryStatusDeepShowsQMDDiagnosticsWhenBinaryMissing(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+	cfg.Memory.Enabled = true
+	cfg.Memory.Backend = "qmd"
+	cfg.Memory.EmbeddingsModel = "text-embedding-3-small"
+	cfg.Memory.EmbeddingsBaseURL = "https://api.openai.com/v1"
+	cfg.Memory.QMD.BinaryPath = "definitely-missing-qmd-binary"
+	cfg.Memory.QMD.Index = "index"
+	cfg.Memory.QMD.SearchMode = "search"
+	cfg.Memory.QMD.Timeout = "1s"
+	cfg.SoulPath = t.TempDir()
+
+	cmd := newMemoryCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"status", "--deep"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	output := out.String()
+	for _, want := range []string{"Backend: qmd", "QMD backend:", "Binary found: false", "Last error: qmd binary not found"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
 func writeCLITestFile(t *testing.T, path, data string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,6 +209,7 @@ type STTConfig struct {
 type MemoryConfig struct {
 	Enabled            bool                    `mapstructure:"enabled"`             // Enable semantic memory
 	Mode               string                  `mapstructure:"mode"`                // Prompt assembly mode: "eager" (default), "retrieval_first", or "startup_recent"
+	Backend            string                  `mapstructure:"backend"`             // Memory search backend: builtin, qmd, or auto
 	EmbeddingsBaseURL  string                  `mapstructure:"embeddings_base_url"` // API base URL for embeddings
 	EmbeddingsAPIKey   string                  `mapstructure:"embeddings_api_key"`  // API key for embeddings (can reuse ai.api_key)
 	EmbeddingsModel    string                  `mapstructure:"embeddings_model"`    // Embeddings model to use
@@ -216,6 +217,7 @@ type MemoryConfig struct {
 	MetadataModel      string                  `mapstructure:"metadata_model"`      // LLM model used for metadata extraction
 	ExtraPaths         []MemoryExtraPathConfig `mapstructure:"extra_paths"`         // Additional named markdown roots to index (Obsidian vaults, shared exports, etc.)
 	MCP                MemoryMCPConfig         `mapstructure:"mcp"`                 // Optional MCP server exposing memory tools
+	QMD                MemoryQMDConfig         `mapstructure:"qmd"`                 // Optional read-only QMD-compatible backend
 	Active             ActiveMemoryConfig      `mapstructure:"active"`              // Pre-reply Active Memory recall (DM only)
 	Sessions           SessionMemoryConfig     `mapstructure:"sessions"`            // Session transcript indexing (off by default)
 	Curation           MemoryCurationConfig    `mapstructure:"curation"`            // Optional scheduled curation suggestions (disabled by default)
@@ -307,6 +309,25 @@ type MemoryCurationConfig struct {
 	Days     int    `mapstructure:"days"`     // Daily-note window for each suggestion run (default 7)
 }
 
+// MemoryQMDConfig holds optional QMD-compatible backend configuration.
+type MemoryQMDConfig struct {
+	BinaryPath       string                     `mapstructure:"binary_path"`       // qmd binary path (default: qmd)
+	Index            string                     `mapstructure:"index"`             // qmd index name (default: index)
+	IndexPath        string                     `mapstructure:"index_path"`        // explicit SQLite index path; avoids inferring ~/.cache/qmd
+	SearchMode       string                     `mapstructure:"search_mode"`       // search, vsearch, or query
+	Timeout          string                     `mapstructure:"timeout"`           // per-command timeout, e.g. 10s
+	FallbackCooldown string                     `mapstructure:"fallback_cooldown"` // suppress failed QMD retries for this duration
+	Collections      MemoryQMDCollectionsConfig `mapstructure:"collections"`       // pre-existing QMD collection names by memory role
+}
+
+// MemoryQMDCollectionsConfig maps ok-gobot memory roles to QMD collection names.
+type MemoryQMDCollectionsConfig struct {
+	Workspace          string   `mapstructure:"workspace"`
+	DailyNotes         string   `mapstructure:"daily_notes"`
+	SessionTranscripts string   `mapstructure:"session_transcripts"`
+	ExtraPaths         []string `mapstructure:"extra_paths"`
+}
+
 // MemoryMCPConfig holds memory MCP server configuration
 type MemoryMCPConfig struct {
 	Enabled     bool   `mapstructure:"enabled"`      // Enable memory MCP server
@@ -375,11 +396,19 @@ func Load() (*Config, error) {
 	v.SetDefault("stt.confidence_threshold", 0.6)
 	v.SetDefault("memory.enabled", false)
 	v.SetDefault("memory.mode", MemoryModeEager)
+	v.SetDefault("memory.backend", "builtin")
 	v.SetDefault("memory.embeddings_base_url", "https://api.openai.com/v1")
 	v.SetDefault("memory.embeddings_api_key", "")
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
 	v.SetDefault("memory.metadata_extraction", false)
 	v.SetDefault("memory.metadata_model", "haiku")
+	v.SetDefault("memory.qmd.binary_path", "qmd")
+	v.SetDefault("memory.qmd.index", "index")
+	v.SetDefault("memory.qmd.index_path", "")
+	v.SetDefault("memory.qmd.search_mode", "search")
+	v.SetDefault("memory.qmd.timeout", "10s")
+	v.SetDefault("memory.qmd.fallback_cooldown", "1m")
+	v.SetDefault("memory.qmd.collections.extra_paths", []string{})
 	v.SetDefault("memory.mcp.enabled", false)
 	v.SetDefault("memory.mcp.host", "127.0.0.1")
 	v.SetDefault("memory.mcp.port", 9233)
@@ -501,11 +530,19 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("stt.confidence_threshold", 0.6)
 	v.SetDefault("memory.enabled", false)
 	v.SetDefault("memory.mode", MemoryModeEager)
+	v.SetDefault("memory.backend", "builtin")
 	v.SetDefault("memory.embeddings_base_url", "https://api.openai.com/v1")
 	v.SetDefault("memory.embeddings_api_key", "")
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
 	v.SetDefault("memory.metadata_extraction", false)
 	v.SetDefault("memory.metadata_model", "haiku")
+	v.SetDefault("memory.qmd.binary_path", "qmd")
+	v.SetDefault("memory.qmd.index", "index")
+	v.SetDefault("memory.qmd.index_path", "")
+	v.SetDefault("memory.qmd.search_mode", "search")
+	v.SetDefault("memory.qmd.timeout", "10s")
+	v.SetDefault("memory.qmd.fallback_cooldown", "1m")
+	v.SetDefault("memory.qmd.collections.extra_paths", []string{})
 	v.SetDefault("memory.mcp.enabled", false)
 	v.SetDefault("memory.mcp.host", "127.0.0.1")
 	v.SetDefault("memory.mcp.port", 9233)
@@ -663,6 +700,25 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	validMemoryBackends := map[string]bool{"": true, "builtin": true, "qmd": true, "auto": true}
+	if !validMemoryBackends[c.Memory.Backend] {
+		return fmt.Errorf("invalid memory.backend: %s (must be 'builtin', 'qmd', or 'auto')", c.Memory.Backend)
+	}
+	validQMDSearchModes := map[string]bool{"": true, "search": true, "vsearch": true, "query": true}
+	if !validQMDSearchModes[c.Memory.QMD.SearchMode] {
+		return fmt.Errorf("invalid memory.qmd.search_mode: %s (must be 'search', 'vsearch', or 'query')", c.Memory.QMD.SearchMode)
+	}
+	if c.Memory.QMD.Timeout != "" {
+		if _, err := time.ParseDuration(c.Memory.QMD.Timeout); err != nil {
+			return fmt.Errorf("invalid memory.qmd.timeout: %w", err)
+		}
+	}
+	if c.Memory.QMD.FallbackCooldown != "" {
+		if _, err := time.ParseDuration(c.Memory.QMD.FallbackCooldown); err != nil {
+			return fmt.Errorf("invalid memory.qmd.fallback_cooldown: %w", err)
+		}
+	}
+
 	// Validate agent capability policies.
 	validFileWriteScopes := map[string]bool{"": true, "full": true, "read_only": true}
 	for _, agent := range c.Agents {
@@ -713,11 +769,24 @@ func (c *Config) Save() error {
 	v.Set("tts.provider", c.TTS.Provider)
 	v.Set("tts.default_voice", c.TTS.DefaultVoice)
 	v.Set("memory.enabled", c.Memory.Enabled)
+	v.Set("memory.mode", c.Memory.Mode)
+	v.Set("memory.backend", c.Memory.Backend)
 	v.Set("memory.embeddings_base_url", c.Memory.EmbeddingsBaseURL)
 	v.Set("memory.embeddings_api_key", c.Memory.EmbeddingsAPIKey)
 	v.Set("memory.embeddings_model", c.Memory.EmbeddingsModel)
 	v.Set("memory.metadata_extraction", c.Memory.MetadataExtraction)
 	v.Set("memory.metadata_model", c.Memory.MetadataModel)
+	v.Set("memory.extra_paths", c.Memory.ExtraPaths)
+	v.Set("memory.qmd.binary_path", c.Memory.QMD.BinaryPath)
+	v.Set("memory.qmd.index", c.Memory.QMD.Index)
+	v.Set("memory.qmd.index_path", c.Memory.QMD.IndexPath)
+	v.Set("memory.qmd.search_mode", c.Memory.QMD.SearchMode)
+	v.Set("memory.qmd.timeout", c.Memory.QMD.Timeout)
+	v.Set("memory.qmd.fallback_cooldown", c.Memory.QMD.FallbackCooldown)
+	v.Set("memory.qmd.collections.workspace", c.Memory.QMD.Collections.Workspace)
+	v.Set("memory.qmd.collections.daily_notes", c.Memory.QMD.Collections.DailyNotes)
+	v.Set("memory.qmd.collections.session_transcripts", c.Memory.QMD.Collections.SessionTranscripts)
+	v.Set("memory.qmd.collections.extra_paths", c.Memory.QMD.Collections.ExtraPaths)
 	v.Set("memory.mcp.enabled", c.Memory.MCP.Enabled)
 	v.Set("memory.mcp.host", c.Memory.MCP.Host)
 	v.Set("memory.mcp.port", c.Memory.MCP.Port)
@@ -728,6 +797,9 @@ func (c *Config) Save() error {
 	v.Set("memory.active.max_snippets", c.Memory.Active.MaxSnippets)
 	v.Set("memory.active.max_chars", c.Memory.Active.MaxChars)
 	v.Set("memory.active.history_turns", c.Memory.Active.HistoryTurns)
+	v.Set("memory.sessions.enabled", c.Memory.Sessions.Enabled)
+	v.Set("memory.sessions.include_groups", c.Memory.Sessions.IncludeGroups)
+	v.Set("memory.sessions.max_messages_per_session", c.Memory.Sessions.MaxMessagesPerSession)
 	v.Set("memory.curation.enabled", c.Memory.Curation.Enabled)
 	v.Set("memory.curation.schedule", c.Memory.Curation.Schedule)
 	v.Set("memory.curation.days", c.Memory.Curation.Days)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,6 +46,15 @@ storage_path: "/tmp/test.db"
 	if cfg.Memory.MetadataModel != "haiku" {
 		t.Errorf("expected memory.metadata_model=%q, got %q", "haiku", cfg.Memory.MetadataModel)
 	}
+	if cfg.Memory.Backend != "builtin" {
+		t.Errorf("expected memory.backend=%q, got %q", "builtin", cfg.Memory.Backend)
+	}
+	if cfg.Memory.QMD.BinaryPath != "qmd" {
+		t.Errorf("expected memory.qmd.binary_path=%q, got %q", "qmd", cfg.Memory.QMD.BinaryPath)
+	}
+	if cfg.Memory.QMD.SearchMode != "search" {
+		t.Errorf("expected memory.qmd.search_mode=%q, got %q", "search", cfg.Memory.QMD.SearchMode)
+	}
 }
 
 func TestLoadFromLegacyRuntimeModeCompatibility(t *testing.T) {
@@ -189,6 +198,84 @@ memory:
 	}
 	if !cfg.Memory.MCP.AllowWrites {
 		t.Fatalf("expected memory.mcp.allow_writes=true")
+	}
+}
+
+func TestLoadFromExplicitQMDMemoryConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "config-test-memory-qmd-explicit-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+  provider: "openrouter"
+storage_path: "/tmp/test.db"
+memory:
+  enabled: true
+  backend: "qmd"
+  qmd:
+    binary_path: "/usr/local/bin/qmd"
+    index: "work"
+    index_path: "/tmp/qmd.sqlite"
+    search_mode: "query"
+    timeout: "5s"
+    fallback_cooldown: "30s"
+    collections:
+      workspace: "ok-workspace"
+      daily_notes: "ok-daily"
+      session_transcripts: "ok-sessions"
+      extra_paths:
+        - "docs"
+        - "notes"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom failed: %v", err)
+	}
+
+	if cfg.Memory.Backend != "qmd" {
+		t.Fatalf("expected qmd backend, got %q", cfg.Memory.Backend)
+	}
+	if cfg.Memory.QMD.BinaryPath != "/usr/local/bin/qmd" || cfg.Memory.QMD.Index != "work" || cfg.Memory.QMD.IndexPath != "/tmp/qmd.sqlite" {
+		t.Fatalf("unexpected qmd paths: %+v", cfg.Memory.QMD)
+	}
+	if cfg.Memory.QMD.SearchMode != "query" || cfg.Memory.QMD.Timeout != "5s" || cfg.Memory.QMD.FallbackCooldown != "30s" {
+		t.Fatalf("unexpected qmd timing/search config: %+v", cfg.Memory.QMD)
+	}
+	if cfg.Memory.QMD.Collections.Workspace != "ok-workspace" {
+		t.Fatalf("workspace collection mismatch: %+v", cfg.Memory.QMD.Collections)
+	}
+	if len(cfg.Memory.QMD.Collections.ExtraPaths) != 2 || cfg.Memory.QMD.Collections.ExtraPaths[1] != "notes" {
+		t.Fatalf("extra paths mismatch: %+v", cfg.Memory.QMD.Collections.ExtraPaths)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected qmd config to validate, got %v", err)
+	}
+}
+
+func TestValidateRejectsInvalidQMDSearchMode(t *testing.T) {
+	cfg := &Config{
+		Telegram:    TelegramConfig{Token: "test-token"},
+		AI:          AIConfig{APIKey: "test-key", Model: "test-model"},
+		StoragePath: "/tmp/test.db",
+		Memory: MemoryConfig{
+			Backend: "qmd",
+			QMD:     MemoryQMDConfig{SearchMode: "bad", Timeout: "1s", FallbackCooldown: "1m"},
+		},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected invalid qmd search mode error")
 	}
 }
 

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -1,0 +1,198 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultBackendCooldown = time.Minute
+
+// Backend searches memory by natural-language query.
+type Backend interface {
+	Name() string
+	Search(ctx context.Context, query string, topK int, expand bool) ([]MemoryResult, error)
+}
+
+// BuiltinBackend is the built-in SQLite/embedding memory backend.
+type BuiltinBackend struct {
+	client EmbeddingQueryClient
+	store  *MemoryStore
+}
+
+// NewBuiltinBackend creates the built-in SQLite/embedding backend.
+func NewBuiltinBackend(client EmbeddingQueryClient, store *MemoryStore) *BuiltinBackend {
+	return &BuiltinBackend{client: client, store: store}
+}
+
+func (b *BuiltinBackend) Name() string {
+	return "builtin"
+}
+
+func (b *BuiltinBackend) Search(ctx context.Context, query string, topK int, expand bool) ([]MemoryResult, error) {
+	if b == nil || b.store == nil {
+		return nil, fmt.Errorf("memory manager is not configured")
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, fmt.Errorf("memory search query is empty")
+	}
+
+	var queryEmbedding []float32
+	if b.client != nil {
+		if embedding, err := b.client.GetEmbedding(ctx, query); err == nil {
+			queryEmbedding = embedding
+		}
+	}
+
+	results, err := b.store.SearchHybrid(ctx, query, queryEmbedding, topK)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search memory chunks: %w", err)
+	}
+	if !expand || len(results) == 0 {
+		return results, nil
+	}
+
+	type branch struct{ file, header string }
+	var branches []branch
+	seen := make(map[branch]bool)
+	bestScores := make(map[branch]float32)
+
+	for _, h := range results {
+		b := branch{h.SourceFile, h.HeaderPath}
+		if h.Similarity > bestScores[b] {
+			bestScores[b] = h.Similarity
+		}
+		if !seen[b] {
+			seen[b] = true
+			branches = append(branches, b)
+		}
+	}
+
+	expanded := make([]MemoryResult, 0, len(branches))
+	for _, br := range branches {
+		chunks, err := b.store.GetBranchChunks(ctx, br.file, br.header)
+		if err != nil || len(chunks) == 0 {
+			continue
+		}
+
+		texts := make([]string, len(chunks))
+		for i, c := range chunks {
+			texts[i] = c.Content
+		}
+
+		expanded = append(expanded, MemoryResult{
+			Source:     br.file,
+			SourceFile: br.file,
+			HeaderPath: br.header,
+			Content:    strings.Join(texts, "\n\n"),
+			Similarity: bestScores[br],
+		})
+	}
+
+	return expanded, nil
+}
+
+// FallbackBackend uses a primary backend, then temporarily suppresses it after
+// failures to avoid retry storms while preserving built-in memory availability.
+type FallbackBackend struct {
+	primary  Backend
+	fallback Backend
+	cooldown time.Duration
+	now      func() time.Time
+
+	mu            sync.Mutex
+	disabledUntil time.Time
+	lastErr       error
+}
+
+// NewFallbackBackend wraps a primary backend with a fallback backend.
+func NewFallbackBackend(primary, fallback Backend, cooldown time.Duration) *FallbackBackend {
+	if cooldown <= 0 {
+		cooldown = defaultBackendCooldown
+	}
+	return &FallbackBackend{
+		primary:  primary,
+		fallback: fallback,
+		cooldown: cooldown,
+		now:      time.Now,
+	}
+}
+
+func (b *FallbackBackend) Name() string {
+	if b == nil || b.primary == nil {
+		return "fallback"
+	}
+	if b.fallback == nil {
+		return b.primary.Name()
+	}
+	return b.primary.Name() + "+" + b.fallback.Name()
+}
+
+func (b *FallbackBackend) Search(ctx context.Context, query string, topK int, expand bool) ([]MemoryResult, error) {
+	if b == nil || b.primary == nil {
+		return nil, fmt.Errorf("memory backend is not configured")
+	}
+
+	if disabled, lastErr := b.isDisabled(); disabled {
+		if b.fallback != nil {
+			return b.fallback.Search(ctx, query, topK, expand)
+		}
+		return nil, fmt.Errorf("%s memory backend is temporarily unavailable: %w", b.primary.Name(), lastErr)
+	}
+
+	results, err := b.primary.Search(ctx, query, topK, expand)
+	if err == nil {
+		b.recordSuccess()
+		return results, nil
+	}
+
+	b.recordFailure(err)
+	if b.fallback == nil {
+		return nil, fmt.Errorf("%s memory backend unavailable: %w", b.primary.Name(), err)
+	}
+
+	fallbackResults, fallbackErr := b.fallback.Search(ctx, query, topK, expand)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("%s memory backend unavailable (%v); %s fallback failed: %w", b.primary.Name(), err, b.fallback.Name(), fallbackErr)
+	}
+	return fallbackResults, nil
+}
+
+// LastError returns the last primary backend error recorded by the fallback.
+func (b *FallbackBackend) LastError() string {
+	if b == nil {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.lastErr == nil {
+		return ""
+	}
+	return b.lastErr.Error()
+}
+
+func (b *FallbackBackend) isDisabled() (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.lastErr == nil || b.now().After(b.disabledUntil) {
+		return false, nil
+	}
+	return true, b.lastErr
+}
+
+func (b *FallbackBackend) recordSuccess() {
+	b.mu.Lock()
+	b.lastErr = nil
+	b.disabledUntil = time.Time{}
+	b.mu.Unlock()
+}
+
+func (b *FallbackBackend) recordFailure(err error) {
+	b.mu.Lock()
+	b.lastErr = err
+	b.disabledUntil = b.now().Add(b.cooldown)
+	b.mu.Unlock()
+}

--- a/internal/memory/backend_test.go
+++ b/internal/memory/backend_test.go
@@ -1,0 +1,81 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestFallbackBackendFallsBackAndSuppressesRetries(t *testing.T) {
+	t.Parallel()
+
+	primary := &stubBackend{name: "qmd", err: fmt.Errorf("qmd unavailable")}
+	fallback := &stubBackend{name: "builtin", results: []MemoryResult{{Source: "MEMORY.md", Content: "fallback"}}}
+	backend := NewFallbackBackend(primary, fallback, time.Minute)
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	backend.now = func() time.Time { return now }
+
+	results, err := backend.Search(context.Background(), "query", 5, false)
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(results) != 1 || results[0].Content != "fallback" {
+		t.Fatalf("unexpected fallback results: %+v", results)
+	}
+	if primary.calls != 1 {
+		t.Fatalf("primary calls=%d, want 1", primary.calls)
+	}
+
+	_, err = backend.Search(context.Background(), "query", 5, false)
+	if err != nil {
+		t.Fatalf("second Search returned error: %v", err)
+	}
+	if primary.calls != 1 {
+		t.Fatalf("primary retried during cooldown; calls=%d", primary.calls)
+	}
+
+	now = now.Add(time.Minute + time.Second)
+	_, err = backend.Search(context.Background(), "query", 5, false)
+	if err != nil {
+		t.Fatalf("third Search returned error: %v", err)
+	}
+	if primary.calls != 2 {
+		t.Fatalf("primary calls after cooldown=%d, want 2", primary.calls)
+	}
+}
+
+func TestMemoryManagerUsesConfiguredBackend(t *testing.T) {
+	t.Parallel()
+
+	backend := &stubBackend{name: "qmd", results: []MemoryResult{{Source: "MEMORY.md", Content: "qmd result"}}}
+	manager := NewMemoryManager(nil, nil, WithBackend(backend))
+
+	results, err := manager.Search(context.Background(), "query", 5)
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("backend calls=%d, want 1", backend.calls)
+	}
+	if len(results) != 1 || results[0].Content != "qmd result" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+type stubBackend struct {
+	name    string
+	results []MemoryResult
+	err     error
+	calls   int
+}
+
+func (s *stubBackend) Name() string { return s.name }
+
+func (s *stubBackend) Search(_ context.Context, _ string, _ int, _ bool) ([]MemoryResult, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.results, nil
+}

--- a/internal/memory/manager.go
+++ b/internal/memory/manager.go
@@ -3,7 +3,6 @@ package memory
 import (
 	"context"
 	"fmt"
-	"strings"
 )
 
 // EmbeddingQueryClient produces one embedding for a search query.
@@ -21,6 +20,7 @@ type MetadataExtractor interface {
 type MemoryManager struct {
 	client    EmbeddingQueryClient
 	store     *MemoryStore
+	backend   Backend
 	extractor MetadataExtractor
 }
 
@@ -34,12 +34,20 @@ func WithMetadataExtractor(extractor MetadataExtractor) MemoryManagerOption {
 	}
 }
 
+// WithBackend overrides the built-in SQLite backend used by the manager.
+func WithBackend(backend Backend) MemoryManagerOption {
+	return func(m *MemoryManager) {
+		m.backend = backend
+	}
+}
+
 // NewMemoryManager creates a new memory manager.
 func NewMemoryManager(client EmbeddingQueryClient, store *MemoryStore, opts ...MemoryManagerOption) *MemoryManager {
 	manager := &MemoryManager{
 		client: client,
 		store:  store,
 	}
+	manager.backend = NewBuiltinBackend(client, store)
 	for _, opt := range opts {
 		if opt != nil {
 			opt(manager)
@@ -68,83 +76,20 @@ func (m *MemoryManager) Embedder() EmbeddingQueryClient {
 
 // Search searches indexed markdown chunks with hybrid lexical and semantic ranking.
 func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
-	if m == nil || m.store == nil {
+	if m == nil || m.backend == nil {
 		return nil, fmt.Errorf("memory manager is not configured")
 	}
-	query = strings.TrimSpace(query)
-	if query == "" {
-		return nil, fmt.Errorf("memory search query is empty")
-	}
-
-	var queryEmbedding []float32
-	if m.client != nil {
-		if embedding, err := m.client.GetEmbedding(ctx, query); err == nil {
-			queryEmbedding = embedding
-		}
-	}
-
-	results, err := m.store.SearchHybrid(ctx, query, queryEmbedding, topK)
-	if err != nil {
-		return nil, fmt.Errorf("failed to search memory chunks: %w", err)
-	}
-
-	return results, nil
+	return m.backend.Search(ctx, query, topK, false)
 }
 
 // SearchExpanded searches for matching chunks, then expands each result to
 // include all chunks from the same branch (source_file + header_path).
 // This gives full section context without replaying the entire history.
 func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK int) ([]MemoryResult, error) {
-	if m == nil || m.store == nil {
+	if m == nil || m.backend == nil {
 		return nil, fmt.Errorf("memory manager is not configured")
 	}
-
-	hits, err := m.Search(ctx, query, topK)
-	if err != nil {
-		return nil, err
-	}
-	if len(hits) == 0 {
-		return nil, nil
-	}
-
-	type branch struct{ file, header string }
-	var branches []branch
-	seen := make(map[branch]bool)
-	bestScores := make(map[branch]float32)
-
-	for _, h := range hits {
-		b := branch{h.SourceFile, h.HeaderPath}
-		if h.Similarity > bestScores[b] {
-			bestScores[b] = h.Similarity
-		}
-		if !seen[b] {
-			seen[b] = true
-			branches = append(branches, b)
-		}
-	}
-
-	expanded := make([]MemoryResult, 0, len(branches))
-	for _, b := range branches {
-		chunks, err := m.store.GetBranchChunks(ctx, b.file, b.header)
-		if err != nil || len(chunks) == 0 {
-			continue
-		}
-
-		texts := make([]string, len(chunks))
-		for i, c := range chunks {
-			texts[i] = c.Content
-		}
-
-		expanded = append(expanded, MemoryResult{
-			Source:     b.file,
-			SourceFile: b.file,
-			HeaderPath: b.header,
-			Content:    strings.Join(texts, "\n\n"),
-			Similarity: bestScores[b],
-		})
-	}
-
-	return expanded, nil
+	return m.backend.Search(ctx, query, topK, true)
 }
 
 // Recall is kept as a compatibility alias for existing callers.

--- a/internal/memory/qmd.go
+++ b/internal/memory/qmd.go
@@ -1,0 +1,713 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const (
+	DefaultQMDBinaryPath = "qmd"
+	DefaultQMDIndex      = "index"
+	DefaultQMDSearchMode = "search"
+	DefaultQMDTimeout    = 10 * time.Second
+)
+
+var qmdHunkLineRegexp = regexp.MustCompile(`@@\s+-(\d+)(?:,(\d+))?`)
+
+// QMDConfig configures the optional read-only QMD CLI backend.
+type QMDConfig struct {
+	BinaryPath  string
+	Index       string
+	IndexPath   string
+	SearchMode  string
+	Timeout     time.Duration
+	Collections QMDCollections
+}
+
+// QMDCollections maps ok-gobot memory roles to pre-existing QMD collection names.
+// ok-gobot does not add/update/remove QMD collections in v1.
+type QMDCollections struct {
+	Workspace          string
+	DailyNotes         string
+	SessionTranscripts string
+	ExtraPaths         []string
+}
+
+// QMDBackend searches a pre-existing QMD index through the qmd CLI.
+type QMDBackend struct {
+	cfg QMDConfig
+
+	mu      sync.Mutex
+	lastErr error
+}
+
+// QMDCollectionStatus describes one QMD collection for deep diagnostics.
+type QMDCollectionStatus struct {
+	Role        string
+	Name        string
+	Path        string
+	Pattern     string
+	Present     bool
+	Documents   int
+	LastUpdated string
+}
+
+// QMDDiagnostics describes read-only QMD backend health.
+type QMDDiagnostics struct {
+	Configured      bool
+	BinaryPath      string
+	BinaryFound     bool
+	Version         string
+	IndexName       string
+	IndexPath       string
+	IndexExists     bool
+	SearchMode      string
+	Collections     []QMDCollectionStatus
+	TotalDocuments  int
+	NeedsEmbedding  int
+	HasVectorIndex  bool
+	EmbeddingReady  bool
+	UpdateState     string
+	LastError       string
+	StableContract  string
+	ModelSafeStatus string
+}
+
+type qmdSearchResult struct {
+	DocID     string          `json:"docid"`
+	Score     json.RawMessage `json:"score"`
+	File      string          `json:"file"`
+	Path      string          `json:"path"`
+	Title     string          `json:"title"`
+	Context   string          `json:"context"`
+	Body      string          `json:"body"`
+	Content   string          `json:"content"`
+	Text      string          `json:"text"`
+	Snippet   string          `json:"snippet"`
+	Line      int             `json:"line"`
+	StartLine int             `json:"start_line"`
+	EndLine   int             `json:"end_line"`
+}
+
+// NewQMDBackend creates a QMD CLI memory backend.
+func NewQMDBackend(cfg QMDConfig) *QMDBackend {
+	return &QMDBackend{cfg: normalizeQMDConfig(cfg)}
+}
+
+func (b *QMDBackend) Name() string {
+	return "qmd"
+}
+
+func (b *QMDBackend) Search(ctx context.Context, query string, topK int, expand bool) ([]MemoryResult, error) {
+	if b == nil {
+		return nil, fmt.Errorf("qmd backend is not configured")
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, fmt.Errorf("qmd query is empty")
+	}
+	if topK <= 0 {
+		topK = DefaultSearchTopK
+	}
+
+	args := b.searchArgs(query, topK, expand)
+	out, err := b.run(ctx, args...)
+	if err != nil {
+		b.setLastError(err)
+		return nil, err
+	}
+
+	rows, err := parseQMDSearchOutput(out)
+	if err != nil {
+		err = fmt.Errorf("parse qmd json output: %w", err)
+		b.setLastError(err)
+		return nil, err
+	}
+
+	results := make([]MemoryResult, 0, len(rows))
+	for i, row := range rows {
+		results = append(results, b.convertResult(row, int64(i+1)))
+	}
+	b.setLastError(nil)
+	return results, nil
+}
+
+// Diagnostics returns read-only QMD health information. It intentionally avoids
+// `qmd status` because QMD 2.1.0 status may initialize local model tooling.
+func (b *QMDBackend) Diagnostics(ctx context.Context) QMDDiagnostics {
+	if b == nil {
+		return QMDDiagnostics{Configured: false}
+	}
+	cfg := normalizeQMDConfig(b.cfg)
+	d := QMDDiagnostics{
+		Configured:      true,
+		BinaryPath:      cfg.BinaryPath,
+		IndexName:       cfg.Index,
+		IndexPath:       inferQMDIndexPath(cfg),
+		SearchMode:      cfg.SearchMode,
+		StableContract:  "qmd --version; qmd search|vsearch|query --json -n N [-c collection]",
+		ModelSafeStatus: "uses qmd --version plus SQLite metadata; does not run qmd status",
+		LastError:       b.LastError(),
+	}
+
+	if _, err := exec.LookPath(cfg.BinaryPath); err != nil {
+		d.LastError = fmt.Sprintf("qmd binary not found: %v", err)
+		d.UpdateState = "qmd unavailable"
+		return d
+	}
+	d.BinaryFound = true
+	if version, err := b.run(ctx, "--version"); err == nil {
+		d.Version = strings.TrimSpace(string(version))
+	} else if d.LastError == "" {
+		d.LastError = err.Error()
+	}
+
+	if _, err := os.Stat(d.IndexPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			d.UpdateState = "index missing"
+		} else {
+			d.UpdateState = "index unavailable"
+			d.LastError = err.Error()
+		}
+		return d
+	}
+	d.IndexExists = true
+
+	if err := loadQMDIndexDiagnostics(&d, cfg.Collections); err != nil {
+		d.UpdateState = "index unreadable"
+		if d.LastError == "" {
+			d.LastError = err.Error()
+		}
+		return d
+	}
+
+	if d.TotalDocuments == 0 {
+		d.UpdateState = "empty index"
+	} else if d.NeedsEmbedding > 0 {
+		d.UpdateState = "pending embeddings"
+	} else {
+		d.UpdateState = "ready"
+	}
+	d.EmbeddingReady = d.HasVectorIndex && d.TotalDocuments > 0 && d.NeedsEmbedding == 0
+	return d
+}
+
+// LastError returns the last search error observed by the QMD backend.
+func (b *QMDBackend) LastError() string {
+	if b == nil {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.lastErr == nil {
+		return ""
+	}
+	return b.lastErr.Error()
+}
+
+func (b *QMDBackend) setLastError(err error) {
+	b.mu.Lock()
+	b.lastErr = err
+	b.mu.Unlock()
+}
+
+func (b *QMDBackend) searchArgs(query string, topK int, expand bool) []string {
+	mode := b.cfg.SearchMode
+	if mode == "" {
+		mode = DefaultQMDSearchMode
+	}
+
+	args := make([]string, 0, 8+len(b.cfg.Collections.Names())*2)
+	if b.cfg.Index != "" {
+		args = append(args, "--index", b.cfg.Index)
+	}
+	args = append(args, mode, query, "--json", "-n", strconv.Itoa(topK))
+	if expand {
+		args = append(args, "--full")
+	}
+	for _, collection := range b.cfg.Collections.Names() {
+		args = append(args, "-c", collection)
+	}
+	return args
+}
+
+func (b *QMDBackend) run(ctx context.Context, args ...string) ([]byte, error) {
+	cfg := normalizeQMDConfig(b.cfg)
+	path, err := exec.LookPath(cfg.BinaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("qmd binary not found: %w", err)
+	}
+
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = DefaultQMDTimeout
+	}
+	runCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, path, args...)
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	if cfg.IndexPath != "" {
+		cmd.Env = append(cmd.Env, "INDEX_PATH="+expandUserPath(cfg.IndexPath))
+	}
+	out, err := cmd.CombinedOutput()
+	if runCtx.Err() != nil {
+		return nil, fmt.Errorf("qmd command timed out after %s", cfg.Timeout)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("qmd command failed: %w: %s", err, truncateForError(strings.TrimSpace(string(out)), 1200))
+	}
+	return out, nil
+}
+
+func (b *QMDBackend) convertResult(row qmdSearchResult, fallbackID int64) MemoryResult {
+	source := firstNonEmpty(row.File, row.Path)
+	sourceFile := b.sourceForQMDFile(source)
+	content := firstNonEmpty(row.Body, row.Content, row.Text, row.Snippet)
+	if row.Context != "" && content != "" && !strings.Contains(content, row.Context) {
+		content = "Context: " + row.Context + "\n\n" + content
+	}
+
+	startLine := row.StartLine
+	endLine := row.EndLine
+	if startLine == 0 && row.Line > 0 {
+		startLine = row.Line
+	}
+	if hunkStart, hunkEnd := parseQMDHunkLine(row.Snippet); hunkStart > 0 {
+		if startLine == 0 {
+			startLine = hunkStart
+		}
+		if endLine == 0 && startLine == hunkStart {
+			endLine = hunkEnd
+		}
+	}
+	if endLine == 0 && startLine > 0 {
+		endLine = startLine
+	}
+
+	return MemoryResult{
+		ID:           fallbackID,
+		Source:       sourceFile,
+		SourceFile:   sourceFile,
+		HeaderPath:   "",
+		StartLine:    startLine,
+		EndLine:      endLine,
+		ChunkOrdinal: startLine,
+		Content:      strings.TrimSpace(content),
+		ContentHash:  strings.TrimPrefix(row.DocID, "#"),
+		Similarity:   parseQMDScore(row.Score),
+	}
+}
+
+func (b *QMDBackend) sourceForQMDFile(file string) string {
+	collection, rel, ok := parseQMDURI(file)
+	if !ok {
+		return strings.TrimSpace(file)
+	}
+
+	role := b.cfg.Collections.Role(collection)
+	switch role {
+	case "workspace":
+		return rel
+	case "daily_notes":
+		return joinSlash("memory", rel)
+	case "session_transcripts":
+		return joinSlash("sessions", rel)
+	default:
+		return rel
+	}
+}
+
+func parseQMDSearchOutput(out []byte) ([]qmdSearchResult, error) {
+	jsonBytes, err := extractFirstJSON(out)
+	if err != nil {
+		return nil, err
+	}
+
+	var rows []qmdSearchResult
+	if err := json.Unmarshal(jsonBytes, &rows); err == nil {
+		return rows, nil
+	}
+
+	var wrapped struct {
+		Results []qmdSearchResult `json:"results"`
+	}
+	if err := json.Unmarshal(jsonBytes, &wrapped); err != nil {
+		return nil, err
+	}
+	return wrapped.Results, nil
+}
+
+func extractFirstJSON(out []byte) ([]byte, error) {
+	start := findLikelyJSONStart(out)
+	if start < 0 {
+		return nil, fmt.Errorf("no JSON object or array found")
+	}
+
+	inString := false
+	escaped := false
+	depth := 0
+	for i := start; i < len(out); i++ {
+		ch := out[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch ch {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch ch {
+		case '"':
+			inString = true
+		case '[', '{':
+			depth++
+		case ']', '}':
+			depth--
+			if depth == 0 {
+				return bytes.TrimSpace(out[start : i+1]), nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("unterminated JSON output")
+}
+
+func findLikelyJSONStart(out []byte) int {
+	for i, ch := range out {
+		switch ch {
+		case '{':
+			return i
+		case '[':
+			j := i + 1
+			for j < len(out) && (out[j] == ' ' || out[j] == '\n' || out[j] == '\r' || out[j] == '\t') {
+				j++
+			}
+			if j < len(out) && (out[j] == '{' || out[j] == ']') {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func parseQMDScore(raw json.RawMessage) float32 {
+	if len(raw) == 0 {
+		return 0
+	}
+	var f float64
+	if err := json.Unmarshal(raw, &f); err == nil {
+		return float32(f)
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		if parsed, err := strconv.ParseFloat(strings.TrimSuffix(s, "%"), 32); err == nil {
+			if strings.HasSuffix(s, "%") {
+				parsed = parsed / 100
+			}
+			return float32(parsed)
+		}
+	}
+	return 0
+}
+
+func parseQMDHunkLine(snippet string) (int, int) {
+	matches := qmdHunkLineRegexp.FindStringSubmatch(snippet)
+	if len(matches) == 0 {
+		return 0, 0
+	}
+	start, _ := strconv.Atoi(matches[1])
+	count := 1
+	if len(matches) > 2 && matches[2] != "" {
+		count, _ = strconv.Atoi(matches[2])
+	}
+	if count <= 0 {
+		count = 1
+	}
+	return start, start + count - 1
+}
+
+func loadQMDIndexDiagnostics(d *QMDDiagnostics, collections QMDCollections) error {
+	db, err := sql.Open("sqlite3", sqliteReadOnlyDSN(d.IndexPath))
+	if err != nil {
+		return fmt.Errorf("open qmd index: %w", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	if exists, err := qmdTableExists(db, "store_collections"); err != nil || !exists {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("qmd store_collections table not found")
+	}
+	if exists, err := qmdTableExists(db, "documents"); err != nil || !exists {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("qmd documents table not found")
+	}
+
+	rows, err := db.Query(`
+		SELECT name, path, pattern
+		FROM store_collections
+		ORDER BY name
+	`)
+	if err != nil {
+		return fmt.Errorf("query qmd collections: %w", err)
+	}
+	defer rows.Close()
+
+	configured := collections.RoleMap()
+	present := make(map[string]bool)
+	for rows.Next() {
+		var name, path, pattern string
+		if err := rows.Scan(&name, &path, &pattern); err != nil {
+			return fmt.Errorf("scan qmd collection: %w", err)
+		}
+		present[name] = true
+		status := QMDCollectionStatus{
+			Role:    configured[name],
+			Name:    name,
+			Path:    path,
+			Pattern: pattern,
+			Present: true,
+		}
+		if status.Role == "" {
+			status.Role = "default"
+		}
+		_ = db.QueryRow(`SELECT COUNT(*) FROM documents WHERE active = 1 AND collection = ?`, name).Scan(&status.Documents)
+		_ = db.QueryRow(`SELECT COALESCE(MAX(modified_at), '') FROM documents WHERE active = 1 AND collection = ?`, name).Scan(&status.LastUpdated)
+		d.Collections = append(d.Collections, status)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read qmd collections: %w", err)
+	}
+
+	for name, role := range configured {
+		if name == "" || present[name] {
+			continue
+		}
+		d.Collections = append(d.Collections, QMDCollectionStatus{Role: role, Name: name, Present: false})
+	}
+	sort.SliceStable(d.Collections, func(i, j int) bool {
+		if d.Collections[i].Role == d.Collections[j].Role {
+			return d.Collections[i].Name < d.Collections[j].Name
+		}
+		return d.Collections[i].Role < d.Collections[j].Role
+	})
+
+	if err := db.QueryRow(`SELECT COUNT(*) FROM documents WHERE active = 1`).Scan(&d.TotalDocuments); err != nil {
+		return fmt.Errorf("count qmd documents: %w", err)
+	}
+	d.NeedsEmbedding = 0
+	if exists, err := qmdTableExists(db, "content_vectors"); err != nil {
+		return err
+	} else if exists {
+		if err := db.QueryRow(`
+			SELECT COUNT(DISTINCT d.hash)
+			FROM documents d
+			LEFT JOIN content_vectors v ON d.hash = v.hash AND v.seq = 0
+			WHERE d.active = 1 AND v.hash IS NULL
+		`).Scan(&d.NeedsEmbedding); err != nil {
+			return fmt.Errorf("count qmd pending embeddings: %w", err)
+		}
+	} else {
+		d.NeedsEmbedding = d.TotalDocuments
+	}
+	d.HasVectorIndex, err = qmdTableExists(db, "vectors_vec")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func sqliteReadOnlyDSN(path string) string {
+	absPath, err := filepath.Abs(path)
+	if err == nil {
+		path = absPath
+	}
+	return (&url.URL{Scheme: "file", Path: path, RawQuery: "mode=ro"}).String()
+}
+
+func qmdTableExists(db *sql.DB, name string) (bool, error) {
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, name).Scan(&count); err != nil {
+		return false, fmt.Errorf("inspect qmd table %s: %w", name, err)
+	}
+	return count > 0, nil
+}
+
+func normalizeQMDConfig(cfg QMDConfig) QMDConfig {
+	cfg.BinaryPath = strings.TrimSpace(cfg.BinaryPath)
+	if cfg.BinaryPath == "" {
+		cfg.BinaryPath = DefaultQMDBinaryPath
+	}
+	cfg.Index = strings.TrimSpace(cfg.Index)
+	if cfg.Index == "" {
+		cfg.Index = DefaultQMDIndex
+	}
+	cfg.IndexPath = strings.TrimSpace(cfg.IndexPath)
+	cfg.SearchMode = strings.ToLower(strings.TrimSpace(cfg.SearchMode))
+	if cfg.SearchMode == "" {
+		cfg.SearchMode = DefaultQMDSearchMode
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = DefaultQMDTimeout
+	}
+	cfg.Collections = cfg.Collections.Normalized()
+	return cfg
+}
+
+// Names returns configured collection names without duplicates.
+func (c QMDCollections) Names() []string {
+	c = c.Normalized()
+	seen := make(map[string]bool)
+	var names []string
+	for _, name := range []string{c.Workspace, c.DailyNotes, c.SessionTranscripts} {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	for _, name := range c.ExtraPaths {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// Role returns the ok-gobot role for a QMD collection name.
+func (c QMDCollections) Role(name string) string {
+	return c.RoleMap()[name]
+}
+
+// RoleMap returns configured collection name to role mappings.
+func (c QMDCollections) RoleMap() map[string]string {
+	c = c.Normalized()
+	out := make(map[string]string)
+	if c.Workspace != "" {
+		out[c.Workspace] = "workspace"
+	}
+	if c.DailyNotes != "" {
+		out[c.DailyNotes] = "daily_notes"
+	}
+	if c.SessionTranscripts != "" {
+		out[c.SessionTranscripts] = "session_transcripts"
+	}
+	for _, name := range c.ExtraPaths {
+		if name != "" {
+			out[name] = "extra_paths"
+		}
+	}
+	return out
+}
+
+// Normalized trims collection names.
+func (c QMDCollections) Normalized() QMDCollections {
+	c.Workspace = strings.TrimSpace(c.Workspace)
+	c.DailyNotes = strings.TrimSpace(c.DailyNotes)
+	c.SessionTranscripts = strings.TrimSpace(c.SessionTranscripts)
+	cleaned := make([]string, 0, len(c.ExtraPaths))
+	for _, name := range c.ExtraPaths {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			cleaned = append(cleaned, name)
+		}
+	}
+	c.ExtraPaths = cleaned
+	return c
+}
+
+func inferQMDIndexPath(cfg QMDConfig) string {
+	if cfg.IndexPath != "" {
+		return expandUserPath(cfg.IndexPath)
+	}
+	if envPath := strings.TrimSpace(os.Getenv("INDEX_PATH")); envPath != "" {
+		return expandUserPath(envPath)
+	}
+	cacheDir := strings.TrimSpace(os.Getenv("XDG_CACHE_HOME"))
+	if cacheDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			home = "."
+		}
+		cacheDir = filepath.Join(home, ".cache")
+	}
+	index := strings.TrimSpace(cfg.Index)
+	if index == "" {
+		index = DefaultQMDIndex
+	}
+	return filepath.Join(expandUserPath(cacheDir), "qmd", index+".sqlite")
+}
+
+func parseQMDURI(file string) (string, string, bool) {
+	file = strings.TrimSpace(file)
+	if !strings.HasPrefix(file, "qmd://") {
+		return "", "", false
+	}
+	path := strings.TrimPrefix(file, "qmd://")
+	path = strings.TrimLeft(path, "/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], filepath.ToSlash(filepath.Clean(parts[1])), true
+}
+
+func joinSlash(prefix, rel string) string {
+	rel = strings.Trim(strings.TrimSpace(rel), "/")
+	if rel == "" || rel == "." {
+		return prefix
+	}
+	return prefix + "/" + filepath.ToSlash(rel)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func expandUserPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+func truncateForError(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/internal/memory/qmd_test.go
+++ b/internal/memory/qmd_test.go
@@ -1,0 +1,233 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestQMDBackendMissingBinary(t *testing.T) {
+	t.Parallel()
+
+	backend := NewQMDBackend(QMDConfig{
+		BinaryPath: "definitely-missing-qmd-binary",
+		Timeout:    time.Second,
+	})
+
+	_, err := backend.Search(context.Background(), "query", 5, false)
+	if err == nil || !strings.Contains(err.Error(), "qmd binary not found") {
+		t.Fatalf("expected missing binary error, got %v", err)
+	}
+
+	d := backend.Diagnostics(context.Background())
+	if d.BinaryFound {
+		t.Fatalf("expected BinaryFound=false")
+	}
+	if !strings.Contains(d.LastError, "qmd binary not found") {
+		t.Fatalf("expected diagnostics last error, got %q", d.LastError)
+	}
+}
+
+func TestQMDBackendMalformedOutput(t *testing.T) {
+	t.Parallel()
+
+	bin := writeQMDTestBinary(t, `#!/bin/sh
+printf 'not json\n'
+`)
+	backend := NewQMDBackend(QMDConfig{BinaryPath: bin, Timeout: time.Second})
+
+	_, err := backend.Search(context.Background(), "query", 5, false)
+	if err == nil || !strings.Contains(err.Error(), "parse qmd json output") {
+		t.Fatalf("expected malformed output error, got %v", err)
+	}
+}
+
+func TestQMDBackendSourceFormatting(t *testing.T) {
+	t.Parallel()
+
+	bin := writeQMDTestBinary(t, `#!/bin/sh
+printf '%s\n' '[{"docid":"#abc123","score":0.91,"file":"qmd://workspace/MEMORY.md","title":"Memory","snippet":"@@ -7,2 @@\nworkspace hit","line":7},{"docid":"#def456","score":"50%","file":"qmd://daily/2026-04-29.md","title":"Daily","snippet":"daily hit"},{"docid":"#ghi789","score":0.4,"file":"qmd://sessions/dm-1.md","title":"Transcript","body":"session hit"}]'
+`)
+	backend := NewQMDBackend(QMDConfig{
+		BinaryPath: bin,
+		Timeout:    time.Second,
+		Collections: QMDCollections{
+			Workspace:          "workspace",
+			DailyNotes:         "daily",
+			SessionTranscripts: "sessions",
+		},
+	})
+
+	results, err := backend.Search(context.Background(), "query", 3, false)
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results)=%d, want 3", len(results))
+	}
+
+	if results[0].Source != "MEMORY.md" || results[0].SourceFile != "MEMORY.md" {
+		t.Fatalf("workspace source=%q source_file=%q", results[0].Source, results[0].SourceFile)
+	}
+	if results[0].StartLine != 7 || results[0].EndLine != 8 {
+		t.Fatalf("workspace lines=%d-%d, want 7-8", results[0].StartLine, results[0].EndLine)
+	}
+	if results[1].Source != "memory/2026-04-29.md" {
+		t.Fatalf("daily source=%q", results[1].Source)
+	}
+	if results[1].Similarity != 0.5 {
+		t.Fatalf("daily similarity=%v, want 0.5", results[1].Similarity)
+	}
+	if results[2].Source != "sessions/dm-1.md" {
+		t.Fatalf("session source=%q", results[2].Source)
+	}
+}
+
+func TestQMDBackendParsesWrappedResultsWithNoise(t *testing.T) {
+	t.Parallel()
+
+	bin := writeQMDTestBinary(t, `#!/bin/sh
+printf '%s\n' '[node-llama-cpp] warning before json'
+printf '%s\n' '{"results":[{"docid":"#abc123","score":0.7,"file":"qmd://workspace/MEMORY.md","snippet":"hit"}]}'
+printf '%s\n' 'trailing notice'
+`)
+	backend := NewQMDBackend(QMDConfig{
+		BinaryPath:  bin,
+		Timeout:     time.Second,
+		Collections: QMDCollections{Workspace: "workspace"},
+	})
+
+	results, err := backend.Search(context.Background(), "query", 1, false)
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(results) != 1 || results[0].Source != "MEMORY.md" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestQMDBackendPassesConfiguredCollections(t *testing.T) {
+	t.Parallel()
+
+	argsPath := filepath.Join(t.TempDir(), "args.txt")
+	bin := writeQMDTestBinary(t, `#!/bin/sh
+printf '%s\n' "$@" > "`+argsPath+`"
+printf '%s\n' '[]'
+`)
+	backend := NewQMDBackend(QMDConfig{
+		BinaryPath: bin,
+		Index:      "work",
+		SearchMode: "query",
+		Timeout:    time.Second,
+		Collections: QMDCollections{
+			Workspace:          "workspace",
+			DailyNotes:         "daily",
+			SessionTranscripts: "sessions",
+			ExtraPaths:         []string{"docs", "notes"},
+		},
+	})
+
+	if _, err := backend.Search(context.Background(), "release plan", 7, true); err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	argsBytes, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(argsBytes)), "\n")
+	want := []string{"--index", "work", "query", "release plan", "--json", "-n", "7", "--full", "-c", "workspace", "-c", "daily", "-c", "sessions", "-c", "docs", "-c", "notes"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("args=%q, want %q", args, want)
+	}
+}
+
+func TestQMDBackendDiagnosticsReadsIndexMetadata(t *testing.T) {
+	t.Parallel()
+
+	bin := writeQMDTestBinary(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf '%s\n' 'qmd 2.1.0'
+  exit 0
+fi
+printf '%s\n' '[]'
+`)
+	dbPath := filepath.Join(t.TempDir(), "qmd.sqlite")
+	seedQMDTestIndex(t, dbPath)
+
+	backend := NewQMDBackend(QMDConfig{
+		BinaryPath: bin,
+		IndexPath:  dbPath,
+		Timeout:    time.Second,
+		Collections: QMDCollections{
+			Workspace:  "workspace",
+			DailyNotes: "daily",
+			ExtraPaths: []string{"missing-extra"},
+		},
+	})
+
+	d := backend.Diagnostics(context.Background())
+	if !d.BinaryFound || d.Version != "qmd 2.1.0" {
+		t.Fatalf("unexpected binary diagnostics: %+v", d)
+	}
+	if !d.IndexExists || d.TotalDocuments != 2 || d.NeedsEmbedding != 1 || !d.HasVectorIndex {
+		t.Fatalf("unexpected index diagnostics: %+v", d)
+	}
+	if d.EmbeddingReady {
+		t.Fatalf("expected embedding readiness false while one document is pending")
+	}
+	if d.UpdateState != "pending embeddings" {
+		t.Fatalf("UpdateState=%q, want pending embeddings", d.UpdateState)
+	}
+	if !hasQMDCollectionStatus(d.Collections, "workspace", true, "workspace") {
+		t.Fatalf("missing workspace collection status: %+v", d.Collections)
+	}
+	if !hasQMDCollectionStatus(d.Collections, "missing-extra", false, "extra_paths") {
+		t.Fatalf("missing absent extra collection status: %+v", d.Collections)
+	}
+}
+
+func writeQMDTestBinary(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "qmd")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake qmd: %v", err)
+	}
+	return path
+}
+
+func seedQMDTestIndex(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	statements := []string{
+		`CREATE TABLE store_collections (name TEXT PRIMARY KEY, path TEXT NOT NULL, pattern TEXT NOT NULL DEFAULT '**/*.md')`,
+		`CREATE TABLE documents (id INTEGER PRIMARY KEY AUTOINCREMENT, collection TEXT NOT NULL, path TEXT NOT NULL, title TEXT NOT NULL, hash TEXT NOT NULL, modified_at TEXT NOT NULL, active INTEGER NOT NULL DEFAULT 1)`,
+		`CREATE TABLE content_vectors (hash TEXT NOT NULL, seq INTEGER NOT NULL DEFAULT 0, pos INTEGER NOT NULL DEFAULT 0, model TEXT NOT NULL, embedded_at TEXT NOT NULL, PRIMARY KEY (hash, seq))`,
+		`CREATE TABLE vectors_vec (id TEXT PRIMARY KEY)`,
+		`INSERT INTO store_collections (name, path, pattern) VALUES ('workspace', '/tmp/workspace', '**/*.md'), ('daily', '/tmp/workspace/memory', '**/*.md')`,
+		`INSERT INTO documents (collection, path, title, hash, modified_at, active) VALUES ('workspace', 'MEMORY.md', 'Memory', 'hash1', '2026-04-29T00:00:00Z', 1), ('daily', '2026-04-29.md', 'Daily', 'hash2', '2026-04-29T00:00:00Z', 1)`,
+		`INSERT INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES ('hash1', 0, 0, 'test-model', '2026-04-29T00:00:00Z')`,
+	}
+	for _, stmt := range statements {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+}
+
+func hasQMDCollectionStatus(collections []QMDCollectionStatus, name string, present bool, role string) bool {
+	for _, col := range collections {
+		if col.Name == name && col.Present == present && col.Role == role {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add a configurable memory backend abstraction with built-in and optional QMD-backed retrieval.
- Integrate read-only QMD CLI search with fallback cooldown to the built-in memory backend.
- Document QMD setup and add deep memory diagnostics for backend health and index state.

## Verification
- go fmt ./...
- go vet ./...
- go test ./...
- go build ./cmd/ok-gobot/
- .maestro/verify.sh

Closes #311

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional QMD CLI backend for memory search, with a `FallbackBackend` that suppresses retries after QMD failures and falls through to the existing built-in SQLite backend. The existing `Search`/`SearchExpanded` logic is cleanly extracted into `BuiltinBackend`, config/validation coverage is solid, and the `--deep` diagnostics path avoids triggering QMD model setup by reading SQLite metadata directly.

<h3>Confidence Score: 4/5</h3>

Safe to merge; findings are non-blocking quality improvements to diagnostics accuracy and variable naming.

No P0 or P1 findings. Two P2 issues: a stale LastError() value after cooldown expiry (misleading diagnostics, no behavioral impact) and a receiver variable shadow inside BuiltinBackend.Search (currently harmless but fragile). Core fallback logic, locking, config validation, and test coverage are all sound.

internal/memory/backend.go — both P2 findings live here.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/memory/backend.go | New Backend interface + BuiltinBackend (extracted from manager) + FallbackBackend with cooldown-based retry suppression. Two P2 findings: stale LastError after cooldown expiry, and receiver variable shadowing. |
| internal/memory/qmd.go | New QMD CLI backend: exec-based search, SQLite diagnostics, URI path mapping, and score parsing. Well-structured with good nil-safety and timeout handling. |
| internal/memory/manager.go | Simplified to delegate Search/SearchExpanded to the selected Backend; adds WithBackend option and built-in default. |
| internal/app/app.go | Wires QMD backend + FallbackBackend when backend is "qmd" or "auto"; adds parseDurationOrDefault and appQMDConfig helpers. |
| internal/cli/memory.go | Adds --deep flag to memory status command with QMD/built-in diagnostics printing; refactors extra-paths display. |
| internal/config/config.go | Adds MemoryQMDConfig and MemoryQMDCollectionsConfig structs, new Viper defaults, and Validate checks for backend and search_mode values. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/memory/backend.go`, line 892-896 ([link](https://github.com/befeast/ok-gobot/blob/eae2c009c936645c70fd7bdb777f9e0d2c64fe57/internal/memory/backend.go#L892-L896)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale `LastError()` after cooldown expiry**

   After the cooldown window expires, `isDisabled()` returns `false` (correctly re-enabling the primary backend), but `b.lastErr` is never cleared here. Until the next call actually *succeeds* and triggers `recordSuccess()`, `FallbackBackend.LastError()` continues to report the old error even though the backend has effectively been re-enabled. This is a misleading diagnostic signal: an operator checking `LastError()` immediately after a successful re-enable attempt could still see the previous failure if the success and the diagnostic read are racing.

   Consider clearing `lastErr` inside `isDisabled()` once the window has passed, so the "disabled" state is atomically reset:

   ```go
   func (b *FallbackBackend) isDisabled() (bool, error) {
       b.mu.Lock()
       defer b.mu.Unlock()
       if b.lastErr == nil {
           return false, nil
       }
       if b.now().After(b.disabledUntil) {
           // Cooldown expired — reset so LastError() no longer reports stale error.
           b.lastErr = nil
           b.disabledUntil = time.Time{}
           return false, nil
       }
       return true, b.lastErr
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/memory/backend.go
   Line: 892-896

   Comment:
   **Stale `LastError()` after cooldown expiry**

   After the cooldown window expires, `isDisabled()` returns `false` (correctly re-enabling the primary backend), but `b.lastErr` is never cleared here. Until the next call actually *succeeds* and triggers `recordSuccess()`, `FallbackBackend.LastError()` continues to report the old error even though the backend has effectively been re-enabled. This is a misleading diagnostic signal: an operator checking `LastError()` immediately after a successful re-enable attempt could still see the previous failure if the success and the diagnostic read are racing.

   Consider clearing `lastErr` inside `isDisabled()` once the window has passed, so the "disabled" state is atomically reset:

   ```go
   func (b *FallbackBackend) isDisabled() (bool, error) {
       b.mu.Lock()
       defer b.mu.Unlock()
       if b.lastErr == nil {
           return false, nil
       }
       if b.now().After(b.disabledUntil) {
           // Cooldown expired — reset so LastError() no longer reports stale error.
           b.lastErr = nil
           b.disabledUntil = time.Time{}
           return false, nil
       }
       return true, b.lastErr
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/memory/backend.go`, line 776-784 ([link](https://github.com/befeast/ok-gobot/blob/eae2c009c936645c70fd7bdb777f9e0d2c64fe57/internal/memory/backend.go#L776-L784)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Receiver variable shadowed inside loop**

   `b` is the `*BuiltinBackend` receiver, but line 777 redeclares `b` as a local `branch` value with `:=`. This compiles correctly because the inner `b` is loop-scoped, but the shadowing means any accidental use of `b.client` or `b.store` inside that first for-body would silently compile against the wrong type. The second loop (line 787) uses `b.store` correctly because it is outside the shadowing scope, but the naming is fragile. Renaming the loop variable (e.g., `key := branch{...}`) removes the risk entirely.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/memory/backend.go
   Line: 776-784

   Comment:
   **Receiver variable shadowed inside loop**

   `b` is the `*BuiltinBackend` receiver, but line 777 redeclares `b` as a local `branch` value with `:=`. This compiles correctly because the inner `b` is loop-scoped, but the shadowing means any accidental use of `b.client` or `b.store` inside that first for-body would silently compile against the wrong type. The second loop (line 787) uses `b.store` correctly because it is outside the shadowing scope, but the naming is fragile. Renaming the loop variable (e.g., `key := branch{...}`) removes the risk entirely.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/memory/backend.go
Line: 892-896

Comment:
**Stale `LastError()` after cooldown expiry**

After the cooldown window expires, `isDisabled()` returns `false` (correctly re-enabling the primary backend), but `b.lastErr` is never cleared here. Until the next call actually *succeeds* and triggers `recordSuccess()`, `FallbackBackend.LastError()` continues to report the old error even though the backend has effectively been re-enabled. This is a misleading diagnostic signal: an operator checking `LastError()` immediately after a successful re-enable attempt could still see the previous failure if the success and the diagnostic read are racing.

Consider clearing `lastErr` inside `isDisabled()` once the window has passed, so the "disabled" state is atomically reset:

```go
func (b *FallbackBackend) isDisabled() (bool, error) {
    b.mu.Lock()
    defer b.mu.Unlock()
    if b.lastErr == nil {
        return false, nil
    }
    if b.now().After(b.disabledUntil) {
        // Cooldown expired — reset so LastError() no longer reports stale error.
        b.lastErr = nil
        b.disabledUntil = time.Time{}
        return false, nil
    }
    return true, b.lastErr
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/memory/backend.go
Line: 776-784

Comment:
**Receiver variable shadowed inside loop**

`b` is the `*BuiltinBackend` receiver, but line 777 redeclares `b` as a local `branch` value with `:=`. This compiles correctly because the inner `b` is loop-scoped, but the shadowing means any accidental use of `b.client` or `b.store` inside that first for-body would silently compile against the wrong type. The second loop (line 787) uses `b.store` correctly because it is outside the shadowing scope, but the naming is fragile. Renaming the loop variable (e.g., `key := branch{...}`) removes the risk entirely.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(memory): add optional QMD backend (..."](https://github.com/befeast/ok-gobot/commit/eae2c009c936645c70fd7bdb777f9e0d2c64fe57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30254863)</sub>

<!-- /greptile_comment -->