### PR TITLE
feat: expose memory health diagnostics (#327)

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -30,7 +30,6 @@ memory:
   embeddings_base_url: "https://api.openai.com/v1"
   embeddings_api_key: ""  # Leave empty to reuse ai.api_key
   embeddings_model: "text-embedding-3-small"
-  extra_paths: []
   qmd_enabled: false
   metadata_extraction: false
   metadata_model: "haiku"

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -30,6 +30,8 @@ memory:
   embeddings_base_url: "https://api.openai.com/v1"
   embeddings_api_key: ""  # Leave empty to reuse ai.api_key
   embeddings_model: "text-embedding-3-small"
+  extra_paths: []
+  qmd_enabled: false
   metadata_extraction: false
   metadata_model: "haiku"
   extra_paths:
@@ -70,6 +72,8 @@ memory:
 - **embeddings_base_url**: API endpoint for embeddings (OpenAI-compatible)
 - **embeddings_api_key**: API key for embeddings (if empty, reuses `ai.api_key`)
 - **embeddings_model**: Embedding model to use (default: `text-embedding-3-small`)
+- **extra_paths**: Additional configured memory source paths shown in diagnostics
+- **qmd_enabled**: Quarto/QMD memory support flag shown in diagnostics
 - **metadata_extraction**: When `true`, extracts structured metadata (`people/topics/action_items/type`) during indexing
 - **metadata_model**: Lightweight LLM model used for metadata extraction (default: `haiku`)
 - **extra_paths**: Additional named markdown roots to index (Obsidian vaults, shared-memory exports). See "External markdown collections" below.
@@ -160,6 +164,11 @@ Inspect the persisted index:
 ```bash
 ok-gobot memory status
 ```
+
+The status output includes whether memory is enabled, backend type, watcher
+state, indexed source/chunk counts, last indexed time, any last error,
+configured extra paths, QMD status, and an action when memory is disabled,
+stale, or in an error state.
 
 Include backend diagnostics, including QMD binary, configured collections,
 index/update state, embedding readiness, and last error:
@@ -285,6 +294,9 @@ collection is rooted at the expected location:
 To use QMD's heavier model-backed behavior, explicitly set `search_mode: "query"`
 or `search_mode: "vsearch"` after configuring QMD. ok-gobot does not download
 QMD models itself and defaults to `search` to avoid triggering model setup.
+
+Telegram operators can use `/memory_status` to see the same health summary in a
+compact format.
 
 ### Agent Tool Commands
 

--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -28,6 +28,7 @@ api:
 | `/api/mission/stats` | GET | Daily and total statistics (tokens, messages, sessions) |
 | `/api/mission/estop` | GET | Current emergency-stop state |
 | `/api/mission/providers` | GET | Active AI provider and model |
+| `/api/mission/memory` | GET | Memory health: enabled state, backend, watcher, counts, freshness, and last error |
 
 Run query parameters: `limit` (1-200), `status` (filter by run status). Stats query parameters: `days` (1-90).
 
@@ -38,6 +39,7 @@ Run query parameters: `limit` (1-200), `status` (filter by run status). Stats qu
 - **Runs** -- whether recent job runs succeeded or failed, with summaries
 - **Stats** -- aggregate token usage and message counts
 - **Controls** -- emergency-stop state and active provider/model
+- **Memory** -- whether the memory index is enabled, fresh, watched, and error-free
 
 ## Architecture
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -390,6 +390,22 @@ func TestHandleMissionProviders(t *testing.T) {
 	}
 }
 
