### PR TITLE
feat: add QMD lifecycle commands (#328)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -67,6 +67,9 @@ memory:
   # retrieval_first is recommended once memory.enabled=true and the index is populated, because
   # daily notes can otherwise grow the system prompt without bound.
   mode: "eager"
+  # Search backend: builtin (default), qmd, or auto. qmd/auto try QMD first and
+  # fall back to the built-in SQLite/FTS backend when QMD is missing or unhealthy.
+  backend: "builtin"
   embeddings_base_url: "https://api.openai.com/v1"
   embeddings_api_key: ""  # Can reuse ai.api_key
   embeddings_model: "text-embedding-3-small"
@@ -88,6 +91,21 @@ memory:
   #   - name: "homelab"
   #     path: "/mnt/shared/memory/homelab"
   #     patterns: ["docs/**/*.md", "runbooks/**/*.md"]
+  # Optional QMD sidecar integration. ok-gobot never installs QMD, downloads
+  # models, or creates collections automatically. Use `ok-gobot qmd status`,
+  # `ok-gobot qmd update`, and `ok-gobot qmd smoke "query"` for explicit checks.
+  qmd:
+    binary_path: "qmd"
+    index: "index"
+    index_path: ""          # Optional explicit QMD SQLite index path
+    search_mode: "search"   # search is model-safe; vsearch/query may use local models
+    timeout: "10s"
+    fallback_cooldown: "1m"
+    collections:
+      workspace: ""          # Existing QMD collection for soul/MEMORY.md
+      daily_notes: ""        # Existing QMD collection for soul/memory/*.md
+      session_transcripts: ""
+      extra_paths: []
   mcp:
     enabled: false       # Optional MCP server for cross-tool memory access
     host: "127.0.0.1"    # Local-only by default

--- a/config.schema.json
+++ b/config.schema.json
@@ -344,6 +344,17 @@
           },
           "type": "object"
         },
+        "backend": {
+          "default": "builtin",
+          "description": "Memory search backend. builtin uses ok-gobot SQLite/FTS search. qmd and auto try QMD first and fall back to builtin when QMD is missing or unhealthy.",
+          "enum": [
+            "",
+            "builtin",
+            "qmd",
+            "auto"
+          ],
+          "type": "string"
+        },
         "embeddings_api_key": {
           "default": "",
           "description": "Embeddings API key. Empty reuses ai.api_key.",
@@ -417,6 +428,83 @@
             "startup_recent"
           ],
           "type": "string"
