### PR TITLE
docs: align current-state docs (#290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ok-gobot
 
-A fast, single-binary Telegram bot and mission-control tool with AI agent capabilities. Ground-up Go rewrite of [OpenClaw](https://github.com/openclaw/openclaw) with opinionated defaults for personal use.
+A fast, single-binary Telegram-first AI agent and operator mission-control tool. Ground-up Go rewrite of [OpenClaw](https://github.com/openclaw/openclaw) with opinionated defaults for personal use.
 
 Competitive landscape: [docs/COMPETITORS.md](docs/COMPETITORS.md).
 
@@ -38,15 +38,17 @@ Use the `darwin` artifact for macOS. See [INSTALL.md](docs/INSTALL.md) for sourc
 git clone https://github.com/BeFeast/ok-gobot.git
 cd ok-gobot
 make build        # or: go build -o ok-gobot ./cmd/ok-gobot
+export PATH="$PWD/bin:$PATH"
 
 # 2. Initialize config
 ok-gobot config init
 
 # 3. Authenticate with your AI provider
-ok-gobot auth anthropic login     # Anthropic OAuth (Claude MAX)
-# or: ok-gobot auth chatgpt login # ChatGPT Plus OAuth
+ok-gobot config set ai.provider openrouter
+ok-gobot config set ai.api_key <OPENROUTER_KEY>
+# or: ok-gobot auth anthropic login
 # or: ok-gobot config set ai.provider openai
-#     ok-gobot config set ai.api_key <YOUR_KEY>
+#     ok-gobot config set ai.api_key <OPENAI_KEY>
 
 # 4. Set Telegram bot token
 ok-gobot config set telegram.token <TOKEN_FROM_BOTFATHER>
@@ -64,11 +66,13 @@ ok-gobot start
 
 | Provider | Auth | Config |
 |----------|------|--------|
-| Anthropic | OAuth (Claude MAX) | `ok-gobot auth anthropic login` |
-| ChatGPT | OAuth (Plus/Team) | `ok-gobot auth chatgpt login` |
+| OpenRouter | API key | `ai.provider: openrouter` (default) |
+| Anthropic | OAuth (Claude MAX) or API key | `ok-gobot auth anthropic login` or `ai.provider: anthropic` |
+| ChatGPT Codex | ChatGPT session JWT | `ai.provider: chatgpt` + `ai.api_key` |
 | OpenAI | API key | `ai.provider: openai` |
-| Hermes | Ollama / OpenAI-compatible | `ai.provider: custom` + hermes model |
-| Gemini | API key via custom | `ai.provider: custom` + `ai.base_url` |
+| Custom OpenAI-compatible | API key + base URL | `ai.provider: custom` + `ai.base_url` |
+| Hermes models | Ollama / OpenAI-compatible | `ai.provider: custom` + a Hermes model ID |
+| Gemini | API key via Google's OpenAI-compatible endpoint | `ai.provider: custom` + `ai.base_url` |
 | Droid | CLI agent transport | `ai.provider: droid` |
 
 Multi-model routing: tag messages with `[task:vision]`, `[task:coding]`, `[task:summarize]`, or `[task:reasoning]` to route to different models.
@@ -78,7 +82,7 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 ## Features
 
 ### AI & LLM
-- **Multi-provider** -- Anthropic, ChatGPT, OpenAI, Hermes, Gemini, Droid, any OpenAI-compatible endpoint
+- **Multi-provider** -- OpenRouter, Anthropic, ChatGPT Codex, OpenAI, Droid, and custom OpenAI-compatible endpoints including Gemini, Ollama/vLLM, and Hermes models
 - **Native tool calling** -- structured `tools` API, not text parsing
 - **Model failover** -- automatic fallback chain with cooldown (`ai.fallback_models`)
 - **Multi-model routing** -- task-type tags route to different models (`internal/ai/router.go`)
@@ -89,13 +93,13 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 - **CLI agent transport** -- use Factory Droid, Claude Code, Codex, Gemini CLI, or OpenCode as backends
 
 ### Roles & Jobs
-- **Prebuilt roles** -- `researcher`, `monitor`, `release-watch` ship as embedded markdown manifests
+- **Prebuilt role templates** -- `researcher`, `monitor`, `release-watch`, and `homelab-runbook` ship as embedded markdown manifests
 - **Custom roles** -- define new roles declaratively (markdown + YAML frontmatter, no Go code)
-- **Scheduled execution** -- roles run via cron and deliver bounded reports to admin chat
-- **Durable jobs** -- job history tracked in SQLite with standardized reports
+- **Scheduled execution** -- roles copied into `roles_path` can run via cron and deliver bounded reports to the admin chat
+- **Durable jobs** -- role, cron, background, and retry history tracked in SQLite with standardized reports and artifacts
 - **Rules-first chat routing** -- incoming turns classified as reply, clarify, or background job
 
-> **Note:** Scheduled autonomy is experimental. Full per-task budget caps are not yet implemented. Set conservative tool allowlists for scheduled roles.
+> **Note:** Scheduled autonomy is experimental. Tool-call and duration limits exist, but centralized token/cost budget enforcement and the full policy gateway are still roadmap work. Set conservative tool allowlists for scheduled roles.
 
 ### Skills & Evolution
 - **Markdown-first skills** -- installable knowledge bases with safety audit (`ok-gobot skills install`)
@@ -124,6 +128,8 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 | `memory_get` | Read markdown memory source by section path |
 | `message` | Send messages to other chats |
 | `cron` | Scheduled tasks |
+| `recommend_roles` | Suggest roles for a task |
+| `denial` | Policy decision logging |
 
 ### Security & Control
 - **Per-agent capability policy** -- declarative restrictions (shell, network, filesystem, cron, spawn) without source changes
@@ -149,8 +155,8 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 - **Debug logging** -- level-aware logging (`debug`/`info`/`warn`/`error`) with hot-reload
 
 ### Infrastructure
-- **Mission Control API** -- roles, schedules, runs, stats endpoints for dashboards
-- **HTTP REST API** -- health, status, send, webhook endpoints (port 8080)
+- **Mission Control API** -- profiles, schedules, runs, stats, estop, and provider/model endpoints for dashboards
+- **HTTP REST API** -- health, status, send, webhook, jobs, and Mission Control endpoints (port 8080)
 - **WebSocket control protocol** -- real-time session control, streaming, approvals (port 8787)
 - **Config hot-reload** -- fsnotify watcher + `/reload` command
 - **Daemon management** -- launchd (macOS) / systemd (Linux) via `ok-gobot daemon`
@@ -159,7 +165,7 @@ See [INSTALL.md](docs/INSTALL.md) for detailed provider setup.
 
 ## Telegram Commands
 
-All commands are auto-registered with BotFather for slash autocomplete.
+Core commands are registered with BotFather for slash autocomplete. `/commands` lists the full runtime command set.
 
 | Command | Description |
 |---------|-------------|
@@ -170,6 +176,7 @@ All commands are auto-registered with BotFather for slash autocomplete.
 | `/new` | Full session reset (history + model + agent) |
 | `/note <text>` | Quick-capture note to today's memory file |
 | `/stop` | Cancel active AI request |
+| `/abort` | Abort active AI request |
 | `/memory` | Show today's memory |
 | `/tools` | List available tools |
 | `/model [name|list|clear]` | View/change AI model |
@@ -179,11 +186,18 @@ All commands are auto-registered with BotFather for slash autocomplete.
 | `/usage [off|tokens|full]` | Token usage footer mode |
 | `/context` | Show context window usage % |
 | `/compact` | Force context compaction |
-| `/think [off|low|medium|high]` | Set thinking level |
+| `/think [off|low|medium|high|adaptive]` | Set thinking level |
 | `/verbose` | Toggle verbose mode |
 | `/queue [collect|steer|interrupt]` | Queue mode for concurrent messages |
 | `/tts [voice]` | Set TTS voice |
+| `/task <description>` | Spawn a sub-agent task |
 | `/btw` | Side query during active task |
+| `/roles` | List available roles |
+| `/role <name>` | Show role details |
+| `/role_run <name> [input]` | Run a role as a durable job (admin) |
+| `/jobs` | List recent durable jobs |
+| `/job <id>` | Show job details |
+| `/job_cancel <id>` | Cancel a durable job (admin) |
 | `/estop [on|off|status]` | Emergency-stop dangerous tool families (admin) |
 | `/activate` | Group: respond to all messages |
 | `/standby` | Group: respond only to mentions |
@@ -202,9 +216,9 @@ telegram:
   token: "BOT_TOKEN"
 
 ai:
-  provider: "anthropic"   # anthropic | chatgpt | openai | droid | custom
-  api_key: "oauth:<auto>" # set by: ok-gobot auth anthropic login
-  model: "claude-sonnet-4-5-20250929"
+  provider: "openrouter"  # openrouter | openai | anthropic | chatgpt | droid | custom
+  api_key: "..."          # or oauth:<auto> after: ok-gobot auth anthropic login
+  model: "moonshotai/kimi-k2.5"
   fallback_models:
     - "claude-haiku-3-5-20241022"
 
@@ -250,21 +264,29 @@ ok-gobot config show              # Show config
 ok-gobot config set <key> <val>   # Set config value
 ok-gobot config models            # List available models
 ok-gobot auth anthropic login     # Anthropic OAuth login (Claude MAX)
-ok-gobot auth chatgpt login       # ChatGPT OAuth login (Plus/Team)
 ok-gobot status                   # Show status
 ok-gobot estop on|off|status      # Toggle emergency stop for dangerous tools
 ok-gobot doctor                   # Check config and dependencies
 ok-gobot daemon install|start|stop|status|logs|uninstall
 ok-gobot providers                # List configured AI providers
-ok-gobot models                   # List available models per provider
-ok-gobot skills list|install|remove|audit  # Manage skills
-ok-gobot jobs                     # View job history
-ok-gobot sessions                 # Manage sessions
+ok-gobot models list              # List available models per provider
+ok-gobot models refresh           # Refresh provider model cache
+ok-gobot skills list|install|remove|audit|history|rollback  # Manage skills
+ok-gobot jobs list|inspect|cancel|retry|tail|export          # Manage job history
+ok-gobot roles list|show|run|enable|disable                  # Manage roles
+ok-gobot memory status|index      # Inspect/index markdown memory
+ok-gobot sessions list|fork       # Manage sessions
+ok-gobot work <task>              # Create a worker worktree for a task
+ok-gobot worktrees list|cleanup|rm  # Manage worker worktrees
 ok-gobot batch                    # Parallel task fan-out
 ok-gobot babysit                  # PR auto-maintenance
-ok-gobot evolution                # Evolution engine status/history
-ok-gobot export                   # Export training data
+ok-gobot evolution status|history|rollback|metrics
+ok-gobot export training-data     # Export training data
+ok-gobot migrate --from <db>      # One-shot OpenClaw migration
+ok-gobot onboard --path <dir>     # Scaffold workspace and config
 ok-gobot voice                    # Voice command processing
+ok-gobot browser setup|status     # Prepare Chrome automation profile
+ok-gobot web                      # Launch web UI
 ok-gobot tui                      # Terminal UI
 ok-gobot version
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,7 +74,7 @@ ok-gobot is a Telegram-first AI agent that runs tools on the operator's machine.
 ### Known Limitations
 
 - **No WASM sandbox.** Tool execution (local, ssh) runs in the host process. Use capability policy and estop to limit blast radius.
-- **Per-task budget caps are incomplete.** Timeout and cancellation work, but tool call count and model cost limits are not yet enforced. Set conservative `allowed_tools` for scheduled roles.
+- **Budget enforcement is incomplete.** Tool-call and duration limits are implemented, but token/cost budget enforcement and the central policy gateway are not complete. Set conservative `allowed_tools`, role `tools`, `max_tool_calls`, and `max_duration` for scheduled roles.
 - **No audit log.** Autonomous actions (tool calls, cron runs, evolution promotions) are logged but not stored in a tamper-evident format. This is planned for Phase 5.
 
 ## Safe Defaults
@@ -103,6 +103,7 @@ Run `ok-gobot doctor` to check for risky configurations. The doctor command warn
 3. If enabling `control`, set `control.token` and set `control.allow_loopback_without_token` to `false`.
 4. Review tool access per agent via `agents[].capabilities` policies.
 5. Use `/estop on` to disable dangerous tool families when not needed.
+6. For scheduled roles, copy only the roles you need into `roles_path`, set explicit `tools`, and add `max_tool_calls` plus `max_duration`.
 
 ## Automated Security Checks
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,14 +8,16 @@ This document defines the active architecture contract for the chat/jobs runtime
 For configuration, this document is the source of truth.
 
 The legacy hub/subagent runtime (`internal/agent/runtime.go`, the Telegram
-`hub_handler` flow, and legacy control-server sub-agent surfaces) is frozen for
-compatibility only. New feature work must target the chat/jobs path backed by
-`internal/runtime`, not the legacy runtime.
+`hub_handler` flow, `browser_task`, and legacy control-server sub-agent surfaces)
+is frozen for compatibility. It can receive bug fixes while the chat/jobs runtime
+takes over, but new product surface area should target `internal/runtime`, durable
+jobs, and the HTTP Mission Control API.
 
 ## 2. Active Runtime Contract
 
-- Chat ingress and scheduled jobs are the product execution surfaces.
-- `internal/runtime` owns mailbox scheduling, queueing, cancellation, and child completion routing.
+- Telegram chat ingress, TUI/control submissions, scheduled role runs, and durable jobs are the product execution surfaces.
+- `internal/runtime` owns rules-first chat routing and durable job lifecycle state.
+- The compatibility `agent.RuntimeHub` still executes some chat and sub-agent runs while the runtime transition is in progress.
 - Different session keys execute in parallel.
 - Each session key executes one run at a time.
 - Transport layers submit work; they do not execute model logic directly.
@@ -38,15 +40,17 @@ length. Forced prefixes (`job:`, `task:`, `background:`) bypass heuristics.
 ### 2.2 Roles and Scheduled Jobs
 
 Roles are markdown-first manifests (`.md` files with YAML frontmatter) loaded from
-`roles_path`. Each role with a `schedule` field registers a cron job on startup.
-Jobs produce standardized reports delivered to the admin chat.
+`roles_path`. Each copied role with a `schedule` field registers a cron job on
+startup. Jobs produce standardized reports delivered to the admin chat.
 
 Four prebuilt roles ship embedded in the binary: `researcher`, `monitor`,
-`release-watch`, `homelab-runbook`. No roles run by default.
+`release-watch`, `homelab-runbook`. These are templates and are not auto-registered
+as schedules until copied into `roles_path`.
 
-> **Note:** Full per-task budget caps (tool call count, model cost) are not yet
-> implemented. Operators should set conservative tool allowlists for scheduled roles
-> until budget enforcement lands.
+Tool-call and duration limits are carried from role manifests into delegated runs
+and durable job records. Token/cost budget enforcement and a centralized policy
+gateway are not complete; scheduled autonomy should still use conservative tool
+allowlists.
 
 **Files:** `internal/role/`, `internal/cron/`
 
@@ -73,29 +77,33 @@ without losing the original conversation.
 
 ## 4. Adapters and Workers
 
-- Telegram, control/TUI, and jobs are adapters over chat/jobs requests and runtime events.
+- Telegram, HTTP API, control/TUI, and jobs are adapters over chat/jobs requests and runtime events.
 - Adapters handle input/output rendering and acknowledgments.
 - Execution, queueing, cancellation, and child completion routing stay in `internal/runtime`.
 - Background tasks run in isolated git worktrees when applicable.
 
 ## 5. Control Plane
 
-The control server provides loopback API/WS access for status, session operations,
-abort, and chat/job control. Legacy sub-agent RPC surfaces remain available only
-as frozen compatibility shims.
+The HTTP API provides REST access for status, send/webhook, jobs, routing, and
+Mission Control. The control server provides loopback WebSocket access for TUI
+status, session operations, streaming, abort, and approvals. Legacy sub-agent RPC
+surfaces remain available only as frozen compatibility shims.
 
 ### 5.1 Mission Control API
 
-The mission control endpoints expose operational data for monitoring and dashboards:
+The active Mission Control endpoints are registered by the HTTP API server when
+`api.enabled` is true. They expose operational data for monitoring and dashboards:
 
-- `GET /api/mission/roles` -- all roles with metadata
+- `GET /api/mission/roles` -- registered agent profiles with metadata
 - `GET /api/mission/schedules` -- scheduled jobs with next run time
 - `GET /api/mission/runs` -- recent job runs with status and summary
 - `GET /api/mission/stats` -- daily token/message/session statistics
+- `GET /api/mission/estop` -- emergency-stop state
+- `GET /api/mission/providers` -- active AI provider and model
 
 See [MISSION-CONTROL.md](MISSION-CONTROL.md) for the concept overview.
 
-**Files:** `internal/control/mission.go`
+**Files:** `internal/api/mission.go`, `internal/control/mission.go`
 
 ## 6. Roles
 
@@ -106,9 +114,11 @@ from the configured `roles_path` directory and from bundled prebuilt roles.
 Operator surfaces:
 - CLI: `ok-gobot roles list|show|run|enable|disable` (`internal/cli/roles.go`)
 - Telegram: `/roles`, `/role`, `/role_run`, `/jobs`, `/job`, `/job_cancel` (`internal/bot/role_commands.go`)
+- Jobs CLI: `ok-gobot jobs list|inspect|cancel|retry|tail|export` (`internal/cli/jobs.go`)
 
 Running a role via CLI or Telegram creates a durable job via `internal/runtime.JobService`.
-Scheduled roles are managed as cron jobs via `internal/cron/roles.go`.
+Scheduled roles are managed as cron jobs via `internal/cron/roles.go` after the
+manifest is copied into `roles_path`.
 Admin-only actions (`/role_run`, `/job_cancel`) require `IsAdmin` authorization.
 
 ## 7. Intelligence Subsystems
@@ -141,9 +151,9 @@ Four hook points: `SessionStart`, `PreToolUse`, `PostToolUse`, `SessionEnd`.
 
 ## 8. Legacy Freeze Policy
 
-- `internal/agent.RuntimeHub` is legacy compatibility code.
-- `browser_task`, `/task`, and legacy control-server sub-agent helpers may still depend on it today.
-- Keep changes there limited to bug fixes or removal prep; do not add new product surface area.
+- `internal/agent.RuntimeHub` and the Telegram `hub_handler` path are compatibility code during the runtime transition.
+- `browser_task`, `/task`, TUI run submission, and legacy control-server sub-agent helpers may still depend on it today.
+- Keep changes there limited to bug fixes, safety hardening, or removal prep; do not add new product surface area.
 
 ## 9. Persistence
 

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -1,6 +1,6 @@
 # Competitive Landscape: OpenFang, ZeroClaw, OpenClaw, and ok-gobot
 
-Original snapshot: March 12, 2026. Updated April 29, 2026 to reflect shipped features.
+Original snapshot: March 12, 2026. Updated April 29, 2026 after the current-state comparison in issue #290.
 
 This document compares two newer Rust competitors, [OpenFang](https://github.com/RightNow-AI/openfang) and [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw), against [OpenClaw](https://github.com/openclaw/openclaw) and this project, [ok-gobot](../README.md).
 
@@ -20,7 +20,13 @@ Important caveat: external benchmark, security-layer, and channel-count claims a
 | **OpenFang** | Rust | Autonomous agent OS with bundled "Hands" and dashboard | Created February 24, 2026. 13.8k stars / 1.6k forks. Dual-license in Cargo manifest (`MIT OR Apache-2.0`); GitHub metadata reports Apache-2.0. |
 | **ZeroClaw** | Rust | Fast, small, fully swappable assistant infrastructure | Created February 13, 2026. 26.2k stars / 3.4k forks. Dual-license in Cargo manifest (`MIT OR Apache-2.0`); GitHub metadata reports Apache-2.0. |
 | **OpenClaw** | TypeScript | Personal AI assistant across channels, apps, and devices | Created November 24, 2025. 303.7k stars / 57.4k forks. MIT. |
-| **ok-gobot** | Go | Fast single-binary Telegram bot and OpenClaw rewrite with opinionated defaults | Local project. README positions it as a Go rewrite of OpenClaw. |
+| **ok-gobot** | Go | Fast single-binary Telegram-first operator bot with Mission Control direction | Local project. README positions it as a Go rewrite of OpenClaw. |
+
+## 2026-04-29 Current-State Note
+
+The April 29 comparison found that ok-gobot had moved beyond the March 12 roadmap snapshot. The docs now treat these as shipped or substantially shipped: OpenRouter default provider support, Anthropic OAuth, ChatGPT Codex manual-token support, Droid CLI transport, markdown-first roles, durable jobs, tool-call/duration budgets, skills audit/versioning, self-evolution, and the Mission Control API.
+
+The same comparison also keeps these limits explicit: ok-gobot does not have a WASM sandbox, token/cost budget enforcement is not complete, and scheduled autonomy should not be described as production-safe until the remaining budget and policy gateway work lands.
 
 ## Comparison Matrix
 
@@ -34,8 +40,8 @@ Important caveat: external benchmark, security-layer, and channel-count claims a
 | **Apps / UI surfaces** | Dashboard, TUI, desktop app | Gateway/daemon/web assets, more infra-oriented | Control UI, WebChat, macOS app, iOS node, Android node, Canvas, voice | Telegram UI, TUI, WebSocket control protocol, REST API, simple web UI |
 | **Multi-agent model** | First-class manifests, capabilities, agent spawn | Agent runtime plus provider/model switching and integrations | Multi-agent routing per channel/account/peer | Multi-agent profiles plus isolated sub-agent runs |
 | **Memory model** | SQLite + vector memory with confidence decay | Configurable storage/memory posture, SQLite/Postgres options, multiple memory modes | Session-centric assistant runtime with skills/extensions ecosystem | Markdown-first memory plus SQLite semantic index and optional memory MCP |
-| **Tool / extension story** | 53 tools, MCP, A2A, WASM modules, FangHub | Skills, integrations, provider/channel/tool swapping, security audit on install | Skills platform, plugin SDKs, browser/canvas/node tooling | Built-in tools (local/ssh/file/patch/search/browser/media/memory/cron); CLI-agent transports; markdown-first skills with safety audit, versioning, and utility scoring |
-| **Security posture** | Most explicit and systematized: capabilities, WASM sandbox, audit chain, taint tracking, manifest signing | Strong infra controls: allowlists, pairing, workspace scoping, estop, sandbox feature flags, skill audit | Sensible assistant safety defaults, DM pairing, remote access controls, but heavier and less isolation-centric | Per-agent capability policy, estop, exec approval, DM auth modes, SSRF protection, rate limiting, log redaction, skill safety audit; no WASM sandbox |
+| **Tool / extension story** | 53 tools, MCP, A2A, WASM modules, FangHub | Skills, integrations, provider/channel/tool swapping, security audit on install | Skills platform, plugin SDKs, browser/canvas/node tooling | Built-in tools (local/ssh/file/patch/web_fetch/browser/frontend verify/media/memory/cron when configured); CLI-agent transports; markdown-first skills with safety audit, versioning, and utility scoring |
+| **Security posture** | Most explicit and systematized: capabilities, WASM sandbox, audit chain, taint tracking, manifest signing | Strong infra controls: allowlists, pairing, workspace scoping, estop, sandbox feature flags, skill audit | Sensible assistant safety defaults, DM pairing, remote access controls, but heavier and less isolation-centric | Per-agent capability policy, estop, exec approval, DM auth modes, SSRF protection, rate limiting, log redaction, tool-call/duration limits, skill safety audit; no WASM sandbox and token/cost budget enforcement still incomplete |
 | **Operational posture** | Broadest promise, highest complexity | Leanest runtime and strongest low-resource story | Broadest ecosystem and surface area, highest Node complexity | Simplest scope and lowest cognitive overhead for one operator |
 | **Migration stance** | Explicitly migrates from OpenClaw | Explicitly migrates from OpenClaw | Ecosystem source project others migrate away from | Explicitly migrates from OpenClaw DB/workspace |
 
@@ -80,6 +86,7 @@ Where the challengers differentiate:
 - **Markdown-first workspace**: `IDENTITY.md`, `SOUL.md`, `USER.md`, `AGENTS.md`, `TOOLS.md`, `MEMORY.md` is easy to understand and hack.
 - **Faster path from OpenClaw to a personal bot**: the project has a focused migration command and a simpler target runtime.
 - **Productized scheduled roles**: four prebuilt roles (researcher, monitor, release-watch, homelab-runbook) with markdown manifests and cron delivery. Declarative custom roles without Go code.
+- **Durable jobs and Mission Control API**: job lifecycle, events, artifacts, schedules, run stats, estop state, and provider/model state are visible through CLI/Telegram/API surfaces.
 - **Self-evolution**: A-Evolve inspired prompt improvement cycle with safety constraints (gating, rollback, human approval thresholds).
 - **Per-agent capability policy**: declarative restrictions (shell, network, filesystem, cron, spawn) without source changes.
 
@@ -88,7 +95,7 @@ Where the challengers differentiate:
 - **Channel breadth**: it does not compete with OpenClaw/OpenFang/ZeroClaw on messaging footprint.
 - **Formal isolation/security**: it has practical safety controls and per-agent capability policy, but not the kind of WASM sandbox architecture marketed by OpenFang and ZeroClaw.
 - **Broader app surface**: it does not currently match OpenClaw's device-node, Canvas, and voice ecosystem.
-- **Budget enforcement**: per-task budget caps (tool call count, model cost) are not yet complete. Operators should set conservative tool allowlists for scheduled roles until this lands.
+- **Budget enforcement**: tool-call and duration caps exist, but token/cost enforcement and the central policy gateway are not complete. Operators should set conservative tool allowlists for scheduled roles until this lands.
 
 ## Recommended Positioning for ok-gobot
 
@@ -103,7 +110,7 @@ Position it as:
 That framing avoids direct head-on competition where the others are stronger:
 
 - do not over-claim on channel count
-- do not over-claim on sandbox/security architecture (no WASM; per-task budget caps still incomplete)
+- do not over-claim on sandbox/security architecture (no WASM; token/cost budget enforcement still incomplete)
 - do not claim scheduled autonomy is production-safe before budget enforcement lands
 
 Instead, lean into:

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -3,16 +3,16 @@
 ## AI & LLM
 
 ### Multi-Provider Support
-Six provider backends with automatic failover:
+Provider backends with automatic failover:
 
 | Provider | Auth | Default Model |
 |----------|------|---------------|
+| OpenRouter | API key | moonshotai/kimi-k2.5 |
 | Anthropic | OAuth (Claude MAX) or API key | claude-sonnet-4-5-20250929 |
-| ChatGPT | OAuth (Pro/Plus JWT) | gpt-5.4 |
+| ChatGPT Codex | ChatGPT session JWT | gpt-5.4 |
 | OpenAI | API key | gpt-4o |
-| Hermes | OpenAI-compatible (Ollama) | hermes3 |
 | Droid | CLI agent transport | glm-5 |
-| Custom | API key + base URL | any OpenAI-compatible |
+| Custom | API key + base URL | any OpenAI-compatible, including Gemini, Ollama/vLLM, and Hermes models |
 
 **Files:** `internal/ai/anthropic_client.go`, `internal/ai/chatgpt_client.go`, `internal/ai/client.go`, `internal/ai/hermes_client.go`, `internal/ai/droid_client.go`
 
@@ -78,7 +78,7 @@ AI-powered summarization when conversation approaches 80% of model context limit
 ## Roles, Jobs, and Skills
 
 ### Markdown-First Roles
-Roles are single `.md` files with optional YAML frontmatter. They define autonomous workflows that run on schedule and deliver bounded reports.
+Roles are single `.md` files with optional YAML frontmatter. They define bounded workflows that can run manually or on a schedule and deliver reports.
 
 **Manifest format:**
 ```markdown
@@ -98,20 +98,22 @@ You are a research agent. Search for news about Go releases...
 | Role | Default Schedule | Description |
 |------|-----------------|-------------|
 | `researcher` | Manual only | Web search + bounded research brief |
-| `monitor` | Every 30 minutes | Service/URL health checks + status report |
-| `release-watch` | Weekly (disabled by default) | Software release tracking for configured projects |
+| `monitor` | Every 30 minutes once copied to `roles_path` | Service/URL health checks + status report |
+| `release-watch` | Weekly once copied to `roles_path` | Software release tracking for configured projects |
 | `homelab-runbook` | Manual only | Turn requests into checklist/runbook notes |
 
-Roles respect capability policy and estop. No roles run by default -- operators must enable them explicitly.
+Bundled roles are templates. They are listed by CLI and Telegram commands, but only manifests copied into `roles_path` are auto-registered as scheduled cron jobs. No bundled role schedules run by default.
 
-> **Note:** Scheduled autonomy is experimental. Full per-task budget caps (tool call count, model cost) are not yet implemented. Operators should review role outputs and set conservative tool allowlists until budget enforcement lands.
+Roles respect capability policy, explicit `tools` allowlists, estop, and per-run tool-call/duration limits. Token/cost budget enforcement and the centralized policy gateway are still roadmap work, so scheduled autonomy should be treated as experimental.
 
 **Files:** `internal/role/manifest.go`, `internal/role/bundled.go`, `internal/role/loader.go`
 
 ### Durable Jobs
 Scheduled roles create durable jobs tracked by the runtime. Jobs produce standardized reports delivered to the admin chat. Job history is persisted in SQLite.
 
-**CLI:** `ok-gobot jobs` -- list and inspect job history.
+**CLI:** `ok-gobot jobs list|inspect|cancel|retry|tail|export` -- manage job history, events, and artifacts.
+
+**Telegram:** `/jobs`, `/job <id>`, `/job_cancel <id>`.
 
 **Files:** `internal/cron/scheduler.go`, `internal/cron/roles.go`, `internal/cron/report.go`
 
@@ -125,7 +127,7 @@ Skills are markdown-only knowledge bases installable from local paths or git URL
 
 Skills are tracked by utility score. The skill router selects relevant skills per query based on accumulated scores.
 
-**CLI:** `ok-gobot skills list|install|remove|audit`
+**CLI:** `ok-gobot skills list|install|remove|audit|history|rollback`
 
 **Files:** `internal/bootstrap/skills.go`, `internal/bootstrap/skills_test.go`
 
@@ -174,27 +176,27 @@ Four hook points for custom behavior: `SessionStart`, `PreToolUse`, `PostToolUse
 
 ### Shell & Files
 - **local** -- Execute shell commands. Dangerous commands (rm -rf, kill, shutdown, etc.) require inline keyboard approval.
-- **ssh** -- Remote execution. Hosts configured in `~/ok-gobot-soul/TOOLS.md`.
-- **file** -- Read/write with path traversal protection.
-- **patch** -- Apply unified diffs to files.
+- **ssh** -- Remote execution for hosts configured in `TOOLS.md`.
+- **file** -- Read/write within the configured workspace with path traversal protection.
+- **patch** -- Apply unified diffs within the configured workspace.
 - **grep** -- Recursive regex search, skips binary files and `.git`/`node_modules`. Max 50 results.
-- **obsidian** -- Obsidian vault CRUD with frontmatter timestamps.
+- **obsidian** -- Obsidian vault CRUD with frontmatter timestamps when `~/Obsidian` exists.
 
 ### Web
-- **search** -- Brave Search or Exa API. Returns 5 results with title/URL/snippet.
+- **search** -- Brave Search or Exa API when a search API key is configured. Returns 5 results with title/URL/snippet.
 - **web_fetch** -- Fetch URLs with Mozilla Readability extraction (go-shiori/go-readability). Falls back to basic HTML stripping. SSRF protection blocks private IPs. 12KB content limit.
 - **browser** -- Chrome automation via ChromeDP: navigate, click, fill, screenshot, wait, extract text.
 - **browser_task** -- Composite browser tasks as isolated sub-agent runs.
 - **frontend_verify** -- CDP screenshot + LLM visual comparison for UI testing.
 
 ### Media
-- **image_gen** -- DALL-E 3. Sizes: 1024x1024, 1792x1024, 1024x1792. Quality: standard/hd.
-- **tts** -- Two providers: OpenAI (paid, 6 voices) and Edge TTS (free, Russian/English voices). Auto OGG conversion for Telegram.
+- **image_gen** -- DALL-E 3 when an OpenAI-compatible image API key is configured. Sizes: 1024x1024, 1792x1024, 1024x1792. Quality: standard/hd.
+- **tts** -- Two providers when TTS is configured: OpenAI (paid, 6 voices) and Edge TTS (free, Russian/English voices). Auto OGG conversion for Telegram.
 
 ### Memory & Scheduling
 - **memory_search** -- Semantic vector search over indexed markdown memory.
 - **memory_get** -- Read markdown memory source by section path.
-- **cron** -- 5-field cron expressions. Persistent in SQLite. Enable/disable without deletion.
+- **cron** -- 5-field expressions are accepted by the tool and stored as 6-field cron entries with seconds. Persistent in SQLite. Enable/disable without deletion.
 - **message** -- Send to other chats by ID or alias. Allowlist-based security.
 
 ### Policy & Routing
@@ -289,11 +291,13 @@ REST API with API key authentication (`X-API-Key` header or Bearer token). Endpo
 See [API.md](API.md) for full reference.
 
 ### Mission Control API
-Monitoring and control endpoints for the operator dashboard:
-- `GET /api/mission/roles` -- list all roles with metadata
+Monitoring endpoints for the operator dashboard, served by the authenticated HTTP API when `api.enabled` is true:
+- `GET /api/mission/roles` -- list registered agent profiles with metadata
 - `GET /api/mission/schedules` -- list scheduled jobs with next run time
 - `GET /api/mission/runs` -- recent job runs with status and summary
 - `GET /api/mission/stats` -- daily token/message/session statistics
+- `GET /api/mission/estop` -- current emergency-stop state
+- `GET /api/mission/providers` -- active AI provider and model
 
 See [MISSION-CONTROL.md](MISSION-CONTROL.md) for the concept overview.
 
@@ -397,14 +401,16 @@ Beyond the core commands (`/start`, `/help`, `/status`, `/clear`, `/model`, `/ag
 | `/new` | Reset session (clear history + model override + agent) |
 | `/note <text>` | Append a quick note directly to today's memory file |
 | `/stop` | Cancel the currently running AI request |
+| `/abort` | Abort the currently running AI request |
 | `/commands` | List all registered commands |
 | `/usage` | Set usage footer mode (off/tokens/full) |
 | `/context` | Show context window usage percentage |
 | `/compact` | Force context compaction |
-| `/think` | Set thinking level (off/low/medium/high) |
+| `/think` | Set thinking level (off/low/medium/high/adaptive) |
 | `/verbose` | Toggle verbose mode |
 | `/queue` | Set queue mode (collect/steer/interrupt) |
 | `/tts` | Set TTS voice |
+| `/task` | Spawn a sub-agent task |
 | `/roles` | List available roles |
 | `/role <name>` | Show role details |
 | `/role_run <name> [input]` | Run a role as a durable job (admin) |
@@ -432,7 +438,7 @@ ok-gobot roles disable <name>               # Disable a scheduled role's cron jo
 **Files:** `internal/cli/roles.go`
 
 ### BotFather Registration
-All commands are automatically registered with BotFather on startup via `bot.api.SetCommands()`, enabling Telegram's slash command autocomplete.
+Core commands are registered with BotFather on startup via `bot.api.SetCommands()`, enabling Telegram slash autocomplete. `/commands` lists the full runtime command set, including role/job handlers that may not be in the BotFather autocomplete list.
 
 ---
 
@@ -477,11 +483,7 @@ Each role defines allowed tools, a default budget (max tool calls per run), a re
 
 ### Usage
 
-1. Export bundled roles to your roles directory:
-   ```
-   ok-gobot roles init ~/my-roles
-   ```
-   Or copy individual files from `internal/role/prebuilt/`.
+1. Copy bundled role templates from `internal/role/prebuilt/` into your roles directory.
 
 2. Set `roles_path` in `config.yaml`:
    ```yaml
@@ -489,7 +491,7 @@ Each role defines allowed tools, a default budget (max tool calls per run), a re
    ```
 
 3. Roles with a `schedule` field are auto-registered as cron jobs on startup.
-   Manual-only roles (no schedule) are available via `/role run <name>`.
+   Manual-only roles (no schedule) are available via `/role_run <name>` or `ok-gobot roles run <name>`.
 
 4. Customise tools, budget, schedule, or prompt in your copy — the bundled
    originals are never modified.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -5,8 +5,9 @@
 - **Go 1.24+** (with CGO enabled for SQLite)
 - **Telegram bot token** from [@BotFather](https://t.me/BotFather)
 - **AI provider access** — one or more of:
+  - **OpenRouter** (default, API key from openrouter.ai)
   - **Anthropic** (OAuth via Claude MAX subscription, or API key)
-  - **ChatGPT** (OAuth via ChatGPT Pro/Plus — uses `chatgpt.com/backend-api` codex endpoint)
+  - **ChatGPT Codex** (ChatGPT session JWT — uses `chatgpt.com/backend-api` codex endpoint)
   - **Google Gemini** (API key from Google AI Studio)
   - **OpenAI** (API key from platform.openai.com)
   - Any **OpenAI-compatible** API with a custom base URL
@@ -70,9 +71,13 @@ make build-all       # All platforms
 ### Install to PATH
 
 ```bash
-make install   # copies to $GOPATH/bin/
-# Or manually:
-cp bin/ok-gobot /usr/local/bin/
+# Local user install:
+mkdir -p ~/.local/bin
+cp bin/ok-gobot ~/.local/bin/ok-gobot
+export PATH="$HOME/.local/bin:$PATH"
+
+# Or keep using the checkout-local binary:
+export PATH="$PWD/bin:$PATH"
 ```
 
 ---
@@ -109,14 +114,13 @@ mkdir -p ok-gobot-assets/workspace/skills
 # 2. Scaffold personality files into the workspace
 cd ok-gobot
 ok-gobot onboard --path ../ok-gobot-assets/workspace
-
-# 3. Move/symlink the generated config to the assets directory
-mv ~/.ok-gobot/config.yaml ../ok-gobot-assets/config/config.yaml
-ln -sf "$(pwd)/../ok-gobot-assets/config/config.yaml" ~/.ok-gobot/config.yaml
 ```
 
-After this, edit `ok-gobot-assets/config/config.yaml` and set `soul_path` to
-point at your workspace:
+`ok-gobot onboard` creates or preserves `~/.ok-gobot/config.yaml` and sets `soul_path`
+to the workspace you passed. If you manage config in a separate assets directory,
+symlink `~/.ok-gobot/config.yaml` yourself and keep file permissions at `0600`.
+
+To set the workspace manually:
 
 ```yaml
 soul_path: "/absolute/path/to/ok-gobot-assets/workspace"
@@ -131,6 +135,23 @@ export OKGOBOT_SOUL_PATH="/absolute/path/to/ok-gobot-assets/workspace"
 ---
 
 ## AI Provider Configuration
+
+### OpenRouter (API Key, Default)
+
+OpenRouter is the default provider in generated config.
+
+```bash
+ok-gobot config set ai.provider openrouter
+ok-gobot config set ai.api_key <your-openrouter-key>
+ok-gobot config set ai.model moonshotai/kimi-k2.5
+```
+
+```yaml
+ai:
+  provider: "openrouter"
+  api_key: "<your-openrouter-key>"
+  model: "moonshotai/kimi-k2.5"
+```
 
 ### Anthropic (OAuth — Claude MAX)
 
@@ -163,22 +184,22 @@ ai:
   model: "claude-sonnet-4-5-20250929"
 ```
 
-### ChatGPT (OAuth — ChatGPT Pro/Plus)
+### ChatGPT Codex (Manual Session JWT)
 
 Uses the `chatgpt.com/backend-api/codex/responses` endpoint with an OAuth JWT
 token from your ChatGPT session.
 
 ```yaml
 ai:
-  provider: "chatgpt"           # or "openai-codex"
+  provider: "chatgpt"
   api_key: "<your-chatgpt-oauth-jwt>"
   base_url: "https://chatgpt.com/backend-api"
   model: "gpt-5.4"
 ```
 
-The auth mode is `oauth` — the token is your ChatGPT session JWT. To obtain it,
-inspect a `chatgpt.com` request in browser DevTools and copy the
-`Authorization: Bearer <token>` value.
+There is no `ok-gobot auth chatgpt login` command. The token is your ChatGPT
+session JWT. To obtain it, inspect a `chatgpt.com` request in browser DevTools
+and copy the `Authorization: Bearer <token>` value.
 
 ### Google Gemini (API Key)
 
@@ -223,7 +244,7 @@ This enables using any installed CLI agent as a transport layer:
 | Factory Droid | `droid` | [factory.ai](https://factory.ai) |
 | Claude Code | `claude` | `npm install -g @anthropic-ai/claude-code` |
 | OpenAI Codex CLI | `codex` | `npm install -g @openai/codex` |
-| Gemini CLI | `gemini` | `npm install -g @anthropic-ai/gemini-cli` |
+| Gemini CLI | `gemini` | Install separately from Gemini CLI docs |
 | Cline | `cline` | VS Code extension / CLI |
 | OpenCode | `opencode` | `go install github.com/opencode-ai/opencode@latest` |
 
@@ -452,24 +473,25 @@ export OKGOBOT_AUTH_MODE="pairing"
 3. If enabling control server, set a strong `control.token`.
 4. Config file permissions should be `0600` (set automatically by `config init`).
 5. OAuth credentials stored in `~/.ok-gobot/oauth/` are automatically set to `0600`.
-6. Set conservative `capabilities` and `allowed_tools` for scheduled roles -- full per-task budget caps are not yet implemented.
+6. Set conservative `capabilities`, role `tools`, `max_tool_calls`, and `max_duration` for scheduled roles. Token/cost enforcement and the central policy gateway are not complete yet.
 7. See [SECURITY.md](../SECURITY.md) for vulnerability reporting and [SECURITY-FIXES.md](SECURITY-FIXES.md) for the hardening changelog.
 
 ---
 
 ## Prebuilt Roles
 
-ok-gobot ships three prebuilt role manifests that operators can use as starting
-points for scheduled autonomous workflows. They are embedded in the binary and
-serve as **examples** — no roles run by default.
+ok-gobot ships four prebuilt role manifests that operators can use as starting
+points for scheduled workflows. They are embedded in the binary and visible in
+role listings, but no bundled role schedule is auto-registered by default.
 
 ### Available prebuilt roles
 
 | Role | Default schedule | Description |
 |------|-----------------|-------------|
-| `researcher` | 09:00 UTC daily | Searches the web and compiles a daily research digest |
-| `monitor` | Every 30 minutes | Checks service/URL health and reports status |
-| `release-watch` | 10:00 UTC every Monday | Tracks software releases for configured projects |
+| `researcher` | Manual only | Searches the web and compiles a bounded research brief |
+| `monitor` | Every 30 minutes once copied to `roles_path` | Checks service/URL health and reports status |
+| `release-watch` | 10:00 UTC every Monday once copied to `roles_path` | Tracks software releases for configured projects |
+| `homelab-runbook` | Manual only | Turns operator requests into checklist/runbook notes |
 
 ### Enabling roles
 
@@ -495,9 +517,8 @@ auth:
 
 **Step 2 — Copy and customise a prebuilt role:**
 
-Copy the files manually or use the bundled examples as a starting point.
-The bundled manifests can also be extracted by placing the file in your
-`roles_path` directory. Each `.md` file in the directory is a role manifest.
+For source installs, copy the templates from `internal/role/prebuilt/*.md` into
+your `roles_path` directory. Each `.md` file in the directory is a role manifest.
 
 You can write a role manifest from scratch — it is a markdown file with optional
 YAML frontmatter:
@@ -530,6 +551,12 @@ restarts). Reports are delivered to `auth.admin_id`.
 | `schedule` | string | 6-field cron expression (seconds included). Empty = no schedule |
 | `approval` | string | `auto` (default), `always`, or `never` |
 | `report_template` | string | Go `text/template` for report formatting |
+| `max_tool_calls` | integer | Maximum tool executions for the run |
+| `max_duration` | duration | Wall-clock timeout for the run, such as `5m` |
+| `max_tokens` | integer | Declared token budget; runtime enforcement is planned |
+| `max_cost_usd` | number | Declared cost budget; runtime enforcement is planned |
+| `memory_policy` | string | `inherit`, `read_only`, or `allow_writes` |
+| `model` | string | Optional model override for the delegated run |
 
 ### Cron expression format
 

--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -2,33 +2,42 @@
 
 ## Concept
 
-Mission Control is the operator-facing view of ok-gobot's autonomous capabilities: roles, schedules, job runs, and system health in a single place.
+Mission Control is the operator-facing view of ok-gobot's autonomous capabilities: agent profiles, role schedules, job runs, provider state, emergency-stop state, and system health in a single place.
 
 The goal is not a full dashboard product. It is the minimum monitoring surface an operator needs to trust that scheduled roles are running correctly and to intervene when they are not.
 
 ## Current State (April 2026)
 
-The Mission Control API exists and serves data. A dashboard UI is planned but not yet built.
+The Mission Control API exists on the authenticated HTTP API server. A dashboard UI is planned but not yet built.
 
 ### API Endpoints
 
-All endpoints are served by the control server (default port 8787, loopback only).
+Enable the HTTP API to serve these endpoints (default port 8080, loopback bind by default):
+
+```yaml
+api:
+  enabled: true
+  api_key: "a-strong-random-token"
+```
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/mission/roles` | GET | All configured roles with metadata (name, display name, model, tools) |
+| `/api/mission/roles` | GET | Registered agent profiles with metadata (name, display name, model, tools) |
 | `/api/mission/schedules` | GET | Scheduled jobs with cron expression, next run time, timeout |
 | `/api/mission/runs` | GET | Recent job runs with status, summary, errors, attempt count |
 | `/api/mission/stats` | GET | Daily and total statistics (tokens, messages, sessions) |
+| `/api/mission/estop` | GET | Current emergency-stop state |
+| `/api/mission/providers` | GET | Active AI provider and model |
 
-Query parameters: `limit` (1-200), `status` (filter by run status).
+Run query parameters: `limit` (1-200), `status` (filter by run status). Stats query parameters: `days` (1-90).
 
 ### What It Monitors
 
-- **Roles** -- which roles are loaded and what tools/models they use
+- **Profiles** -- which agent profiles are loaded and what tools/models they use
 - **Schedules** -- when each role is next due to run
 - **Runs** -- whether recent job runs succeeded or failed, with summaries
 - **Stats** -- aggregate token usage and message counts
+- **Controls** -- emergency-stop state and active provider/model
 
 ## Architecture
 
@@ -61,14 +70,15 @@ Scheduled roles execute with whatever tools and capabilities their manifest decl
 
 1. Set explicit `tools` allowlists in role manifests (do not leave empty/all-tools).
 2. Use per-agent `capabilities` to restrict shell, network, and filesystem access.
-3. Review role output regularly until per-task budget enforcement is complete.
-4. Use `/estop on` to immediately halt all dangerous tool execution if something goes wrong.
+3. Set `max_tool_calls` and `max_duration` on scheduled roles.
+4. Review role output regularly until token/cost budget enforcement and the central policy gateway are complete.
+5. Use `/estop on` to immediately halt all dangerous tool execution if something goes wrong.
 
-Full per-task budget caps (tool call count, model cost) are planned for Phase 5 of the [Roadmap](ROADMAP.md).
+Token/cost budget enforcement and the central policy gateway are tracked in Phase 5 of the [Roadmap](ROADMAP.md).
 
 ## Planned (Phase 6)
 
-- Dashboard page rendering roles, schedules, runs, and stats in a single view
-- Role health monitoring with alerts for repeated failures or exceeded token budgets
+- Dashboard page rendering profiles, schedules, runs, and stats in a single view
+- Role health monitoring with alerts for repeated failures or exceeded enforced budgets
 - One-click role enable/disable from dashboard and TUI
 - Operator playbook system: composable multi-role workflows with dependency ordering

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,12 +24,12 @@ The original Phase 1-3 items are all shipped or substantially shipped. This sect
 
 4. **Operator can restrict an agent to read-only tools without editing Go code** -- SHIPPED. Per-agent `capabilities` block in config: `shell`, `network`, `network_allowlist`, `cron`, `memory_write`, `spawn`, `filesystem_roots`, `file_write_scope`.
 5. **Denied tool calls show a clear reason in Telegram instead of silently failing** -- SHIPPED. Consistent "Tool [name] blocked: [reason]" messages across Telegram, TUI, and API.
-6. **Operator can install and audit third-party skills from the CLI** -- SHIPPED. `ok-gobot skills list|install|remove|audit`. Safety audit rejects symlinks, scripts, pipe-to-shell, and escaping links. Skill versioning with rollback.
+6. **Operator can install and audit third-party skills from the CLI** -- SHIPPED. `ok-gobot skills list|install|remove|audit|history|rollback`. Safety audit rejects symlinks, scripts, pipe-to-shell, and escaping links. Skill versioning with rollback.
 
 ### Phase 3: Productized Autonomy -- MOSTLY SHIPPED
 
-7. **Operator can cap a background task's tool calls, duration, and model cost** -- PARTIALLY SHIPPED. Timeout and cancellation work. Full per-task budget caps (tool call count, model cost) deferred to Phase 5.
-8. **Operator can enable a prebuilt role that runs on schedule and posts a report** -- SHIPPED. Four prebuilt roles: `researcher`, `monitor`, `release-watch`, `homelab-runbook`. Roles load from `roles_path`, run via cron, deliver bounded reports to admin.
+7. **Operator can cap a background task's tool calls, duration, and model cost** -- PARTIALLY SHIPPED. Tool-call limits, duration timeouts, cancellation, and `budget_exceeded` job state are implemented. Token/cost accounting and enforcement remain Phase 5 work.
+8. **Operator can enable a prebuilt role that runs on schedule and posts a report** -- SHIPPED. Four prebuilt role templates: `researcher`, `monitor`, `release-watch`, `homelab-runbook`. Roles copied into `roles_path` run via cron and deliver bounded reports to admin.
 9. **Operator can define new roles declaratively without writing Go code** -- SHIPPED. Markdown-first role manifests with YAML frontmatter: prompt, tools, schedule, report_template, approval mode.
 
 ---
@@ -45,17 +45,18 @@ The original Phase 1-3 items are all shipped or substantially shipped. This sect
 
 ### Phase 5: Hardened Autonomy -- IN PROGRESS
 
-14. Full per-task budget caps: max tool calls, max model cost, per-task model override.
-15. Policy enforcement gateway: centralized pre-execution check that validates budget + capability policy before every tool call.
-16. Formal vulnerability reporting process (`SECURITY.md` shipped with this docs refresh).
-17. Audit log for all autonomous actions (tool calls, cron runs, evolution promotions) with tamper-evident storage.
+14. **Token/cost budget enforcement** -- IN PROGRESS. Role manifests and delegated-run contracts carry `max_tokens` and `max_cost_usd`, but runtime enforcement is not complete.
+15. **Policy enforcement gateway** -- IN PROGRESS. Per-agent capability policy and tool-call limits are shipped; the remaining work is a centralized pre-execution check that combines budget, capability, and audit policy before every autonomous action.
+16. **Formal vulnerability reporting process** -- SHIPPED. Root [SECURITY.md](../SECURITY.md) now documents reporting, threat model, safe defaults, and hardening checklist.
+17. **Audit log for all autonomous actions** -- PLANNED. Tool calls, cron runs, and evolution promotions should be recorded with tamper-evident storage.
 
-### Phase 6: Mission Control v1 -- PLANNED
+### Phase 6: Mission Control v1 -- PARTIALLY SHIPPED
 
-18. Mission Control dashboard page: roles, schedules, recent runs, daily stats in a single view.
-19. Role health monitoring: alert when a scheduled role fails repeatedly or exceeds token budgets.
-20. One-click role enable/disable from the dashboard and TUI.
-21. Operator playbook system: composable multi-role workflows with dependency ordering.
+18. Mission Control API: roles/profiles, schedules, recent runs, daily stats, estop, provider/model -- SHIPPED.
+19. Mission Control dashboard page: roles, schedules, recent runs, daily stats in a single view -- PLANNED.
+20. Role health monitoring: alert when a scheduled role fails repeatedly or exceeds enforced budgets -- PLANNED.
+21. One-click role enable/disable from the dashboard and TUI -- PLANNED.
+22. Operator playbook system: composable multi-role workflows with dependency ordering -- PLANNED.
 
 ---
 
@@ -72,8 +73,10 @@ These capabilities shipped outside the original Phase 1-3 plan:
 - **PR babysitting** -- `ok-gobot babysit` auto-maintains PRs.
 - **Auto-worktree management** -- isolated git worktrees per background task.
 - **Export training data** -- `ok-gobot export` for fine-tuning datasets.
-- **Hermes provider** -- native Hermes tool call parser for local models (Ollama + hermes3).
+- **Hermes model parser** -- native Hermes tool call parser for local/OpenAI-compatible models (Ollama + hermes3).
 - **`/btw` side queries** -- ask questions during active task execution without interrupting.
+- **Mission Control API** -- authenticated HTTP endpoints for roles/profiles, schedules, runs, stats, estop, and provider/model state.
+- **Root security policy** -- vulnerability reporting, threat model, safe defaults, and hardening checklist in [SECURITY.md](../SECURITY.md).
 
 ## Non-Goals for Now
 
@@ -87,7 +90,7 @@ These capabilities shipped outside the original Phase 1-3 plan:
 
 If only five things get done next, the order should be:
 
-1. Per-task budget caps -- operators can set hard limits on tool calls and model cost
+1. Token/cost budget enforcement -- operators can set hard limits beyond the shipped tool-call and duration caps
 2. Policy enforcement gateway -- single choke point for all pre-execution checks
 3. Audit log -- tamper-evident record of all autonomous actions
 4. Mission Control dashboard -- single-page view of roles, schedules, and runs

--- a/internal/role/prebuilt/researcher.md
+++ b/internal/role/prebuilt/researcher.md
@@ -36,6 +36,6 @@ If nothing relevant was found, state that clearly rather than padding the report
 
 ## Scheduling
 
-This role is manual only — trigger it on demand via `/role run researcher`
+This role is manual only — trigger it on demand via `/role_run researcher`
 or by referencing it in a task. Add a schedule in your copy if you want
 periodic research runs.


### PR DESCRIPTION
## Summary
- Refresh current-state docs across README, install, architecture, features, roadmap, competitors, Mission Control, and security guidance.
- Correct provider, CLI, Telegram role/job, bundled role, and scheduled autonomy documentation to match the codebase.
- Clarify shipped versus planned Mission Control, dashboard, budget, and safety-gateway work.

## Tests
- go fmt ./...
- go vet ./...
- go test ./...
- go build ./cmd/ok-gobot/

Implements #290.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR aligns README, INSTALL, ARCHITECTURE, FEATURES, ROADMAP, COMPETITORS, MISSION-CONTROL, SECURITY, and the bundled `researcher.md` with the current codebase state (issue #290). Key factual corrections include: OpenRouter is now the default provider, ChatGPT drops OAuth in favor of a manual session JWT, the Mission Control API moves from the control-server (port 8787) to the HTTP API (port 8080), bundled roles are templates that require explicit copy to `roles_path` before any schedule activates, and the researcher role's default schedule is corrected from "09:00 UTC daily" to "Manual only" — consistent with the embedded manifest. Budget-enforcement language is consistently updated across all documents to distinguish shipped tool-call/duration limits from the still-incomplete token/cost enforcement.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only changes, no executable code modified except a single command-name fix in researcher.md

All changes are in markdown documentation files plus one embedded role manifest. The corrections are internally consistent across all nine files (provider tables, command names, port numbers, schedule defaults, budget caveats), and the only non-doc file touched (internal/role/prebuilt/researcher.md) fixes a command name from the non-existent /role run to the actual /role_run.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Refreshes provider table (OpenRouter default), Telegram commands, CLI reference, and config example to match current codebase state |
| SECURITY.md | Corrects budget-enforcement language and adds a hardening checklist item for scheduled roles (max_tool_calls, max_duration) |
| docs/ARCHITECTURE.md | Clarifies runtime transition, Mission Control API location (HTTP port 8080 vs control-server 8787), and legacy freeze policy |
| docs/COMPETITORS.md | Adds an April 29 current-state note and corrects the security/budget posture description; all statements internally consistent |
| docs/FEATURES.md | Adds OpenRouter, corrects ChatGPT to Codex/session-JWT, clarifies bundled-role template semantics, documents new manifest fields, corrects /role_run command name |
| docs/INSTALL.md | Adds OpenRouter setup, corrects Gemini CLI install note (removed wrong @anthropic-ai/gemini-cli package), corrects researcher default schedule from "09:00 UTC daily" to "Manual only", and adds new manifest fields table |
| docs/MISSION-CONTROL.md | Corrects Mission Control API port from control-server 8787 to HTTP API 8080, adds estop/providers endpoints, and updates planned vs shipped status |
| docs/ROADMAP.md | Updates Phase 3/5/6 shipped/in-progress/planned status to reflect current state; consistent with FEATURES and ARCHITECTURE changes |
| internal/role/prebuilt/researcher.md | Corrects the trigger command from the non-existent `/role run` to the actual `/role_run` command; consistent with all other docs |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: align current-state docs (#290)"](https://github.com/befeast/ok-gobot/commit/46a00ab108e0661e7b6924600cacbcc22afc70c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30256956)</sub>

<!-- /greptile_comment -->