+func TestHandleMissionMemory(t *testing.T) {
+	srv := NewAPIServer(config.APIConfig{
+		Enabled: true,
+		Port:    8080,
+		APIKey:  "test-key",
+	}, nil)
+	// Without bot, should return error
+	req := httptest.NewRequest(http.MethodGet, "/api/mission/memory", nil)
+	w := httptest.NewRecorder()
+	srv.handleMissionMemory(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("Expected 500 without bot, got %d", w.Code)
+	}
+}
+
 func TestHandleMissionEstop_WrongMethod(t *testing.T) {
 	srv := newTestServer(&mockDataProvider{})
 	req := httptest.NewRequest(http.MethodPost, "/api/mission/estop", nil)
@@ -406,6 +422,17 @@ func TestHandleMissionProviders_WrongMethod(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/mission/providers", nil)
 	w := httptest.NewRecorder()
 	srv.handleMissionProviders(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleMissionMemory_WrongMethod(t *testing.T) {
+	srv := newTestServer(&mockDataProvider{})
+	req := httptest.NewRequest(http.MethodPost, "/api/mission/memory", nil)
+	w := httptest.NewRecorder()
+	srv.handleMissionMemory(w, req)
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("Expected 405, got %d", w.Code)

--- a/internal/api/mission.go
+++ b/internal/api/mission.go
@@ -248,6 +248,25 @@ func (s *APIServer) handleMissionProviders(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, result)
 }
 
+// handleMissionMemory returns memory health for Mission Control.
+func (s *APIServer) handleMissionMemory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.bot == nil {
+		writeJSONError(w, "Bot not available", http.StatusInternalServerError)
+		return
+	}
+
+	status, err := s.bot.GetMemoryStatus(r.Context())
+	if err != nil {
+		writeJSONError(w, "Failed to read memory status: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, status)
+}
+
 // handleMissionStats returns daily aggregate statistics.
 func (s *APIServer) handleMissionStats(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -69,6 +69,7 @@ func (s *APIServer) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/mission/stats", s.handleMissionStats)
 	mux.HandleFunc("/api/mission/estop", s.handleMissionEstop)
 	mux.HandleFunc("/api/mission/providers", s.handleMissionProviders)
+	mux.HandleFunc("/api/mission/memory", s.handleMissionMemory)
 
 	// Apply middleware
 	handler := loggingMiddleware(mux)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -37,6 +37,7 @@ type App struct {
 	memory        *agent.Memory
 	scheduler     *cron.Scheduler
 	memoryManager *memory.MemoryManager
+	memoryStatus  *memory.StatusReporter
 	memoryMCP     *memorymcp.Server
 	memoryWatcher *memory.Watcher
 	apiServer     *api.APIServer
@@ -53,6 +54,10 @@ type stateAdapter struct {
 
 func (a *stateAdapter) GetStatus() map[string]interface{} {
 	return a.b.GetStatus()
+}
+
+func (a *stateAdapter) GetMemoryStatus(ctx context.Context) (memory.IndexStatus, error) {
+	return a.b.GetMemoryStatus(ctx)
 }
 
 func (a *stateAdapter) RespondToApproval(id string, approved bool) error {
@@ -177,6 +182,14 @@ func (a *App) Start(ctx context.Context) error {
 
 	// Initialize memory system
 	a.memory = agent.NewMemory(soulPath)
+	a.memoryStatus = memory.NewStatusReporter(nil, memory.StatusOptions{
+		Enabled:      a.config.Memory.Enabled,
+		RootPath:     soulPath,
+		BackendType:  appMemoryBackendName(a.config),
+		WatcherState: memory.WatcherStateDisabled,
+		ExtraPaths:   appMemoryExtraPathLabels(a.config),
+		QMDStatus:    appMemoryQMDStatus(a.config),
+	})
 
 	aiAPIKey := strings.TrimSpace(a.config.AI.APIKey)
 	if aiAPIKey == "" && a.config.AI.Provider == "anthropic" {
@@ -263,6 +276,7 @@ func (a *App) Start(ctx context.Context) error {
 
 	// Initialize semantic memory manager if enabled
 	if a.config.Memory.Enabled {
+		a.memoryStatus.SetWatcherState(memory.WatcherStateStarting)
 		apiKey := a.config.Memory.EmbeddingsAPIKey
 		if apiKey == "" {
 			apiKey = a.config.AI.APIKey
@@ -278,7 +292,10 @@ func (a *App) Start(ctx context.Context) error {
 		memStore, err := memory.NewMemoryStore(a.store.DB())
 		if err != nil {
 			log.Printf("⚠️ Failed to initialize memory store: %v", err)
+			a.memoryStatus.SetWatcherState(memory.WatcherStateError)
+			a.memoryStatus.SetLastError("memory store initialization failed", err)
 		} else {
+			a.memoryStatus.SetStore(memStore)
 			var options []memory.MemoryManagerOption
 			builtinBackend := memory.NewBuiltinBackend(embClient, memStore)
 
@@ -321,7 +338,7 @@ func (a *App) Start(ctx context.Context) error {
 			} else {
 				log.Println("🧠 Hybrid memory initialized")
 			}
-			a.startMemoryIndexer(ctx, soulPath, memStore, embClient)
+			a.startMemoryIndexer(ctx, soulPath, memStore, embClient, a.memoryStatus)
 		}
 	}
 
@@ -360,7 +377,7 @@ func (a *App) Start(ctx context.Context) error {
 		log.Printf("⚠️ [memory] extra paths config error: %v", err)
 		memoryExtras = nil
 	}
-	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.config.Browser, a.config.STT, a.scheduler, a.memoryManager, memoryExtras, a.config.Memory.Sessions.Enabled, a.config.Contacts)
+	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.config.Browser, a.config.STT, a.scheduler, a.memoryManager, memoryExtras, a.config.Memory.Sessions.Enabled, a.memoryStatus, a.config.Contacts)
 	if err != nil {
 		return fmt.Errorf("failed to create bot: %w", err)
 	}
@@ -526,6 +543,45 @@ func appQMDConfig(cfg config.MemoryQMDConfig) memory.QMDConfig {
 	}
 }
 
+func appMemoryBackendName(cfg *config.Config) string {
+	if cfg == nil {
+		return "builtin"
+	}
+	name := strings.ToLower(strings.TrimSpace(cfg.Memory.Backend))
+	if name == "" {
+		return "builtin"
+	}
+	return name
+}
+
+func appMemoryQMDStatus(cfg *config.Config) string {
+	backend := appMemoryBackendName(cfg)
+	if backend == "qmd" || backend == "auto" {
+		return "configured"
+	}
+	return "disabled"
+}
+
+func appMemoryExtraPathLabels(cfg *config.Config) []string {
+	if cfg == nil || len(cfg.Memory.ExtraPaths) == 0 {
+		return nil
+	}
+	labels := make([]string, 0, len(cfg.Memory.ExtraPaths))
+	for _, extra := range cfg.Memory.ExtraPaths {
+		name := strings.TrimSpace(extra.Name)
+		path := strings.TrimSpace(extra.Path)
+		switch {
+		case name != "" && path != "":
+			labels = append(labels, fmt.Sprintf("%s=%s", name, path))
+		case name != "":
+			labels = append(labels, name)
+		case path != "":
+			labels = append(labels, path)
+		}
+	}
+	return labels
+}
+
 func parseDurationOrDefault(value string, fallback time.Duration) time.Duration {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -538,7 +594,7 @@ func parseDurationOrDefault(value string, fallback time.Duration) time.Duration 
 	return duration
 }
 
-func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *memory.MemoryStore, embedder memory.EmbeddingBatchClient) {
+func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *memory.MemoryStore, embedder memory.EmbeddingBatchClient, reporter *memory.StatusReporter) {
 	if strings.TrimSpace(rootPath) == "" || store == nil {
 		return
 	}
@@ -547,28 +603,35 @@ func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *me
 	stats, err := memory.IndexManagedSources(ctx, rootPath, indexer)
 	if err != nil {
 		log.Printf("⚠️ [memory] initial index failed: %v", err)
+		reporter.SetLastError("initial index failed", err)
 	} else {
+		reporter.ClearLastError()
 		log.Printf("🧠 [memory] indexed %d managed source file(s)", stats.FilesIndexed)
 	}
 
 	extras, extraErr := a.normalizedExtraPaths()
 	if extraErr != nil {
 		log.Printf("⚠️ [memory] extra paths config error: %v", extraErr)
+		reporter.SetLastError("extra paths config error", extraErr)
 	}
 	if len(extras) > 0 {
 		extraStats, errs := memory.IndexExtraPaths(ctx, extras, indexer)
 		log.Printf("🧠 [memory] indexed %d extra source file(s) across %d collection(s)", extraStats.FilesIndexed, len(extras))
 		for _, e := range errs {
 			log.Printf("⚠️ [memory] extra path indexing: %v", e)
+			reporter.SetLastError("extra path indexing failed", e)
 		}
 	}
 
 	watcher, err := memory.NewWatcher(rootPath)
 	if err != nil {
 		log.Printf("⚠️ [memory] failed to start memory watcher: %v", err)
+		reporter.SetWatcherState(memory.WatcherStateError)
+		reporter.SetLastError("memory watcher failed", err)
 	} else {
 		a.memoryWatcher = watcher
-		go a.runMemoryWatcher(ctx, rootPath, watcher, indexer)
+		reporter.SetWatcherState(memory.WatcherStateActive)
+		go a.runMemoryWatcher(ctx, rootPath, watcher, indexer, reporter)
 		log.Printf("🧠 [memory] watcher active for %s", rootPath)
 	}
 
@@ -576,14 +639,16 @@ func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *me
 		extraWatcher, err := memory.NewWatcher(extra.Path)
 		if err != nil {
 			log.Printf("⚠️ [memory] extra path %q watcher unavailable (%v) — index won't auto-refresh", extra.Name, err)
+			reporter.SetLastError(fmt.Sprintf("extra path %q watcher unavailable", extra.Name), err)
 			continue
 		}
-		go a.runExtraPathWatcher(ctx, extra, extraWatcher, indexer)
+		reporter.SetWatcherState(memory.WatcherStateActive)
+		go a.runExtraPathWatcher(ctx, extra, extraWatcher, indexer, reporter)
 		log.Printf("🧠 [memory] watcher active for extra path %q (%s)", extra.Name, extra.Path)
 	}
 }
 
-func (a *App) runMemoryWatcher(ctx context.Context, rootPath string, watcher *memory.Watcher, indexer *memory.Indexer) {
+func (a *App) runMemoryWatcher(ctx context.Context, rootPath string, watcher *memory.Watcher, indexer *memory.Indexer, reporter *memory.StatusReporter) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -594,6 +659,8 @@ func (a *App) runMemoryWatcher(ctx context.Context, rootPath string, watcher *me
 				return
 			}
 			log.Printf("⚠️ [memory] watcher error: %v", err)
+			reporter.SetWatcherState(memory.WatcherStateError)
+			reporter.SetLastError("memory watcher error", err)
 		case event, ok := <-watcher.Events():
 			if !ok {
 				return
@@ -604,14 +671,17 @@ func (a *App) runMemoryWatcher(ctx context.Context, rootPath string, watcher *me
 			}
 			if err := indexer.IndexFile(ctx, event.Path, rel); err != nil {
 				log.Printf("⚠️ [memory] reindex failed for %s: %v", rel, err)
+				reporter.SetLastError("reindex failed for "+rel, err)
 				continue
 			}
+			reporter.SetWatcherState(memory.WatcherStateActive)
+			reporter.ClearLastError()
 			log.Printf("🧠 [memory] reindexed %s", rel)
 		}
 	}
 }
 
-func (a *App) runExtraPathWatcher(ctx context.Context, extra memory.ExtraPath, watcher *memory.Watcher, indexer *memory.Indexer) {
+func (a *App) runExtraPathWatcher(ctx context.Context, extra memory.ExtraPath, watcher *memory.Watcher, indexer *memory.Indexer, reporter *memory.StatusReporter) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -622,6 +692,7 @@ func (a *App) runExtraPathWatcher(ctx context.Context, extra memory.ExtraPath, w
 				return
 			}
 			log.Printf("⚠️ [memory] extra path %q watcher error: %v", extra.Name, err)
+			reporter.SetLastError(fmt.Sprintf("extra path %q watcher error", extra.Name), err)
 		case event, ok := <-watcher.Events():
 			if !ok {
 				return
@@ -633,8 +704,11 @@ func (a *App) runExtraPathWatcher(ctx context.Context, extra memory.ExtraPath, w
 			label := memory.SourceLabelForExtra(extra.Name, rel)
 			if err := indexer.IndexFile(ctx, event.Path, label); err != nil {
 				log.Printf("⚠️ [memory] reindex failed for %s: %v", label, err)
+				reporter.SetLastError("reindex failed for "+label, err)
 				continue
 			}
+			reporter.SetWatcherState(memory.WatcherStateActive)
+			reporter.ClearLastError()
 			log.Printf("🧠 [memory] reindexed %s", label)
 		}
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -692,6 +692,7 @@ func (a *App) runExtraPathWatcher(ctx context.Context, extra memory.ExtraPath, w
 				return
 			}
 			log.Printf("⚠️ [memory] extra path %q watcher error: %v", extra.Name, err)
+			reporter.SetWatcherState(memory.WatcherStateError)
 			reporter.SetLastError(fmt.Sprintf("extra path %q watcher error", extra.Name), err)
 		case event, ok := <-watcher.Events():
 			if !ok {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -642,7 +642,9 @@ func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *me
 			reporter.SetLastError(fmt.Sprintf("extra path %q watcher unavailable", extra.Name), err)
 			continue
 		}
-		reporter.SetWatcherState(memory.WatcherStateActive)
+		if reporter.WatcherState() != memory.WatcherStateError {
+			reporter.SetWatcherState(memory.WatcherStateActive)
+		}
 		go a.runExtraPathWatcher(ctx, extra, extraWatcher, indexer, reporter)
 		log.Printf("🧠 [memory] watcher active for extra path %q (%s)", extra.Name, extra.Path)
 	}
@@ -708,8 +710,10 @@ func (a *App) runExtraPathWatcher(ctx context.Context, extra memory.ExtraPath, w
 				reporter.SetLastError("reindex failed for "+label, err)
 				continue
 			}
-			reporter.SetWatcherState(memory.WatcherStateActive)
-			reporter.ClearLastError()
+			if reporter.WatcherState() != memory.WatcherStateError {
+				reporter.SetWatcherState(memory.WatcherStateActive)
+				reporter.ClearLastError()
+			}
 			log.Printf("🧠 [memory] reindexed %s", label)
 		}
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -695,7 +695,7 @@ func (a *App) runExtraPathWatcher(ctx context.Context, extra memory.ExtraPath, w
 			}
 			log.Printf("⚠️ [memory] extra path %q watcher error: %v", extra.Name, err)
 			reporter.SetWatcherState(memory.WatcherStateError)
-			reporter.SetLastError(fmt.Sprintf("extra path %q watcher error", extra.Name), err)
+			reporter.SetLastError(extraWatcherError(extra.Name), err)
 		case event, ok := <-watcher.Events():
 			if !ok {
 				return
@@ -705,18 +705,25 @@ func (a *App) runExtraPathWatcher(ctx context.Context, extra memory.ExtraPath, w
 				continue
 			}
 			label := memory.SourceLabelForExtra(extra.Name, rel)
+			reindexError := "reindex failed for " + label
 			if err := indexer.IndexFile(ctx, event.Path, label); err != nil {
 				log.Printf("⚠️ [memory] reindex failed for %s: %v", label, err)
-				reporter.SetLastError("reindex failed for "+label, err)
+				reporter.SetLastError(reindexError, err)
 				continue
 			}
-			if reporter.WatcherState() != memory.WatcherStateError {
+			if reporter.ClearLastErrorIfPrefix(extraWatcherError(extra.Name), reindexError) {
+				reporter.SetWatcherState(memory.WatcherStateActive)
+			} else if reporter.WatcherState() != memory.WatcherStateError {
 				reporter.SetWatcherState(memory.WatcherStateActive)
 				reporter.ClearLastError()
 			}
 			log.Printf("🧠 [memory] reindexed %s", label)
 		}
 	}
+}
+
+func extraWatcherError(name string) string {
+	return fmt.Sprintf("extra path %q watcher error", name)
 }
 
 func (a *App) normalizedExtraPaths() ([]memory.ExtraPath, error) {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -59,6 +59,12 @@ type Bot struct {
 	voiceTranscriber *VoiceTranscriber
 	rolesPath        string // directory of role manifests; set via SetRolesPath
 	activeMemory     *agent.ActiveMemory
+	memoryStatus     MemoryStatusProvider
+}
+
+// MemoryStatusProvider supplies memory health for Telegram and local APIs.
+type MemoryStatusProvider interface {
+	Status(ctx context.Context) (memory.IndexStatus, error)
 }
 
 // AIConfig holds AI configuration for status display
@@ -75,7 +81,7 @@ type AIConfig struct {
 }
 
 // New creates a new bot instance
-func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, browserCfg config.BrowserConfig, sttCfg config.STTConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager, memoryExtraPaths []memory.ExtraPath, sessionMemoryEnabled bool, contacts map[string]int64) (*Bot, error) {
+func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, browserCfg config.BrowserConfig, sttCfg config.STTConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager, memoryExtraPaths []memory.ExtraPath, sessionMemoryEnabled bool, memoryStatus MemoryStatusProvider, contacts map[string]int64) (*Bot, error) {
 	pref := telebot.Settings{
 		Token:  token,
 		Poller: &telebot.LongPoller{Timeout: 10 * time.Second},
@@ -159,6 +165,7 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		queueManager:     NewQueueManager(),
 		ackManager:       NewAckHandleManager(),
 		scheduler:        scheduler,
+		memoryStatus:     memoryStatus,
 	}
 
 	// Initialize voice transcriber if STT is configured
@@ -338,6 +345,7 @@ func (b *Bot) Start(ctx context.Context) error {
 /clear - Clear conversation history
 /note <text> - Quick note to today's memory
 /memory - Show today's memory
+/memory_status - Show memory index health
 /tools - List available tools
 /model - Manage AI model (list/set/clear)
 /agent - Manage agents (list/switch)
@@ -379,6 +387,10 @@ func (b *Bot) Start(ctx context.Context) error {
 
 		return c.Send(fmt.Sprintf("📓 *Today's Memory*\n\n%s", note.Content),
 			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+	}))
+
+	b.api.Handle("/memory_status", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
+		return b.handleMemoryStatusCommand(c)
 	}))
 
 	b.api.Handle("/model", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
@@ -788,6 +800,28 @@ func (b *Bot) GetAgentRegistry() *agent.AgentRegistry { return b.agentRegistry }
 // GetScheduler returns the cron scheduler.
 func (b *Bot) GetScheduler() tools.CronScheduler { return b.scheduler }
 
+// GetMemoryStatus returns current memory health diagnostics.
+func (b *Bot) GetMemoryStatus(ctx context.Context) (memory.IndexStatus, error) {
+	if b == nil || b.memoryStatus == nil {
+		return memory.CollectStatus(ctx, nil, memory.StatusOptions{
+			Enabled:      false,
+			BackendType:  "none",
+			WatcherState: memory.WatcherStateDisabled,
+		})
+	}
+	status, err := b.memoryStatus.Status(ctx)
+	if err != nil && status.LastError != "" {
+		if status.State == "" {
+			status.State = memory.MemoryStateError
+		}
+		if status.Action == "" {
+			status.Action = "Fix the error, then run ok-gobot memory index --force."
+		}
+		return status, nil
+	}
+	return status, err
+}
+
 // GetStatus returns bot status information for API
 func (b *Bot) GetStatus() map[string]interface{} {
 	status := map[string]interface{}{
@@ -810,6 +844,15 @@ func (b *Bot) GetStatus() map[string]interface{} {
 	// Estop state
 	if enabled, err := b.store.IsEmergencyStopEnabled(); err == nil {
 		status["estop_enabled"] = enabled
+	}
+
+	if memoryStatus, err := b.GetMemoryStatus(context.Background()); err == nil {
+		status["memory"] = memoryStatus
+	} else {
+		status["memory"] = map[string]interface{}{
+			"state":      memory.MemoryStateError,
+			"last_error": err.Error(),
+		}
 	}
 
 	return status

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -164,6 +164,7 @@ func (b *Bot) handleCommandsCommand(c telebot.Context) error {
 		{"stop", "Stop the current run"},
 		{"abort", "Abort the current run"},
 		{"memory", "Show today's memory"},
+		{"memory_status", "Show memory index health"},
 		{"tools", "List available tools"},
 		{"model", "Show or set AI model"},
 		{"agent", "Manage agents"},

--- a/internal/bot/status.go
+++ b/internal/bot/status.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/bootstrap"
+	"ok-gobot/internal/memory"
 	"ok-gobot/internal/tools"
 	"ok-gobot/internal/version"
 )
@@ -19,6 +21,24 @@ var startTime = time.Now()
 // handleStatusCommand shows rich bot status
 func (b *Bot) handleStatusCommand(c telebot.Context) error {
 	return c.Send(b.buildStatusString(c.Chat().ID), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+}
+
+func (b *Bot) handleMemoryStatusCommand(c telebot.Context) error {
+	return c.Send(b.buildMemoryStatusString(context.Background()))
+}
+
+func (b *Bot) buildMemoryStatusString(ctx context.Context) string {
+	status, err := b.GetMemoryStatus(ctx)
+	if err != nil {
+		if status.LastError == "" {
+			status.LastError = err.Error()
+		}
+		status.State = memory.MemoryStateError
+		if status.Action == "" {
+			status.Action = "Check memory configuration and storage, then run ok-gobot memory index --force."
+		}
+	}
+	return memory.FormatStatusTelegram(status)
 }
 
 // buildStatusString builds the full status string for a given chatID.

--- a/internal/bot/status_test.go
+++ b/internal/bot/status_test.go
@@ -1,0 +1,57 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/memory"
+)
+
+type fakeMemoryStatusProvider struct {
+	status memory.IndexStatus
+	err    error
+}
+
+func (f fakeMemoryStatusProvider) Status(context.Context) (memory.IndexStatus, error) {
+	return f.status, f.err
+}
+
+func TestBuildMemoryStatusStringIncludesCounts(t *testing.T) {
+	b := &Bot{memoryStatus: fakeMemoryStatusProvider{status: memory.IndexStatus{
+		Enabled:       true,
+		State:         memory.MemoryStateOK,
+		BackendType:   memory.BackendSQLite,
+		WatcherState:  memory.WatcherStateActive,
+		SourceCount:   2,
+		ChunkCount:    12,
+		LastIndexedAt: "2026-04-30 12:00:00",
+	}}}
+
+	out := b.buildMemoryStatusString(t.Context())
+	for _, want := range []string{"Memory status: ok", "Indexed: 2 source(s), 12 chunk(s)", "Watcher: active"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output: %q", want, out)
+		}
+	}
+}
+
+func TestBuildMemoryStatusStringShowsProviderError(t *testing.T) {
+	b := &Bot{memoryStatus: fakeMemoryStatusProvider{
+		status: memory.IndexStatus{
+			Enabled:      true,
+			BackendType:  memory.BackendSQLite,
+			WatcherState: memory.WatcherStateError,
+			LastError:    "initial index failed",
+		},
+		err: errors.New("memory store is not configured"),
+	}}
+
+	out := b.buildMemoryStatusString(t.Context())
+	for _, want := range []string{"Memory status: error", "Last error: initial index failed", "Action:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output: %q", want, out)
+		}
+	}
+}

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -33,33 +33,40 @@ func newMemoryStatusCommand(cfg *config.Config) *cobra.Command {
 		Use:   "status",
 		Short: "Show memory index status",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			store, memStore, err := openMemoryStore(cfg)
-			if err != nil {
-				return err
+			var memStore *memory.MemoryStore
+			if cfg.Memory.Enabled {
+				store, openedMemStore, err := openMemoryStore(cfg)
+				if err != nil {
+					return err
+				}
+				memStore = openedMemStore
+				defer store.Close() //nolint:errcheck
 			}
-			defer store.Close() //nolint:errcheck
 
-			status, err := memStore.Status(cmd.Context(), cfg.Memory.Enabled, cfg.GetSoulPath())
+			watcherState := memory.WatcherStateDisabled
+			if cfg.Memory.Enabled {
+				watcherState = memory.WatcherStateNotRunning
+			}
+
+			status, err := memory.CollectStatus(cmd.Context(), memStore, memory.StatusOptions{
+				Enabled:      cfg.Memory.Enabled,
+				RootPath:     cfg.GetSoulPath(),
+				BackendType:  memoryBackendName(cfg),
+				WatcherState: watcherState,
+				ExtraPaths:   memoryExtraPathLabels(cfg),
+				QMDStatus:    memoryQMDStatus(cfg),
+			})
 			if err != nil {
 				return err
 			}
 
 			out := cmd.OutOrStdout()
-			fmt.Fprintf(out, "Memory enabled: %v\n", status.Enabled)
-			fmt.Fprintf(out, "Backend: %s\n", memoryBackendName(cfg))
-			fmt.Fprintf(out, "Root: %s\n", status.RootPath)
-			fmt.Fprintf(out, "Sources: %d\n", status.SourceCount)
-			fmt.Fprintf(out, "Chunks: %d\n", status.ChunkCount)
-			if status.LastIndexedAt != "" {
-				fmt.Fprintf(out, "Last indexed: %s\n", status.LastIndexedAt)
-			} else {
-				fmt.Fprintln(out, "Last indexed: never")
-			}
+			fmt.Fprint(out, memory.FormatStatusCLI(status))
 
 			extras, err := extraPathsFromConfig(cfg)
 			if err != nil {
 				fmt.Fprintf(out, "Extra paths: configuration error: %v\n", err)
-			} else if len(extras) > 0 {
+			} else if len(extras) > 0 && memStore != nil {
 				fmt.Fprintf(out, "Extra paths (%d):\n", len(extras))
 				for _, diag := range memStore.ExtraPathDiagnostics(cmd.Context(), extras) {
 					state := "ok"
@@ -596,6 +603,34 @@ func memoryBackendName(cfg *config.Config) string {
 		return "builtin"
 	}
 	return name
+}
+
+func memoryQMDStatus(cfg *config.Config) string {
+	backend := memoryBackendName(cfg)
+	if backend == "qmd" || backend == "auto" {
+		return "configured"
+	}
+	return "disabled"
+}
+
+func memoryExtraPathLabels(cfg *config.Config) []string {
+	if cfg == nil || len(cfg.Memory.ExtraPaths) == 0 {
+		return nil
+	}
+	labels := make([]string, 0, len(cfg.Memory.ExtraPaths))
+	for _, extra := range cfg.Memory.ExtraPaths {
+		name := strings.TrimSpace(extra.Name)
+		path := strings.TrimSpace(extra.Path)
+		switch {
+		case name != "" && path != "":
+			labels = append(labels, fmt.Sprintf("%s=%s", name, path))
+		case name != "":
+			labels = append(labels, name)
+		case path != "":
+			labels = append(labels, path)
+		}
+	}
+	return labels
 }
 
 func cliQMDConfig(cfg config.MemoryQMDConfig) memory.QMDConfig {

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -38,7 +38,30 @@ func TestMemoryStatusShowsIndexedSources(t *testing.T) {
 		t.Fatalf("Execute error = %v", err)
 	}
 	output := out.String()
-	for _, want := range []string{"Memory enabled: true", "Sources: 2", "Chunks: 2"} {
+	for _, want := range []string{"Memory: ok", "Enabled: true", "Sources: 2", "Chunks: 2", "Watcher: not_running"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
+func TestMemoryStatusDisabledIsExplicit(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+	cfg.Memory.Enabled = false
+	cfg.SoulPath = t.TempDir()
+
+	cmd := newMemoryCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	output := out.String()
+	for _, want := range []string{"Memory: disabled", "Enabled: false", "Action: Set memory.enabled: true"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected %q in output: %q", want, output)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -400,6 +400,7 @@ func Load() (*Config, error) {
 	v.SetDefault("memory.embeddings_base_url", "https://api.openai.com/v1")
 	v.SetDefault("memory.embeddings_api_key", "")
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
+	v.SetDefault("memory.extra_paths", []string{})
 	v.SetDefault("memory.metadata_extraction", false)
 	v.SetDefault("memory.metadata_model", "haiku")
 	v.SetDefault("memory.qmd.binary_path", "qmd")
@@ -482,6 +483,7 @@ func Load() (*Config, error) {
 	cfg.StoragePath = expandPath(cfg.StoragePath)
 	cfg.SoulPath = expandPath(cfg.SoulPath)
 	cfg.RolesPath = expandPath(cfg.RolesPath)
+	cfg.Memory.ExtraPaths = expandMemoryExtraPaths(cfg.Memory.ExtraPaths)
 	cfg.Evolution.BenchmarksDir = expandPath(cfg.Evolution.BenchmarksDir)
 	cfg.Evolution.EvolutionDir = expandPath(cfg.Evolution.EvolutionDir)
 	cfg.ConfigPath = v.ConfigFileUsed()
@@ -534,6 +536,7 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("memory.embeddings_base_url", "https://api.openai.com/v1")
 	v.SetDefault("memory.embeddings_api_key", "")
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
+	v.SetDefault("memory.extra_paths", []string{})
 	v.SetDefault("memory.metadata_extraction", false)
 	v.SetDefault("memory.metadata_model", "haiku")
 	v.SetDefault("memory.qmd.binary_path", "qmd")
@@ -597,6 +600,7 @@ func LoadFrom(configPath string) (*Config, error) {
 	cfg.StoragePath = expandPath(cfg.StoragePath)
 	cfg.SoulPath = expandPath(cfg.SoulPath)
 	cfg.RolesPath = expandPath(cfg.RolesPath)
+	cfg.Memory.ExtraPaths = expandMemoryExtraPaths(cfg.Memory.ExtraPaths)
 	cfg.Evolution.BenchmarksDir = expandPath(cfg.Evolution.BenchmarksDir)
 	cfg.Evolution.EvolutionDir = expandPath(cfg.Evolution.EvolutionDir)
 	cfg.ConfigPath = configPath
@@ -774,9 +778,9 @@ func (c *Config) Save() error {
 	v.Set("memory.embeddings_base_url", c.Memory.EmbeddingsBaseURL)
 	v.Set("memory.embeddings_api_key", c.Memory.EmbeddingsAPIKey)
 	v.Set("memory.embeddings_model", c.Memory.EmbeddingsModel)
+	v.Set("memory.extra_paths", c.Memory.ExtraPaths)
 	v.Set("memory.metadata_extraction", c.Memory.MetadataExtraction)
 	v.Set("memory.metadata_model", c.Memory.MetadataModel)
-	v.Set("memory.extra_paths", c.Memory.ExtraPaths)
 	v.Set("memory.qmd.binary_path", c.Memory.QMD.BinaryPath)
 	v.Set("memory.qmd.index", c.Memory.QMD.Index)
 	v.Set("memory.qmd.index_path", c.Memory.QMD.IndexPath)
@@ -856,4 +860,16 @@ func expandPath(path string) string {
 		return filepath.Join(homeDir, path[2:])
 	}
 	return path
+}
+
+func expandMemoryExtraPaths(paths []MemoryExtraPathConfig) []MemoryExtraPathConfig {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make([]MemoryExtraPathConfig, len(paths))
+	copy(out, paths)
+	for i := range out {
+		out[i].Path = expandPath(out[i].Path)
+	}
+	return out
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,6 +78,10 @@ runtime:
 session:
   dm_scope: "per_user"
 memory:
+  backend: auto
+  extra_paths:
+    - name: notes
+      path: "~/ok-memory"
   metadata_extraction: true
   metadata_model: "claude-haiku-3.5"
 `
@@ -104,6 +108,12 @@ memory:
 	}
 	if cfg.Memory.MetadataModel != "claude-haiku-3.5" {
 		t.Errorf("expected memory.metadata_model override, got %q", cfg.Memory.MetadataModel)
+	}
+	if cfg.Memory.Backend != "auto" {
+		t.Errorf("expected memory.backend=auto, got %q", cfg.Memory.Backend)
+	}
+	if len(cfg.Memory.ExtraPaths) != 1 || !filepath.IsAbs(cfg.Memory.ExtraPaths[0].Path) {
+		t.Errorf("expected expanded memory.extra_paths, got %#v", cfg.Memory.ExtraPaths)
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("expected legacy runtime.mode compatibility to validate, got %v", err)

--- a/internal/control/mission.go
+++ b/internal/control/mission.go
@@ -1,12 +1,14 @@
 package control
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/memory"
 	"ok-gobot/internal/storage"
 	"ok-gobot/internal/tools"
 )
@@ -17,6 +19,7 @@ type MissionProvider interface {
 	GetStore() *storage.Store
 	GetAgentRegistry() *agent.AgentRegistry
 	GetScheduler() tools.CronScheduler
+	GetMemoryStatus(ctx context.Context) (memory.IndexStatus, error)
 }
 
 // registerMissionRoutes adds mission-control HTTP routes to the mux if the
@@ -32,6 +35,7 @@ func (s *Server) registerMissionRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/mission/stats", s.corsWrap(missionStats(mp)))
 	mux.HandleFunc("/api/mission/estop", s.corsWrap(missionEstop(mp)))
 	mux.HandleFunc("/api/mission/providers", s.corsWrap(missionProviders(s)))
+	mux.HandleFunc("/api/mission/memory", s.corsWrap(missionMemory(mp)))
 }
 
 // corsWrap adds permissive CORS headers for loopback origins.
@@ -305,5 +309,20 @@ func missionProviders(srv *Server) http.HandlerFunc {
 			}
 		}
 		writeJSON(w, result)
+	}
+}
+
+func missionMemory(mp MissionProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeJSONErr(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		status, err := mp.GetMemoryStatus(r.Context())
+		if err != nil {
+			writeJSONErr(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, status)
 	}
 }

--- a/internal/memory/lifecycle.go
+++ b/internal/memory/lifecycle.go
@@ -24,12 +24,47 @@ type IndexRunStats struct {
 
 // IndexStatus describes the current state of the persisted memory index.
 type IndexStatus struct {
-	Enabled       bool
-	RootPath      string
-	ChunkCount    int
-	SourceCount   int
-	LastIndexedAt string
+	Enabled       bool     `json:"enabled"`
+	RootPath      string   `json:"root_path"`
+	BackendType   string   `json:"backend_type"`
+	WatcherState  string   `json:"watcher_state"`
+	ChunkCount    int      `json:"chunk_count"`
+	SourceCount   int      `json:"source_count"`
+	LastIndexedAt string   `json:"last_indexed_at"`
+	LastError     string   `json:"last_error"`
+	Stale         bool     `json:"stale"`
+	State         string   `json:"state"`
+	Action        string   `json:"action,omitempty"`
+	ExtraPaths    []string `json:"extra_paths,omitempty"`
+	QMDStatus     string   `json:"qmd_status"`
 }
+
+// StatusOptions carries runtime/config state that is not persisted in SQLite.
+type StatusOptions struct {
+	Enabled      bool
+	RootPath     string
+	BackendType  string
+	WatcherState string
+	LastError    string
+	ExtraPaths   []string
+	QMDStatus    string
+}
+
+const (
+	BackendSQLite = "sqlite"
+
+	WatcherStateDisabled   = "disabled"
+	WatcherStateStarting   = "starting"
+	WatcherStateActive     = "active"
+	WatcherStateNotRunning = "not_running"
+	WatcherStateError      = "error"
+	WatcherStateUnknown    = "unknown"
+
+	MemoryStateDisabled = "disabled"
+	MemoryStateOK       = "ok"
+	MemoryStateStale    = "stale"
+	MemoryStateError    = "error"
+)
 
 // ManagedSources returns the canonical markdown memory files for rootPath:
 // MEMORY.md plus memory/*.md. Missing files/directories are skipped.
@@ -152,28 +187,102 @@ func (s *MemoryStore) ClearManagedSources(ctx context.Context) error {
 }
 
 // Status returns lightweight diagnostics for the persisted memory index.
-func (s *MemoryStore) Status(ctx context.Context, enabled bool, rootPath string) (IndexStatus, error) {
+func (s *MemoryStore) Status(ctx context.Context, opts StatusOptions) (IndexStatus, error) {
+	return CollectStatus(ctx, s, opts)
+}
+
+// CollectStatus returns persisted and runtime memory health diagnostics.
+func CollectStatus(ctx context.Context, store *MemoryStore, opts StatusOptions) (IndexStatus, error) {
 	status := IndexStatus{
-		Enabled:  enabled,
-		RootPath: rootPath,
+		Enabled:      opts.Enabled,
+		RootPath:     opts.RootPath,
+		BackendType:  strings.TrimSpace(opts.BackendType),
+		WatcherState: strings.TrimSpace(opts.WatcherState),
+		LastError:    strings.TrimSpace(opts.LastError),
+		ExtraPaths:   append([]string(nil), opts.ExtraPaths...),
 	}
-	if s == nil || s.db == nil {
+	if status.BackendType == "" {
+		status.BackendType = BackendSQLite
+	}
+	if status.WatcherState == "" {
+		if status.Enabled {
+			status.WatcherState = WatcherStateUnknown
+		} else {
+			status.WatcherState = WatcherStateDisabled
+		}
+	}
+	status.QMDStatus = strings.TrimSpace(opts.QMDStatus)
+	if status.QMDStatus == "" {
+		status.QMDStatus = "disabled"
+	}
+
+	if !status.Enabled {
+		status.State = MemoryStateDisabled
+		status.Action = "Set memory.enabled: true, configure embeddings, then run ok-gobot memory index."
+		return status, nil
+	}
+
+	if store == nil || store.db == nil {
+		if status.LastError == "" {
+			status.LastError = "memory store is not configured"
+		}
+		status.State = MemoryStateError
+		status.Action = "Check storage_path and restart ok-gobot."
 		return status, fmt.Errorf("memory store is not configured")
 	}
 
-	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM memory_chunks`).Scan(&status.ChunkCount); err != nil {
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM memory_chunks`).Scan(&status.ChunkCount); err != nil {
+		status.LastError = fmt.Sprintf("count memory chunks: %v", err)
+		status.State = MemoryStateError
+		status.Action = "Check the memory database and run ok-gobot memory index --force."
 		return status, fmt.Errorf("count memory chunks: %w", err)
 	}
-	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT source_file) FROM memory_chunks`).Scan(&status.SourceCount); err != nil {
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT source_file) FROM memory_chunks`).Scan(&status.SourceCount); err != nil {
+		status.LastError = fmt.Sprintf("count memory sources: %v", err)
+		status.State = MemoryStateError
+		status.Action = "Check the memory database and run ok-gobot memory index --force."
 		return status, fmt.Errorf("count memory sources: %w", err)
 	}
 
 	var last sql.NullString
-	if err := s.db.QueryRowContext(ctx, `SELECT MAX(indexed_at) FROM memory_chunks`).Scan(&last); err != nil {
+	if err := store.db.QueryRowContext(ctx, `SELECT MAX(indexed_at) FROM memory_chunks`).Scan(&last); err != nil {
+		status.LastError = fmt.Sprintf("read last indexed time: %v", err)
+		status.State = MemoryStateError
+		status.Action = "Check the memory database and run ok-gobot memory index --force."
 		return status, fmt.Errorf("read last indexed time: %w", err)
 	}
 	if last.Valid {
 		status.LastIndexedAt = last.String
 	}
+	finalizeStatus(&status)
 	return status, nil
+}
+
+func finalizeStatus(status *IndexStatus) {
+	if status == nil {
+		return
+	}
+	if !status.Enabled {
+		status.State = MemoryStateDisabled
+		if status.Action == "" {
+			status.Action = "Set memory.enabled: true, configure embeddings, then run ok-gobot memory index."
+		}
+		return
+	}
+	if status.LastError != "" || status.WatcherState == WatcherStateError {
+		status.State = MemoryStateError
+		if status.Action == "" {
+			status.Action = "Fix the error, then run ok-gobot memory index --force."
+		}
+		return
+	}
+	if status.LastIndexedAt == "" || status.ChunkCount == 0 {
+		status.State = MemoryStateStale
+		status.Stale = true
+		if status.Action == "" {
+			status.Action = "Run ok-gobot memory index to build the memory index."
+		}
+		return
+	}
+	status.State = MemoryStateOK
 }

--- a/internal/memory/lifecycle_test.go
+++ b/internal/memory/lifecycle_test.go
@@ -92,11 +92,16 @@ func TestIndexManagedSourcesAndClear(t *testing.T) {
 		t.Fatalf("notes.md should not be indexed, got %d chunk(s)", count)
 	}
 
-	status, err := store.Status(context.Background(), true, root)
+	status, err := store.Status(context.Background(), StatusOptions{
+		Enabled:      true,
+		RootPath:     root,
+		BackendType:  BackendSQLite,
+		WatcherState: WatcherStateActive,
+	})
 	if err != nil {
 		t.Fatalf("Status failed: %v", err)
 	}
-	if !status.Enabled || status.SourceCount != 2 || status.ChunkCount != 2 || status.LastIndexedAt == "" {
+	if !status.Enabled || status.SourceCount != 2 || status.ChunkCount != 2 || status.LastIndexedAt == "" || status.State != MemoryStateOK {
 		t.Fatalf("unexpected status: %+v", status)
 	}
 

--- a/internal/memory/status_format.go
+++ b/internal/memory/status_format.go
@@ -1,0 +1,79 @@
+package memory
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatStatusCLI renders memory health for terminal output.
+func FormatStatusCLI(status IndexStatus) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Memory: %s\n", status.State))
+	sb.WriteString(fmt.Sprintf("Enabled: %v\n", status.Enabled))
+	sb.WriteString(fmt.Sprintf("Backend: %s\n", valueOr(status.BackendType, "unknown")))
+	sb.WriteString(fmt.Sprintf("Root: %s\n", valueOr(status.RootPath, "not configured")))
+	sb.WriteString(fmt.Sprintf("Watcher: %s\n", valueOr(status.WatcherState, WatcherStateUnknown)))
+	sb.WriteString(fmt.Sprintf("Sources: %d\n", status.SourceCount))
+	sb.WriteString(fmt.Sprintf("Chunks: %d\n", status.ChunkCount))
+	if status.LastIndexedAt != "" {
+		sb.WriteString(fmt.Sprintf("Last indexed: %s\n", status.LastIndexedAt))
+	} else {
+		sb.WriteString("Last indexed: never\n")
+	}
+	if len(status.ExtraPaths) > 0 {
+		sb.WriteString(fmt.Sprintf("Extra paths: %s\n", strings.Join(status.ExtraPaths, ", ")))
+	} else {
+		sb.WriteString("Extra paths: none configured\n")
+	}
+	sb.WriteString(fmt.Sprintf("QMD: %s\n", valueOr(status.QMDStatus, "disabled")))
+	if status.Stale {
+		sb.WriteString("Stale: true\n")
+	}
+	if status.LastError != "" {
+		sb.WriteString(fmt.Sprintf("Last error: %s\n", status.LastError))
+	}
+	if status.Action != "" {
+		sb.WriteString(fmt.Sprintf("Action: %s\n", status.Action))
+	}
+	return sb.String()
+}
+
+// FormatStatusTelegram renders memory health in compact Telegram-safe text.
+func FormatStatusTelegram(status IndexStatus) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Memory status: %s\n", status.State))
+	sb.WriteString(fmt.Sprintf("Enabled: %v | Backend: %s | Watcher: %s\n",
+		status.Enabled,
+		valueOr(status.BackendType, "unknown"),
+		valueOr(status.WatcherState, WatcherStateUnknown),
+	))
+	sb.WriteString(fmt.Sprintf("Indexed: %d source(s), %d chunk(s)\n", status.SourceCount, status.ChunkCount))
+	if status.LastIndexedAt != "" {
+		sb.WriteString(fmt.Sprintf("Last indexed: %s\n", status.LastIndexedAt))
+	} else {
+		sb.WriteString("Last indexed: never\n")
+	}
+	if len(status.ExtraPaths) > 0 {
+		sb.WriteString(fmt.Sprintf("Extra paths: %s\n", strings.Join(status.ExtraPaths, ", ")))
+	}
+	if status.QMDStatus != "" {
+		sb.WriteString(fmt.Sprintf("QMD: %s\n", status.QMDStatus))
+	}
+	if status.Stale {
+		sb.WriteString("Stale: true\n")
+	}
+	if status.LastError != "" {
+		sb.WriteString(fmt.Sprintf("Last error: %s\n", status.LastError))
+	}
+	if status.Action != "" {
+		sb.WriteString(fmt.Sprintf("Action: %s\n", status.Action))
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func valueOr(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/memory/status_format_test.go
+++ b/internal/memory/status_format_test.go
@@ -1,0 +1,55 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatStatusCLIDisabledIsActionable(t *testing.T) {
+	status, err := CollectStatus(t.Context(), nil, StatusOptions{Enabled: false})
+	if err != nil {
+		t.Fatalf("CollectStatus returned error: %v", err)
+	}
+
+	out := FormatStatusCLI(status)
+	for _, want := range []string{
+		"Memory: disabled",
+		"Enabled: false",
+		"Sources: 0",
+		"Chunks: 0",
+		"Action: Set memory.enabled: true",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output: %q", want, out)
+		}
+	}
+}
+
+func TestFormatStatusTelegramIncludesErrorAndConfiguredPaths(t *testing.T) {
+	status := IndexStatus{
+		Enabled:      true,
+		State:        MemoryStateError,
+		BackendType:  BackendSQLite,
+		WatcherState: WatcherStateError,
+		SourceCount:  3,
+		ChunkCount:   42,
+		LastError:    "embed batch failed",
+		ExtraPaths:   []string{"notes", "runbooks"},
+		QMDStatus:    "configured",
+		Action:       "Fix the error, then run ok-gobot memory index --force.",
+	}
+
+	out := FormatStatusTelegram(status)
+	for _, want := range []string{
+		"Memory status: error",
+		"Indexed: 3 source(s), 42 chunk(s)",
+		"Extra paths: notes, runbooks",
+		"QMD: configured",
+		"Last error: embed batch failed",
+		"Action: Fix the error",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output: %q", want, out)
+		}
+	}
+}

--- a/internal/memory/status_reporter.go
+++ b/internal/memory/status_reporter.go
@@ -77,6 +77,24 @@ func (r *StatusReporter) ClearLastError() {
 	r.opts.LastError = ""
 }
 
+// ClearLastErrorIfPrefix clears the runtime error only when it belongs to a known source.
+func (r *StatusReporter) ClearLastErrorIfPrefix(prefixes ...string) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lastError := strings.TrimSpace(r.opts.LastError)
+	for _, prefix := range prefixes {
+		prefix = strings.TrimSpace(prefix)
+		if prefix != "" && strings.HasPrefix(lastError, prefix) {
+			r.opts.LastError = ""
+			return true
+		}
+	}
+	return false
+}
+
 // Status returns the current memory health snapshot.
 func (r *StatusReporter) Status(ctx context.Context) (IndexStatus, error) {
 	if r == nil {

--- a/internal/memory/status_reporter.go
+++ b/internal/memory/status_reporter.go
@@ -39,6 +39,16 @@ func (r *StatusReporter) SetWatcherState(state string) {
 	r.opts.WatcherState = strings.TrimSpace(state)
 }
 
+// WatcherState returns the current watcher lifecycle state.
+func (r *StatusReporter) WatcherState() string {
+	if r == nil {
+		return WatcherStateUnknown
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return normalizeStatusOptions(r.opts).WatcherState
+}
+
 // SetLastError records the latest memory indexing or watcher error.
 func (r *StatusReporter) SetLastError(message string, err error) {
 	if r == nil {

--- a/internal/memory/status_reporter.go
+++ b/internal/memory/status_reporter.go
@@ -1,0 +1,99 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// StatusReporter combines persisted index counters with runtime health state.
+type StatusReporter struct {
+	mu    sync.RWMutex
+	store *MemoryStore
+	opts  StatusOptions
+}
+
+// NewStatusReporter creates a reporter for memory health diagnostics.
+func NewStatusReporter(store *MemoryStore, opts StatusOptions) *StatusReporter {
+	return &StatusReporter{store: store, opts: normalizeStatusOptions(opts)}
+}
+
+// SetStore updates the store used for persisted index counters.
+func (r *StatusReporter) SetStore(store *MemoryStore) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.store = store
+}
+
+// SetWatcherState records the memory watcher lifecycle state.
+func (r *StatusReporter) SetWatcherState(state string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.opts.WatcherState = strings.TrimSpace(state)
+}
+
+// SetLastError records the latest memory indexing or watcher error.
+func (r *StatusReporter) SetLastError(message string, err error) {
+	if r == nil {
+		return
+	}
+	text := strings.TrimSpace(message)
+	if err != nil {
+		if text == "" {
+			text = err.Error()
+		} else {
+			text = fmt.Sprintf("%s: %v", text, err)
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.opts.LastError = text
+}
+
+// ClearLastError clears any previously recorded runtime error.
+func (r *StatusReporter) ClearLastError() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.opts.LastError = ""
+}
+
+// Status returns the current memory health snapshot.
+func (r *StatusReporter) Status(ctx context.Context) (IndexStatus, error) {
+	if r == nil {
+		return CollectStatus(ctx, nil, StatusOptions{Enabled: false, BackendType: "none", WatcherState: WatcherStateDisabled})
+	}
+	r.mu.RLock()
+	store := r.store
+	opts := normalizeStatusOptions(r.opts)
+	r.mu.RUnlock()
+	return CollectStatus(ctx, store, opts)
+}
+
+func normalizeStatusOptions(opts StatusOptions) StatusOptions {
+	opts.BackendType = strings.TrimSpace(opts.BackendType)
+	if opts.BackendType == "" {
+		opts.BackendType = BackendSQLite
+	}
+	opts.WatcherState = strings.TrimSpace(opts.WatcherState)
+	if opts.WatcherState == "" {
+		if opts.Enabled {
+			opts.WatcherState = WatcherStateUnknown
+		} else {
+			opts.WatcherState = WatcherStateDisabled
+		}
+	}
+	opts.LastError = strings.TrimSpace(opts.LastError)
+	opts.QMDStatus = strings.TrimSpace(opts.QMDStatus)
+	opts.ExtraPaths = append([]string(nil), opts.ExtraPaths...)
+	return opts
+}

--- a/internal/memory/status_reporter_test.go
+++ b/internal/memory/status_reporter_test.go
@@ -1,6 +1,9 @@
 package memory
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestStatusReporterWatcherStateNormalizesEmptyState(t *testing.T) {
 	reporter := NewStatusReporter(nil, StatusOptions{Enabled: true})
@@ -17,4 +20,34 @@ func TestStatusReporterWatcherStateReturnsCurrentState(t *testing.T) {
 	if got := reporter.WatcherState(); got != WatcherStateError {
 		t.Fatalf("WatcherState()=%q, want %q", got, WatcherStateError)
 	}
+}
+
+func TestStatusReporterClearLastErrorIfPrefixClearsMatchingError(t *testing.T) {
+	reporter := NewStatusReporter(nil, StatusOptions{Enabled: true})
+	reporter.SetLastError(`extra path "notes" watcher error`, errors.New("boom"))
+
+	if !reporter.ClearLastErrorIfPrefix(`extra path "notes" watcher error`) {
+		t.Fatalf("expected matching last error to be cleared")
+	}
+	if got := reporterLastError(reporter); got != "" {
+		t.Fatalf("LastError=%q, want empty", got)
+	}
+}
+
+func TestStatusReporterClearLastErrorIfPrefixKeepsDifferentError(t *testing.T) {
+	reporter := NewStatusReporter(nil, StatusOptions{Enabled: true})
+	reporter.SetLastError("memory watcher error", errors.New("boom"))
+
+	if reporter.ClearLastErrorIfPrefix(`extra path "notes" watcher error`) {
+		t.Fatalf("expected different last error to remain")
+	}
+	if got := reporterLastError(reporter); got == "" {
+		t.Fatalf("expected LastError to remain")
+	}
+}
+
+func reporterLastError(reporter *StatusReporter) string {
+	reporter.mu.RLock()
+	defer reporter.mu.RUnlock()
+	return reporter.opts.LastError
 }

--- a/internal/memory/status_reporter_test.go
+++ b/internal/memory/status_reporter_test.go
@@ -1,0 +1,20 @@
+package memory
+
+import "testing"
+
+func TestStatusReporterWatcherStateNormalizesEmptyState(t *testing.T) {
+	reporter := NewStatusReporter(nil, StatusOptions{Enabled: true})
+
+	if got := reporter.WatcherState(); got != WatcherStateUnknown {
+		t.Fatalf("WatcherState()=%q, want %q", got, WatcherStateUnknown)
+	}
+}
+
+func TestStatusReporterWatcherStateReturnsCurrentState(t *testing.T) {
+	reporter := NewStatusReporter(nil, StatusOptions{Enabled: true})
+	reporter.SetWatcherState(WatcherStateError)
+
+	if got := reporter.WatcherState(); got != WatcherStateError {
+		t.Fatalf("WatcherState()=%q, want %q", got, WatcherStateError)
+	}
+}


### PR DESCRIPTION
Implements #327

## Changes
- Adds shared memory health status data with source/chunk counts, freshness, last error, watcher state, backend, extra paths, and QMD status.
- Exposes memory health through CLI `memory status`, Telegram `/memory_status`, `/api/status`, and Mission Control `/api/mission/memory` routes.
- Adds focused tests for formatting, disabled/error states, and API route handling, plus docs for operators.

## Testing
- `.maestro/verify.sh`
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes memory health diagnostics through a shared `StatusReporter`, wiring it into the CLI (`memory status`), Telegram (`/memory_status`), the existing `/api/status` endpoint, and a new `/api/mission/memory` Mission Control route. The watcher lifecycle fixes from prior review rounds are in place, and the new `ClearLastErrorIfPrefix` mechanism correctly scopes error recovery to the owning watcher goroutine.

One logic issue remains: the `else if` success branch in `runExtraPathWatcher` calls `reporter.ClearLastError()` unconditionally, which can silently erase a primary-watcher reindex failure (primary reindex failures set `LastError` but do not advance `WatcherState` to `error`, so the `WatcherState != error` guard does not protect them).

<h3>Confidence Score: 4/5</h3>

Safe to merge with one logic fix; the diagnostic inaccuracy is transient and non-data-loss

One P2 logic finding: the extra-path watcher can transiently clear a primary-watcher reindex error, causing /memory_status to briefly report ok when it should report error. No P0 issues; no security concerns; core indexing and storage are unaffected.

internal/app/app.go — runExtraPathWatcher success branch (line ~714)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/memory/status_reporter.go | New StatusReporter type combining persisted index counters with runtime health state; nil-safe, mutex-protected, and well-tested |
| internal/memory/lifecycle.go | Adds IndexStatus struct and CollectStatus/finalizeStatus logic; state machine is correct for enabled/disabled/error/stale/ok transitions |
| internal/app/app.go | Watcher lifecycle management for status reporting; primary-watcher guard added at launch is correct, but extra-path success path can erroneously clear a primary reindex error |
| internal/memory/status_format.go | CLI and Telegram formatters are clean; consistent field coverage, with Telegram variant correctly trimming trailing newlines |
| internal/api/mission.go | New handleMissionMemory handler correctly uses r.Context() and follows existing guard/error patterns |
| internal/api/server.go | Registers /api/mission/memory route behind existing auth middleware; no issues |
| internal/bot/status.go | New handleMemoryStatusCommand and buildMemoryStatusString delegate correctly to GetMemoryStatus and FormatStatusTelegram |
| internal/bot/bot.go | GetMemoryStatus correctly suppresses errors when LastError is already captured in status; GetStatus includes memory field in API response |
| internal/cli/memory.go | memory status subcommand correctly sets WatcherStateNotRunning for CLI context and renders FormatStatusCLI output |
| docs/MEMORY.md | Documentation has two issues introduced by this PR: qmd_enabled added to the config YAML example is not a real config key, and extra_paths appears twice in the Configuration Options description list |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/MEMORY.md`, line 10 ([link](https://github.com/befeast/ok-gobot/blob/37c509737be628884ed794a0c8553a3d0d7b52fb/docs/MEMORY.md#L10)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`qmd_enabled` is not a real config key**

   The diff inserts `qmd_enabled: false` into the config YAML example and adds a description entry for it as a "Quarto/QMD memory support flag". No such field exists in the config struct — QMD support is controlled by `memory.backend: qmd` (or `auto`). An operator following this example will set a silently-ignored key, believing it controls QMD, which it does not. The description line also duplicates the existing `extra_paths` entry already present a few lines below.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/MEMORY.md
   Line: 10

   Comment:
   **`qmd_enabled` is not a real config key**

   The diff inserts `qmd_enabled: false` into the config YAML example and adds a description entry for it as a "Quarto/QMD memory support flag". No such field exists in the config struct — QMD support is controlled by `memory.backend: qmd` (or `auto`). An operator following this example will set a silently-ignored key, believing it controls QMD, which it does not. The description line also duplicates the existing `extra_paths` entry already present a few lines below.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/app/app.go:714-718
**Extra-path watcher success clears primary watcher's reindex error**

The `else if` branch calls `reporter.ClearLastError()` unconditionally when `WatcherState != error`. However, `runMemoryWatcher` sets `LastError` on a reindex failure without advancing to `WatcherStateError` — it only calls `SetLastError`, not `SetWatcherState(WatcherStateError)`. A successful extra-path index event that reaches this branch silently clears a live primary-watcher reindex failure: `ClearLastErrorIfPrefix` returns `false` (prefix mismatch), `WatcherState() != error` is `true` (still "active"), and `ClearLastError()` erases the primary's error. `finalizeStatus` will then report `ok` or `stale` until the failing primary file changes again.

Replace the unconditional `ClearLastError()` with `ClearLastErrorIfPrefix(...)` so this watcher only clears errors it owns:

```go
} else if reporter.WatcherState() != memory.WatcherStateError {
    reporter.SetWatcherState(memory.WatcherStateActive)
    // Only clear errors owned by this watcher; primary reindex failures
    // set LastError without advancing WatcherState to error.
    reporter.ClearLastErrorIfPrefix(extraWatcherError(extra.Name), reindexError)
}
```

```suggestion
			if reporter.ClearLastErrorIfPrefix(extraWatcherError(extra.Name), reindexError) {
				reporter.SetWatcherState(memory.WatcherStateActive)
			} else if reporter.WatcherState() != memory.WatcherStateError {
				reporter.SetWatcherState(memory.WatcherStateActive)
				reporter.ClearLastErrorIfPrefix(extraWatcherError(extra.Name), reindexError)
			}
```


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(memory): recover extra watcher error..."](https://github.com/befeast/ok-gobot/commit/7f777d98a8d913b4ba58f7edffaf3a43512b6477) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30306293)</sub>

<!-- /greptile_comment -->