+        },
+        "qmd": {
+          "additionalProperties": false,
+          "default": {},
+          "description": "Optional QMD sidecar configuration. ok-gobot does not install QMD or download models automatically.",
+          "properties": {
+            "binary_path": {
+              "default": "qmd",
+              "description": "Path to the QMD CLI binary.",
+              "type": "string"
+            },
+            "collections": {
+              "additionalProperties": false,
+              "default": {},
+              "description": "Pre-existing QMD collection names mapped to ok-gobot memory roles.",
+              "properties": {
+                "daily_notes": {
+                  "default": "",
+                  "description": "QMD collection rooted at soul/memory.",
+                  "type": "string"
+                },
+                "extra_paths": {
+                  "default": [],
+                  "description": "Additional pre-existing QMD collection names.",
+                  "items": {
+                    "default": "",
+                    "description": "QMD collection name.",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "session_transcripts": {
+                  "default": "",
+                  "description": "QMD collection for exported session transcripts.",
+                  "type": "string"
+                },
+                "workspace": {
+                  "default": "",
+                  "description": "QMD collection rooted at the soul/workspace directory.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "fallback_cooldown": {
+              "default": "1m",
+              "description": "How long QMD failures suppress retries before the built-in fallback tries QMD again.",
+              "type": "string"
+            },
+            "index": {
+              "default": "index",
+              "description": "QMD index name passed to the CLI.",
+              "type": "string"
+            },
+            "index_path": {
+              "default": "",
+              "description": "Optional explicit QMD SQLite index path; maps to INDEX_PATH for QMD commands.",
+              "type": "string"
+            },
+            "search_mode": {
+              "default": "search",
+              "description": "QMD search mode. search is the model-safe default; vsearch/query may use local model-backed QMD features.",
+              "enum": [
+                "",
+                "search",
+                "vsearch",
+                "query"
+              ],
+              "type": "string"
+            },
+            "timeout": {
+              "default": "10s",
+              "description": "Per-command QMD timeout.",
+              "type": "string"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -433,6 +433,12 @@ single source of truth for configuration keys, types, defaults, and descriptions
           "enum": ["", "eager", "retrieval_first", "startup_recent"],
           "description": "Memory prompt mode. eager: inline MEMORY.md + today's and yesterday's daily notes (current default). retrieval_first: inline MEMORY.md only; daily notes are reachable via memory_search/memory_get. startup_recent: inline MEMORY.md + today's daily note only."
         },
+        "backend": {
+          "type": "string",
+          "default": "builtin",
+          "enum": ["", "builtin", "qmd", "auto"],
+          "description": "Memory search backend. builtin uses ok-gobot SQLite/FTS search. qmd and auto try QMD first and fall back to builtin when QMD is missing or unhealthy."
+        },
         "embeddings_base_url": {
           "type": "string",
           "default": "https://api.openai.com/v1",
@@ -486,6 +492,76 @@ single source of truth for configuration keys, types, defaults, and descriptions
                 "type": "string",
                 "default": "",
                 "description": "Optional human-readable scope label, e.g. 'obsidian' or 'homelab'."
+              }
+            }
+          }
+        },
+        "qmd": {
+          "type": "object",
+          "default": {},
+          "description": "Optional QMD sidecar configuration. ok-gobot does not install QMD or download models automatically.",
+          "properties": {
+            "binary_path": {
+              "type": "string",
+              "default": "qmd",
+              "description": "Path to the QMD CLI binary."
+            },
+            "index": {
+              "type": "string",
+              "default": "index",
+              "description": "QMD index name passed to the CLI."
+            },
+            "index_path": {
+              "type": "string",
+              "default": "",
+              "description": "Optional explicit QMD SQLite index path; maps to INDEX_PATH for QMD commands."
+            },
+            "search_mode": {
+              "type": "string",
+              "default": "search",
+              "enum": ["", "search", "vsearch", "query"],
+              "description": "QMD search mode. search is the model-safe default; vsearch/query may use local model-backed QMD features."
+            },
+            "timeout": {
+              "type": "string",
+              "default": "10s",
+              "description": "Per-command QMD timeout."
+            },
+            "fallback_cooldown": {
+              "type": "string",
+              "default": "1m",
+              "description": "How long QMD failures suppress retries before the built-in fallback tries QMD again."
+            },
+            "collections": {
+              "type": "object",
+              "default": {},
+              "description": "Pre-existing QMD collection names mapped to ok-gobot memory roles.",
+              "properties": {
+                "workspace": {
+                  "type": "string",
+                  "default": "",
+                  "description": "QMD collection rooted at the soul/workspace directory."
+                },
+                "daily_notes": {
+                  "type": "string",
+                  "default": "",
+                  "description": "QMD collection rooted at soul/memory."
+                },
+                "session_transcripts": {
+                  "type": "string",
+                  "default": "",
+                  "description": "QMD collection for exported session transcripts."
+                },
+                "extra_paths": {
+                  "type": "array",
+                  "default": [],
+                  "description": "Additional pre-existing QMD collection names.",
+                  "items": {
+                    "type": "string",
+                    "default": "",
+                    "description": "QMD collection name."
+                  }
+                }
               }
             }
           }

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -30,7 +30,6 @@ memory:
   embeddings_base_url: "https://api.openai.com/v1"
   embeddings_api_key: ""  # Leave empty to reuse ai.api_key
   embeddings_model: "text-embedding-3-small"
-  qmd_enabled: false
   metadata_extraction: false
   metadata_model: "haiku"
   extra_paths:
@@ -72,7 +71,6 @@ memory:
 - **embeddings_api_key**: API key for embeddings (if empty, reuses `ai.api_key`)
 - **embeddings_model**: Embedding model to use (default: `text-embedding-3-small`)
 - **extra_paths**: Additional configured memory source paths shown in diagnostics
-- **qmd_enabled**: Quarto/QMD memory support flag shown in diagnostics
 - **metadata_extraction**: When `true`, extracts structured metadata (`people/topics/action_items/type`) during indexing
 - **metadata_model**: Lightweight LLM model used for metadata extraction (default: `haiku`)
 - **extra_paths**: Additional named markdown roots to index (Obsidian vaults, shared-memory exports). See "External markdown collections" below.
@@ -180,6 +178,20 @@ ok-gobot memory status --deep
 status command can initialize local model tooling. ok-gobot instead uses the
 stable read-only contract `qmd --version` and QMD SQLite index metadata.
 
+Explicit QMD lifecycle checks are available when `memory.backend` is `qmd` or
+`auto`:
+
+```bash
+ok-gobot qmd status
+ok-gobot qmd update   # alias: ok-gobot qmd index
+ok-gobot qmd smoke "release decisions"
+```
+
+`qmd status` and `qmd smoke` show whether QMD is used, skipped, or unavailable,
+including the fallback reason. `qmd update` delegates to the configured QMD CLI
+only when an operator runs it; startup and tests do not run QMD update/embed or
+download models.
+
 Force a rebuild of the managed markdown sources:
 
 ```bash
@@ -256,8 +268,8 @@ Use QMD when:
 - You want local-first search over additional markdown collections.
 - You are prepared to manage QMD updates and embeddings yourself.
 
-QMD v1 integration is read-only from ok-gobot's perspective. Create and maintain
-collections with QMD directly, for example:
+QMD search integration is read-only during normal bot replies. Create and
+maintain collections with QMD directly, for example:
 
 ```bash
 qmd collection add ~/ok-gobot-soul --name ok-workspace
@@ -294,8 +306,8 @@ To use QMD's heavier model-backed behavior, explicitly set `search_mode: "query"
 or `search_mode: "vsearch"` after configuring QMD. ok-gobot does not download
 QMD models itself and defaults to `search` to avoid triggering model setup.
 
-Telegram operators can use `/memory_status` to see the same health summary in a
-compact format.
+Telegram operators can use `/memory_status` for memory health and `/qmd` for the
+QMD used/skipped/unavailable state in a compact format.
 
 ### Agent Tool Commands
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -556,10 +557,17 @@ func appMemoryBackendName(cfg *config.Config) string {
 
 func appMemoryQMDStatus(cfg *config.Config) string {
 	backend := appMemoryBackendName(cfg)
-	if backend == "qmd" || backend == "auto" {
-		return "configured"
+	if cfg == nil || !cfg.Memory.Enabled {
+		return "skipped (memory.enabled=false)"
 	}
-	return "disabled"
+	if backend == "qmd" || backend == "auto" {
+		qmdCfg := appQMDConfig(cfg.Memory.QMD)
+		if _, err := exec.LookPath(qmdCfg.BinaryPath); err != nil {
+			return fmt.Sprintf("unavailable: qmd binary not found (%v); fallback=builtin", err)
+		}
+		return "used (primary=qmd, fallback=builtin)"
+	}
+	return fmt.Sprintf("skipped (memory.backend=%s)", backend)
 }
 
 func appMemoryExtraPathLabels(cfg *config.Config) []string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -189,7 +188,7 @@ func (a *App) Start(ctx context.Context) error {
 		BackendType:  appMemoryBackendName(a.config),
 		WatcherState: memory.WatcherStateDisabled,
 		ExtraPaths:   appMemoryExtraPathLabels(a.config),
-		QMDStatus:    appMemoryQMDStatus(a.config),
+		QMDStatus:    appMemoryQMDStatus(ctx, a.config),
 	})
 
 	aiAPIKey := strings.TrimSpace(a.config.AI.APIKey)
@@ -329,7 +328,11 @@ func (a *App) Start(ctx context.Context) error {
 			if backendName == "qmd" || backendName == "auto" {
 				qmdBackend := memory.NewQMDBackend(appQMDConfig(a.config.Memory.QMD))
 				cooldown := parseDurationOrDefault(a.config.Memory.QMD.FallbackCooldown, time.Minute)
-				options = append(options, memory.WithBackend(memory.NewFallbackBackend(qmdBackend, builtinBackend, cooldown)))
+				fallbackBackend := memory.NewFallbackBackend(qmdBackend, builtinBackend, cooldown)
+				options = append(options, memory.WithBackend(fallbackBackend))
+				a.memoryStatus.SetQMDStatusFunc(func(ctx context.Context) string {
+					return appMemoryQMDRuntimeStatus(ctx, a.config, qmdBackend, fallbackBackend)
+				})
 				log.Printf("🧠 QMD memory backend configured (mode=%s, fallback=builtin)", a.config.Memory.QMD.SearchMode)
 			}
 
@@ -555,17 +558,24 @@ func appMemoryBackendName(cfg *config.Config) string {
 	return name
 }
 
-func appMemoryQMDStatus(cfg *config.Config) string {
+func appMemoryQMDStatus(ctx context.Context, cfg *config.Config) string {
+	return appMemoryQMDRuntimeStatus(ctx, cfg, nil, nil)
+}
+
+func appMemoryQMDRuntimeStatus(ctx context.Context, cfg *config.Config, qmdBackend *memory.QMDBackend, fallbackBackend *memory.FallbackBackend) string {
 	backend := appMemoryBackendName(cfg)
 	if cfg == nil || !cfg.Memory.Enabled {
 		return "skipped (memory.enabled=false)"
 	}
 	if backend == "qmd" || backend == "auto" {
-		qmdCfg := appQMDConfig(cfg.Memory.QMD)
-		if _, err := exec.LookPath(qmdCfg.BinaryPath); err != nil {
-			return fmt.Sprintf("unavailable: qmd binary not found (%v); fallback=builtin", err)
+		if qmdBackend == nil {
+			qmdBackend = memory.NewQMDBackend(appQMDConfig(cfg.Memory.QMD))
 		}
-		return "used (primary=qmd, fallback=builtin)"
+		runtimeReason := ""
+		if fallbackBackend != nil {
+			runtimeReason = fallbackBackend.FallbackReason()
+		}
+		return qmdBackend.Diagnostics(ctx).RuntimeStatus(runtimeReason)
 	}
 	return fmt.Sprintf("skipped (memory.backend=%s)", backend)
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,123 @@
+package app
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/memory"
+)
+
+func TestAppMemoryQMDStatusUsesDiagnosticsForMissingIndex(t *testing.T) {
+	t.Parallel()
+	cfg := newAppQMDTestConfig(t)
+	cfg.Memory.QMD.IndexPath = filepath.Join(t.TempDir(), "missing.sqlite")
+
+	got := appMemoryQMDStatus(t.Context(), cfg)
+	for _, want := range []string{"unavailable", "index missing", "fallback=builtin"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in status %q", want, got)
+		}
+	}
+	if strings.Contains(got, "used") {
+		t.Fatalf("expected missing index to be unavailable, got %q", got)
+	}
+}
+
+func TestAppMemoryQMDStatusIncludesRuntimeFallbackReason(t *testing.T) {
+	t.Parallel()
+	cfg := newAppQMDTestConfig(t)
+	cfg.Memory.QMD.IndexPath = filepath.Join(t.TempDir(), "qmd.sqlite")
+	seedAppQMDTestIndex(t, cfg.Memory.QMD.IndexPath)
+
+	qmdBackend := memory.NewQMDBackend(appQMDConfig(cfg.Memory.QMD))
+	fallbackBackend := memory.NewFallbackBackend(
+		appTestBackend{name: "qmd", err: fmt.Errorf("server unavailable")},
+		appTestBackend{name: "builtin", results: []memory.MemoryResult{{Source: "MEMORY.md", Content: "fallback"}}},
+		time.Minute,
+	)
+	if _, err := fallbackBackend.Search(context.Background(), "query", 1, false); err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+
+	got := appMemoryQMDRuntimeStatus(t.Context(), cfg, qmdBackend, fallbackBackend)
+	for _, want := range []string{"unavailable", "server unavailable", "fallback=builtin"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in status %q", want, got)
+		}
+	}
+}
+
+func newAppQMDTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{Memory: config.MemoryConfig{
+		Enabled: true,
+		Backend: "qmd",
+		QMD: config.MemoryQMDConfig{
+			BinaryPath: writeAppQMDTestBinary(t),
+			Index:      "work",
+			SearchMode: "search",
+			Timeout:    "1s",
+		},
+	}}
+}
+
+func writeAppQMDTestBinary(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "qmd")
+	script := `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf '%s\n' 'qmd 2.1.0'
+  exit 0
+fi
+printf '%s\n' '[]'
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake qmd: %v", err)
+	}
+	return path
+}
+
+func seedAppQMDTestIndex(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	statements := []string{
+		`CREATE TABLE store_collections (name TEXT PRIMARY KEY, path TEXT NOT NULL, pattern TEXT NOT NULL DEFAULT '**/*.md')`,
+		`CREATE TABLE documents (id INTEGER PRIMARY KEY AUTOINCREMENT, collection TEXT NOT NULL, path TEXT NOT NULL, title TEXT NOT NULL, hash TEXT NOT NULL, modified_at TEXT NOT NULL, active INTEGER NOT NULL DEFAULT 1)`,
+		`CREATE TABLE vectors_vec (id TEXT PRIMARY KEY)`,
+		`INSERT INTO store_collections (name, path, pattern) VALUES ('workspace', '/tmp/workspace', '**/*.md')`,
+	}
+	for _, stmt := range statements {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+}
+
+type appTestBackend struct {
+	name    string
+	results []memory.MemoryResult
+	err     error
+}
+
+func (b appTestBackend) Name() string { return b.name }
+
+func (b appTestBackend) Search(context.Context, string, int, bool) ([]memory.MemoryResult, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	return b.results, nil
+}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -275,6 +275,8 @@ func (b *Bot) registerCommands() {
 		{Text: "stop", Description: "Stop the current run"},
 		{Text: "abort", Description: "Abort the current run"},
 		{Text: "memory", Description: "Show today's memory"},
+		{Text: "memory_status", Description: "Show memory index health"},
+		{Text: "qmd", Description: "Show QMD sidecar status"},
 		{Text: "tools", Description: "List available tools"},
 		{Text: "model", Description: "Show or set AI model"},
 		{Text: "agent", Description: "Manage agents (list/switch)"},
@@ -346,6 +348,7 @@ func (b *Bot) Start(ctx context.Context) error {
 /note <text> - Quick note to today's memory
 /memory - Show today's memory
 /memory_status - Show memory index health
+/qmd - Show QMD sidecar status
 /tools - List available tools
 /model - Manage AI model (list/set/clear)
 /agent - Manage agents (list/switch)

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -117,6 +117,10 @@ func (b *Bot) registerExtraHandlers() {
 	b.api.Handle("/memory_curate", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleMemoryCurateCommand(c)
 	}))
+
+	b.api.Handle("/qmd", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
+		return b.handleQMDCommand(c)
+	}))
 }
 
 // handleWhoamiCommand shows sender info
@@ -165,6 +169,7 @@ func (b *Bot) handleCommandsCommand(c telebot.Context) error {
 		{"abort", "Abort the current run"},
 		{"memory", "Show today's memory"},
 		{"memory_status", "Show memory index health"},
+		{"qmd", "Show QMD sidecar status and fallback"},
 		{"tools", "List available tools"},
 		{"model", "Show or set AI model"},
 		{"agent", "Manage agents"},

--- a/internal/bot/status.go
+++ b/internal/bot/status.go
@@ -27,6 +27,10 @@ func (b *Bot) handleMemoryStatusCommand(c telebot.Context) error {
 	return c.Send(b.buildMemoryStatusString(context.Background()))
 }
 
+func (b *Bot) handleQMDCommand(c telebot.Context) error {
+	return c.Send(b.buildQMDStatusString(context.Background()))
+}
+
 func (b *Bot) buildMemoryStatusString(ctx context.Context) string {
 	status, err := b.GetMemoryStatus(ctx)
 	if err != nil {
@@ -39,6 +43,34 @@ func (b *Bot) buildMemoryStatusString(ctx context.Context) string {
 		}
 	}
 	return memory.FormatStatusTelegram(status)
+}
+
+func (b *Bot) buildQMDStatusString(ctx context.Context) string {
+	status, err := b.GetMemoryStatus(ctx)
+	if err != nil && status.LastError == "" {
+		status.LastError = err.Error()
+	}
+
+	qmdStatus := strings.TrimSpace(status.QMDStatus)
+	if qmdStatus == "" {
+		qmdStatus = "skipped (not configured)"
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("QMD: %s\n", qmdStatus))
+	sb.WriteString(fmt.Sprintf("Memory backend: %s\n", valueOrStatus(status.BackendType, "unknown")))
+	if status.BackendType == "qmd" || status.BackendType == "auto" {
+		sb.WriteString("Fallback: builtin\n")
+	} else {
+		sb.WriteString("Fallback: not needed\n")
+	}
+	if status.LastError != "" {
+		sb.WriteString(fmt.Sprintf("Last error: %s\n", status.LastError))
+	}
+	if status.Action != "" {
+		sb.WriteString(fmt.Sprintf("Action: %s\n", status.Action))
+	}
+	return strings.TrimRight(sb.String(), "\n")
 }
 
 // buildStatusString builds the full status string for a given chatID.
@@ -166,4 +198,11 @@ func formatDuration(d time.Duration) string {
 	days := int(d.Hours()) / 24
 	hours := int(d.Hours()) % 24
 	return fmt.Sprintf("%dd %dh", days, hours)
+}
+
+func valueOrStatus(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }

--- a/internal/bot/status_test.go
+++ b/internal/bot/status_test.go
@@ -55,3 +55,51 @@ func TestBuildMemoryStatusStringShowsProviderError(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildQMDStatusStringShowsFallbackState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status memory.IndexStatus
+		want   []string
+	}{
+		{
+			name: "used",
+			status: memory.IndexStatus{
+				BackendType: "qmd",
+				QMDStatus:   "used (primary=qmd, fallback=builtin)",
+			},
+			want: []string{"QMD: used", "Fallback: builtin"},
+		},
+		{
+			name: "skipped",
+			status: memory.IndexStatus{
+				BackendType: memory.BackendSQLite,
+				QMDStatus:   "skipped (memory.backend=builtin)",
+			},
+			want: []string{"QMD: skipped", "memory.backend=builtin"},
+		},
+		{
+			name: "unavailable",
+			status: memory.IndexStatus{
+				BackendType: "qmd",
+				QMDStatus:   "unavailable: qmd binary not found; fallback=builtin",
+			},
+			want: []string{"QMD: unavailable", "qmd binary not found", "Fallback: builtin"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			b := &Bot{memoryStatus: fakeMemoryStatusProvider{status: tt.status}}
+			out := b.buildQMDStatusString(t.Context())
+			for _, want := range tt.want {
+				if !strings.Contains(out, want) {
+					t.Fatalf("expected %q in output: %q", want, out)
+				}
+			}
+		})
+	}
+}

--- a/internal/bot/status_test.go
+++ b/internal/bot/status_test.go
@@ -103,3 +103,28 @@ func TestBuildQMDStatusStringShowsFallbackState(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildQMDStatusStringUsesRuntimeQMDStatus(t *testing.T) {
+	t.Parallel()
+
+	reporter := memory.NewStatusReporter(nil, memory.StatusOptions{
+		Enabled:      false,
+		BackendType:  "qmd",
+		QMDStatus:    "used (primary=qmd, fallback=builtin)",
+		WatcherState: memory.WatcherStateDisabled,
+	})
+	reporter.SetQMDStatusFunc(func(context.Context) string {
+		return "unavailable: server unavailable; fallback=builtin"
+	})
+	b := &Bot{memoryStatus: reporter}
+
+	out := b.buildQMDStatusString(t.Context())
+	for _, want := range []string{"QMD: unavailable", "server unavailable", "Fallback: builtin"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output: %q", want, out)
+		}
+	}
+	if strings.Contains(out, "QMD: used") {
+		t.Fatalf("expected runtime QMD status to replace startup status: %q", out)
+	}
+}

--- a/internal/cli/qmd.go
+++ b/internal/cli/qmd.go
@@ -152,17 +152,9 @@ func collectQMDCommandStatus(ctx context.Context, cfg *config.Config) qmdCommand
 	status.Fallback = "builtin"
 	diagnostics := memory.NewQMDBackend(cliQMDConfig(cfg.Memory.QMD)).Diagnostics(ctx)
 	status.Diagnostics = diagnostics
-	if !diagnostics.BinaryFound {
+	if reason := diagnostics.UnavailableReason(); reason != "" {
 		status.State = "unavailable"
-		status.Reason = valueOrString(diagnostics.LastError, "qmd binary not found")
-		return status
-	}
-	if !diagnostics.IndexExists {
-		status.State = "unavailable"
-		status.Reason = valueOrString(diagnostics.LastError, diagnostics.UpdateState)
-		if status.Reason == "" {
-			status.Reason = "qmd index missing"
-		}
+		status.Reason = reason
 		return status
 	}
 

--- a/internal/cli/qmd.go
+++ b/internal/cli/qmd.go
@@ -1,0 +1,212 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/memory"
+)
+
+type qmdCommandStatus struct {
+	State       string
+	Reason      string
+	Backend     string
+	Fallback    string
+	Configured  bool
+	Diagnostics memory.QMDDiagnostics
+}
+
+func newQMDCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "qmd",
+		Short: "Inspect and run explicit QMD sidecar lifecycle checks",
+	}
+	cmd.AddCommand(newQMDStatusCommand(cfg))
+	cmd.AddCommand(newQMDUpdateCommand(cfg))
+	cmd.AddCommand(newQMDSmokeCommand(cfg))
+	return cmd
+}
+
+func newQMDStatusCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show QMD backend availability and fallback state",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			status := collectQMDCommandStatus(cmd.Context(), cfg)
+			printQMDCommandStatus(cmd.OutOrStdout(), status)
+			return nil
+		},
+	}
+}
+
+func newQMDUpdateCommand(cfg *config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:     "update",
+		Aliases: []string{"index"},
+		Short:   "Run explicit QMD update/index for configured collections",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			status := collectQMDCommandStatus(cmd.Context(), cfg)
+			out := cmd.OutOrStdout()
+			if status.State == "skipped" {
+				fmt.Fprintln(out, "QMD update: skipped")
+				fmt.Fprintf(out, "Reason: %s\n", status.Reason)
+				return nil
+			}
+
+			qmd := memory.NewQMDBackend(cliQMDConfig(cfg.Memory.QMD))
+			output, err := qmd.Update(cmd.Context())
+			if err != nil {
+				fmt.Fprintln(out, "QMD update: unavailable")
+				fmt.Fprintf(out, "Reason: %v\n", err)
+				fmt.Fprintln(out, "Fallback: run `ok-gobot memory index --force` to refresh the built-in backend")
+				return err
+			}
+
+			fmt.Fprintln(out, "QMD update: used")
+			if trimmed := strings.TrimSpace(string(output)); trimmed != "" {
+				fmt.Fprintln(out, trimmed)
+			}
+			return nil
+		},
+	}
+}
+
+func newQMDSmokeCommand(cfg *config.Config) *cobra.Command {
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "smoke [query]",
+		Short: "Run a QMD query smoke test and report built-in fallback",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := "ok-gobot memory smoke test"
+			if len(args) > 0 && strings.TrimSpace(args[0]) != "" {
+				query = strings.TrimSpace(args[0])
+			}
+
+			status := collectQMDCommandStatus(cmd.Context(), cfg)
+			out := cmd.OutOrStdout()
+			if status.State == "skipped" {
+				fmt.Fprintln(out, "QMD smoke: skipped")
+				fmt.Fprintf(out, "Reason: %s\n", status.Reason)
+				return nil
+			}
+
+			qmd := memory.NewQMDBackend(cliQMDConfig(cfg.Memory.QMD))
+			results, err := qmd.Search(cmd.Context(), query, limit, false)
+			if err == nil {
+				fmt.Fprintln(out, "QMD: used")
+				fmt.Fprintf(out, "Results: %d\n", len(results))
+				if len(results) > 0 {
+					fmt.Fprintf(out, "First source: %s\n", results[0].Source)
+				}
+				return nil
+			}
+
+			fmt.Fprintln(out, "QMD: unavailable")
+			fmt.Fprintf(out, "Reason: %v\n", err)
+
+			store, memStore, openErr := openMemoryStore(cfg)
+			if openErr != nil {
+				fmt.Fprintf(out, "Fallback: builtin unavailable: %v\n", openErr)
+				return openErr
+			}
+			defer store.Close() //nolint:errcheck
+			fallbackResults, fallbackErr := memory.NewBuiltinBackend(nil, memStore).Search(cmd.Context(), query, limit, false)
+			if fallbackErr != nil {
+				fmt.Fprintf(out, "Fallback: builtin failed: %v\n", fallbackErr)
+				return fallbackErr
+			}
+			fmt.Fprintf(out, "Fallback: builtin used (%d result(s))\n", len(fallbackResults))
+			if len(fallbackResults) > 0 {
+				fmt.Fprintf(out, "First fallback source: %s\n", fallbackResults[0].Source)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 1, "maximum QMD smoke-test results")
+	return cmd
+}
+
+func collectQMDCommandStatus(ctx context.Context, cfg *config.Config) qmdCommandStatus {
+	status := qmdCommandStatus{State: "skipped", Backend: "builtin", Fallback: "not needed"}
+	if cfg == nil {
+		status.Reason = "config is nil"
+		return status
+	}
+
+	status.Backend = memoryBackendName(cfg)
+	if !cfg.Memory.Enabled {
+		status.Reason = "memory.enabled=false"
+		return status
+	}
+	if status.Backend != "qmd" && status.Backend != "auto" {
+		status.Reason = "memory.backend=" + status.Backend
+		return status
+	}
+
+	status.Configured = true
+	status.Fallback = "builtin"
+	diagnostics := memory.NewQMDBackend(cliQMDConfig(cfg.Memory.QMD)).Diagnostics(ctx)
+	status.Diagnostics = diagnostics
+	if !diagnostics.BinaryFound {
+		status.State = "unavailable"
+		status.Reason = valueOrString(diagnostics.LastError, "qmd binary not found")
+		return status
+	}
+	if !diagnostics.IndexExists {
+		status.State = "unavailable"
+		status.Reason = valueOrString(diagnostics.LastError, diagnostics.UpdateState)
+		if status.Reason == "" {
+			status.Reason = "qmd index missing"
+		}
+		return status
+	}
+
+	status.State = "used"
+	status.Reason = valueOrString(diagnostics.UpdateState, "primary=qmd")
+	return status
+}
+
+func printQMDCommandStatus(out qmdStatusWriter, status qmdCommandStatus) {
+	fmt.Fprintf(out, "QMD: %s\n", status.State)
+	if status.Reason != "" {
+		fmt.Fprintf(out, "Reason: %s\n", status.Reason)
+	}
+	fmt.Fprintf(out, "Memory backend: %s\n", status.Backend)
+	fmt.Fprintf(out, "Fallback: %s\n", status.Fallback)
+
+	if !status.Configured {
+		return
+	}
+	d := status.Diagnostics
+	fmt.Fprintf(out, "Binary: %s\n", d.BinaryPath)
+	fmt.Fprintf(out, "Binary found: %v\n", d.BinaryFound)
+	if d.Version != "" {
+		fmt.Fprintf(out, "Version: %s\n", d.Version)
+	}
+	fmt.Fprintf(out, "Search mode: %s\n", d.SearchMode)
+	fmt.Fprintf(out, "Index: %s\n", d.IndexName)
+	fmt.Fprintf(out, "Index path: %s\n", d.IndexPath)
+	fmt.Fprintf(out, "Index exists: %v\n", d.IndexExists)
+	if d.UpdateState != "" {
+		fmt.Fprintf(out, "Update state: %s\n", d.UpdateState)
+	}
+	if d.LastError != "" {
+		fmt.Fprintf(out, "Last error: %s\n", d.LastError)
+	}
+}
+
+type qmdStatusWriter interface {
+	Write(p []byte) (n int, err error)
+}
+
+func valueOrString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/cli/qmd_test.go
+++ b/internal/cli/qmd_test.go
@@ -48,6 +48,34 @@ func TestQMDStatusReportsMissingBinary(t *testing.T) {
 	}
 }
 
+func TestQMDStatusReportsUnreadableIndex(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+	cfg.Memory.Enabled = true
+	cfg.Memory.Backend = "qmd"
+	cfg.Memory.QMD.BinaryPath = writeCLIqmdTestBinary(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf '%s\n' 'qmd 2.1.0'
+  exit 0
+fi
+printf '%s\n' '[]'
+`)
+	cfg.Memory.QMD.IndexPath = filepath.Join(t.TempDir(), "qmd.sqlite")
+	if err := os.WriteFile(cfg.Memory.QMD.IndexPath, []byte("not sqlite"), 0o644); err != nil {
+		t.Fatalf("write unreadable index: %v", err)
+	}
+
+	output, err := executeQMDTestCommand(cfg, "status")
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	for _, want := range []string{"QMD: unavailable", "index unreadable", "Fallback: builtin"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
 func TestQMDSmokeFallsBackWhenServerUnhealthy(t *testing.T) {
 	t.Parallel()
 	store, cfg := newTestStore(t)

--- a/internal/cli/qmd_test.go
+++ b/internal/cli/qmd_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/memory"
+)
+
+func TestQMDStatusSkippedWhenConfigDisabled(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+	cfg.Memory.Enabled = false
+	cfg.Memory.Backend = "builtin"
+	cfg.Memory.QMD.BinaryPath = "definitely-missing-qmd"
+
+	output, err := executeQMDTestCommand(cfg, "status")
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	for _, want := range []string{"QMD: skipped", "memory.enabled=false", "Fallback: not needed"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
+func TestQMDStatusReportsMissingBinary(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+	cfg.Memory.Enabled = true
+	cfg.Memory.Backend = "qmd"
+	cfg.Memory.QMD.BinaryPath = "definitely-missing-qmd"
+
+	output, err := executeQMDTestCommand(cfg, "status")
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	for _, want := range []string{"QMD: unavailable", "qmd binary not found", "Fallback: builtin"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
+func TestQMDSmokeFallsBackWhenServerUnhealthy(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+	cfg.Memory.Enabled = true
+	cfg.Memory.Backend = "qmd"
+	cfg.Memory.QMD.BinaryPath = writeCLIqmdTestBinary(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf '%s\n' 'qmd 2.1.0'
+  exit 0
+fi
+printf '%s\n' 'server unavailable' >&2
+exit 1
+`)
+	cfg.SoulPath = t.TempDir()
+	writeCLITestFile(t, filepath.Join(cfg.SoulPath, "MEMORY.md"), "# Memory\n\nphoenix fallback memory.")
+	memStore, err := memory.NewMemoryStore(store.DB())
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+	if _, _, err := runMemoryIndex(context.Background(), cfg, memStore, nil, true); err != nil {
+		t.Fatalf("runMemoryIndex failed: %v", err)
+	}
+
+	output, err := executeQMDTestCommand(cfg, "smoke", "phoenix")
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	for _, want := range []string{"QMD: unavailable", "server unavailable", "Fallback: builtin used", "MEMORY.md"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
+func TestQMDUpdateRunsExplicitLifecycleCommand(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+	cfg.Memory.Enabled = true
+	cfg.Memory.Backend = "qmd"
+	cfg.Memory.QMD.Index = "work"
+	argsPath := filepath.Join(t.TempDir(), "qmd-args.txt")
+	cfg.Memory.QMD.BinaryPath = writeCLIqmdTestBinary(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf '%s\n' 'qmd 2.1.0'
+  exit 0
+fi
+printf '%s\n' "$@" > "`+argsPath+`"
+printf '%s\n' 'updated ok'
+`)
+
+	output, err := executeQMDTestCommand(cfg, "update")
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	if !strings.Contains(output, "QMD update: used") || !strings.Contains(output, "updated ok") {
+		t.Fatalf("unexpected output: %q", output)
+	}
+	argsBytes, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(argsBytes)), "\n")
+	want := []string{"--index", "work", "update"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("args=%q, want %q", args, want)
+	}
+}
+
+func executeQMDTestCommand(cfg *config.Config, args ...string) (string, error) {
+	cmd := newQMDCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func writeCLIqmdTestBinary(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "qmd")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake qmd: %v", err)
+	}
+	return path
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -43,6 +43,7 @@ Supports Telegram bot integration with personality and memory.`,
 	root.AddCommand(newProvidersCommand(cfg))
 	root.AddCommand(newModelsCommand(cfg))
 	root.AddCommand(newMemoryCommand(cfg))
+	root.AddCommand(newQMDCommand(cfg))
 	root.AddCommand(newSkillsCommand(cfg))
 	root.AddCommand(newSessionsCommand(cfg))
 	root.AddCommand(newWorkCommand(cfg))

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -174,6 +174,19 @@ func (b *FallbackBackend) LastError() string {
 	return b.lastErr.Error()
 }
 
+// FallbackReason returns the active primary backend error while searches are
+// being routed to the fallback backend.
+func (b *FallbackBackend) FallbackReason() string {
+	if b == nil {
+		return ""
+	}
+	disabled, lastErr := b.isDisabled()
+	if !disabled || lastErr == nil {
+		return ""
+	}
+	return lastErr.Error()
+}
+
 func (b *FallbackBackend) isDisabled() (bool, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -61,13 +61,13 @@ func (b *BuiltinBackend) Search(ctx context.Context, query string, topK int, exp
 	bestScores := make(map[branch]float32)
 
 	for _, h := range results {
-		b := branch{h.SourceFile, h.HeaderPath}
-		if h.Similarity > bestScores[b] {
-			bestScores[b] = h.Similarity
+		key := branch{h.SourceFile, h.HeaderPath}
+		if h.Similarity > bestScores[key] {
+			bestScores[key] = h.Similarity
 		}
-		if !seen[b] {
-			seen[b] = true
-			branches = append(branches, b)
+		if !seen[key] {
+			seen[key] = true
+			branches = append(branches, key)
 		}
 	}
 
@@ -177,7 +177,12 @@ func (b *FallbackBackend) LastError() string {
 func (b *FallbackBackend) isDisabled() (bool, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.lastErr == nil || b.now().After(b.disabledUntil) {
+	if b.lastErr == nil {
+		return false, nil
+	}
+	if b.now().After(b.disabledUntil) {
+		b.lastErr = nil
+		b.disabledUntil = time.Time{}
 		return false, nil
 	}
 	return true, b.lastErr

--- a/internal/memory/backend_test.go
+++ b/internal/memory/backend_test.go
@@ -72,6 +72,28 @@ func TestFallbackBackendClearsReasonAfterCooldown(t *testing.T) {
 	}
 }
 
+func TestFallbackBackendFallbackReasonFollowsCooldown(t *testing.T) {
+	t.Parallel()
+
+	primary := &stubBackend{name: "qmd", err: fmt.Errorf("server unavailable")}
+	fallback := &stubBackend{name: "builtin", results: []MemoryResult{{Source: "MEMORY.md", Content: "fallback"}}}
+	backend := NewFallbackBackend(primary, fallback, time.Minute)
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	backend.now = func() time.Time { return now }
+
+	if _, err := backend.Search(context.Background(), "query", 5, false); err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if got := backend.FallbackReason(); !strings.Contains(got, "server unavailable") {
+		t.Fatalf("FallbackReason=%q, want server unavailable", got)
+	}
+
+	now = now.Add(time.Minute + time.Second)
+	if got := backend.FallbackReason(); got != "" {
+		t.Fatalf("FallbackReason after cooldown=%q, want empty", got)
+	}
+}
+
 func TestMemoryManagerUsesConfiguredBackend(t *testing.T) {
 	t.Parallel()
 

--- a/internal/memory/backend_test.go
+++ b/internal/memory/backend_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -42,6 +43,32 @@ func TestFallbackBackendFallsBackAndSuppressesRetries(t *testing.T) {
 	}
 	if primary.calls != 2 {
 		t.Fatalf("primary calls after cooldown=%d, want 2", primary.calls)
+	}
+}
+
+func TestFallbackBackendClearsReasonAfterCooldown(t *testing.T) {
+	t.Parallel()
+
+	primary := &stubBackend{name: "qmd", err: fmt.Errorf("server unavailable")}
+	fallback := &stubBackend{name: "builtin", results: []MemoryResult{{Source: "MEMORY.md", Content: "fallback"}}}
+	backend := NewFallbackBackend(primary, fallback, time.Minute)
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	backend.now = func() time.Time { return now }
+
+	if _, err := backend.Search(context.Background(), "query", 5, false); err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if got := backend.LastError(); !strings.Contains(got, "server unavailable") {
+		t.Fatalf("LastError=%q, want server unavailable", got)
+	}
+
+	now = now.Add(time.Minute + time.Second)
+	primary.err = nil
+	if _, err := backend.Search(context.Background(), "query", 5, false); err != nil {
+		t.Fatalf("Search after cooldown returned error: %v", err)
+	}
+	if got := backend.LastError(); got != "" {
+		t.Fatalf("LastError after cooldown success=%q, want empty", got)
 	}
 }
 

--- a/internal/memory/qmd.go
+++ b/internal/memory/qmd.go
@@ -223,6 +223,38 @@ func (b *QMDBackend) Diagnostics(ctx context.Context) QMDDiagnostics {
 	return d
 }
 
+// UnavailableReason returns a fallback reason when diagnostics show QMD cannot
+// be used reliably for search.
+func (d QMDDiagnostics) UnavailableReason() string {
+	if !d.Configured {
+		return "qmd is not configured"
+	}
+	if !d.BinaryFound {
+		return firstNonEmpty(d.LastError, "qmd binary not found")
+	}
+	if !d.IndexExists {
+		return firstNonEmpty(d.LastError, d.UpdateState, "qmd index missing")
+	}
+
+	switch strings.ToLower(strings.TrimSpace(d.UpdateState)) {
+	case "qmd unavailable", "index unavailable", "index unreadable":
+		return firstNonEmpty(d.LastError, d.UpdateState)
+	}
+	return ""
+}
+
+// RuntimeStatus formats QMD availability for operator surfaces, including the
+// active runtime fallback reason when QMD diagnostics are otherwise healthy.
+func (d QMDDiagnostics) RuntimeStatus(fallbackReason string) string {
+	if reason := d.UnavailableReason(); reason != "" {
+		return fmt.Sprintf("unavailable: %s; fallback=builtin", reason)
+	}
+	if reason := strings.TrimSpace(fallbackReason); reason != "" {
+		return fmt.Sprintf("unavailable: %s; fallback=builtin", reason)
+	}
+	return "used (primary=qmd, fallback=builtin)"
+}
+
 // LastError returns the last search error observed by the QMD backend.
 func (b *QMDBackend) LastError() string {
 	if b == nil {

--- a/internal/memory/qmd.go
+++ b/internal/memory/qmd.go
@@ -148,6 +148,21 @@ func (b *QMDBackend) Search(ctx context.Context, query string, topK int, expand 
 	return results, nil
 }
 
+// Update runs QMD's explicit update/index lifecycle command. This is only
+// called from operator commands; ok-gobot never updates QMD automatically.
+func (b *QMDBackend) Update(ctx context.Context) ([]byte, error) {
+	if b == nil {
+		return nil, fmt.Errorf("qmd backend is not configured")
+	}
+	out, err := b.run(ctx, b.updateArgs()...)
+	if err != nil {
+		b.setLastError(err)
+		return nil, err
+	}
+	b.setLastError(nil)
+	return out, nil
+}
+
 // Diagnostics returns read-only QMD health information. It intentionally avoids
 // `qmd status` because QMD 2.1.0 status may initialize local model tooling.
 func (b *QMDBackend) Diagnostics(ctx context.Context) QMDDiagnostics {
@@ -245,6 +260,14 @@ func (b *QMDBackend) searchArgs(query string, topK int, expand bool) []string {
 		args = append(args, "-c", collection)
 	}
 	return args
+}
+
+func (b *QMDBackend) updateArgs() []string {
+	args := make([]string, 0, 3)
+	if b.cfg.Index != "" {
+		args = append(args, "--index", b.cfg.Index)
+	}
+	return append(args, "update")
 }
 
 func (b *QMDBackend) run(ctx context.Context, args ...string) ([]byte, error) {

--- a/internal/memory/status_reporter.go
+++ b/internal/memory/status_reporter.go
@@ -9,9 +9,10 @@ import (
 
 // StatusReporter combines persisted index counters with runtime health state.
 type StatusReporter struct {
-	mu    sync.RWMutex
-	store *MemoryStore
-	opts  StatusOptions
+	mu        sync.RWMutex
+	store     *MemoryStore
+	opts      StatusOptions
+	qmdStatus func(context.Context) string
 }
 
 // NewStatusReporter creates a reporter for memory health diagnostics.
@@ -27,6 +28,16 @@ func (r *StatusReporter) SetStore(store *MemoryStore) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.store = store
+}
+
+// SetQMDStatusFunc updates the runtime QMD status provider used by Status.
+func (r *StatusReporter) SetQMDStatusFunc(fn func(context.Context) string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.qmdStatus = fn
 }
 
 // SetWatcherState records the memory watcher lifecycle state.
@@ -103,7 +114,11 @@ func (r *StatusReporter) Status(ctx context.Context) (IndexStatus, error) {
 	r.mu.RLock()
 	store := r.store
 	opts := normalizeStatusOptions(r.opts)
+	qmdStatus := r.qmdStatus
 	r.mu.RUnlock()
+	if qmdStatus != nil {
+		opts.QMDStatus = strings.TrimSpace(qmdStatus(ctx))
+	}
 	return CollectStatus(ctx, store, opts)
 }
 


### PR DESCRIPTION
Implements #328

## Changes
- Add explicit `qmd status`, `qmd update`/`qmd index`, and `qmd smoke` CLI commands with used/skipped/unavailable reporting.
- Surface QMD fallback state through Telegram `/qmd` and startup memory diagnostics.
- Preserve built-in memory fallback on QMD failures and document local QMD setup without automatic installs or model downloads.

## Testing
- `go test ./internal/cli/...`
- `go test ./internal/memory/...`
- `go test ./internal/bot/...`
- `./.maestro/verify.sh`
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds explicit `qmd status`, `qmd update`/`qmd index`, and `qmd smoke` CLI subcommands, a `/qmd` Telegram command, and promotes the QMD status from a one-time startup snapshot to a live runtime closure backed by `FallbackBackend.FallbackReason()`. The `isDisabled()` change that clears `lastErr` on cooldown expiry is a meaningful correctness improvement, and the `StatusReporter.SetQMDStatusFunc` pattern is thread-safe (func is copied under read lock before invocation).

<h3>Confidence Score: 5/5</h3>

Safe to merge; no logic bugs found in the changed paths.

All P0/P1 concerns were verified away: appMemoryBackendName handles nil config, the mutex discipline in StatusReporter and FallbackBackend is correct, and the runtime-status closure is safely copied before being invoked outside the lock. Only a P2 UX note remains about Cobra double-printing errors from RunE.

internal/cli/qmd.go — minor Cobra error double-print on update/smoke failure paths

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cli/qmd.go | New CLI qmd status/update/smoke commands; returning raw errors from RunE causes Cobra to double-print error messages alongside the user-friendly lines already written to out |
| internal/memory/backend.go | Adds FallbackReason() and refactors isDisabled() to clear state on cooldown expiry; variable-shadow rename in BuiltinBackend.Search; logic is correct and tested |
| internal/memory/status_reporter.go | Adds qmdStatus dynamic function field and SetQMDStatusFunc; correctly copies func under read lock before invoking to avoid holding the lock during the closure call |
| internal/app/app.go | Promotes QMD status to a live runtime closure using SetQMDStatusFunc; appMemoryBackendName handles nil config safely, so the ordering of the nil guard after the call is benign |
| internal/bot/status.go | Adds handleQMDCommand and buildQMDStatusString; correctly propagates runtime QMD status through GetMemoryStatus |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/cli/qmd.go:739-743
**Double error output when RunE returns an error**

Returning `err` directly from `RunE` causes Cobra to write `"Error: <message>"` to stderr after the command already printed the user-facing `"QMD update: unavailable"` block to `out`. Operators will see the reason twice. The same pattern applies to the `return openErr` and `return fallbackErr` paths in `newQMDSmokeCommand`. A common fix is to silence Cobra's auto-printing for these expected failure paths and rely solely on the already-printed message:

Alternatively, call `cmd.SilenceErrors()` at construction time and let the printed lines carry the full signal.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(memory): report live QMD fallback st..."](https://github.com/befeast/ok-gobot/commit/a381b029aa4bcc3e8597a6c9cb3b8a8a8536e5d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30327499)</sub>

<!-- /greptile_comment -->