### PR TITLE
feat(memory): add scoped recall policy

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,7 +1,8 @@
 # Semantic Memory System
 
 > Current architecture note: memory v2 is markdown-first. `MEMORY.md` and
-> `memory/*.md` are the source of truth; SQLite stores an embedding index over
+> legacy `memory/*.md`, and scoped `memory/<scope>/<id>/*.md` files are the
+> source of truth; SQLite stores an embedding index over
 > those files. QMD can be configured as an optional read-only search backend for
 > advanced local-first search, but it is never required. Legacy record-style
 > commands such as `memory save/list/forget` are deprecated.
@@ -204,10 +205,30 @@ When `memory.enabled: true`, bot startup automatically indexes:
 - `memory/*.md`
 - Every collection configured under `memory.extra_paths` (see "External
   markdown collections" above).
+- `memory/users/<telegram-user-id>/*.md`
+- `memory/chats/<telegram-chat-id>/*.md`
+- `memory/sessions/<session-id>/*.md`
+- `memory/roles/<role-name>/*.md`
+- `memory/jobs/<job-id>/*.md`
 
 The bot also starts debounced filesystem watchers for the workspace memory
 sources and for each extra path. Changes update the `memory_chunks` index;
 deleted files remove their chunks.
+
+Other markdown files are intentionally ignored unless they are indexed with an
+explicit external source label such as `extra:<collection>/...`.
+
+### Scoped Recall Policy
+
+Telegram active recall is scoped before results enter prompts or Telegram output:
+
+- Private chats can recall only matching `users/<id>`, `chats/<id>`, current `sessions/<id>`, current role, current job, and explicitly allowed extra path labels.
+- Group chats do not recall memory by default. A group must be active to recall its own `chats/<id>` memory, and it still cannot recall private user memory.
+- Legacy global `MEMORY.md` and `memory/*.md` are treated as private legacy memory and are not available in group recall.
+- Extra paths keep their `extra:<collection>/...` source label and are denied unless that label is explicitly allowed by runtime policy.
+- Memory snippets returned by `memory_search` and `memory_get` are redacted before being passed back to the model.
+
+The current policy summary is visible in `/status` and in memory tool output.
 
 ### Curation Drafts (manual promotion)
 

--- a/internal/agent/lifecycle_memory.go
+++ b/internal/agent/lifecycle_memory.go
@@ -136,7 +136,7 @@ func (f *LifecycleFlusher) Flush(rec FlushRecord) (FlushResult, error) {
 	}
 
 	body := formatFlushBody(rec, f.clock())
-	if err := f.mem.appendToTodayRaw(body); err != nil {
+	if err := f.mem.appendToTodayRaw("", body); err != nil {
 		// Release the dedup slot so a follow-up retry can proceed once the
 		// underlying write problem (disk full, perms) is resolved.
 		f.mu.Lock()

--- a/internal/agent/memory.go
+++ b/internal/agent/memory.go
@@ -35,9 +35,27 @@ func (m *Memory) GetTodayNote() (*DailyNote, error) {
 	return m.GetNote(date)
 }
 
+// GetScopedTodayNote returns today's note for a relative memory scope such as
+// "users/123" or "chats/-100".
+func (m *Memory) GetScopedTodayNote(scopeDir string) (*DailyNote, error) {
+	date := time.Now().Format("2006-01-02")
+	return m.getNote(date, scopeDir)
+}
+
 // GetNote returns a specific day's note
 func (m *Memory) GetNote(date string) (*DailyNote, error) {
+	return m.getNote(date, "")
+}
+
+func (m *Memory) getNote(date, scopeDir string) (*DailyNote, error) {
+	scopeDir, err := cleanMemoryScopeDir(scopeDir)
+	if err != nil {
+		return nil, err
+	}
 	memoryDir := filepath.Join(m.BasePath, "memory")
+	if scopeDir != "" {
+		memoryDir = filepath.Join(memoryDir, filepath.FromSlash(scopeDir))
+	}
 	if err := os.MkdirAll(memoryDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create memory directory: %w", err)
 	}
@@ -76,7 +94,16 @@ func (m *Memory) AppendToToday(content string) error {
 	timestamp := time.Now().Format("15:04")
 	entry := fmt.Sprintf("\n## %s\n\n%s\n", timestamp, content)
 
-	return m.appendToTodayRaw(entry)
+	return m.appendToTodayRaw("", entry)
+}
+
+// AppendToScopedToday appends content to today's note under a scoped memory
+// directory such as "users/123" or "chats/-100".
+func (m *Memory) AppendToScopedToday(scopeDir, content string) error {
+	timestamp := time.Now().Format("15:04")
+	entry := fmt.Sprintf("\n## %s\n\n%s\n", timestamp, content)
+
+	return m.appendToTodayRaw(scopeDir, entry)
 }
 
 // AppendQuickNoteToToday appends a quick-capture note to today's note.
@@ -85,11 +112,19 @@ func (m *Memory) AppendQuickNoteToToday(content string) error {
 	timestamp := time.Now().Format("15:04")
 	entry := fmt.Sprintf("\n\n## Quick Note (%s)\n%s", timestamp, content)
 
-	return m.appendToTodayRaw(entry)
+	return m.appendToTodayRaw("", entry)
 }
 
-func (m *Memory) appendToTodayRaw(entry string) error {
-	note, err := m.GetTodayNote()
+// AppendScopedQuickNoteToToday appends a quick note under a scoped memory directory.
+func (m *Memory) AppendScopedQuickNoteToToday(scopeDir, content string) error {
+	timestamp := time.Now().Format("15:04")
+	entry := fmt.Sprintf("\n\n## Quick Note (%s)\n%s", timestamp, content)
+
+	return m.appendToTodayRaw(scopeDir, entry)
+}
+
+func (m *Memory) appendToTodayRaw(scopeDir, entry string) error {
+	note, err := m.getNote(time.Now().Format("2006-01-02"), scopeDir)
 	if err != nil {
 		return err
 	}
@@ -111,6 +146,21 @@ func (m *Memory) appendToTodayRaw(entry string) error {
 
 	_, err = f.WriteString(entry)
 	return err
+}
+
+func cleanMemoryScopeDir(scopeDir string) (string, error) {
+	scopeDir = strings.TrimSpace(scopeDir)
+	if scopeDir == "" {
+		return "", nil
+	}
+	scopeDir = filepath.ToSlash(filepath.Clean(scopeDir))
+	if scopeDir == "." {
+		return "", nil
+	}
+	if filepath.IsAbs(scopeDir) || strings.HasPrefix(scopeDir, "../") || scopeDir == ".." {
+		return "", fmt.Errorf("memory scope %q escapes memory directory", scopeDir)
+	}
+	return scopeDir, nil
 }
 
 // LoadLongTermMemory reads MEMORY.md

--- a/internal/agent/memory_test.go
+++ b/internal/agent/memory_test.go
@@ -75,3 +75,32 @@ func TestAppendQuickNoteToToday_AppendsToExistingNote(t *testing.T) {
 		t.Fatalf("quick note text should be the last line; got: %q", content)
 	}
 }
+
+func TestAppendToScopedToday_WritesUnderScope(t *testing.T) {
+	basePath := t.TempDir()
+	m := &Memory{BasePath: basePath}
+
+	if err := m.AppendToScopedToday("users/101", "User: scoped note"); err != nil {
+		t.Fatalf("AppendToScopedToday failed: %v", err)
+	}
+
+	today := time.Now().Format("2006-01-02")
+	notePath := filepath.Join(basePath, "memory", "users", "101", today+".md")
+	data, err := os.ReadFile(notePath)
+	if err != nil {
+		t.Fatalf("failed to read scoped note: %v", err)
+	}
+	if !strings.Contains(string(data), "User: scoped note") {
+		t.Fatalf("scoped note content missing: %q", string(data))
+	}
+	if _, err := os.Stat(filepath.Join(basePath, "memory", today+".md")); !os.IsNotExist(err) {
+		t.Fatalf("unscoped note should not be created, stat err = %v", err)
+	}
+}
+
+func TestAppendToScopedToday_RejectsEscapingScope(t *testing.T) {
+	m := &Memory{BasePath: t.TempDir()}
+	if err := m.AppendToScopedToday("../outside", "nope"); err == nil {
+		t.Fatal("expected escaping scope to fail")
+	}
+}

--- a/internal/agent/personality_test.go
+++ b/internal/agent/personality_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"ok-gobot/internal/memory"
 	"ok-gobot/internal/tools"
 )
 
@@ -179,6 +180,36 @@ func TestBuildSystemPrompt_RetrievalFirstSkipsDailyNotes(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "Memory mode: retrieval_first.") {
 		t.Fatalf("retrieval_first prompt should advertise its mode")
+	}
+}
+
+func TestBuildSystemPrompt_AppliesMemoryRecallPolicy(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(&staticTool{name: "memory_search", desc: "Search memory"})
+
+	today := time.Now().Format("2006-01-02")
+	personality := &Personality{
+		Files: map[string]string{
+			"SOUL.md":                 "SOUL_SECTION",
+			"MEMORY.md":               "LEGACY_PRIVATE_MEMORY",
+			"memory/" + today + ".md": "LEGACY_DAILY_MEMORY",
+		},
+	}
+
+	agent := NewToolCallingAgent(nil, registry, personality)
+	agent.SetMemoryRecallPolicy(memory.NewRecallPolicy(memory.RecallContext{
+		UserID:     101,
+		ChatID:     101,
+		SessionKey: "dm:101",
+		ChatType:   "private",
+	}))
+
+	prompt := agent.buildSystemPrompt()
+	if strings.Contains(prompt, "LEGACY_PRIVATE_MEMORY") || strings.Contains(prompt, "LEGACY_DAILY_MEMORY") {
+		t.Fatalf("legacy memory should be filtered by scoped recall policy:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "memory recall policy: scoped") {
+		t.Fatalf("prompt should include inspectable memory policy, got:\n%s", prompt)
 	}
 }
 

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -118,9 +118,6 @@ func (r *RunResolver) buildMemoryRecallPolicy(chatID int64, profile *AgentProfil
 	if ctx.RoleName == "" && profile != nil {
 		ctx.RoleName = profile.Name
 	}
-	if ctx.JobID == "" && job != nil {
-		ctx.JobID = ctx.SessionKey
-	}
 	return memory.NewRecallPolicy(ctx)
 }
 

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -69,12 +69,17 @@ type RunComponents struct {
 // Resolve creates the tool-calling agent and its dependencies for a chat session.
 // isSubagent prevents injecting browser_task (avoids recursive subagent spawning).
 func (r *RunResolver) Resolve(chatID int64, overrides *RunOverrides, job *delegation.Job, isSubagent ...bool) (*RunComponents, error) {
+	return r.resolve(chatID, overrides, job, nil, isSubagent...)
+}
+
+func (r *RunResolver) resolve(chatID int64, overrides *RunOverrides, job *delegation.Job, recallCtx *memory.RecallContext, isSubagent ...bool) (*RunComponents, error) {
 	profile := r.resolveProfile(chatID)
 	model := r.resolveModel(chatID, profile, overrides)
 	thinkLevel := r.resolveThinkLevel(chatID, overrides)
 	aiClient := r.buildAIClient(model, thinkLevel)
 	sub := len(isSubagent) > 0 && isSubagent[0]
-	toolReg := r.buildToolRegistry(chatID, profile, sub, job)
+	memoryPolicy := r.buildMemoryRecallPolicy(chatID, profile, job, recallCtx)
+	toolReg := r.buildToolRegistryWithMemoryPolicy(chatID, profile, sub, job, memoryPolicy)
 
 	aliases := r.AIConfig.ModelAliases
 	if aliases == nil {
@@ -84,6 +89,9 @@ func (r *RunResolver) Resolve(chatID int64, overrides *RunOverrides, job *delega
 	ta := NewToolCallingAgent(aiClient, toolReg, profile.Personality)
 	ta.SetModel(model)
 	ta.SetModelAliases(aliases)
+	if memoryPolicy != nil {
+		ta.SetMemoryRecallPolicy(memoryPolicy)
+	}
 	if thinkLevel != "" {
 		ta.SetThinkLevel(thinkLevel)
 	}
@@ -93,6 +101,27 @@ func (r *RunResolver) Resolve(chatID int64, overrides *RunOverrides, job *delega
 	ta.SetHookRunner(NewHookRunner(r.HooksDir))
 
 	return &RunComponents{Agent: ta, Profile: profile}, nil
+}
+
+func (r *RunResolver) buildMemoryRecallPolicy(chatID int64, profile *AgentProfile, job *delegation.Job, recallCtx *memory.RecallContext) *memory.RecallPolicy {
+	if recallCtx == nil && chatID == 0 {
+		return nil
+	}
+
+	ctx := memory.RecallContext{ChatID: chatID}
+	if recallCtx != nil {
+		ctx = *recallCtx
+		if ctx.ChatID == 0 {
+			ctx.ChatID = chatID
+		}
+	}
+	if ctx.RoleName == "" && profile != nil {
+		ctx.RoleName = profile.Name
+	}
+	if ctx.JobID == "" && job != nil {
+		ctx.JobID = ctx.SessionKey
+	}
+	return memory.NewRecallPolicy(ctx)
 }
 
 func (r *RunResolver) resolveProfile(chatID int64) *AgentProfile {
@@ -189,6 +218,10 @@ func (r *RunResolver) buildAIClient(model, thinkLevel string) ai.Client {
 }
 
 func (r *RunResolver) buildToolRegistry(chatID int64, profile *AgentProfile, isSubagent bool, job *delegation.Job) *tools.Registry {
+	return r.buildToolRegistryWithMemoryPolicy(chatID, profile, isSubagent, job, nil)
+}
+
+func (r *RunResolver) buildToolRegistryWithMemoryPolicy(chatID int64, profile *AgentProfile, isSubagent bool, job *delegation.Job, memoryPolicy *memory.RecallPolicy) *tools.Registry {
 	base := r.ToolRegistry
 
 	// Filter by agent's allowed tools.
@@ -242,6 +275,10 @@ func (r *RunResolver) buildToolRegistry(chatID int64, profile *AgentProfile, isS
 			}
 		}
 		base = filtered
+	}
+
+	if memoryPolicy != nil {
+		base = tools.ApplyMemoryRecallPolicy(base, memoryPolicy)
 	}
 
 	// Apply capability policy last so it covers all tools including

--- a/internal/agent/resolver_policy_test.go
+++ b/internal/agent/resolver_policy_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"ok-gobot/internal/delegation"
+	"ok-gobot/internal/memory"
 	"ok-gobot/internal/tools"
 )
 
@@ -44,6 +46,30 @@ func TestBuildToolRegistry_PolicyDeniesShell(t *testing.T) {
 	_, err = reg.Execute(context.Background(), "file", "read")
 	if err != nil {
 		t.Fatalf("expected file tool to be allowed: %v", err)
+	}
+}
+
+func TestBuildMemoryRecallPolicyDoesNotUseEphemeralSessionAsJobID(t *testing.T) {
+	t.Parallel()
+
+	resolver := &RunResolver{}
+	policy := resolver.buildMemoryRecallPolicy(101, nil, &delegation.Job{}, &memory.RecallContext{
+		UserID:     101,
+		ChatID:     101,
+		SessionKey: "subagent:101:123456789",
+		ChatType:   "private",
+	})
+	if policy.Context.JobID != "" {
+		t.Fatalf("JobID=%q, want empty when no stable job id is supplied", policy.Context.JobID)
+	}
+
+	explicit := resolver.buildMemoryRecallPolicy(101, nil, &delegation.Job{}, &memory.RecallContext{
+		UserID: 101,
+		ChatID: 101,
+		JobID:  "job-abc",
+	})
+	if explicit.Context.JobID != "job-abc" {
+		t.Fatalf("explicit JobID=%q, want job-abc", explicit.Context.JobID)
 	}
 }
 

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -43,6 +43,17 @@ func emptyRecallContext(ctx memory.RecallContext) bool {
 		len(ctx.ExtraPathLabels) == 0
 }
 
+func timeoutSubagentMemoryScope(req RunRequest) memory.RecallContext {
+	scope := req.MemoryScope
+	if scope.ChatID == 0 {
+		scope.ChatID = req.ChatID
+	}
+	if scope.SessionKey == "" {
+		scope.SessionKey = string(req.SessionKey)
+	}
+	return scope
+}
+
 // RunEventType describes the kind of event emitted by the hub.
 type RunEventType string
 
@@ -224,11 +235,12 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 			log.Printf("[hub] tool %s timed out for session %s — spawning subagent %s", toolName, req.SessionKey, subKey)
 
 			h.Submit(RunRequest{
-				SessionKey: subKey,
-				ChatID:     req.ChatID,
-				Content:    task,
-				Context:    context.Background(),
-				IsSubagent: true,
+				SessionKey:  subKey,
+				ChatID:      req.ChatID,
+				Content:     task,
+				Context:     context.Background(),
+				IsSubagent:  true,
+				MemoryScope: timeoutSubagentMemoryScope(req),
 			})
 
 			return fmt.Sprintf("⏳ Tool '%s' exceeded %s — moved to subagent. You'll get a notification when it finishes.", toolName, DefaultToolTimeout)

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -31,6 +31,18 @@ func NewGroupSessionKey(chatID int64) SessionKey {
 	return SessionKey(fmt.Sprintf("group:%d", chatID))
 }
 
+func emptyRecallContext(ctx memory.RecallContext) bool {
+	return ctx.UserID == 0 &&
+		ctx.ChatID == 0 &&
+		ctx.SessionKey == "" &&
+		ctx.ChatType == "" &&
+		ctx.RoleName == "" &&
+		ctx.JobID == "" &&
+		!ctx.AllowGlobalPrivate &&
+		!ctx.AllowGroupChat &&
+		len(ctx.ExtraPathLabels) == 0
+}
+
 // RunEventType describes the kind of event emitted by the hub.
 type RunEventType string
 
@@ -70,6 +82,7 @@ type RunRequest struct {
 	// system prompt and the current user message. Used by Active Memory to
 	// pass recall results as untrusted context.
 	PreUserSystemNotes []string
+	MemoryScope        memory.RecallContext
 }
 
 // runSlot holds the state of a single active run.
@@ -147,7 +160,18 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 	}
 
 	// Resolve agent components.
-	components, err := h.resolver.Resolve(req.ChatID, overrides, job, req.IsSubagent)
+	var recallCtx *memory.RecallContext
+	if req.ChatID != 0 || !emptyRecallContext(req.MemoryScope) {
+		memoryScope := req.MemoryScope
+		if memoryScope.ChatID == 0 {
+			memoryScope.ChatID = req.ChatID
+		}
+		if memoryScope.SessionKey == "" {
+			memoryScope.SessionKey = string(req.SessionKey)
+		}
+		recallCtx = &memoryScope
+	}
+	components, err := h.resolver.resolve(req.ChatID, overrides, job, recallCtx, req.IsSubagent)
 	if err != nil {
 		events <- RunEvent{Type: RunEventError, Err: err}
 		close(events)

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"ok-gobot/internal/ai"
+	"ok-gobot/internal/memory"
 	"ok-gobot/internal/tools"
 )
 
@@ -266,6 +267,45 @@ func TestRuntimeHub_ToolEventCallback(t *testing.T) {
 	}
 	if toolEvents[1].Type != ToolEventFinished {
 		t.Errorf("expected finished event, got %s", toolEvents[1].Type)
+	}
+}
+
+func TestTimeoutSubagentMemoryScopeInheritsParentScope(t *testing.T) {
+	req := RunRequest{
+		SessionKey: "dm:42",
+		ChatID:     42,
+		MemoryScope: memory.RecallContext{
+			UserID:             777,
+			ChatID:             42,
+			SessionKey:         "dm:42",
+			ChatType:           "private",
+			AllowGlobalPrivate: true,
+			ExtraPathLabels:    []string{"obsidian"},
+		},
+	}
+
+	got := timeoutSubagentMemoryScope(req)
+	if got.UserID != 777 || got.ChatID != 42 || got.SessionKey != "dm:42" {
+		t.Fatalf("unexpected inherited memory scope: %+v", got)
+	}
+	if !got.AllowGlobalPrivate {
+		t.Fatalf("expected inherited private-global allowance: %+v", got)
+	}
+	if len(got.ExtraPathLabels) != 1 || got.ExtraPathLabels[0] != "obsidian" {
+		t.Fatalf("expected inherited extra path labels, got %+v", got.ExtraPathLabels)
+	}
+}
+
+func TestTimeoutSubagentMemoryScopeDefaultsFromParentRequest(t *testing.T) {
+	got := timeoutSubagentMemoryScope(RunRequest{
+		SessionKey: "dm:99",
+		ChatID:     99,
+	})
+	if got.ChatID != 99 {
+		t.Fatalf("expected parent chat id, got %+v", got)
+	}
+	if got.SessionKey != "dm:99" {
+		t.Fatalf("expected parent session key, got %+v", got)
 	}
 }
 

--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -64,6 +64,7 @@ type ToolCallingAgent struct {
 	memoryContextBuilder *memory.ContextPackBuilder
 	memoryContextScope   memory.ContextPackScope
 	memoryContextBudget  memory.ContextPackBudget
+	memoryPolicy         *memory.RecallPolicy
 }
 
 // SetToolEventCallback sets a callback that fires on tool lifecycle events.
@@ -158,6 +159,11 @@ func (a *ToolCallingAgent) SetModel(model string) {
 // SetModelAliases sets the model alias map for system prompt generation.
 func (a *ToolCallingAgent) SetModelAliases(aliases map[string]string) {
 	a.modelAliases = aliases
+}
+
+// SetMemoryRecallPolicy attaches the scoped memory policy for this run.
+func (a *ToolCallingAgent) SetMemoryRecallPolicy(policy *memory.RecallPolicy) {
+	a.memoryPolicy = policy
 }
 
 // ProcessRequest handles a user request, potentially invoking tools
@@ -626,11 +632,24 @@ type ToolCall struct {
 
 // buildSystemPrompt creates the system prompt with tool descriptions
 func (a *ToolCallingAgent) buildSystemPrompt() string {
+	var allowMemory func(string) bool
+	var sanitizeMemory func(string, string) string
+	memorySummary := ""
+	if a.memoryPolicy != nil {
+		allowMemory = a.memoryPolicy.AllowSource
+		sanitizeMemory = func(_ string, content string) string {
+			return memory.SanitizeSnippet(content)
+		}
+		memorySummary = a.memoryPolicy.Summary()
+	}
 	return bootstrap.BuildPrompt(a.personality.Loader(), a.tools, bootstrap.PromptOptions{
-		Mode:         a.PromptMode,
-		ThinkLevel:   a.ThinkLevel,
-		MemoryMode:   a.MemoryMode,
-		ModelAliases: a.modelAliases,
+		Mode:                   a.PromptMode,
+		ThinkLevel:             a.ThinkLevel,
+		MemoryMode:             a.MemoryMode,
+		ModelAliases:           a.modelAliases,
+		MemorySourceAllowed:    allowMemory,
+		MemoryContentSanitizer: sanitizeMemory,
+		MemoryPolicySummary:    memorySummary,
 	})
 }
 

--- a/internal/bootstrap/loader.go
+++ b/internal/bootstrap/loader.go
@@ -168,6 +168,18 @@ func (l *Loader) SystemPrompt() string {
 // are always loaded so the bot retains stable bootstrap context regardless
 // of mode.
 func (l *Loader) SystemPromptForMode(mode string) string {
+	return l.SystemPromptFilteredForMode(mode, nil, nil)
+}
+
+// SystemPromptFiltered builds the bootstrap prompt while applying an optional
+// memory-source allow function and sanitizer to memory sections.
+func (l *Loader) SystemPromptFiltered(allowMemorySource func(source string) bool, sanitizeMemoryContent func(source, content string) string) string {
+	return l.SystemPromptFilteredForMode(MemoryModeEager, allowMemorySource, sanitizeMemoryContent)
+}
+
+// SystemPromptFilteredForMode builds the bootstrap prompt with both memory mode
+// selection and optional source filtering/sanitization.
+func (l *Loader) SystemPromptFilteredForMode(mode string, allowMemorySource func(source string) bool, sanitizeMemoryContent func(source, content string) string) string {
 	if l == nil {
 		return ""
 	}
@@ -212,19 +224,19 @@ func (l *Loader) SystemPromptForMode(mode string) string {
 		prompt.WriteString("\n\n")
 	}
 
-	if memory, ok := l.Files["MEMORY.md"]; ok {
+	if memory, ok := l.Files["MEMORY.md"]; ok && memorySourceAllowed(allowMemorySource, "MEMORY.md") {
 		prompt.WriteString("## LONG-TERM MEMORY\n\n")
-		prompt.WriteString(memory)
+		prompt.WriteString(sanitizeMemorySection(sanitizeMemoryContent, "MEMORY.md", memory))
 		prompt.WriteString("\n\n")
 	}
 
 	for _, date := range l.dailyNoteCandidatesForMode(mode) {
 		key := "memory/" + date + ".md"
-		if note, ok := l.Files[key]; ok {
+		if note, ok := l.Files[key]; ok && memorySourceAllowed(allowMemorySource, key) {
 			prompt.WriteString("## DAILY MEMORY: ")
 			prompt.WriteString(date)
 			prompt.WriteString("\n\n")
-			prompt.WriteString(note)
+			prompt.WriteString(sanitizeMemorySection(sanitizeMemoryContent, key, note))
 			prompt.WriteString("\n\n")
 		}
 	}
@@ -307,6 +319,17 @@ func normalizeMode(mode string) string {
 	default:
 		return MemoryModeEager
 	}
+}
+
+func memorySourceAllowed(allow func(source string) bool, source string) bool {
+	return allow == nil || allow(source)
+}
+
+func sanitizeMemorySection(sanitize func(source, content string) string, source, content string) string {
+	if sanitize == nil {
+		return content
+	}
+	return sanitize(source, content)
 }
 
 // MinimalPrompt builds the minimal IDENTITY+SOUL bootstrap prompt.

--- a/internal/bootstrap/prompt.go
+++ b/internal/bootstrap/prompt.go
@@ -11,11 +11,14 @@ import (
 
 // PromptOptions controls full system prompt assembly.
 type PromptOptions struct {
-	Mode         string
-	ThinkLevel   string
-	MemoryMode   string // "eager" (default), "retrieval_first", or "startup_recent"
-	ModelAliases map[string]string
-	Now          func() time.Time
+	Mode                   string
+	ThinkLevel             string
+	MemoryMode             string // "eager" (default), "retrieval_first", or "startup_recent"
+	ModelAliases           map[string]string
+	Now                    func() time.Time
+	MemorySourceAllowed    func(source string) bool
+	MemoryContentSanitizer func(source, content string) string
+	MemoryPolicySummary    string
 }
 
 // BuildPrompt assembles the canonical startup prompt.
@@ -35,7 +38,7 @@ func BuildPrompt(loader *Loader, registry *tools.Registry, opts PromptOptions) s
 	case "minimal":
 		prompt.WriteString(loader.MinimalPrompt())
 	default:
-		prompt.WriteString(loader.SystemPromptForMode(memoryMode))
+		prompt.WriteString(loader.SystemPromptFilteredForMode(memoryMode, opts.MemorySourceAllowed, opts.MemoryContentSanitizer))
 
 		skillsSummary := loader.SkillsSummary()
 		if skillsSummary != "" {
@@ -75,7 +78,7 @@ func BuildPrompt(loader *Loader, registry *tools.Registry, opts PromptOptions) s
 		if registry != nil {
 			if _, hasMemorySearch := registry.Get("memory_search"); hasMemorySearch {
 				_, hasMemoryGet := registry.Get("memory_get")
-				prompt.WriteString(buildMemorySection(memoryMode, loader, hasMemoryGet))
+				prompt.WriteString(buildMemorySection(memoryMode, loader, hasMemoryGet, opts.MemoryPolicySummary))
 			}
 		}
 
@@ -117,9 +120,14 @@ func BuildPrompt(loader *Loader, registry *tools.Registry, opts PromptOptions) s
 // buildMemorySection emits the "## Memory" guidance block. The text is
 // mode-aware so the agent gets clear direction about whether to rely on
 // inlined daily notes or to retrieve them on demand.
-func buildMemorySection(memoryMode string, loader *Loader, hasMemoryGet bool) string {
+func buildMemorySection(memoryMode string, loader *Loader, hasMemoryGet bool, policySummary string) string {
 	var b strings.Builder
 	b.WriteString("## Memory\n\n")
+	if policySummary != "" {
+		b.WriteString(policySummary)
+		b.WriteString("\n")
+		b.WriteString("Only use memory sources permitted by this policy. Denied scopes are unavailable.\n\n")
+	}
 
 	switch memoryMode {
 	case MemoryModeRetrievalFirst:

--- a/internal/bot/active_memory.go
+++ b/internal/bot/active_memory.go
@@ -17,13 +17,14 @@ import (
 // Translation only — no policy decisions live here.
 type memoryManagerRecaller struct {
 	manager *memory.MemoryManager
+	policy  *memory.RecallPolicy
 }
 
 // Recall delegates to MemoryManager.Recall and converts MemoryResult into the
 // agent-package ActiveMemorySnippet so the agent package does not depend on
 // the memory package.
 func (r *memoryManagerRecaller) Recall(ctx context.Context, query string, topK int) ([]agent.ActiveMemorySnippet, error) {
-	results, err := r.manager.Recall(ctx, query, topK)
+	results, err := r.manager.SearchScoped(ctx, query, topK, r.policy)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +33,7 @@ func (r *memoryManagerRecaller) Recall(ctx context.Context, query string, topK i
 		out = append(out, agent.ActiveMemorySnippet{
 			SourceFile: h.SourceFile,
 			HeaderPath: h.HeaderPath,
-			Content:    h.Content,
+			Content:    memory.SanitizeSnippet(h.Content),
 			Similarity: h.Similarity,
 		})
 	}
@@ -102,7 +103,12 @@ func (b *Bot) runActiveMemoryRecall(
 	}
 
 	eligible := b.activeMemoryEnabledForSession(chatID)
-	res := b.activeMemory.Recall(ctx, eligible, content, history)
+	activeMemory := b.activeMemory
+	if b.memoryManager != nil {
+		policy := memory.NewRecallPolicy(b.memoryRecallContext(chatID, chatID, string(telebot.ChatPrivate), sessionKey))
+		activeMemory = agent.NewActiveMemory(&memoryManagerRecaller{manager: b.memoryManager, policy: policy}, b.activeMemory.Config())
+	}
+	res := activeMemory.Recall(ctx, eligible, content, history)
 	log.Printf("[active_memory] session=%s status=%s duration=%s", sessionKey, res.Status, res.Duration)
 
 	pack := buildActiveMemoryContextPack(res, b.activeMemory.Config(), sessionKey, chatID)

--- a/internal/bot/active_memory.go
+++ b/internal/bot/active_memory.go
@@ -85,6 +85,7 @@ func (b *Bot) runActiveMemoryRecall(
 	ctx context.Context,
 	sessionKey agent.SessionKey,
 	chatID int64,
+	userID int64,
 	content string,
 	history []ai.ChatMessage,
 ) ([]string, string) {
@@ -105,7 +106,7 @@ func (b *Bot) runActiveMemoryRecall(
 	eligible := b.activeMemoryEnabledForSession(chatID)
 	activeMemory := b.activeMemory
 	if b.memoryManager != nil {
-		policy := memory.NewRecallPolicy(b.memoryRecallContext(chatID, chatID, string(telebot.ChatPrivate), sessionKey))
+		policy := memory.NewRecallPolicy(b.memoryRecallContext(chatID, userID, string(telebot.ChatPrivate), sessionKey))
 		activeMemory = agent.NewActiveMemory(&memoryManagerRecaller{manager: b.memoryManager, policy: policy}, b.activeMemory.Config())
 	}
 	res := activeMemory.Recall(ctx, eligible, content, history)

--- a/internal/bot/active_memory_test.go
+++ b/internal/bot/active_memory_test.go
@@ -53,6 +53,7 @@ func TestRunActiveMemoryRecall_GroupChat_Skipped(t *testing.T) {
 		context.Background(),
 		agent.NewGroupSessionKey(123),
 		123,
+		123,
 		"what did we decide?",
 		nil,
 	)
@@ -77,6 +78,7 @@ func TestRunActiveMemoryRecall_DM_DisabledConfig_NoRecall(t *testing.T) {
 	notes, _ := bot.runActiveMemoryRecall(
 		context.Background(),
 		agent.NewDMSessionKey(456),
+		456,
 		456,
 		"hi",
 		nil,
@@ -104,6 +106,7 @@ func TestRunActiveMemoryRecall_DM_SessionOverrideOn_TriggersRecall(t *testing.T)
 	notes, diag := bot.runActiveMemoryRecall(
 		context.Background(),
 		agent.NewDMSessionKey(chatID),
+		chatID,
 		chatID,
 		"what did we pick?",
 		nil,
@@ -141,6 +144,7 @@ func TestRunActiveMemoryRecall_DM_SessionOverrideOff_OverridesEnabledConfig(t *t
 		context.Background(),
 		agent.NewDMSessionKey(chatID),
 		chatID,
+		chatID,
 		"hi",
 		nil,
 	)
@@ -160,6 +164,7 @@ func TestRunActiveMemoryRecall_DM_NoResults_NoInjection(t *testing.T) {
 	notes, diag := bot.runActiveMemoryRecall(
 		context.Background(),
 		agent.NewDMSessionKey(1),
+		1,
 		1,
 		"hi",
 		nil,
@@ -183,6 +188,7 @@ func TestRunActiveMemoryRecall_DM_TimeoutFallback_DoesNotInject(t *testing.T) {
 	notes, diag := bot.runActiveMemoryRecall(
 		context.Background(),
 		agent.NewDMSessionKey(1),
+		1,
 		1,
 		"hi",
 		nil,
@@ -217,6 +223,7 @@ func TestRunActiveMemoryRecall_DM_RecallerError_NoInjection(t *testing.T) {
 		context.Background(),
 		agent.NewDMSessionKey(1),
 		1,
+		1,
 		"hi",
 		nil,
 	)
@@ -235,6 +242,7 @@ func TestRunActiveMemoryRecall_NoActiveMemory_QuietNoOp(t *testing.T) {
 	notes, diag := bot.runActiveMemoryRecall(
 		context.Background(),
 		agent.NewDMSessionKey(1),
+		1,
 		1,
 		"hi",
 		nil,
@@ -258,6 +266,7 @@ func TestRunActiveMemoryRecall_InjectionTagsCannotBeForgedByRecall(t *testing.T)
 	notes, _ := bot.runActiveMemoryRecall(
 		context.Background(),
 		agent.NewDMSessionKey(1),
+		1,
 		1,
 		"hi",
 		nil,

--- a/internal/bot/agent_handler.go
+++ b/internal/bot/agent_handler.go
@@ -56,10 +56,7 @@ func (b *Bot) handleStreamingRequestWithProfile(ctx context.Context, c telebot.C
 	// Final update
 	finalContent := editor.Finish()
 
-	// Save to memory
-	if err := b.memory.AppendToToday(fmt.Sprintf("Assistant: %s", finalContent)); err != nil {
-		log.Printf("Failed to save to memory: %v", err)
-	}
+	b.appendToTelegramMemory(c.Chat(), senderIDFromMessage(c.Message()), fmt.Sprintf("Assistant: %s", finalContent))
 
 	// Save session
 	if err := b.store.SaveSession(chatID, finalContent); err != nil {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -25,41 +25,42 @@ import (
 // Telegram currently still uses the legacy agent.RuntimeHub compatibility path.
 // New architecture work should target the chat/jobs mailbox runtime in internal/runtime.
 type Bot struct {
-	ctx              context.Context // bot lifetime context, set during Start
-	api              *telebot.Bot
-	store            *storage.Store
-	ai               ai.Client
-	streamingAI      ai.StreamingClient
-	aiConfig         AIConfig
-	personality      *agent.Personality
-	agentRegistry    *agent.AgentRegistry
-	toolRegistry     *tools.Registry
-	safety           *agent.Safety
-	memory           *agent.Memory
-	lifecycleFlush   *agent.LifecycleFlusher
-	memoryManager    *memory.MemoryManager
-	authManager      *AuthManager
-	groupManager     *GroupManager
-	approvalManager  *ApprovalManager
-	hub              *agent.RuntimeHub // legacy hub/subagent compatibility runtime for Telegram/TUI bridging
-	subagentHub      *runtime.Hub      // event bus for sub-agent completion routing
-	subagentNotifier *SubagentNotifier // routes child completions to parent Telegram chats
-	adminID          int64
-	enableStream     bool
-	debouncer        *Debouncer
-	rateLimiter      *RateLimiter
-	configWatcher    ConfigWatcher
-	usageTracker     *UsageTracker
-	fragmentBuffer   *FragmentBuffer
-	mediaGroupBuf    *MediaGroupBuffer
-	queueManager     *QueueManager
-	scheduler        tools.CronScheduler
-	ackManager       *AckHandleManager
-	controlHub       *control.Hub // optional: emit run/tool/approval events over WebSocket
-	voiceTranscriber *VoiceTranscriber
-	rolesPath        string // directory of role manifests; set via SetRolesPath
-	activeMemory     *agent.ActiveMemory
-	memoryStatus     MemoryStatusProvider
+	ctx                   context.Context // bot lifetime context, set during Start
+	api                   *telebot.Bot
+	store                 *storage.Store
+	ai                    ai.Client
+	streamingAI           ai.StreamingClient
+	aiConfig              AIConfig
+	personality           *agent.Personality
+	agentRegistry         *agent.AgentRegistry
+	toolRegistry          *tools.Registry
+	safety                *agent.Safety
+	memory                *agent.Memory
+	lifecycleFlush        *agent.LifecycleFlusher
+	memoryManager         *memory.MemoryManager
+	authManager           *AuthManager
+	groupManager          *GroupManager
+	approvalManager       *ApprovalManager
+	hub                   *agent.RuntimeHub // legacy hub/subagent compatibility runtime for Telegram/TUI bridging
+	subagentHub           *runtime.Hub      // event bus for sub-agent completion routing
+	subagentNotifier      *SubagentNotifier // routes child completions to parent Telegram chats
+	adminID               int64
+	enableStream          bool
+	debouncer             *Debouncer
+	rateLimiter           *RateLimiter
+	configWatcher         ConfigWatcher
+	usageTracker          *UsageTracker
+	fragmentBuffer        *FragmentBuffer
+	mediaGroupBuf         *MediaGroupBuffer
+	queueManager          *QueueManager
+	scheduler             tools.CronScheduler
+	ackManager            *AckHandleManager
+	controlHub            *control.Hub // optional: emit run/tool/approval events over WebSocket
+	voiceTranscriber      *VoiceTranscriber
+	rolesPath             string // directory of role manifests; set via SetRolesPath
+	activeMemory          *agent.ActiveMemory
+	memoryStatus          MemoryStatusProvider
+	memoryExtraPathLabels []string
 }
 
 // MemoryStatusProvider supplies memory health for Telegram and local APIs.
@@ -69,15 +70,16 @@ type MemoryStatusProvider interface {
 
 // AIConfig holds AI configuration for status display
 type AIConfig struct {
-	Provider        string
-	Model           string
-	APIKey          string
-	BaseURL         string
-	FallbackModels  []string
-	ModelAliases    map[string]string
-	DefaultThinking string                    // Default thinking level when no session override is set
-	Routing         config.ModelRoutingConfig // Per-task-type model routing
-	MemoryMode      string                    // Memory prompt mode: "eager", "retrieval_first", "startup_recent"
+	Provider              string
+	Model                 string
+	APIKey                string
+	BaseURL               string
+	FallbackModels        []string
+	ModelAliases          map[string]string
+	DefaultThinking       string                    // Default thinking level when no session override is set
+	Routing               config.ModelRoutingConfig // Per-task-type model routing
+	MemoryMode            string                    // Memory prompt mode: "eager", "retrieval_first", "startup_recent"
+	MemoryExtraPathLabels []string                  // configured external memory source labels allowed for recall
 }
 
 // New creates a new bot instance
@@ -138,34 +140,44 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		memoryBasePath = personality.BasePath
 	}
 	botMemory := agent.NewMemory(memoryBasePath)
+	memoryExtraPathLabels := append([]string(nil), aiCfg.MemoryExtraPathLabels...)
+	if len(memoryExtraPathLabels) == 0 && len(memoryExtraPaths) > 0 {
+		for _, extra := range memoryExtraPaths {
+			if name := strings.TrimSpace(extra.Name); name != "" {
+				memoryExtraPathLabels = append(memoryExtraPathLabels, name)
+			}
+		}
+	}
 
 	b := &Bot{
-		api:              api,
-		store:            store,
-		ai:               aiClient,
-		streamingAI:      streamingClient,
-		aiConfig:         aiCfg,
-		personality:      personality,
-		agentRegistry:    agentRegistry,
-		toolRegistry:     toolRegistry,
-		safety:           agent.NewSafety(),
-		memory:           botMemory,
-		lifecycleFlush:   agent.NewLifecycleFlusher(botMemory),
-		memoryManager:    memoryManager,
-		authManager:      authManager,
-		groupManager:     groupManager,
-		approvalManager:  NewApprovalManager(api),
-		subagentNotifier: NewSubagentNotifier(api),
-		enableStream:     streamingClient != nil,
-		debouncer:        NewDebouncer(1500 * time.Millisecond),
-		rateLimiter:      NewRateLimiter(10, 1*time.Minute),
-		usageTracker:     NewUsageTracker(),
-		fragmentBuffer:   NewFragmentBuffer(),
-		mediaGroupBuf:    NewMediaGroupBuffer(),
-		queueManager:     NewQueueManager(),
-		ackManager:       NewAckHandleManager(),
-		scheduler:        scheduler,
-		memoryStatus:     memoryStatus,
+		api:                   api,
+		store:                 store,
+		ai:                    aiClient,
+		streamingAI:           streamingClient,
+		aiConfig:              aiCfg,
+		personality:           personality,
+		agentRegistry:         agentRegistry,
+		toolRegistry:          toolRegistry,
+		safety:                agent.NewSafety(),
+		memory:                botMemory,
+		lifecycleFlush:        agent.NewLifecycleFlusher(botMemory),
+		memoryManager:         memoryManager,
+		authManager:           authManager,
+		groupManager:          groupManager,
+		approvalManager:       NewApprovalManager(api),
+		subagentNotifier:      NewSubagentNotifier(api),
+		enableStream:          streamingClient != nil,
+		debouncer:             NewDebouncer(1500 * time.Millisecond),
+		rateLimiter:           NewRateLimiter(10, 1*time.Minute),
+		usageTracker:          NewUsageTracker(),
+		fragmentBuffer:        NewFragmentBuffer(),
+		mediaGroupBuf:         NewMediaGroupBuffer(),
+		queueManager:          NewQueueManager(),
+		ackManager:            NewAckHandleManager(),
+		scheduler:             scheduler,
+		adminID:               authCfg.AdminID,
+		memoryStatus:          memoryStatus,
+		memoryExtraPathLabels: memoryExtraPathLabels,
 	}
 
 	// Initialize voice transcriber if STT is configured
@@ -214,9 +226,10 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 			ModelAliases:    aiCfg.ModelAliases,
 			MemoryMode:      aiCfg.MemoryMode,
 		},
-		ToolRegistry: toolRegistry,
-		Scheduler:    scheduler,
-		Router:       modelRouter,
+		ToolRegistry:  toolRegistry,
+		Scheduler:     scheduler,
+		Router:        modelRouter,
+		MemoryManager: memoryManager,
 	}
 	b.hub = agent.NewRuntimeHub(resolver)
 
@@ -379,7 +392,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	}))
 
 	b.api.Handle("/memory", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
-		note, err := b.memory.GetTodayNote()
+		note, err := b.scopedTodayNote(c.Chat(), senderIDFromMessage(c.Message()))
 		if err != nil {
 			return c.Send("❌ Failed to load memory")
 		}
@@ -481,10 +494,7 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 		log.Printf("Failed to save message: %v", err)
 	}
 
-	// Append to daily memory
-	if err := b.memory.AppendToToday(fmt.Sprintf("User: %s", content)); err != nil {
-		log.Printf("Failed to append to memory: %v", err)
-	}
+	b.appendToTelegramMemory(msg.Chat, userID, fmt.Sprintf("User: %s", content))
 
 	// Handle special commands
 	if strings.HasPrefix(content, "/") {
@@ -601,10 +611,7 @@ func (b *Bot) handleStreamingRequest(ctx context.Context, c telebot.Context, con
 	// Final update
 	finalContent := editor.Finish()
 
-	// Save to memory
-	if err := b.memory.AppendToToday(fmt.Sprintf("Assistant: %s", finalContent)); err != nil {
-		log.Printf("Failed to save to memory: %v", err)
-	}
+	b.appendToTelegramMemory(c.Chat(), senderIDFromMessage(c.Message()), fmt.Sprintf("Assistant: %s", finalContent))
 
 	// Save session
 	if err := b.store.SaveSession(c.Chat().ID, finalContent); err != nil {
@@ -847,6 +854,11 @@ func (b *Bot) GetStatus() map[string]interface{} {
 	// Estop state
 	if enabled, err := b.store.IsEmergencyStopEnabled(); err == nil {
 		status["estop_enabled"] = enabled
+	}
+	status["memory_recall"] = map[string]interface{}{
+		"policy":                "scoped",
+		"group_default":         "deny unless group recall is active",
+		"external_path_default": "deny unless label is allowed",
 	}
 
 	if memoryStatus, err := b.GetMemoryStatus(context.Background()); err == nil {

--- a/internal/bot/btw.go
+++ b/internal/bot/btw.go
@@ -54,12 +54,13 @@ func (b *Bot) handleBtwCommand(c telebot.Context) error {
 
 		session, _ := b.store.GetSession(chatID)
 		events := b.hub.Submit(agent.RunRequest{
-			SessionKey: btwKey,
-			ChatID:     chatID,
-			Content:    question,
-			Session:    session,
-			History:    history,
-			Context:    context.Background(),
+			SessionKey:  btwKey,
+			ChatID:      chatID,
+			Content:     question,
+			Session:     session,
+			History:     history,
+			Context:     context.Background(),
+			MemoryScope: b.memoryRecallContext(chatID, senderIDFromMessage(c.Message()), string(chat.Type), btwKey),
 		})
 
 		var result *agent.AgentResponse

--- a/internal/bot/chat_routing.go
+++ b/internal/bot/chat_routing.go
@@ -83,9 +83,7 @@ func (b *Bot) respondWithClarification(
 	if err := b.store.SaveSessionMessagePairV2(string(sessionKey), userContent, clarification, ""); err != nil {
 		log.Printf("[router] failed to persist clarification transcript for chat=%d: %v", chatID, err)
 	}
-	if err := b.memory.AppendToToday(fmt.Sprintf("Assistant (router): %s", clarification)); err != nil {
-		log.Printf("[router] failed to append clarification to memory for chat=%d: %v", chatID, err)
-	}
+	b.appendToTelegramMemory(c.Chat(), senderIDFromMessage(c.Message()), fmt.Sprintf("Assistant (router): %s", clarification))
 	return nil
 }
 
@@ -128,13 +126,14 @@ func (b *Bot) startTaskRun(chat *telebot.Chat, chatID int64, req agent.SubagentS
 		subKey := agent.SessionKey(fmt.Sprintf("subagent:%d:%d", chatID, time.Now().UnixNano()))
 
 		events := b.hub.Submit(agent.RunRequest{
-			SessionKey: subKey,
-			ChatID:     chatID,
-			Content:    req.Description,
-			Session:    "",
-			Context:    context.Background(),
-			Job:        &job,
-			IsSubagent: true,
+			SessionKey:  subKey,
+			ChatID:      chatID,
+			Content:     req.Description,
+			Session:     "",
+			Context:     context.Background(),
+			Job:         &job,
+			IsSubagent:  true,
+			MemoryScope: b.memoryRecallContext(chatID, 0, string(chat.Type), subKey),
 		})
 
 		var notifText string

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -227,7 +227,7 @@ func (b *Bot) handleNoteCommand(c telebot.Context) error {
 		return c.Send("❌ Usage: /note <text>")
 	}
 
-	if err := b.memory.AppendQuickNoteToToday(noteText); err != nil {
+	if err := b.appendQuickNoteToTelegramMemory(c.Chat(), senderIDFromMessage(c.Message()), noteText); err != nil {
 		log.Printf("Failed to append quick note: %v", err)
 		return c.Send("❌ Failed to save quick note")
 	}
@@ -335,6 +335,7 @@ func (b *Bot) handleContextCommand(c telebot.Context) error {
 	} else {
 		sb.WriteString("• Memory context pack builder: disabled\n")
 	}
+	sb.WriteString("• Memory recall: scoped by user/chat/session policy\n")
 
 	// Session info
 	sb.WriteString(fmt.Sprintf("\n*Session:*\n"))

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -231,7 +231,8 @@ func (b *Bot) processViaHubWithContent(
 	// Run the bounded pre-reply Active Memory recall step. The result is
 	// always non-nil; on disabled/skipped/timeout/no-results we fall through
 	// to the main run with no injected context. Errors never block the reply.
-	preNotes, activeMemDiag := b.runActiveMemoryRecall(ctx, sessionKey, chatID, content, history)
+	userID := senderIDFromMessage(delivery.Message)
+	preNotes, activeMemDiag := b.runActiveMemoryRecall(ctx, sessionKey, chatID, userID, content, history)
 	if activeMemDiag != "" {
 		b.maybeSendVerboseDiagnostic(chatID, delivery.Chat, activeMemDiag)
 	}
@@ -250,7 +251,7 @@ func (b *Bot) processViaHubWithContent(
 		OnDelta:            onDelta,
 		OnDeltaReset:       onDeltaReset,
 		PreUserSystemNotes: preNotes,
-		MemoryScope:        b.memoryRecallContext(chatID, senderIDFromMessage(delivery.Message), string(delivery.Chat.Type), sessionKey),
+		MemoryScope:        b.memoryRecallContext(chatID, userID, string(delivery.Chat.Type), sessionKey),
 	}
 	events := b.hub.Submit(req)
 

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -250,6 +250,7 @@ func (b *Bot) processViaHubWithContent(
 		OnDelta:            onDelta,
 		OnDeltaReset:       onDeltaReset,
 		PreUserSystemNotes: preNotes,
+		MemoryScope:        b.memoryRecallContext(chatID, senderIDFromMessage(delivery.Message), string(delivery.Chat.Type), sessionKey),
 	}
 	events := b.hub.Submit(req)
 
@@ -403,14 +404,12 @@ func (b *Bot) processViaHubWithContent(
 		}
 	}
 
-	// Persist to daily memory.
+	// Persist to scoped daily memory.
 	memoryEntry := fmt.Sprintf("Assistant (%s): %s", profileName, result.Message)
 	if result.ToolUsed {
 		memoryEntry += fmt.Sprintf(" [Tool: %s]", result.ToolName)
 	}
-	if err := b.memory.AppendToToday(memoryEntry); err != nil {
-		log.Printf("[bot] failed to save to memory: %v", err)
-	}
+	b.appendToTelegramMemory(delivery.Chat, senderIDFromMessage(delivery.Message), memoryEntry)
 
 	// Persist session state unless the response is a synthetic fallback.
 	// Fallback messages pollute history and cause the model to lose track of tasks.

--- a/internal/bot/memory_scope.go
+++ b/internal/bot/memory_scope.go
@@ -1,0 +1,70 @@
+package bot
+
+import (
+	"fmt"
+	"log"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/memory"
+)
+
+func (b *Bot) appendToTelegramMemory(chat *telebot.Chat, userID int64, content string) {
+	if b == nil || b.memory == nil {
+		return
+	}
+	scopeDir := telegramMemoryScopeDir(chat, userID)
+	if err := b.memory.AppendToScopedToday(scopeDir, content); err != nil {
+		log.Printf("[bot] failed to save scoped memory: %v", err)
+	}
+}
+
+func (b *Bot) appendQuickNoteToTelegramMemory(chat *telebot.Chat, userID int64, content string) error {
+	if b == nil || b.memory == nil {
+		return nil
+	}
+	return b.memory.AppendScopedQuickNoteToToday(telegramMemoryScopeDir(chat, userID), content)
+}
+
+func (b *Bot) scopedTodayNote(chat *telebot.Chat, userID int64) (*agent.DailyNote, error) {
+	return b.memory.GetScopedTodayNote(telegramMemoryScopeDir(chat, userID))
+}
+
+func telegramMemoryScopeDir(chat *telebot.Chat, userID int64) string {
+	if chat == nil {
+		return ""
+	}
+	if chat.Type == telebot.ChatPrivate {
+		if userID == 0 {
+			userID = chat.ID
+		}
+		return fmt.Sprintf("users/%d", userID)
+	}
+	return fmt.Sprintf("chats/%d", chat.ID)
+}
+
+func (b *Bot) memoryRecallContext(chatID, userID int64, chatType string, sessionKey agent.SessionKey) memory.RecallContext {
+	allowGroup := false
+	if chatType == string(telebot.ChatGroup) || chatType == string(telebot.ChatSuperGroup) || chatType == string(telebot.ChatChannel) {
+		allowGroup = b.groupManager != nil && b.groupManager.GetMode(chatID) == ModeActive
+	}
+	allowGlobal := b.adminID != 0 && userID == b.adminID && chatType == string(telebot.ChatPrivate)
+
+	return memory.RecallContext{
+		UserID:             userID,
+		ChatID:             chatID,
+		SessionKey:         string(sessionKey),
+		ChatType:           chatType,
+		AllowGroupChat:     allowGroup,
+		AllowGlobalPrivate: allowGlobal,
+		ExtraPathLabels:    b.memoryExtraPathLabels,
+	}
+}
+
+func senderIDFromMessage(msg *telebot.Message) int64 {
+	if msg == nil || msg.Sender == nil {
+		return 0
+	}
+	return msg.Sender.ID
+}

--- a/internal/bot/memory_scope_test.go
+++ b/internal/bot/memory_scope_test.go
@@ -1,0 +1,36 @@
+package bot
+
+import (
+	"testing"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/agent"
+)
+
+func TestMemoryRecallContextUsesSenderIDForUserScope(t *testing.T) {
+	bot := &Bot{adminID: 777}
+
+	ctx := bot.memoryRecallContext(555, 777, string(telebot.ChatPrivate), agent.NewDMSessionKey(555))
+	if ctx.ChatID != 555 {
+		t.Fatalf("expected chat id 555, got %+v", ctx)
+	}
+	if ctx.UserID != 777 {
+		t.Fatalf("expected sender user id 777, got %+v", ctx)
+	}
+	if ctx.SessionKey != "dm:555" {
+		t.Fatalf("expected chat session key, got %+v", ctx)
+	}
+	if !ctx.AllowGlobalPrivate {
+		t.Fatalf("expected admin sender to allow private-global recall, got %+v", ctx)
+	}
+}
+
+func TestMemoryRecallContextDoesNotTreatChatIDAsAdminUserID(t *testing.T) {
+	bot := &Bot{adminID: 555}
+
+	ctx := bot.memoryRecallContext(555, 777, string(telebot.ChatPrivate), agent.NewDMSessionKey(555))
+	if ctx.AllowGlobalPrivate {
+		t.Fatalf("chat id must not grant admin private-global recall when sender differs: %+v", ctx)
+	}
+}

--- a/internal/bot/status.go
+++ b/internal/bot/status.go
@@ -20,7 +20,7 @@ var startTime = time.Now()
 
 // handleStatusCommand shows rich bot status
 func (b *Bot) handleStatusCommand(c telebot.Context) error {
-	return c.Send(b.buildStatusString(c.Chat().ID), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+	return c.Send(b.buildStatusStringForScope(c.Chat().ID, senderIDFromMessage(c.Message()), string(c.Chat().Type)), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 }
 
 func (b *Bot) handleMemoryStatusCommand(c telebot.Context) error {
@@ -76,6 +76,10 @@ func (b *Bot) buildQMDStatusString(ctx context.Context) string {
 // buildStatusString builds the full status string for a given chatID.
 // Pass chatID=-1 for TUI (no per-chat session data).
 func (b *Bot) buildStatusString(chatID int64) string {
+	return b.buildStatusStringForScope(chatID, 0, "")
+}
+
+func (b *Bot) buildStatusStringForScope(chatID, userID int64, chatType string) string {
 	name := b.personality.GetName()
 	emoji := b.personality.GetEmoji()
 
@@ -133,6 +137,10 @@ func (b *Bot) buildStatusString(chatID int64) string {
 	}
 	queueDepth := b.debouncer.GetPendingCount()
 	sb.WriteString(fmt.Sprintf("⚙️ Think: %s · 🪢 Queue: %s (depth %d)\n", thinkLevel, queueMode, queueDepth))
+	if chatID >= 0 {
+		policy := memory.NewRecallPolicy(b.memoryRecallContext(chatID, userID, chatType, sessionKeyForStatus(chatID, chatType)))
+		sb.WriteString(fmt.Sprintf("🧠 Memory: `%s`\n", strings.ReplaceAll(policy.Summary(), "`", "'")))
+	}
 
 	memoryMode := bootstrap.NormalizeMemoryMode(b.aiConfig.MemoryMode)
 	memoryToolStatus := "off"
@@ -158,6 +166,13 @@ func (b *Bot) buildStatusString(chatID int64) string {
 	sb.WriteString(fmt.Sprintf("\n🟢 Running for %s", formatDuration(uptime)))
 
 	return sb.String()
+}
+
+func sessionKeyForStatus(chatID int64, chatType string) agent.SessionKey {
+	if chatType == string(telebot.ChatPrivate) {
+		return agent.NewDMSessionKey(chatID)
+	}
+	return agent.NewGroupSessionKey(chatID)
 }
 
 func maskAPIKey(key string) string {

--- a/internal/bot/tui_runtime.go
+++ b/internal/bot/tui_runtime.go
@@ -70,11 +70,12 @@ func (b *Bot) RunCronTask(ctx context.Context, chatID int64, task string, budget
 	subKey := agent.SessionKey(fmt.Sprintf("cron:%d:%d", chatID, time.Now().UnixNano()))
 
 	events := b.hub.Submit(agent.RunRequest{
-		SessionKey: subKey,
-		ChatID:     chatID,
-		Content:    task,
-		Context:    ctx,
-		Job:        budget,
+		SessionKey:  subKey,
+		ChatID:      chatID,
+		Content:     task,
+		Context:     ctx,
+		Job:         budget,
+		MemoryScope: b.memoryRecallContext(chatID, 0, "", subKey),
 	})
 
 	for ev := range events {

--- a/internal/memory/backend.go
+++ b/internal/memory/backend.go
@@ -32,6 +32,12 @@ func (b *BuiltinBackend) Name() string {
 }
 
 func (b *BuiltinBackend) Search(ctx context.Context, query string, topK int, expand bool) ([]MemoryResult, error) {
+	return b.SearchScoped(ctx, query, topK, expand, nil)
+}
+
+// SearchScoped searches the built-in index after applying recall policy before
+// ranking and before branch expansion.
+func (b *BuiltinBackend) SearchScoped(ctx context.Context, query string, topK int, expand bool, policy *RecallPolicy) ([]MemoryResult, error) {
 	if b == nil || b.store == nil {
 		return nil, fmt.Errorf("memory manager is not configured")
 	}
@@ -47,7 +53,7 @@ func (b *BuiltinBackend) Search(ctx context.Context, query string, topK int, exp
 		}
 	}
 
-	results, err := b.store.SearchHybrid(ctx, query, queryEmbedding, topK)
+	results, err := b.store.SearchHybridScoped(ctx, query, queryEmbedding, topK, policy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search memory chunks: %w", err)
 	}
@@ -132,18 +138,24 @@ func (b *FallbackBackend) Name() string {
 }
 
 func (b *FallbackBackend) Search(ctx context.Context, query string, topK int, expand bool) ([]MemoryResult, error) {
+	return b.SearchScoped(ctx, query, topK, expand, nil)
+}
+
+// SearchScoped preserves fallback behavior while passing recall policies to
+// scoped-aware backends when available.
+func (b *FallbackBackend) SearchScoped(ctx context.Context, query string, topK int, expand bool, policy *RecallPolicy) ([]MemoryResult, error) {
 	if b == nil || b.primary == nil {
 		return nil, fmt.Errorf("memory backend is not configured")
 	}
 
 	if disabled, lastErr := b.isDisabled(); disabled {
 		if b.fallback != nil {
-			return b.fallback.Search(ctx, query, topK, expand)
+			return searchBackendWithPolicy(ctx, b.fallback, query, topK, expand, policy)
 		}
 		return nil, fmt.Errorf("%s memory backend is temporarily unavailable: %w", b.primary.Name(), lastErr)
 	}
 
-	results, err := b.primary.Search(ctx, query, topK, expand)
+	results, err := searchBackendWithPolicy(ctx, b.primary, query, topK, expand, policy)
 	if err == nil {
 		b.recordSuccess()
 		return results, nil
@@ -154,11 +166,25 @@ func (b *FallbackBackend) Search(ctx context.Context, query string, topK int, ex
 		return nil, fmt.Errorf("%s memory backend unavailable: %w", b.primary.Name(), err)
 	}
 
-	fallbackResults, fallbackErr := b.fallback.Search(ctx, query, topK, expand)
+	fallbackResults, fallbackErr := searchBackendWithPolicy(ctx, b.fallback, query, topK, expand, policy)
 	if fallbackErr != nil {
 		return nil, fmt.Errorf("%s memory backend unavailable (%v); %s fallback failed: %w", b.primary.Name(), err, b.fallback.Name(), fallbackErr)
 	}
 	return fallbackResults, nil
+}
+
+func searchBackendWithPolicy(ctx context.Context, backend Backend, query string, topK int, expand bool, policy *RecallPolicy) ([]MemoryResult, error) {
+	if scoped, ok := backend.(interface {
+		SearchScoped(context.Context, string, int, bool, *RecallPolicy) ([]MemoryResult, error)
+	}); ok {
+		return scoped.SearchScoped(ctx, query, topK, expand, policy)
+	}
+	results, err := backend.Search(ctx, query, topK, expand)
+	if err != nil || policy == nil {
+		return results, err
+	}
+	filtered, _ := policy.FilterResults(results)
+	return filtered, nil
 }
 
 // LastError returns the last primary backend error recorded by the fallback.

--- a/internal/memory/hybrid_search.go
+++ b/internal/memory/hybrid_search.go
@@ -45,6 +45,19 @@ func (s *MemoryStore) SearchText(ctx context.Context, query string, topK int) ([
 
 // SearchHybrid combines FTS5/BM25 lexical candidates with bounded vector scoring.
 func (s *MemoryStore) SearchHybrid(ctx context.Context, query string, queryEmbedding []float32, topK int) ([]MemoryResult, error) {
+	return s.searchHybridFiltered(ctx, query, queryEmbedding, topK, nil)
+}
+
+// SearchHybridScoped combines lexical and semantic search after applying a
+// recall policy before ranking, so denied scopes cannot crowd out allowed hits.
+func (s *MemoryStore) SearchHybridScoped(ctx context.Context, query string, queryEmbedding []float32, topK int, policy *RecallPolicy) ([]MemoryResult, error) {
+	if policy == nil {
+		return s.SearchHybrid(ctx, query, queryEmbedding, topK)
+	}
+	return s.searchHybridFiltered(ctx, query, queryEmbedding, topK, policy.AllowResult)
+}
+
+func (s *MemoryStore) searchHybridFiltered(ctx context.Context, query string, queryEmbedding []float32, topK int, allow func(MemoryResult) bool) ([]MemoryResult, error) {
 	if s == nil || s.db == nil {
 		return nil, fmt.Errorf("memory store is not configured")
 	}
@@ -74,6 +87,9 @@ func (s *MemoryStore) SearchHybrid(ctx context.Context, query string, queryEmbed
 			return nil, err
 		}
 		for rank, candidate := range lexical {
+			if allow != nil && !allow(candidate.result) {
+				continue
+			}
 			entry := ensureMemorySearchCandidate(candidates, candidate.result)
 			entry.hasLexical = true
 			entry.lexicalRank = rank
@@ -96,6 +112,9 @@ func (s *MemoryStore) SearchHybrid(ctx context.Context, query string, queryEmbed
 			}
 			normalized, ok := normalizeEmbedding(embedding)
 			if !ok || len(normalized) != len(queryVector) {
+				continue
+			}
+			if allow != nil && !allow(row.result) {
 				continue
 			}
 

--- a/internal/memory/lifecycle.go
+++ b/internal/memory/lifecycle.go
@@ -66,8 +66,8 @@ const (
 	MemoryStateError    = "error"
 )
 
-// ManagedSources returns the canonical markdown memory files for rootPath:
-// MEMORY.md plus memory/*.md. Missing files/directories are skipped.
+// ManagedSources returns canonical markdown memory files for rootPath: MEMORY.md,
+// legacy memory/*.md, and scoped memory/<scope>/<id>/*.md files.
 func ManagedSources(rootPath string) ([]ManagedSource, error) {
 	rootPath = strings.TrimSpace(rootPath)
 	if rootPath == "" {
@@ -92,6 +92,11 @@ func ManagedSources(rootPath string) ([]ManagedSource, error) {
 	if err != nil {
 		return nil, fmt.Errorf("glob daily memory files: %w", err)
 	}
+	scopedMatches, err := scopedMemoryMatches(absRoot)
+	if err != nil {
+		return nil, err
+	}
+	matches = append(matches, scopedMatches...)
 	sort.Strings(matches)
 	for _, match := range matches {
 		info, err := os.Stat(match)
@@ -118,8 +123,8 @@ func ManagedSources(rootPath string) ([]ManagedSource, error) {
 }
 
 // ManagedRelativePath returns the canonical relative source path when absPath is
-// part of the built-in memory source set. It intentionally excludes unrelated
-// markdown files until extra indexed paths are introduced.
+// part of the built-in memory source set. Unlabelled external markdown files are
+// intentionally excluded.
 func ManagedRelativePath(rootPath, absPath string) (string, bool) {
 	rootPath = strings.TrimSpace(rootPath)
 	absPath = strings.TrimSpace(absPath)
@@ -145,6 +150,9 @@ func ManagedRelativePath(rootPath, absPath string) (string, bool) {
 		return rel, true
 	}
 	if strings.HasPrefix(rel, "memory/") && strings.Count(rel, "/") == 1 && strings.EqualFold(filepath.Ext(rel), ".md") {
+		return rel, true
+	}
+	if isScopedMemoryRelativePath(rel) {
 		return rel, true
 	}
 	return "", false
@@ -184,6 +192,36 @@ func (s *MemoryStore) ClearManagedSources(ctx context.Context) error {
 		return fmt.Errorf("clear managed memory sources: %w", err)
 	}
 	return nil
+}
+
+func scopedMemoryMatches(absRoot string) ([]string, error) {
+	scopes := []string{"users", "chats", "sessions", "roles", "jobs", "external"}
+	var matches []string
+	for _, scope := range scopes {
+		pattern := filepath.Join(absRoot, "memory", scope, "*", "*.md")
+		found, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("glob scoped memory files: %w", err)
+		}
+		matches = append(matches, found...)
+	}
+	return matches, nil
+}
+
+func isScopedMemoryRelativePath(rel string) bool {
+	if !strings.HasPrefix(rel, "memory/") || !strings.EqualFold(filepath.Ext(rel), ".md") {
+		return false
+	}
+	parts := strings.Split(rel, "/")
+	if len(parts) != 4 {
+		return false
+	}
+	switch parts[1] {
+	case "users", "chats", "sessions", "roles", "jobs", "external":
+		return strings.TrimSpace(parts[2]) != "" && strings.TrimSpace(parts[3]) != ""
+	default:
+		return false
+	}
 }
 
 // Status returns lightweight diagnostics for the persisted memory index.

--- a/internal/memory/lifecycle_test.go
+++ b/internal/memory/lifecycle_test.go
@@ -15,6 +15,8 @@ func TestManagedSourcesFindsOnlyCanonicalMemoryFiles(t *testing.T) {
 	mustWrite(t, filepath.Join(root, "MEMORY.md"), "# Memory\n")
 	mustWrite(t, filepath.Join(root, "memory", "2026-04-28.md"), "# Yesterday\n")
 	mustWrite(t, filepath.Join(root, "memory", "2026-04-29.md"), "# Today\n")
+	mustWrite(t, filepath.Join(root, "memory", "users", "101", "2026-04-29.md"), "# User\n")
+	mustWrite(t, filepath.Join(root, "memory", "chats", "-100", "2026-04-29.md"), "# Chat\n")
 	mustWrite(t, filepath.Join(root, "notes.md"), "# Not indexed yet\n")
 	mustWrite(t, filepath.Join(root, "memory", "nested", "ignore.md"), "# Nested\n")
 
@@ -27,7 +29,7 @@ func TestManagedSourcesFindsOnlyCanonicalMemoryFiles(t *testing.T) {
 	for i, source := range sources {
 		got[i] = source.RelativePath
 	}
-	want := []string{"MEMORY.md", "memory/2026-04-28.md", "memory/2026-04-29.md"}
+	want := []string{"MEMORY.md", "memory/2026-04-28.md", "memory/2026-04-29.md", "memory/chats/-100/2026-04-29.md", "memory/users/101/2026-04-29.md"}
 	if len(got) != len(want) {
 		t.Fatalf("sources = %v, want %v", got, want)
 	}
@@ -48,8 +50,11 @@ func TestManagedRelativePath(t *testing.T) {
 	}{
 		{name: "root memory", path: filepath.Join(root, "MEMORY.md"), want: "MEMORY.md", ok: true},
 		{name: "daily memory", path: filepath.Join(root, "memory", "2026-04-29.md"), want: "memory/2026-04-29.md", ok: true},
+		{name: "user scoped memory", path: filepath.Join(root, "memory", "users", "101", "2026-04-29.md"), want: "memory/users/101/2026-04-29.md", ok: true},
+		{name: "chat scoped memory", path: filepath.Join(root, "memory", "chats", "-100", "2026-04-29.md"), want: "memory/chats/-100/2026-04-29.md", ok: true},
 		{name: "other markdown", path: filepath.Join(root, "notes.md"), ok: false},
 		{name: "nested memory", path: filepath.Join(root, "memory", "nested", "x.md"), ok: false},
+		{name: "too deep scoped memory", path: filepath.Join(root, "memory", "users", "101", "nested", "x.md"), ok: false},
 		{name: "outside", path: filepath.Join(filepath.Dir(root), "MEMORY.md"), ok: false},
 	}
 

--- a/internal/memory/manager.go
+++ b/internal/memory/manager.go
@@ -82,6 +82,30 @@ func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]M
 	return m.backend.Search(ctx, query, topK, false)
 }
 
+// SearchScoped searches indexed markdown chunks using a scoped recall policy.
+func (m *MemoryManager) SearchScoped(ctx context.Context, query string, topK int, policy *RecallPolicy) ([]MemoryResult, error) {
+	if policy == nil {
+		return m.Search(ctx, query, topK)
+	}
+	if m == nil || m.backend == nil {
+		return nil, fmt.Errorf("memory manager is not configured")
+	}
+	if scoped, ok := m.backend.(interface {
+		SearchScoped(context.Context, string, int, bool, *RecallPolicy) ([]MemoryResult, error)
+	}); ok {
+		return scoped.SearchScoped(ctx, query, topK, false, policy)
+	}
+	results, err := m.backend.Search(ctx, query, topK*3, false)
+	if err != nil {
+		return nil, err
+	}
+	filtered, _ := policy.FilterResults(results)
+	if len(filtered) > topK && topK > 0 {
+		filtered = filtered[:topK]
+	}
+	return filtered, nil
+}
+
 // SearchExpanded searches for matching chunks, then expands each result to
 // include all chunks from the same branch (source_file + header_path).
 // This gives full section context without replaying the entire history.
@@ -90,6 +114,31 @@ func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK i
 		return nil, fmt.Errorf("memory manager is not configured")
 	}
 	return m.backend.Search(ctx, query, topK, true)
+}
+
+// SearchExpandedScoped searches with policy filtering, then expands allowed
+// branches only.
+func (m *MemoryManager) SearchExpandedScoped(ctx context.Context, query string, topK int, policy *RecallPolicy) ([]MemoryResult, error) {
+	if policy == nil {
+		return m.SearchExpanded(ctx, query, topK)
+	}
+	if m == nil || m.backend == nil {
+		return nil, fmt.Errorf("memory manager is not configured")
+	}
+	if scoped, ok := m.backend.(interface {
+		SearchScoped(context.Context, string, int, bool, *RecallPolicy) ([]MemoryResult, error)
+	}); ok {
+		return scoped.SearchScoped(ctx, query, topK, true, policy)
+	}
+	results, err := m.backend.Search(ctx, query, topK*3, true)
+	if err != nil {
+		return nil, err
+	}
+	filtered, _ := policy.FilterResults(results)
+	if len(filtered) > topK && topK > 0 {
+		filtered = filtered[:topK]
+	}
+	return filtered, nil
 }
 
 // Recall is kept as a compatibility alias for existing callers.

--- a/internal/memory/recall_policy.go
+++ b/internal/memory/recall_policy.go
@@ -1,0 +1,361 @@
+package memory
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"ok-gobot/internal/redact"
+)
+
+// RecallScopeKind identifies the privacy boundary attached to a memory source.
+type RecallScopeKind string
+
+const (
+	ScopeUnknown      RecallScopeKind = "unknown"
+	ScopeUser         RecallScopeKind = "user"
+	ScopeChat         RecallScopeKind = "chat"
+	ScopeSession      RecallScopeKind = "session"
+	ScopeRole         RecallScopeKind = "role"
+	ScopeJob          RecallScopeKind = "job"
+	ScopeExtraPath    RecallScopeKind = "extra_path"
+	ScopeLegacyGlobal RecallScopeKind = "legacy_global"
+)
+
+var legacyDailySourceRegexp = regexp.MustCompile(`^memory/\d{4}-\d{2}-\d{2}\.md$`)
+
+// RecallScope is the parsed scope of one memory source label.
+type RecallScope struct {
+	Kind  RecallScopeKind
+	ID    string
+	Label string
+}
+
+// RecallContext describes the current Telegram/job scope for active recall.
+type RecallContext struct {
+	UserID             int64
+	ChatID             int64
+	SessionKey         string
+	ChatType           string
+	RoleName           string
+	JobID              string
+	AllowGlobalPrivate bool
+	AllowGroupChat     bool
+	ExtraPathLabels    []string
+}
+
+// RecallDecision records why a memory source was allowed or denied.
+type RecallDecision struct {
+	Source  string
+	Scope   RecallScope
+	Allowed bool
+	Reason  string
+}
+
+// RecallPolicy enforces memory source boundaries for one active run.
+type RecallPolicy struct {
+	Context RecallContext
+}
+
+// NewRecallPolicy returns a normalized recall policy for the provided context.
+func NewRecallPolicy(ctx RecallContext) *RecallPolicy {
+	ctx.ChatType = strings.ToLower(strings.TrimSpace(ctx.ChatType))
+	ctx.SessionKey = strings.TrimSpace(ctx.SessionKey)
+	ctx.RoleName = strings.TrimSpace(ctx.RoleName)
+	ctx.JobID = strings.TrimSpace(ctx.JobID)
+	ctx.ExtraPathLabels = compactLabels(ctx.ExtraPathLabels)
+	return &RecallPolicy{Context: ctx}
+}
+
+// Decide evaluates whether a source label can be recalled in this context.
+func (p *RecallPolicy) Decide(source string) RecallDecision {
+	clean := cleanSourceLabel(source)
+	scope := ClassifySource(clean)
+	decision := RecallDecision{Source: clean, Scope: scope}
+
+	if p == nil {
+		decision.Allowed = true
+		decision.Reason = "no recall policy configured"
+		return decision
+	}
+
+	switch scope.Kind {
+	case ScopeUser:
+		want := idString(p.Context.UserID)
+		decision.Allowed = want != "" && scope.ID == want
+		decision.Reason = allowReason(decision.Allowed, "matches current Telegram user", "different Telegram user")
+	case ScopeChat:
+		want := idString(p.Context.ChatID)
+		matches := want != "" && scope.ID == want
+		if !matches {
+			decision.Allowed = false
+			decision.Reason = "different Telegram chat"
+		} else if p.isGroupLike() && !p.Context.AllowGroupChat {
+			decision.Allowed = false
+			decision.Reason = "group chat memory recall is not enabled for this chat"
+		} else {
+			decision.Allowed = true
+			decision.Reason = "matches current Telegram chat"
+		}
+	case ScopeSession:
+		want := SafeScopeID(p.Context.SessionKey)
+		decision.Allowed = want != "" && scope.ID == want
+		decision.Reason = allowReason(decision.Allowed, "matches current session", "different session")
+	case ScopeRole:
+		want := SafeScopeID(p.Context.RoleName)
+		decision.Allowed = want != "" && scope.ID == want
+		decision.Reason = allowReason(decision.Allowed, "matches current role", "different role")
+	case ScopeJob:
+		want := SafeScopeID(p.Context.JobID)
+		decision.Allowed = want != "" && scope.ID == want
+		decision.Reason = allowReason(decision.Allowed, "matches current job", "different job")
+	case ScopeExtraPath:
+		decision.Allowed = containsLabel(p.Context.ExtraPathLabels, scope.Label)
+		decision.Reason = allowReason(decision.Allowed, "configured extra memory path label", "external memory path is not allowed by policy")
+	case ScopeLegacyGlobal:
+		decision.Allowed = p.Context.AllowGlobalPrivate && !p.isGroupLike()
+		decision.Reason = allowReason(decision.Allowed, "legacy private memory explicitly enabled", "legacy global memory is not allowed in this scope")
+	default:
+		decision.Allowed = false
+		decision.Reason = "unrecognized memory source scope"
+	}
+
+	return decision
+}
+
+// AllowSource reports whether a source label can be recalled.
+func (p *RecallPolicy) AllowSource(source string) bool {
+	return p.Decide(source).Allowed
+}
+
+// AllowResult reports whether a search result can be recalled.
+func (p *RecallPolicy) AllowResult(result MemoryResult) bool {
+	return p.AllowSource(result.SourceFile)
+}
+
+// FilterResults drops denied results and returns one decision per inspected source.
+func (p *RecallPolicy) FilterResults(results []MemoryResult) ([]MemoryResult, []RecallDecision) {
+	if p == nil {
+		return results, nil
+	}
+	filtered := make([]MemoryResult, 0, len(results))
+	decisions := make([]RecallDecision, 0, len(results))
+	for _, result := range results {
+		decision := p.Decide(result.SourceFile)
+		decisions = append(decisions, decision)
+		if decision.Allowed {
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered, decisions
+}
+
+// Summary returns a compact operator-readable description of the current policy.
+func (p *RecallPolicy) Summary() string {
+	if p == nil {
+		return "memory recall policy: unrestricted"
+	}
+
+	parts := []string{"memory recall policy: scoped"}
+	if p.Context.UserID != 0 {
+		parts = append(parts, fmt.Sprintf("user:%d", p.Context.UserID))
+	}
+	if p.Context.ChatID != 0 {
+		parts = append(parts, fmt.Sprintf("chat:%d", p.Context.ChatID))
+	}
+	if p.Context.SessionKey != "" {
+		parts = append(parts, "session:"+SafeScopeID(p.Context.SessionKey))
+	}
+	if p.Context.RoleName != "" {
+		parts = append(parts, "role:"+SafeScopeID(p.Context.RoleName))
+	}
+	if p.Context.JobID != "" {
+		parts = append(parts, "job:"+SafeScopeID(p.Context.JobID))
+	}
+	if p.isGroupLike() {
+		parts = append(parts, fmt.Sprintf("group_recall:%t", p.Context.AllowGroupChat))
+	}
+	parts = append(parts, fmt.Sprintf("legacy_global:%t", p.Context.AllowGlobalPrivate && !p.isGroupLike()))
+	if len(p.Context.ExtraPathLabels) > 0 {
+		labels := append([]string(nil), p.Context.ExtraPathLabels...)
+		sort.Strings(labels)
+		parts = append(parts, "extra_paths:"+strings.Join(labels, ","))
+	} else {
+		parts = append(parts, "extra_paths:deny")
+	}
+	return strings.Join(parts, " ")
+}
+
+// ClassifySource parses a memory source label into a recall scope.
+func ClassifySource(source string) RecallScope {
+	clean := cleanSourceLabel(source)
+	if clean == "" {
+		return RecallScope{Kind: ScopeUnknown}
+	}
+	if clean == "MEMORY.md" || legacyDailySourceRegexp.MatchString(clean) {
+		return RecallScope{Kind: ScopeLegacyGlobal, ID: "private", Label: "legacy"}
+	}
+
+	if collection, _, ok := ParseExtraSourceLabel(clean); ok {
+		label := SafeScopeID(collection)
+		return RecallScope{Kind: ScopeExtraPath, ID: label, Label: label}
+	}
+
+	if strings.HasPrefix(clean, "external://") {
+		rest := strings.TrimPrefix(clean, "external://")
+		label := firstPathSegment(rest)
+		return RecallScope{Kind: ScopeExtraPath, ID: label, Label: label}
+	}
+
+	parts := strings.Split(clean, "/")
+	if len(parts) >= 3 && parts[0] == "memory" {
+		if scope := classifyScopedParts(parts[1], parts[2]); scope.Kind != ScopeUnknown {
+			return scope
+		}
+	}
+	if len(parts) >= 2 {
+		if scope := classifyScopedParts(parts[0], parts[1]); scope.Kind != ScopeUnknown {
+			return scope
+		}
+	}
+
+	if filepath.IsAbs(clean) || strings.Contains(clean, ":") || strings.Contains(clean, "/") {
+		label := firstPathSegment(clean)
+		if filepath.IsAbs(clean) {
+			label = "absolute"
+		}
+		return RecallScope{Kind: ScopeExtraPath, ID: label, Label: label}
+	}
+
+	return RecallScope{Kind: ScopeUnknown, Label: clean}
+}
+
+func classifyScopedParts(kind, id string) RecallScope {
+	id = SafeScopeID(id)
+	switch kind {
+	case "users", "user":
+		return RecallScope{Kind: ScopeUser, ID: id, Label: id}
+	case "chats", "chat", "groups", "group":
+		return RecallScope{Kind: ScopeChat, ID: id, Label: id}
+	case "sessions", "session":
+		return RecallScope{Kind: ScopeSession, ID: id, Label: id}
+	case "roles", "role":
+		return RecallScope{Kind: ScopeRole, ID: id, Label: id}
+	case "jobs", "job":
+		return RecallScope{Kind: ScopeJob, ID: id, Label: id}
+	case "external", "extra", "extra_paths":
+		return RecallScope{Kind: ScopeExtraPath, ID: id, Label: id}
+	default:
+		return RecallScope{Kind: ScopeUnknown}
+	}
+}
+
+// SanitizeSnippet redacts sensitive values and strips unsafe control characters.
+func SanitizeSnippet(input string) string {
+	redacted := redact.Redact(input)
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\t':
+			return r
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, redacted)
+}
+
+// SafeScopeID turns a scope identifier into a stable path-safe label.
+func SafeScopeID(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range input {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func cleanSourceLabel(source string) string {
+	clean := strings.TrimSpace(source)
+	clean = filepath.ToSlash(clean)
+	clean = strings.TrimPrefix(clean, "./")
+	return clean
+}
+
+func (p *RecallPolicy) isGroupLike() bool {
+	if p.Context.ChatType == "" && p.Context.ChatID < 0 {
+		return true
+	}
+	switch p.Context.ChatType {
+	case "group", "supergroup", "channel":
+		return true
+	default:
+		return false
+	}
+}
+
+func idString(id int64) string {
+	if id == 0 {
+		return ""
+	}
+	return strconv.FormatInt(id, 10)
+}
+
+func allowReason(allowed bool, yes, no string) string {
+	if allowed {
+		return yes
+	}
+	return no
+}
+
+func firstPathSegment(path string) string {
+	path = strings.Trim(strings.TrimSpace(path), "/")
+	if path == "" {
+		return ""
+	}
+	if idx := strings.Index(path, "/"); idx >= 0 {
+		path = path[:idx]
+	}
+	return SafeScopeID(path)
+}
+
+func compactLabels(labels []string) []string {
+	seen := make(map[string]struct{}, len(labels))
+	out := make([]string, 0, len(labels))
+	for _, label := range labels {
+		label = SafeScopeID(label)
+		if label == "" {
+			continue
+		}
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		out = append(out, label)
+	}
+	return out
+}
+
+func containsLabel(labels []string, want string) bool {
+	want = SafeScopeID(want)
+	if want == "" {
+		return false
+	}
+	for _, label := range labels {
+		if label == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/memory/recall_policy.go
+++ b/internal/memory/recall_policy.go
@@ -26,7 +26,7 @@ const (
 	ScopeLegacyGlobal RecallScopeKind = "legacy_global"
 )
 
-var legacyDailySourceRegexp = regexp.MustCompile(`^memory/\d{4}-\d{2}-\d{2}\.md$`)
+var legacyMemorySourceRegexp = regexp.MustCompile(`^memory/[^/]+\.md$`)
 
 // RecallScope is the parsed scope of one memory source label.
 type RecallScope struct {
@@ -196,7 +196,7 @@ func ClassifySource(source string) RecallScope {
 	if clean == "" {
 		return RecallScope{Kind: ScopeUnknown}
 	}
-	if clean == "MEMORY.md" || legacyDailySourceRegexp.MatchString(clean) {
+	if clean == "MEMORY.md" {
 		return RecallScope{Kind: ScopeLegacyGlobal, ID: "private", Label: "legacy"}
 	}
 
@@ -221,6 +221,9 @@ func ClassifySource(source string) RecallScope {
 		if scope := classifyScopedParts(parts[0], parts[1]); scope.Kind != ScopeUnknown {
 			return scope
 		}
+	}
+	if legacyMemorySourceRegexp.MatchString(clean) {
+		return RecallScope{Kind: ScopeLegacyGlobal, ID: "private", Label: "legacy"}
 	}
 
 	if filepath.IsAbs(clean) || strings.Contains(clean, ":") || strings.Contains(clean, "/") {

--- a/internal/memory/recall_policy_test.go
+++ b/internal/memory/recall_policy_test.go
@@ -1,0 +1,90 @@
+package memory
+
+import "testing"
+
+func TestRecallPolicyPrivateChatIsolation(t *testing.T) {
+	policy := NewRecallPolicy(RecallContext{
+		UserID:     101,
+		ChatID:     101,
+		SessionKey: "dm:101",
+		ChatType:   "private",
+	})
+
+	tests := []struct {
+		source string
+		want   bool
+	}{
+		{source: "memory/users/101/2026-04-30.md", want: true},
+		{source: "memory/chats/101/2026-04-30.md", want: true},
+		{source: "memory/sessions/dm_101/notes.md", want: true},
+		{source: "memory/users/202/2026-04-30.md", want: false},
+		{source: "memory/chats/202/2026-04-30.md", want: false},
+		{source: "MEMORY.md", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			if got := policy.AllowSource(tt.source); got != tt.want {
+				t.Fatalf("AllowSource(%q) = %v, want %v", tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecallPolicyGroupChatIsOptIn(t *testing.T) {
+	standby := NewRecallPolicy(RecallContext{
+		ChatID:     -1001,
+		SessionKey: "group:-1001",
+		ChatType:   "group",
+	})
+	if standby.AllowSource("memory/chats/-1001/2026-04-30.md") {
+		t.Fatal("standby group should not recall chat memory")
+	}
+	if standby.AllowSource("memory/users/101/2026-04-30.md") {
+		t.Fatal("group should not recall private user memory")
+	}
+
+	active := NewRecallPolicy(RecallContext{
+		ChatID:         -1001,
+		SessionKey:     "group:-1001",
+		ChatType:       "group",
+		AllowGroupChat: true,
+	})
+	if !active.AllowSource("memory/chats/-1001/2026-04-30.md") {
+		t.Fatal("active group should recall its own chat-scoped memory")
+	}
+	if active.AllowSource("memory/chats/-1002/2026-04-30.md") {
+		t.Fatal("group should not recall another chat's memory")
+	}
+}
+
+func TestRecallPolicyExternalPathsRequireLabel(t *testing.T) {
+	policy := NewRecallPolicy(RecallContext{UserID: 101, ChatID: 101, ChatType: "private"})
+	decision := policy.Decide("external://team-vault/projects/notes.md")
+	if decision.Allowed {
+		t.Fatal("external memory should be denied by default")
+	}
+	if decision.Scope.Kind != ScopeExtraPath || decision.Scope.Label != "team-vault" {
+		t.Fatalf("unexpected external scope: %+v", decision.Scope)
+	}
+
+	allowed := NewRecallPolicy(RecallContext{
+		UserID:          101,
+		ChatID:          101,
+		ChatType:        "private",
+		ExtraPathLabels: []string{"team-vault"},
+	})
+	if !allowed.AllowSource("external://team-vault/projects/notes.md") {
+		t.Fatal("configured external label should be allowed")
+	}
+	if allowed.AllowSource("external://other-vault/projects/notes.md") {
+		t.Fatal("unconfigured external label should remain denied")
+	}
+}
+
+func TestSanitizeSnippetRedactsBeforePromptUse(t *testing.T) {
+	got := SanitizeSnippet("token: Bearer demo\x00")
+	if got != "token: Bearer ***" {
+		t.Fatalf("SanitizeSnippet() = %q", got)
+	}
+}

--- a/internal/memory/recall_policy_test.go
+++ b/internal/memory/recall_policy_test.go
@@ -82,6 +82,44 @@ func TestRecallPolicyExternalPathsRequireLabel(t *testing.T) {
 	}
 }
 
+func TestRecallPolicyLegacyMemoryMarkdownFilesStayPrivate(t *testing.T) {
+	policy := NewRecallPolicy(RecallContext{
+		UserID:             101,
+		ChatID:             101,
+		ChatType:           "private",
+		AllowGlobalPrivate: true,
+	})
+
+	for _, source := range []string{"MEMORY.md", "memory/2026-04-30.md", "memory/notes.md", "memory/projects.md"} {
+		t.Run(source, func(t *testing.T) {
+			decision := policy.Decide(source)
+			if decision.Scope.Kind != ScopeLegacyGlobal {
+				t.Fatalf("scope=%s, want %s", decision.Scope.Kind, ScopeLegacyGlobal)
+			}
+			if !decision.Allowed {
+				t.Fatalf("expected %q to be allowed for private legacy memory: %+v", source, decision)
+			}
+		})
+	}
+
+	otherUser := NewRecallPolicy(RecallContext{UserID: 202, ChatID: 202, ChatType: "private"})
+	if otherUser.AllowSource("memory/notes.md") {
+		t.Fatal("legacy memory should still require explicit private-global allowance")
+	}
+}
+
+func TestRecallPolicyScopedMemoryPathsAreNotLegacy(t *testing.T) {
+	userScoped := ClassifySource("memory/users/101/notes.md")
+	if userScoped.Kind != ScopeUser || userScoped.ID != "101" {
+		t.Fatalf("unexpected user scope: %+v", userScoped)
+	}
+
+	extraScoped := ClassifySource("extra:obsidian/memory/notes.md")
+	if extraScoped.Kind != ScopeExtraPath || extraScoped.Label != "obsidian" {
+		t.Fatalf("unexpected extra scope: %+v", extraScoped)
+	}
+}
+
 func TestSanitizeSnippetRedactsBeforePromptUse(t *testing.T) {
 	got := SanitizeSnippet("token: Bearer demo\x00")
 	if got != "token: Bearer ***" {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -409,6 +409,12 @@ func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32
 	return s.SearchHybrid(ctx, "", queryEmbedding, topK)
 }
 
+// SearchChunksScoped finds similar chunks after applying a recall policy before
+// ranking, so denied scopes cannot crowd out allowed results.
+func (s *MemoryStore) SearchChunksScoped(ctx context.Context, queryEmbedding []float32, topK int, policy *RecallPolicy) ([]MemoryResult, error) {
+	return s.SearchHybridScoped(ctx, "", queryEmbedding, topK, policy)
+}
+
 // GetBranchChunks loads all chunks for a specific (sourceFile, headerPath) branch,
 // ordered by chunk_ordinal. Used by branch expansion to reconstruct full sections.
 func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPath string) ([]MemoryResult, error) {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -364,6 +364,39 @@ func TestMemoryStoreSearchTextWorksWithoutEmbeddings(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreSearchChunksScopedFiltersBeforeRanking(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+	for _, source := range []string{
+		"memory/users/202/2026-04-30.md",
+		"memory/users/101/2026-04-30.md",
+		"memory/chats/-100/2026-04-30.md",
+	} {
+		if err := store.IndexChunk(ctx, source, "root", 1, 1, "same topic", []float32{1, 0}); err != nil {
+			t.Fatalf("IndexChunk(%q) failed: %v", source, err)
+		}
+	}
+
+	policy := NewRecallPolicy(RecallContext{UserID: 101, ChatID: 101, ChatType: "private"})
+	results, err := store.SearchChunksScoped(ctx, []float32{1, 0}, 10, policy)
+	if err != nil {
+		t.Fatalf("SearchChunksScoped failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 scoped result, got %d: %+v", len(results), results)
+	}
+	if results[0].SourceFile != "memory/users/101/2026-04-30.md" {
+		t.Fatalf("unexpected source: %q", results[0].SourceFile)
+	}
+}
+
 func TestMemoryManagerFallsBackToLexicalWhenEmbeddingUnavailable(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/tools/memory_get_tool.go
+++ b/internal/tools/memory_get_tool.go
@@ -16,6 +16,7 @@ var markdownHeaderRegexp = regexp.MustCompile(`^(#{1,6})\s+(.+?)\s*$`)
 type MemoryGetTool struct {
 	basePath string
 	extras   []memory.ExtraPath
+	policy   *memory.RecallPolicy
 }
 
 // NewMemoryGetTool creates a memory_get tool.
@@ -35,6 +36,21 @@ func (m *MemoryGetTool) WithExtraPaths(extras []memory.ExtraPath) *MemoryGetTool
 	return &clone
 }
 
+// WithPolicy returns a copy of the tool constrained by the given recall policy.
+func (m *MemoryGetTool) WithPolicy(policy *memory.RecallPolicy) *MemoryGetTool {
+	if m == nil {
+		return nil
+	}
+	clone := *m
+	clone.policy = policy
+	return &clone
+}
+
+// NewScopedMemoryGetTool creates a memory_get tool constrained by policy.
+func NewScopedMemoryGetTool(basePath string, policy *memory.RecallPolicy) *MemoryGetTool {
+	return &MemoryGetTool{basePath: basePath, policy: policy}
+}
+
 func (m *MemoryGetTool) Name() string {
 	return "memory_get"
 }
@@ -49,6 +65,17 @@ func (m *MemoryGetTool) Execute(ctx context.Context, args ...string) (string, er
 	}
 
 	source := strings.TrimSpace(args[0])
+	if m.policy != nil {
+		decision := m.policy.Decide(source)
+		if !decision.Allowed {
+			return "", &ToolDenial{
+				ToolName:    m.Name(),
+				Family:      "memory_recall",
+				Reason:      fmt.Sprintf("source %q denied: %s", source, decision.Reason),
+				Remediation: "Use a memory source in the current user/chat/session scope or ask the operator to update memory recall policy.",
+			}
+		}
+	}
 	headerPath := ""
 	if len(args) > 1 {
 		headerPath = strings.TrimSpace(args[1])
@@ -66,7 +93,7 @@ func (m *MemoryGetTool) Execute(ctx context.Context, args ...string) (string, er
 	content := string(contentBytes)
 
 	if headerPath == "" {
-		return content, nil
+		return memory.SanitizeSnippet(content), nil
 	}
 
 	section, err := extractMarkdownSectionByHeaderPath(content, headerPath)
@@ -74,7 +101,7 @@ func (m *MemoryGetTool) Execute(ctx context.Context, args ...string) (string, er
 		return "", err
 	}
 
-	return section, nil
+	return memory.SanitizeSnippet(section), nil
 }
 
 // resolveSource picks the right backing root for a given source label.

--- a/internal/tools/memory_policy.go
+++ b/internal/tools/memory_policy.go
@@ -1,0 +1,24 @@
+package tools
+
+import "ok-gobot/internal/memory"
+
+// ApplyMemoryRecallPolicy returns a child registry with memory tools constrained
+// to the current user/chat/session recall policy.
+func ApplyMemoryRecallPolicy(registry *Registry, policy *memory.RecallPolicy) *Registry {
+	if registry == nil || policy == nil {
+		return registry
+	}
+
+	result := registry.Child()
+	for _, tool := range registry.List() {
+		switch t := tool.(type) {
+		case *MemorySearchTool:
+			result.Register(NewScopedMemorySearchTool(t.manager, policy))
+		case *MemoryGetTool:
+			result.Register(t.WithPolicy(policy))
+		default:
+			result.Register(tool)
+		}
+	}
+	return result
+}

--- a/internal/tools/memory_search_tool.go
+++ b/internal/tools/memory_search_tool.go
@@ -12,11 +12,17 @@ import (
 // MemorySearchTool performs hybrid lexical and semantic search over indexed markdown memory chunks.
 type MemorySearchTool struct {
 	manager *memory.MemoryManager
+	policy  *memory.RecallPolicy
 }
 
 // NewMemorySearchTool creates a memory_search tool.
 func NewMemorySearchTool(manager *memory.MemoryManager) *MemorySearchTool {
 	return &MemorySearchTool{manager: manager}
+}
+
+// NewScopedMemorySearchTool creates a memory_search tool constrained by policy.
+func NewScopedMemorySearchTool(manager *memory.MemoryManager, policy *memory.RecallPolicy) *MemorySearchTool {
+	return &MemorySearchTool{manager: manager, policy: policy}
 }
 
 func (m *MemorySearchTool) Name() string {
@@ -52,15 +58,18 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 	var results []memory.MemoryResult
 	var err error
 	if expand {
-		results, err = m.manager.SearchExpanded(ctx, query, limit)
+		results, err = m.manager.SearchExpandedScoped(ctx, query, limit, m.policy)
 	} else {
-		results, err = m.manager.Search(ctx, query, limit)
+		results, err = m.manager.SearchScoped(ctx, query, limit, m.policy)
 	}
 	if err != nil {
 		return "", fmt.Errorf("failed to search memory index: %w", err)
 	}
 
 	if len(results) == 0 {
+		if m.policy != nil {
+			return m.policy.Summary() + "\n\nNo memory chunks found matching your query in the allowed scopes.", nil
+		}
 		return "No memory chunks found matching your query.", nil
 	}
 
@@ -70,6 +79,10 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 	}
 
 	var out strings.Builder
+	if m.policy != nil {
+		out.WriteString(m.policy.Summary())
+		out.WriteString("\n\n")
+	}
 	out.WriteString(fmt.Sprintf("Found %d relevant memory %s:\n\n", len(results), label))
 	for i, result := range results {
 		headerPath := result.HeaderPath
@@ -86,7 +99,7 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 		if result.LexicalScore > 0 || result.VectorScore != 0 {
 			out.WriteString(fmt.Sprintf("   Score Components: lexical=%.2f vector=%.2f\n", result.LexicalScore, result.VectorScore))
 		}
-		out.WriteString(fmt.Sprintf("   %s\n\n", result.Content))
+		out.WriteString(fmt.Sprintf("   %s\n\n", memory.SanitizeSnippet(result.Content)))
 	}
 
 	return out.String(), nil

--- a/internal/tools/memory_tools_test.go
+++ b/internal/tools/memory_tools_test.go
@@ -124,3 +124,45 @@ func TestMemoryGetTool_UnknownExtraCollectionFails(t *testing.T) {
 		t.Fatal("expected unknown collection error")
 	}
 }
+
+func TestMemoryGetTool_PolicyBlocksOtherUserSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "memory", "users", "202", "2026-04-30.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create fixture dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("private note"), 0644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	policy := memory.NewRecallPolicy(memory.RecallContext{UserID: 101, ChatID: 101, ChatType: "private"})
+	tool := NewScopedMemoryGetTool(tmpDir, policy)
+	_, err := tool.Execute(context.Background(), "memory/users/202/2026-04-30.md")
+	if err == nil {
+		t.Fatal("expected memory_get to deny another user's source")
+	}
+	if denial, ok := IsToolDenial(err); !ok || denial.Family != "memory_recall" {
+		t.Fatalf("expected memory_recall denial, got %v", err)
+	}
+}
+
+func TestMemoryGetTool_RedactsAllowedSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "memory", "users", "101", "2026-04-30.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create fixture dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("header\nBearer demo"), 0644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	policy := memory.NewRecallPolicy(memory.RecallContext{UserID: 101, ChatID: 101, ChatType: "private"})
+	tool := NewScopedMemoryGetTool(tmpDir, policy)
+	got, err := tool.Execute(context.Background(), "memory/users/101/2026-04-30.md")
+	if err != nil {
+		t.Fatalf("memory_get failed: %v", err)
+	}
+	if strings.Contains(got, "Bearer demo") || !strings.Contains(got, "Bearer ***") {
+		t.Fatalf("expected redacted output, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add scoped memory source classification and recall policy enforcement for Telegram user/chat/session/role/job/extra-path boundaries.
- Apply scoped filtering and redaction to prompt memory, Active Memory, `memory_search`, `memory_get`, and hybrid backend ranking.
- Document the scoped memory layout and policy behavior.

## Verification
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./cmd/ok-gobot/`

Closes #329

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a comprehensive scoped memory recall policy enforced across prompt injection, Active Memory, `memory_search`, `memory_get`, and hybrid backend ranking. Memory sources are classified into user/chat/session/role/job/extra-path/legacy-global scopes and filtered before results reach the model, with `SanitizeSnippet` redacting sensitive values throughout.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the one flagged issue is guarded by the v1 DM-only gate and does not affect current behavior

Only P2 findings present. The hardcoded chat type in runActiveMemoryRecall cannot trigger today because isDMSession returns early for all non-DM sessions. No P0/P1 bugs found across the 37 changed files.

internal/bot/active_memory.go — hardcoded chat type should be addressed before the v1 DM-only gate is lifted

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/memory/recall_policy.go | New file defining RecallPolicy, RecallScope classification, and helper utilities; logic is sound for all documented scopes including legacy global path matching |
| internal/bot/memory_scope.go | New helper file for scoped memory writes and recall context construction; correctly derives userID and chat type from Telegram message context |
| internal/bot/active_memory.go | Active memory recall now creates a scoped policy, but the chat type is hardcoded to "private"; currently safe under the DM-only v1 gate but will misclassify group chats if the gate is lifted |
| internal/memory/manager.go | Adds SearchScoped and SearchExpandedScoped with correct policy delegation; fallback over-fetch (topK*3) is a reasonable safety margin for non-scoped backends |
| internal/memory/hybrid_search.go | Policy filtering applied to both lexical and vector candidate sets before ranking; correctly prevents denied scopes from crowding out allowed results |
| internal/agent/resolver.go | Recall policy wired into resolver via buildMemoryRecallPolicy; when Resolve is called without RecallContext a minimal ChatID-only policy is built (defensive, no external callers affected) |
| internal/agent/runtime.go | RunRequest gains MemoryScope field; scope is correctly propagated to timeout subagents; emptyRecallContext guard prevents spurious policy construction |
| internal/memory/lifecycle.go | ManagedSources extended to glob scoped memory/<scope>/<id>/*.md; isScopedMemoryRelativePath correctly validates 4-level paths matching the indexer glob pattern |
| internal/tools/memory_policy.go | ApplyMemoryRecallPolicy correctly wraps MemorySearchTool and MemoryGetTool with scoped variants; other tools pass through unchanged |
| internal/bot/bot.go | memoryExtraPathLabels populated from config or extra paths, stored on Bot, and passed into recall context; adminID now set at construction time |
| internal/memory/backend.go | BuiltinBackend and FallbackBackend both implement SearchScoped; searchBackendWithPolicy dispatches to scoped-aware backends or falls back to post-filter |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/bot/active_memory.go:109-110
**Hardcoded `"private"` chat type in recall policy**

`memoryRecallContext` is called with `string(telebot.ChatPrivate)` regardless of the actual session's chat type. When the v1 gate (`isDMSession`) is lifted in a future release, any group-chat session will silently build a policy whose `ChatType` is `"private"`, making `isGroupLike()` return `false`. For a group session where `userID == adminID`, that results in `AllowGlobalPrivate = true`, which allows `MEMORY.md` and all `memory/*.md` legacy global memory to leak into group active-memory recall.

The correct chat type is available in `delivery.Chat.Type` at the call site in `hub_handler.go`. Either pass it through as a parameter or derive it from the session key.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(memory): address scoped recall revie..."](https://github.com/befeast/ok-gobot/commit/d341f368d19896762f7ee539b8014ae2cf7c8f55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30340796)</sub>

<!-- /greptile_comment -->