### PR TITLE
Scoped memory privacy and recall policy for Telegram chats (#329)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -106,6 +106,14 @@ memory:
       daily_notes: ""        # Existing QMD collection for soul/memory/*.md
       session_transcripts: ""
       extra_paths: []
+  recall:
+    group_recall: false             # Conservative default: groups do not recall memory unless enabled
+    include_legacy_private: false   # Legacy MEMORY.md/memory/*.md are not injected into Telegram prompts by default
+    extra_paths: []                 # Extra/external paths must be labeled explicitly
+    # - label: "project-notes"
+    #   path: "~/notes/project"
+    #   allow_private: true
+    #   allow_groups: false
   mcp:
     enabled: false       # Optional MCP server for cross-tool memory access
     host: "127.0.0.1"    # Local-only by default

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -53,6 +53,10 @@ memory:
       daily_notes: ""        # QMD collection rooted at memory/
       session_transcripts: "" # QMD collection rooted at exported session transcripts
       extra_paths: []         # Additional pre-existing QMD collection names
+  recall:
+    group_recall: false
+    include_legacy_private: false
+    extra_paths: []
   mcp:
     enabled: false
     host: "127.0.0.1"
@@ -70,7 +74,6 @@ memory:
 - **embeddings_base_url**: API endpoint for embeddings (OpenAI-compatible)
 - **embeddings_api_key**: API key for embeddings (if empty, reuses `ai.api_key`)
 - **embeddings_model**: Embedding model to use (default: `text-embedding-3-small`)
-- **extra_paths**: Additional configured memory source paths shown in diagnostics
 - **metadata_extraction**: When `true`, extracts structured metadata (`people/topics/action_items/type`) during indexing
 - **metadata_model**: Lightweight LLM model used for metadata extraction (default: `haiku`)
 - **extra_paths**: Additional named markdown roots to index (Obsidian vaults, shared-memory exports). See "External markdown collections" below.
@@ -79,6 +82,9 @@ memory:
 - **qmd.search_mode**: `search` is BM25 and the safe default. `vsearch` and `query` can use QMD's local embedding/reranking models and should only be enabled after you have intentionally prepared those models with QMD.
 - **qmd.fallback_cooldown**: How long ok-gobot suppresses QMD retries after a failure before trying QMD again.
 - **qmd.collections**: Names of pre-existing QMD collections. ok-gobot v1 does not create, update, embed, or delete QMD collections.
+- **recall.group_recall**: When `true`, group chats may recall memory explicitly scoped to that chat/session. Default is `false`.
+- **recall.include_legacy_private**: When `true`, private Telegram chats may use legacy `MEMORY.md` and `memory/*.md` sources. Default is `false`.
+- **recall.extra_paths**: Explicitly labeled external source roots. Labels match `extra:<label>/...` or `external/<label>/...` source labels and must opt into private and/or group recall.
 - **mcp.enabled**: Enable optional MCP server exposing `memory_search`, `memory_get`, `memory_capture`
 - **mcp.host / mcp.port / mcp.endpoint**: MCP bind/interface settings (`127.0.0.1` by default for local-only access)
 - **mcp.allow_writes**: Must be explicitly `true` to allow `memory_capture` writes
@@ -204,10 +210,27 @@ When `memory.enabled: true`, bot startup automatically indexes:
 - `memory/*.md`
 - Every collection configured under `memory.extra_paths` (see "External
   markdown collections" above).
+- Scoped Telegram memory under `telegram/users/<user_id>/memory/*.md`
+- Scoped group memory under `telegram/chats/<chat_id>/memory/*.md`
+- Scoped session, role, and job memory under `sessions/`, `roles/`, and `jobs/`
 
 The bot also starts debounced filesystem watchers for the workspace memory
 sources and for each extra path. Changes update the `memory_chunks` index;
 deleted files remove their chunks.
+
+### Scoped Recall Policy
+
+Telegram active recall is source-filtered before snippets enter prompts or tool
+output. Private chats can use memory labeled for the current Telegram user,
+current chat, current session, active role, current job, and explicitly allowed
+external labels. Group chats deny recall by default unless `group_recall: true`,
+and even then only matching chat/session/role/job or group-allowed external
+labels are eligible. Legacy `MEMORY.md` and `memory/*.md` are not used in
+Telegram prompts or recall unless `include_legacy_private: true` is set.
+
+Configured extra paths keep their `extra:<label>/...` source label and are not
+treated as global private memory. If another backend emits `external/<label>/...`,
+that label is governed by the same `memory.recall.extra_paths` allowlist.
 
 ### Curation Drafts (manual promotion)
 

--- a/internal/agent/memory.go
+++ b/internal/agent/memory.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	memorypkg "ok-gobot/internal/memory"
 )
 
 // Memory manages daily notes and long-term memory
@@ -57,6 +59,13 @@ func (m *Memory) GetNote(date string) (*DailyNote, error) {
 	}, nil
 }
 
+// GetTelegramTodayNote returns today's scoped Telegram note for the chat/user.
+func (m *Memory) GetTelegramTodayNote(chatType string, chatID, userID int64) (*DailyNote, error) {
+	date := time.Now()
+	source := memorypkg.TelegramDailySource(chatType, chatID, userID, date)
+	return m.getSourceNote(source, date.Format("2006-01-02"))
+}
+
 // EnsureTodayNote creates today's memory file with a header if it doesn't exist yet.
 // Safe to call multiple times.
 func (m *Memory) EnsureTodayNote() error {
@@ -88,6 +97,24 @@ func (m *Memory) AppendQuickNoteToToday(content string) error {
 	return m.appendToTodayRaw(entry)
 }
 
+// AppendTelegramToToday appends content to today's scoped Telegram note.
+func (m *Memory) AppendTelegramToToday(chatType string, chatID, userID int64, content string) error {
+	date := time.Now()
+	source := memorypkg.TelegramDailySource(chatType, chatID, userID, date)
+	timestamp := date.Format("15:04")
+	entry := fmt.Sprintf("\n## %s\n\n%s\n", timestamp, content)
+	return m.appendToSourceRaw(source, date.Format("2006-01-02"), entry)
+}
+
+// AppendTelegramQuickNoteToToday appends a quick-capture note to today's scoped Telegram note.
+func (m *Memory) AppendTelegramQuickNoteToToday(chatType string, chatID, userID int64, content string) error {
+	date := time.Now()
+	source := memorypkg.TelegramDailySource(chatType, chatID, userID, date)
+	timestamp := date.Format("15:04")
+	entry := fmt.Sprintf("\n\n## Quick Note (%s)\n%s", timestamp, content)
+	return m.appendToSourceRaw(source, date.Format("2006-01-02"), entry)
+}
+
 func (m *Memory) appendToTodayRaw(entry string) error {
 	note, err := m.GetTodayNote()
 	if err != nil {
@@ -111,6 +138,52 @@ func (m *Memory) appendToTodayRaw(entry string) error {
 
 	_, err = f.WriteString(entry)
 	return err
+}
+
+func (m *Memory) getSourceNote(source, date string) (*DailyNote, error) {
+	path, err := m.resolveRelativeSource(source)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, fmt.Errorf("failed to create memory directory: %w", err)
+	}
+	content := ""
+	if data, err := os.ReadFile(path); err == nil {
+		content = string(data)
+	}
+	return &DailyNote{Date: date, Content: content, Path: path}, nil
+}
+
+func (m *Memory) appendToSourceRaw(source, date, entry string) error {
+	note, err := m.getSourceNote(source, date)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(note.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open note: %w", err)
+	}
+	defer f.Close()
+	if note.Content == "" {
+		header := fmt.Sprintf("# Scoped Memory: %s\n\n", note.Date)
+		if _, err := f.WriteString(header); err != nil {
+			return err
+		}
+	}
+	_, err = f.WriteString(entry)
+	return err
+}
+
+func (m *Memory) resolveRelativeSource(source string) (string, error) {
+	source = filepath.ToSlash(filepath.Clean(strings.TrimSpace(source)))
+	if source == "" || source == "." {
+		return "", fmt.Errorf("memory source is empty")
+	}
+	if filepath.IsAbs(source) || source == ".." || strings.HasPrefix(source, "../") {
+		return "", fmt.Errorf("memory source %q escapes memory base path", source)
+	}
+	return filepath.Join(m.BasePath, filepath.FromSlash(source)), nil
 }
 
 // LoadLongTermMemory reads MEMORY.md

--- a/internal/agent/personality_test.go
+++ b/internal/agent/personality_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	memorypkg "ok-gobot/internal/memory"
 	"ok-gobot/internal/tools"
 )
 
@@ -228,5 +229,30 @@ func TestBuildSystemPrompt_DefaultMemoryModeIsEager(t *testing.T) {
 		if !strings.Contains(prompt, want) {
 			t.Errorf("default eager prompt missing %q", want)
 		}
+	}
+}
+
+func TestBuildSystemPrompt_ScopedPolicyOmitsLegacyMemoryByDefault(t *testing.T) {
+	registry := tools.NewRegistry()
+	personality := &Personality{
+		Files: map[string]string{
+			"IDENTITY.md": "Test Bot",
+			"MEMORY.md":   "PRIVATE_LEGACY_MEMORY",
+		},
+	}
+	agent := NewToolCallingAgent(nil, registry, personality)
+	agent.SetMemoryPolicy(memorypkg.NewRecallPolicy(memorypkg.RecallContext{
+		UserID:     1001,
+		ChatID:     1001,
+		ChatType:   "private",
+		SessionKey: "dm:1001",
+	}))
+
+	prompt := agent.buildSystemPrompt()
+	if strings.Contains(prompt, "PRIVATE_LEGACY_MEMORY") {
+		t.Fatalf("legacy memory should be omitted by default scoped policy")
+	}
+	if !strings.Contains(prompt, "Test Bot") {
+		t.Fatalf("non-memory prompt content should remain")
 	}
 }

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"log"
+	"strings"
 
 	"ok-gobot/internal/ai"
 	"ok-gobot/internal/config"
@@ -47,6 +48,7 @@ type RunResolver struct {
 	Router             *ai.Router              // optional: task-type model router
 	MemoryManager      *memory.MemoryManager   // optional: active recall context pack source
 	MemoryPackBudget   memory.ContextPackBudget
+	MemoryRecall       config.MemoryRecallConfig
 }
 
 // RunOverrides allows callers to explicitly override model/thinking level
@@ -251,4 +253,61 @@ func (r *RunResolver) buildToolRegistry(chatID int64, profile *AgentProfile, isS
 	}
 
 	return base
+}
+
+func (r *RunResolver) buildMemoryRecallPolicy(req RunRequest, profile *AgentProfile, job *delegation.Job) *memory.RecallPolicy {
+	chatType := strings.TrimSpace(req.ChatType)
+	if chatType == "" {
+		sessionKey := string(req.SessionKey)
+		switch {
+		case strings.HasPrefix(sessionKey, "dm:"):
+			chatType = "private"
+		case strings.HasPrefix(sessionKey, "group:"):
+			chatType = "group"
+		case req.ChatID < 0:
+			chatType = "group"
+		}
+	}
+
+	userID := req.UserID
+	if userID == 0 && chatType == "private" {
+		userID = req.ChatID
+	}
+
+	roleName := ""
+	if profile != nil {
+		roleName = profile.Name
+	}
+	jobID := ""
+	if req.JobID != "" {
+		jobID = req.JobID
+	}
+
+	return memory.NewRecallPolicy(memory.RecallContext{
+		UserID:               userID,
+		ChatID:               req.ChatID,
+		ChatType:             chatType,
+		SessionKey:           string(req.SessionKey),
+		Role:                 roleName,
+		JobID:                jobID,
+		AllowGroupRecall:     r.MemoryRecall.GroupRecall,
+		IncludeLegacyPrivate: r.MemoryRecall.IncludeLegacyPrivate,
+		ExtraPaths:           toMemoryExtraPathPolicies(r.MemoryRecall.ExtraPaths),
+	})
+}
+
+func toMemoryExtraPathPolicies(extra []config.MemoryExtraPathConfig) []memory.ExtraPathPolicy {
+	if len(extra) == 0 {
+		return nil
+	}
+	out := make([]memory.ExtraPathPolicy, 0, len(extra))
+	for _, item := range extra {
+		out = append(out, memory.ExtraPathPolicy{
+			Label:        item.Label,
+			Path:         item.Path,
+			AllowPrivate: item.AllowPrivate,
+			AllowGroups:  item.AllowGroups,
+		})
+	}
+	return out
 }

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -15,6 +15,7 @@ import (
 	"ok-gobot/internal/ai"
 	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/memory"
+	"ok-gobot/internal/tools"
 )
 
 // SessionKey is the canonical identifier for a chat session.
@@ -55,6 +56,8 @@ type RunEvent struct {
 type RunRequest struct {
 	SessionKey   SessionKey
 	ChatID       int64
+	UserID       int64
+	ChatType     string
 	Content      string
 	UserContent  []ai.ContentBlock // optional multimodal user blocks (e.g. image + text)
 	Session      string            // legacy: last assistant text (single turn)
@@ -65,6 +68,7 @@ type RunRequest struct {
 	OnDeltaReset func()          // optional callback when tool calls follow text
 	Overrides    *RunOverrides   // optional explicit model/thinking overrides
 	Job          *delegation.Job // optional delegated-run contract
+	JobID        string          // optional stable job/run identifier for job-scoped memory
 	IsSubagent   bool            // true = don't inject browser_task into the run
 	// PreUserSystemNotes are extra system-role messages to inject between the
 	// system prompt and the current user message. Used by Active Memory to
@@ -153,12 +157,23 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 		close(events)
 		return events
 	}
+	var memoryPolicy *memory.RecallPolicy
+	if req.ChatID != 0 || req.ChatType != "" {
+		memoryPolicy = h.resolver.buildMemoryRecallPolicy(req, components.Profile, job)
+		components.Agent.SetMemoryPolicy(memoryPolicy)
+		components.Agent.tools = tools.ScopeMemoryTools(components.Agent.tools, memoryPolicy)
+	}
 	if h.resolver.MemoryManager != nil {
+		var searcher memory.ContextPackSearcher = h.resolver.MemoryManager
+		if memoryPolicy != nil {
+			searcher = scopedMemorySearcher{manager: h.resolver.MemoryManager, policy: memoryPolicy}
+		}
 		components.Agent.SetMemoryContextBuilder(
-			memory.NewContextPackBuilder(h.resolver.MemoryManager),
+			memory.NewContextPackBuilder(searcher),
 			memory.ContextPackScope{
 				SessionKey: string(req.SessionKey),
 				ChatID:     req.ChatID,
+				UserID:     req.UserID,
 				AgentName:  components.Profile.Name,
 				Surface:    "runtime",
 			},
@@ -202,6 +217,8 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 			h.Submit(RunRequest{
 				SessionKey: subKey,
 				ChatID:     req.ChatID,
+				UserID:     req.UserID,
+				ChatType:   req.ChatType,
 				Content:    task,
 				Context:    context.Background(),
 				IsSubagent: true,
@@ -332,6 +349,7 @@ func (h *RuntimeHub) SubmitAndWait(ctx context.Context, chatID int64, task strin
 	events := h.Submit(RunRequest{
 		SessionKey: subKey,
 		ChatID:     chatID,
+		ChatType:   chatTypeForChatID(chatID),
 		Content:    task,
 		Context:    ctx,
 		Job:        &job,
@@ -358,4 +376,27 @@ func (h *RuntimeHub) SubmitAndWait(ctx context.Context, chatID int64, task strin
 		h.Cancel(subKey)
 		return "", ctx.Err()
 	}
+}
+
+func chatTypeForChatID(chatID int64) string {
+	if chatID < 0 {
+		return "group"
+	}
+	if chatID > 0 {
+		return "private"
+	}
+	return ""
+}
+
+type scopedMemorySearcher struct {
+	manager *memory.MemoryManager
+	policy  *memory.RecallPolicy
+}
+
+func (s scopedMemorySearcher) Search(ctx context.Context, query string, topK int) ([]memory.MemoryResult, error) {
+	result, err := s.manager.SearchScoped(ctx, query, topK, s.policy)
+	if err != nil {
+		return nil, err
+	}
+	return result.Results, nil
 }

--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -64,6 +64,7 @@ type ToolCallingAgent struct {
 	memoryContextBuilder *memory.ContextPackBuilder
 	memoryContextScope   memory.ContextPackScope
 	memoryContextBudget  memory.ContextPackBudget
+	memoryPolicy         *memory.RecallPolicy
 }
 
 // SetToolEventCallback sets a callback that fires on tool lifecycle events.
@@ -111,6 +112,11 @@ func (a *ToolCallingAgent) SetMemoryContextBuilder(builder *memory.ContextPackBu
 	a.memoryContextBuilder = builder
 	a.memoryContextScope = scope
 	a.memoryContextBudget = budget
+}
+
+// SetMemoryPolicy attaches the active recall/prompt memory policy for this run.
+func (a *ToolCallingAgent) SetMemoryPolicy(policy *memory.RecallPolicy) {
+	a.memoryPolicy = policy
 }
 
 // NewToolCallingAgent creates a new agent
@@ -626,7 +632,11 @@ type ToolCall struct {
 
 // buildSystemPrompt creates the system prompt with tool descriptions
 func (a *ToolCallingAgent) buildSystemPrompt() string {
-	return bootstrap.BuildPrompt(a.personality.Loader(), a.tools, bootstrap.PromptOptions{
+	loader := a.personality.Loader()
+	if a.memoryPolicy != nil {
+		loader = scopedPromptLoader(loader, a.memoryPolicy)
+	}
+	return bootstrap.BuildPrompt(loader, a.tools, bootstrap.PromptOptions{
 		Mode:         a.PromptMode,
 		ThinkLevel:   a.ThinkLevel,
 		MemoryMode:   a.MemoryMode,
@@ -668,6 +678,38 @@ func appendMemoryContextPack(systemPrompt string, pack *memory.ContextPack) stri
 	}
 	out.WriteString("Use this cited memory only when relevant to the user's request.\n")
 	return out.String()
+}
+
+func scopedPromptLoader(loader *bootstrap.Loader, policy *memory.RecallPolicy) *bootstrap.Loader {
+	if loader == nil || policy == nil {
+		return loader
+	}
+	files := make(map[string]string, len(loader.Files))
+	for name, content := range loader.Files {
+		if isMemoryPromptSource(name) {
+			if !policy.AllowsSource(name) {
+				continue
+			}
+			content = memory.RedactMemorySnippet(content)
+		}
+		files[name] = content
+	}
+	skills := make([]bootstrap.SkillEntry, len(loader.Skills))
+	copy(skills, loader.Skills)
+	return &bootstrap.Loader{BasePath: loader.BasePath, Files: files, Skills: skills}
+}
+
+func isMemoryPromptSource(name string) bool {
+	name = strings.TrimSpace(name)
+	return name == "MEMORY.md" ||
+		strings.HasPrefix(name, "memory/") ||
+		strings.HasPrefix(name, "telegram/") ||
+		strings.HasPrefix(name, "sessions/") ||
+		strings.HasPrefix(name, "roles/") ||
+		strings.HasPrefix(name, "jobs/") ||
+		strings.HasPrefix(name, "external/") ||
+		strings.HasPrefix(name, "extra/") ||
+		strings.HasPrefix(name, memory.ExtraSourcePrefix)
 }
 
 // parseToolCall extracts tool call from AI response (legacy fallback)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -381,7 +381,7 @@ func (a *App) Start(ctx context.Context) error {
 		log.Printf("⚠️ [memory] extra paths config error: %v", err)
 		memoryExtras = nil
 	}
-	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.config.Browser, a.config.STT, a.scheduler, a.memoryManager, memoryExtras, a.config.Memory.Sessions.Enabled, a.memoryStatus, a.config.Contacts)
+	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.config.Browser, a.config.STT, a.scheduler, a.memoryManager, memoryExtras, a.config.Memory.Sessions.Enabled, a.memoryStatus, a.config.Memory.Recall, a.config.Contacts)
 	if err != nil {
 		return fmt.Errorf("failed to create bot: %w", err)
 	}

--- a/internal/bot/active_memory.go
+++ b/internal/bot/active_memory.go
@@ -17,13 +17,21 @@ import (
 // Translation only — no policy decisions live here.
 type memoryManagerRecaller struct {
 	manager *memory.MemoryManager
+	policy  *memory.RecallPolicy
 }
 
 // Recall delegates to MemoryManager.Recall and converts MemoryResult into the
 // agent-package ActiveMemorySnippet so the agent package does not depend on
 // the memory package.
 func (r *memoryManagerRecaller) Recall(ctx context.Context, query string, topK int) ([]agent.ActiveMemorySnippet, error) {
-	results, err := r.manager.Recall(ctx, query, topK)
+	var results []memory.MemoryResult
+	var err error
+	if r.policy != nil {
+		search, searchErr := r.manager.SearchScoped(ctx, query, topK, r.policy)
+		results, err = search.Results, searchErr
+	} else {
+		results, err = r.manager.Recall(ctx, query, topK)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +110,20 @@ func (b *Bot) runActiveMemoryRecall(
 	}
 
 	eligible := b.activeMemoryEnabledForSession(chatID)
-	res := b.activeMemory.Recall(ctx, eligible, content, history)
+	activeMemory := b.activeMemory
+	if b.memoryManager != nil {
+		policy := memory.NewRecallPolicy(memory.RecallContext{
+			UserID:               chatID,
+			ChatID:               chatID,
+			ChatType:             "private",
+			SessionKey:           string(sessionKey),
+			AllowGroupRecall:     b.memoryRecall.GroupRecall,
+			IncludeLegacyPrivate: b.memoryRecall.IncludeLegacyPrivate,
+			ExtraPaths:           botExtraPathPolicies(b.memoryRecall.ExtraPaths),
+		})
+		activeMemory = agent.NewActiveMemory(&memoryManagerRecaller{manager: b.memoryManager, policy: policy}, b.activeMemory.Config())
+	}
+	res := activeMemory.Recall(ctx, eligible, content, history)
 	log.Printf("[active_memory] session=%s status=%s duration=%s", sessionKey, res.Status, res.Duration)
 
 	pack := buildActiveMemoryContextPack(res, b.activeMemory.Config(), sessionKey, chatID)
@@ -128,7 +149,7 @@ func buildActiveMemoryContextPack(res agent.ActiveMemoryResult, cfg agent.Active
 			SourceFile:   snippet.SourceFile,
 			HeaderPath:   snippet.HeaderPath,
 			ChunkOrdinal: i,
-			Content:      snippet.Content,
+			Content:      memory.RedactMemorySnippet(snippet.Content),
 			Score:        snippet.Similarity,
 			Similarity:   snippet.Similarity,
 		})

--- a/internal/bot/agent_handler.go
+++ b/internal/bot/agent_handler.go
@@ -56,8 +56,12 @@ func (b *Bot) handleStreamingRequestWithProfile(ctx context.Context, c telebot.C
 	// Final update
 	finalContent := editor.Finish()
 
-	// Save to memory
-	if err := b.memory.AppendToToday(fmt.Sprintf("Assistant: %s", finalContent)); err != nil {
+	// Save to scoped memory
+	userID := int64(0)
+	if c.Sender() != nil {
+		userID = c.Sender().ID
+	}
+	if err := b.memory.AppendTelegramToToday(string(c.Chat().Type), chatID, userID, fmt.Sprintf("Assistant: %s", finalContent)); err != nil {
 		log.Printf("Failed to save to memory: %v", err)
 	}
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -60,6 +60,7 @@ type Bot struct {
 	rolesPath        string // directory of role manifests; set via SetRolesPath
 	activeMemory     *agent.ActiveMemory
 	memoryStatus     MemoryStatusProvider
+	memoryRecall     config.MemoryRecallConfig
 }
 
 // MemoryStatusProvider supplies memory health for Telegram and local APIs.
@@ -81,7 +82,7 @@ type AIConfig struct {
 }
 
 // New creates a new bot instance
-func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, browserCfg config.BrowserConfig, sttCfg config.STTConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager, memoryExtraPaths []memory.ExtraPath, sessionMemoryEnabled bool, memoryStatus MemoryStatusProvider, contacts map[string]int64) (*Bot, error) {
+func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, browserCfg config.BrowserConfig, sttCfg config.STTConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager, memoryExtraPaths []memory.ExtraPath, sessionMemoryEnabled bool, memoryStatus MemoryStatusProvider, memoryRecall config.MemoryRecallConfig, contacts map[string]int64) (*Bot, error) {
 	pref := telebot.Settings{
 		Token:  token,
 		Poller: &telebot.LongPoller{Timeout: 10 * time.Second},
@@ -166,6 +167,7 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		ackManager:       NewAckHandleManager(),
 		scheduler:        scheduler,
 		memoryStatus:     memoryStatus,
+		memoryRecall:     memoryRecall,
 	}
 
 	// Initialize voice transcriber if STT is configured
@@ -214,9 +216,11 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 			ModelAliases:    aiCfg.ModelAliases,
 			MemoryMode:      aiCfg.MemoryMode,
 		},
-		ToolRegistry: toolRegistry,
-		Scheduler:    scheduler,
-		Router:       modelRouter,
+		ToolRegistry:  toolRegistry,
+		Scheduler:     scheduler,
+		Router:        modelRouter,
+		MemoryManager: memoryManager,
+		MemoryRecall:  memoryRecall,
 	}
 	b.hub = agent.NewRuntimeHub(resolver)
 
@@ -379,7 +383,11 @@ func (b *Bot) Start(ctx context.Context) error {
 	}))
 
 	b.api.Handle("/memory", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
-		note, err := b.memory.GetTodayNote()
+		senderID := int64(0)
+		if c.Sender() != nil {
+			senderID = c.Sender().ID
+		}
+		note, err := b.memory.GetTelegramTodayNote(string(c.Chat().Type), c.Chat().ID, senderID)
 		if err != nil {
 			return c.Send("❌ Failed to load memory")
 		}
@@ -388,7 +396,7 @@ func (b *Bot) Start(ctx context.Context) error {
 			return c.Send("📓 No entries for today yet")
 		}
 
-		return c.Send(fmt.Sprintf("📓 *Today's Memory*\n\n%s", note.Content),
+		return c.Send(fmt.Sprintf("📓 *Today's Scoped Memory*\n\n%s", memory.RedactMemorySnippet(note.Content)),
 			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 	}))
 
@@ -481,8 +489,8 @@ func (b *Bot) handleMessage(ctx context.Context, c telebot.Context) error {
 		log.Printf("Failed to save message: %v", err)
 	}
 
-	// Append to daily memory
-	if err := b.memory.AppendToToday(fmt.Sprintf("User: %s", content)); err != nil {
+	// Append to scoped daily memory.
+	if err := b.memory.AppendTelegramToToday(string(msg.Chat.Type), chatID, userID, fmt.Sprintf("User: %s", content)); err != nil {
 		log.Printf("Failed to append to memory: %v", err)
 	}
 
@@ -601,8 +609,12 @@ func (b *Bot) handleStreamingRequest(ctx context.Context, c telebot.Context, con
 	// Final update
 	finalContent := editor.Finish()
 
-	// Save to memory
-	if err := b.memory.AppendToToday(fmt.Sprintf("Assistant: %s", finalContent)); err != nil {
+	// Save to scoped memory
+	userID := int64(0)
+	if c.Sender() != nil {
+		userID = c.Sender().ID
+	}
+	if err := b.memory.AppendTelegramToToday(string(c.Chat().Type), c.Chat().ID, userID, fmt.Sprintf("Assistant: %s", finalContent)); err != nil {
 		log.Printf("Failed to save to memory: %v", err)
 	}
 

--- a/internal/bot/btw.go
+++ b/internal/bot/btw.go
@@ -51,11 +51,17 @@ func (b *Bot) handleBtwCommand(c telebot.Context) error {
 	go func() {
 		// Use a unique session key so the hub does not cancel the main run.
 		btwKey := agent.SessionKey(fmt.Sprintf("btw:%d:%d", chatID, time.Now().UnixNano()))
+		userID := int64(0)
+		if c.Sender() != nil {
+			userID = c.Sender().ID
+		}
 
 		session, _ := b.store.GetSession(chatID)
 		events := b.hub.Submit(agent.RunRequest{
 			SessionKey: btwKey,
 			ChatID:     chatID,
+			UserID:     userID,
+			ChatType:   string(chat.Type),
 			Content:    question,
 			Session:    session,
 			History:    history,

--- a/internal/bot/chat_routing.go
+++ b/internal/bot/chat_routing.go
@@ -83,7 +83,11 @@ func (b *Bot) respondWithClarification(
 	if err := b.store.SaveSessionMessagePairV2(string(sessionKey), userContent, clarification, ""); err != nil {
 		log.Printf("[router] failed to persist clarification transcript for chat=%d: %v", chatID, err)
 	}
-	if err := b.memory.AppendToToday(fmt.Sprintf("Assistant (router): %s", clarification)); err != nil {
+	userID := int64(0)
+	if c.Sender() != nil {
+		userID = c.Sender().ID
+	}
+	if err := b.memory.AppendTelegramToToday(string(c.Chat().Type), chatID, userID, fmt.Sprintf("Assistant (router): %s", clarification)); err != nil {
 		log.Printf("[router] failed to append clarification to memory for chat=%d: %v", chatID, err)
 	}
 	return nil
@@ -130,6 +134,7 @@ func (b *Bot) startTaskRun(chat *telebot.Chat, chatID int64, req agent.SubagentS
 		events := b.hub.Submit(agent.RunRequest{
 			SessionKey: subKey,
 			ChatID:     chatID,
+			ChatType:   string(chat.Type),
 			Content:    req.Description,
 			Session:    "",
 			Context:    context.Background(),

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -220,14 +220,18 @@ func (b *Bot) handleNewCommand(c telebot.Context) error {
 	return c.Send("✅ New session started. History and counters cleared.")
 }
 
-// handleNoteCommand appends a quick note directly to today's memory file.
+// handleNoteCommand appends a quick note directly to today's scoped memory file.
 func (b *Bot) handleNoteCommand(c telebot.Context) error {
 	noteText := strings.TrimSpace(c.Message().Payload)
 	if noteText == "" {
 		return c.Send("❌ Usage: /note <text>")
 	}
 
-	if err := b.memory.AppendQuickNoteToToday(noteText); err != nil {
+	senderID := int64(0)
+	if c.Sender() != nil {
+		senderID = c.Sender().ID
+	}
+	if err := b.memory.AppendTelegramQuickNoteToToday(string(c.Chat().Type), c.Chat().ID, senderID, noteText); err != nil {
 		log.Printf("Failed to append quick note: %v", err)
 		return c.Send("❌ Failed to save quick note")
 	}
@@ -335,6 +339,7 @@ func (b *Bot) handleContextCommand(c telebot.Context) error {
 	} else {
 		sb.WriteString("• Memory context pack builder: disabled\n")
 	}
+	sb.WriteString("• Memory recall: scoped by chat/user/session policy\n")
 
 	// Session info
 	sb.WriteString(fmt.Sprintf("\n*Session:*\n"))

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -67,7 +67,7 @@ func (b *Bot) runViaHubAsync(
 
 					b.sendImmediateAck(delivery.Chat, 0)
 					nextToken := b.queueManager.StartRun(chatID)
-					b.runViaHubAsync(ctx, telegramDelivery{Chat: delivery.Chat}, sessionKey, qCombined, nil, session, errorText, nextToken)
+					b.runViaHubAsync(ctx, delivery, sessionKey, qCombined, nil, session, errorText, nextToken)
 				})
 			}
 		}()
@@ -238,9 +238,12 @@ func (b *Bot) processViaHubWithContent(
 
 	// Submit to the hub — the hub owns agent resolution, tool execution,
 	// and run lifecycle. We only provide the inbound envelope.
+	chatType, _, userID := delivery.memoryContext()
 	req := agent.RunRequest{
 		SessionKey:         sessionKey,
 		ChatID:             chatID,
+		UserID:             userID,
+		ChatType:           chatType,
 		Content:            content,
 		UserContent:        userContent,
 		Session:            session,
@@ -408,7 +411,8 @@ func (b *Bot) processViaHubWithContent(
 	if result.ToolUsed {
 		memoryEntry += fmt.Sprintf(" [Tool: %s]", result.ToolName)
 	}
-	if err := b.memory.AppendToToday(memoryEntry); err != nil {
+	chatType, _, userID = delivery.memoryContext()
+	if err := b.memory.AppendTelegramToToday(chatType, chatID, userID, memoryEntry); err != nil {
 		log.Printf("[bot] failed to save to memory: %v", err)
 	}
 

--- a/internal/bot/job_lifecycle.go
+++ b/internal/bot/job_lifecycle.go
@@ -30,6 +30,20 @@ func newTelegramDelivery(c telebot.Context) telegramDelivery {
 	}
 }
 
+func (d telegramDelivery) memoryContext() (chatType string, chatID, userID int64) {
+	if d.Chat != nil {
+		chatType = string(d.Chat.Type)
+		chatID = d.Chat.ID
+	}
+	if d.Message != nil && d.Message.Sender != nil {
+		userID = d.Message.Sender.ID
+	}
+	if userID == 0 && chatType == string(telebot.ChatPrivate) {
+		userID = chatID
+	}
+	return chatType, chatID, userID
+}
+
 func newTelegramJobID(chatID int64, messageID int) string {
 	if messageID > 0 {
 		return fmt.Sprintf("tg-%d-%d", messageID, time.Now().UnixNano())

--- a/internal/bot/status.go
+++ b/internal/bot/status.go
@@ -11,6 +11,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/bootstrap"
+	"ok-gobot/internal/config"
 	"ok-gobot/internal/memory"
 	"ok-gobot/internal/tools"
 	"ok-gobot/internal/version"
@@ -133,6 +134,9 @@ func (b *Bot) buildStatusString(chatID int64) string {
 	}
 	queueDepth := b.debouncer.GetPendingCount()
 	sb.WriteString(fmt.Sprintf("⚙️ Think: %s · 🪢 Queue: %s (depth %d)\n", thinkLevel, queueMode, queueDepth))
+	if chatID >= 0 || chatID < -1 {
+		sb.WriteString(fmt.Sprintf("🧠 %s\n", b.memoryRecallStatus(chatID)))
+	}
 
 	memoryMode := bootstrap.NormalizeMemoryMode(b.aiConfig.MemoryMode)
 	memoryToolStatus := "off"
@@ -158,6 +162,51 @@ func (b *Bot) buildStatusString(chatID int64) string {
 	sb.WriteString(fmt.Sprintf("\n🟢 Running for %s", formatDuration(uptime)))
 
 	return sb.String()
+}
+
+func (b *Bot) memoryRecallStatus(chatID int64) string {
+	chatType := "private"
+	userID := chatID
+	if chatID < 0 {
+		chatType = "group"
+		userID = 0
+	}
+	policy := memory.NewRecallPolicy(memory.RecallContext{
+		UserID:               userID,
+		ChatID:               chatID,
+		ChatType:             chatType,
+		SessionKey:           string(agent.NewDMSessionKey(chatID)),
+		AllowGroupRecall:     b.memoryRecall.GroupRecall,
+		IncludeLegacyPrivate: b.memoryRecall.IncludeLegacyPrivate,
+		ExtraPaths:           botExtraPathPolicies(b.memoryRecall.ExtraPaths),
+	})
+	if chatID < 0 {
+		policy = memory.NewRecallPolicy(memory.RecallContext{
+			ChatID:               chatID,
+			ChatType:             chatType,
+			SessionKey:           string(agent.NewGroupSessionKey(chatID)),
+			AllowGroupRecall:     b.memoryRecall.GroupRecall,
+			IncludeLegacyPrivate: b.memoryRecall.IncludeLegacyPrivate,
+			ExtraPaths:           botExtraPathPolicies(b.memoryRecall.ExtraPaths),
+		})
+	}
+	return policy.Describe()
+}
+
+func botExtraPathPolicies(paths []config.MemoryExtraPathConfig) []memory.ExtraPathPolicy {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make([]memory.ExtraPathPolicy, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, memory.ExtraPathPolicy{
+			Label:        path.Label,
+			Path:         path.Path,
+			AllowPrivate: path.AllowPrivate,
+			AllowGroups:  path.AllowGroups,
+		})
+	}
+	return out
 }
 
 func maskAPIKey(key string) string {

--- a/internal/bot/tui_runtime.go
+++ b/internal/bot/tui_runtime.go
@@ -72,6 +72,7 @@ func (b *Bot) RunCronTask(ctx context.Context, chatID int64, task string, budget
 	events := b.hub.Submit(agent.RunRequest{
 		SessionKey: subKey,
 		ChatID:     chatID,
+		ChatType:   chatTypeForChatID(chatID),
 		Content:    task,
 		Context:    ctx,
 		Job:        budget,
@@ -89,4 +90,14 @@ func (b *Bot) RunCronTask(ctx context.Context, chatID int64, task string, budget
 		}
 	}
 	return nil
+}
+
+func chatTypeForChatID(chatID int64) string {
+	if chatID < 0 {
+		return "group"
+	}
+	if chatID > 0 {
+		return "private"
+	}
+	return ""
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,11 +216,19 @@ type MemoryConfig struct {
 	MetadataExtraction bool                    `mapstructure:"metadata_extraction"` // Extract structured metadata while indexing memories
 	MetadataModel      string                  `mapstructure:"metadata_model"`      // LLM model used for metadata extraction
 	ExtraPaths         []MemoryExtraPathConfig `mapstructure:"extra_paths"`         // Additional named markdown roots to index (Obsidian vaults, shared exports, etc.)
+	Recall             MemoryRecallConfig      `mapstructure:"recall"`              // Scoped active recall policy
 	MCP                MemoryMCPConfig         `mapstructure:"mcp"`                 // Optional MCP server exposing memory tools
 	QMD                MemoryQMDConfig         `mapstructure:"qmd"`                 // Optional read-only QMD-compatible backend
 	Active             ActiveMemoryConfig      `mapstructure:"active"`              // Pre-reply Active Memory recall (DM only)
 	Sessions           SessionMemoryConfig     `mapstructure:"sessions"`            // Session transcript indexing (off by default)
 	Curation           MemoryCurationConfig    `mapstructure:"curation"`            // Optional scheduled curation suggestions (disabled by default)
+}
+
+// MemoryRecallConfig controls which scoped sources active recall may use.
+type MemoryRecallConfig struct {
+	GroupRecall          bool                    `mapstructure:"group_recall"`           // Allow group chat-scoped/session-scoped recall. Default: false.
+	IncludeLegacyPrivate bool                    `mapstructure:"include_legacy_private"` // Allow legacy MEMORY.md/memory/*.md in private chats. Default: false.
+	ExtraPaths           []MemoryExtraPathConfig `mapstructure:"extra_paths"`            // Explicit external source labels.
 }
 
 // ActiveMemoryConfig configures the pre-reply Active Memory recall step.
@@ -240,11 +248,14 @@ type ActiveMemoryConfig struct {
 // "extra:<name>/...". Extra paths are read-only by default; writes to these
 // roots are never performed automatically.
 type MemoryExtraPathConfig struct {
-	Name     string   `mapstructure:"name"`      // Collection identifier (required, [a-z0-9-_]+)
-	Path     string   `mapstructure:"path"`      // Absolute or "~/..." path to the markdown root
-	Patterns []string `mapstructure:"patterns"`  // Glob patterns relative to path (defaults to ["**/*.md"])
-	ReadOnly *bool    `mapstructure:"read_only"` // Defaults to true; reserved for future write enablement
-	Scope    string   `mapstructure:"scope"`     // Optional human-readable scope label (e.g. "obsidian", "homelab")
+	Name         string   `mapstructure:"name"`          // Collection identifier for memory.extra_paths (required, [a-z0-9-_]+)
+	Label        string   `mapstructure:"label"`         // Recall policy label for memory.recall.extra_paths
+	Path         string   `mapstructure:"path"`          // Absolute or "~/..." path to the markdown root
+	Patterns     []string `mapstructure:"patterns"`      // Glob patterns relative to path (defaults to ["**/*.md"])
+	ReadOnly     *bool    `mapstructure:"read_only"`     // Defaults to true; reserved for future write enablement
+	Scope        string   `mapstructure:"scope"`         // Optional human-readable scope label (e.g. "obsidian", "homelab")
+	AllowPrivate bool     `mapstructure:"allow_private"` // Allow this recall label in private chats
+	AllowGroups  bool     `mapstructure:"allow_groups"`  // Allow this recall label in group chats
 }
 
 // SessionMemoryConfig controls indexing of past session transcripts as a
@@ -400,7 +411,7 @@ func Load() (*Config, error) {
 	v.SetDefault("memory.embeddings_base_url", "https://api.openai.com/v1")
 	v.SetDefault("memory.embeddings_api_key", "")
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
-	v.SetDefault("memory.extra_paths", []string{})
+	v.SetDefault("memory.extra_paths", []MemoryExtraPathConfig{})
 	v.SetDefault("memory.metadata_extraction", false)
 	v.SetDefault("memory.metadata_model", "haiku")
 	v.SetDefault("memory.qmd.binary_path", "qmd")
@@ -410,6 +421,9 @@ func Load() (*Config, error) {
 	v.SetDefault("memory.qmd.timeout", "10s")
 	v.SetDefault("memory.qmd.fallback_cooldown", "1m")
 	v.SetDefault("memory.qmd.collections.extra_paths", []string{})
+	v.SetDefault("memory.recall.group_recall", false)
+	v.SetDefault("memory.recall.include_legacy_private", false)
+	v.SetDefault("memory.recall.extra_paths", []MemoryExtraPathConfig{})
 	v.SetDefault("memory.mcp.enabled", false)
 	v.SetDefault("memory.mcp.host", "127.0.0.1")
 	v.SetDefault("memory.mcp.port", 9233)
@@ -486,6 +500,7 @@ func Load() (*Config, error) {
 	cfg.Memory.ExtraPaths = expandMemoryExtraPaths(cfg.Memory.ExtraPaths)
 	cfg.Evolution.BenchmarksDir = expandPath(cfg.Evolution.BenchmarksDir)
 	cfg.Evolution.EvolutionDir = expandPath(cfg.Evolution.EvolutionDir)
+	cfg.Memory.Recall.ExtraPaths = expandMemoryExtraPaths(cfg.Memory.Recall.ExtraPaths)
 	cfg.ConfigPath = v.ConfigFileUsed()
 
 	// Migrate legacy openai config to ai config
@@ -536,7 +551,7 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("memory.embeddings_base_url", "https://api.openai.com/v1")
 	v.SetDefault("memory.embeddings_api_key", "")
 	v.SetDefault("memory.embeddings_model", "text-embedding-3-small")
-	v.SetDefault("memory.extra_paths", []string{})
+	v.SetDefault("memory.extra_paths", []MemoryExtraPathConfig{})
 	v.SetDefault("memory.metadata_extraction", false)
 	v.SetDefault("memory.metadata_model", "haiku")
 	v.SetDefault("memory.qmd.binary_path", "qmd")
@@ -546,6 +561,9 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("memory.qmd.timeout", "10s")
 	v.SetDefault("memory.qmd.fallback_cooldown", "1m")
 	v.SetDefault("memory.qmd.collections.extra_paths", []string{})
+	v.SetDefault("memory.recall.group_recall", false)
+	v.SetDefault("memory.recall.include_legacy_private", false)
+	v.SetDefault("memory.recall.extra_paths", []MemoryExtraPathConfig{})
 	v.SetDefault("memory.mcp.enabled", false)
 	v.SetDefault("memory.mcp.host", "127.0.0.1")
 	v.SetDefault("memory.mcp.port", 9233)
@@ -603,6 +621,7 @@ func LoadFrom(configPath string) (*Config, error) {
 	cfg.Memory.ExtraPaths = expandMemoryExtraPaths(cfg.Memory.ExtraPaths)
 	cfg.Evolution.BenchmarksDir = expandPath(cfg.Evolution.BenchmarksDir)
 	cfg.Evolution.EvolutionDir = expandPath(cfg.Evolution.EvolutionDir)
+	cfg.Memory.Recall.ExtraPaths = expandMemoryExtraPaths(cfg.Memory.Recall.ExtraPaths)
 	cfg.ConfigPath = configPath
 
 	// Migrate legacy openai config to ai config
@@ -689,6 +708,23 @@ func (c *Config) Validate() error {
 	validDMScope := map[string]bool{"main": true, "per_user": true}
 	if c.Session.DMScope != "" && !validDMScope[c.Session.DMScope] {
 		return fmt.Errorf("invalid session.dm_scope: %s (must be 'main' or 'per_user')", c.Session.DMScope)
+	}
+	seenExtraLabels := map[string]struct{}{}
+	for _, extra := range c.Memory.Recall.ExtraPaths {
+		label := strings.TrimSpace(extra.Label)
+		if label == "" {
+			return fmt.Errorf("memory.recall.extra_paths: label is required")
+		}
+		if strings.ContainsAny(label, `/\\`) {
+			return fmt.Errorf("memory.recall.extra_paths[%s].label must not contain path separators", label)
+		}
+		if strings.TrimSpace(extra.Path) == "" {
+			return fmt.Errorf("memory.recall.extra_paths[%s].path is required", label)
+		}
+		if _, ok := seenExtraLabels[label]; ok {
+			return fmt.Errorf("memory.recall.extra_paths: duplicate label %q", label)
+		}
+		seenExtraLabels[label] = struct{}{}
 	}
 
 	// Validate memory prompt mode
@@ -791,6 +827,9 @@ func (c *Config) Save() error {
 	v.Set("memory.qmd.collections.daily_notes", c.Memory.QMD.Collections.DailyNotes)
 	v.Set("memory.qmd.collections.session_transcripts", c.Memory.QMD.Collections.SessionTranscripts)
 	v.Set("memory.qmd.collections.extra_paths", c.Memory.QMD.Collections.ExtraPaths)
+	v.Set("memory.recall.group_recall", c.Memory.Recall.GroupRecall)
+	v.Set("memory.recall.include_legacy_private", c.Memory.Recall.IncludeLegacyPrivate)
+	v.Set("memory.recall.extra_paths", c.Memory.Recall.ExtraPaths)
 	v.Set("memory.mcp.enabled", c.Memory.MCP.Enabled)
 	v.Set("memory.mcp.host", c.Memory.MCP.Host)
 	v.Set("memory.mcp.port", c.Memory.MCP.Port)
@@ -867,9 +906,12 @@ func expandMemoryExtraPaths(paths []MemoryExtraPathConfig) []MemoryExtraPathConf
 		return nil
 	}
 	out := make([]MemoryExtraPathConfig, len(paths))
-	copy(out, paths)
-	for i := range out {
-		out[i].Path = expandPath(out[i].Path)
+	for i, path := range paths {
+		out[i] = path
+		out[i].Name = strings.TrimSpace(path.Name)
+		out[i].Label = strings.TrimSpace(path.Label)
+		out[i].Scope = strings.TrimSpace(path.Scope)
+		out[i].Path = expandPath(strings.TrimSpace(path.Path))
 	}
 	return out
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,6 +55,12 @@ storage_path: "/tmp/test.db"
 	if cfg.Memory.QMD.SearchMode != "search" {
 		t.Errorf("expected memory.qmd.search_mode=%q, got %q", "search", cfg.Memory.QMD.SearchMode)
 	}
+	if cfg.Memory.Recall.GroupRecall {
+		t.Errorf("expected memory.recall.group_recall=false by default")
+	}
+	if cfg.Memory.Recall.IncludeLegacyPrivate {
+		t.Errorf("expected memory.recall.include_legacy_private=false by default")
+	}
 }
 
 func TestLoadFromLegacyRuntimeModeCompatibility(t *testing.T) {
@@ -84,6 +90,14 @@ memory:
       path: "~/ok-memory"
   metadata_extraction: true
   metadata_model: "claude-haiku-3.5"
+  recall:
+    group_recall: true
+    include_legacy_private: true
+    extra_paths:
+      - label: "project"
+        path: "~/project-notes"
+        allow_private: true
+        allow_groups: false
 `
 	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
 		t.Fatalf("Failed to write config file: %v", err)
@@ -114,6 +128,18 @@ memory:
 	}
 	if len(cfg.Memory.ExtraPaths) != 1 || !filepath.IsAbs(cfg.Memory.ExtraPaths[0].Path) {
 		t.Errorf("expected expanded memory.extra_paths, got %#v", cfg.Memory.ExtraPaths)
+	}
+	if !cfg.Memory.Recall.GroupRecall {
+		t.Errorf("expected memory.recall.group_recall=true")
+	}
+	if !cfg.Memory.Recall.IncludeLegacyPrivate {
+		t.Errorf("expected memory.recall.include_legacy_private=true")
+	}
+	if len(cfg.Memory.Recall.ExtraPaths) != 1 || cfg.Memory.Recall.ExtraPaths[0].Label != "project" {
+		t.Fatalf("expected one configured memory extra path, got %#v", cfg.Memory.Recall.ExtraPaths)
+	}
+	if cfg.Memory.Recall.ExtraPaths[0].Path == "~/project-notes" {
+		t.Fatalf("expected extra path to be expanded, got %q", cfg.Memory.Recall.ExtraPaths[0].Path)
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("expected legacy runtime.mode compatibility to validate, got %v", err)

--- a/internal/memory/lifecycle.go
+++ b/internal/memory/lifecycle.go
@@ -67,7 +67,8 @@ const (
 )
 
 // ManagedSources returns the canonical markdown memory files for rootPath:
-// MEMORY.md plus memory/*.md. Missing files/directories are skipped.
+// MEMORY.md, memory/*.md, and explicitly scoped Telegram/session/role/job
+// memory paths. Missing files/directories are skipped.
 func ManagedSources(rootPath string) ([]ManagedSource, error) {
 	rootPath = strings.TrimSpace(rootPath)
 	if rootPath == "" {
@@ -113,6 +114,9 @@ func ManagedSources(rootPath string) ([]ManagedSource, error) {
 			RelativePath: filepath.ToSlash(rel),
 		})
 	}
+	if err := appendScopedManagedSources(absRoot, &sources); err != nil {
+		return nil, err
+	}
 
 	return sources, nil
 }
@@ -145,6 +149,9 @@ func ManagedRelativePath(rootPath, absPath string) (string, bool) {
 		return rel, true
 	}
 	if strings.HasPrefix(rel, "memory/") && strings.Count(rel, "/") == 1 && strings.EqualFold(filepath.Ext(rel), ".md") {
+		return rel, true
+	}
+	if isScopedManagedRelativePath(rel) {
 		return rel, true
 	}
 	return "", false
@@ -184,6 +191,63 @@ func (s *MemoryStore) ClearManagedSources(ctx context.Context) error {
 		return fmt.Errorf("clear managed memory sources: %w", err)
 	}
 	return nil
+}
+
+func appendScopedManagedSources(rootPath string, sources *[]ManagedSource) error {
+	scopedRoots := []string{"telegram", "sessions", "roles", "jobs"}
+	for _, root := range scopedRoots {
+		base := filepath.Join(rootPath, root)
+		info, err := os.Stat(base)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("stat scoped memory root %s: %w", root, err)
+		}
+		if !info.IsDir() {
+			continue
+		}
+		if err := filepath.WalkDir(base, func(path string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			rel, err := filepath.Rel(rootPath, path)
+			if err != nil {
+				return nil
+			}
+			rel = filepath.ToSlash(rel)
+			if !isScopedManagedRelativePath(rel) {
+				return nil
+			}
+			*sources = append(*sources, ManagedSource{Path: filepath.Clean(path), RelativePath: rel})
+			return nil
+		}); err != nil {
+			return fmt.Errorf("walk scoped memory root %s: %w", root, err)
+		}
+	}
+	return nil
+}
+
+func isScopedManagedRelativePath(rel string) bool {
+	rel = filepath.ToSlash(filepath.Clean(strings.TrimSpace(rel)))
+	if rel == "." || !strings.EqualFold(filepath.Ext(rel), ".md") {
+		return false
+	}
+	parts := strings.Split(rel, "/")
+	if len(parts) < 3 {
+		return false
+	}
+	switch parts[0] {
+	case "telegram":
+		return len(parts) >= 5 && (parts[1] == "users" || parts[1] == "chats") && parts[3] == "memory"
+	case "sessions", "roles", "jobs":
+		return len(parts) >= 3
+	default:
+		return false
+	}
 }
 
 // Status returns lightweight diagnostics for the persisted memory index.

--- a/internal/memory/manager.go
+++ b/internal/memory/manager.go
@@ -24,6 +24,12 @@ type MemoryManager struct {
 	extractor MetadataExtractor
 }
 
+// RecallSearchResult includes both returned memory and policy decisions.
+type RecallSearchResult struct {
+	Results   []MemoryResult
+	Decisions []RecallDecision
+}
+
 // MemoryManagerOption customizes manager initialization.
 type MemoryManagerOption func(*MemoryManager)
 
@@ -82,6 +88,11 @@ func (m *MemoryManager) Search(ctx context.Context, query string, topK int) ([]M
 	return m.backend.Search(ctx, query, topK, false)
 }
 
+// SearchScoped searches indexed markdown chunks while enforcing the supplied recall policy.
+func (m *MemoryManager) SearchScoped(ctx context.Context, query string, topK int, policy *RecallPolicy) (RecallSearchResult, error) {
+	return m.searchScoped(ctx, query, topK, false, policy)
+}
+
 // SearchExpanded searches for matching chunks, then expands each result to
 // include all chunks from the same branch (source_file + header_path).
 // This gives full section context without replaying the entire history.
@@ -90,6 +101,37 @@ func (m *MemoryManager) SearchExpanded(ctx context.Context, query string, topK i
 		return nil, fmt.Errorf("memory manager is not configured")
 	}
 	return m.backend.Search(ctx, query, topK, true)
+}
+
+// SearchExpandedScoped searches under policy and expands matching branches.
+func (m *MemoryManager) SearchExpandedScoped(ctx context.Context, query string, topK int, policy *RecallPolicy) (RecallSearchResult, error) {
+	return m.searchScoped(ctx, query, topK, true, policy)
+}
+
+func (m *MemoryManager) searchScoped(ctx context.Context, query string, topK int, expand bool, policy *RecallPolicy) (RecallSearchResult, error) {
+	if m == nil || m.backend == nil {
+		return RecallSearchResult{}, fmt.Errorf("memory manager is not configured")
+	}
+	if policy == nil {
+		results, err := m.backend.Search(ctx, query, topK, expand)
+		return RecallSearchResult{Results: results}, err
+	}
+
+	limit := normalizeMemoryTopK(topK)
+	candidateLimit := limit * 20
+	if candidateLimit < 50 {
+		candidateLimit = 50
+	}
+	if candidateLimit > 200 {
+		candidateLimit = 200
+	}
+
+	results, err := m.backend.Search(ctx, query, candidateLimit, expand)
+	if err != nil {
+		return RecallSearchResult{}, err
+	}
+	filtered, decisions := filterRecallResults(results, limit, policy)
+	return RecallSearchResult{Results: filtered, Decisions: decisions}, nil
 }
 
 // Recall is kept as a compatibility alias for existing callers.
@@ -110,4 +152,41 @@ func (m *MemoryManager) ForgetByID(id int64) error {
 // ListRecent is deprecated in v2 where markdown files are canonical.
 func (m *MemoryManager) ListRecent(limit int) ([]MemoryResult, error) {
 	return nil, fmt.Errorf("memory list is deprecated in v2; use memory_search")
+}
+
+func filterRecallResults(results []MemoryResult, topK int, policy *RecallPolicy) ([]MemoryResult, []RecallDecision) {
+	limit := normalizeMemoryTopK(topK)
+	if policy == nil {
+		if len(results) > limit {
+			return results[:limit], nil
+		}
+		return results, nil
+	}
+
+	filtered := make([]MemoryResult, 0, min(len(results), limit))
+	decisions := make([]RecallDecision, 0)
+	seenDecisions := make(map[string]struct{})
+
+	for _, result := range results {
+		source := result.SourceFile
+		if source == "" {
+			source = result.Source
+		}
+		decision := policy.DecisionForSource(source)
+		decisionKey := fmt.Sprintf("%s\x00%t\x00%s", decision.Source, decision.Allowed, decision.Reason)
+		if _, ok := seenDecisions[decisionKey]; !ok {
+			seenDecisions[decisionKey] = struct{}{}
+			decisions = append(decisions, decision)
+		}
+		if !decision.Allowed {
+			continue
+		}
+		result.Content = RedactMemorySnippet(result.Content)
+		filtered = append(filtered, result)
+		if len(filtered) >= limit {
+			break
+		}
+	}
+
+	return filtered, decisions
 }

--- a/internal/memory/policy.go
+++ b/internal/memory/policy.go
@@ -1,0 +1,402 @@
+package memory
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RecallScope names the policy boundary attached to a memory source label.
+type RecallScope string
+
+const (
+	ScopeUser         RecallScope = "user"
+	ScopeChat         RecallScope = "chat"
+	ScopeSession      RecallScope = "session"
+	ScopeRole         RecallScope = "role"
+	ScopeJob          RecallScope = "job"
+	ScopeExternalPath RecallScope = "external_path"
+	ScopeLegacyGlobal RecallScope = "legacy_global"
+	ScopeUnknown      RecallScope = "unknown"
+)
+
+// ExtraPathPolicy describes an operator-configured external memory source.
+// The source label is matched against external/<label>/... and extra/<label>/...
+// index source labels. External paths are denied unless explicitly listed here.
+type ExtraPathPolicy struct {
+	Label        string
+	Path         string
+	AllowPrivate bool
+	AllowGroups  bool
+}
+
+// RecallContext describes the chat/session currently requesting memory recall.
+type RecallContext struct {
+	UserID     int64
+	ChatID     int64
+	ChatType   string
+	SessionKey string
+	Role       string
+	JobID      string
+
+	AllowGroupRecall     bool
+	IncludeLegacyPrivate bool
+	ExtraPaths           []ExtraPathPolicy
+}
+
+// RecallPolicy makes source-level allow/deny decisions for active memory recall.
+type RecallPolicy struct {
+	ctx    RecallContext
+	extra  map[string]ExtraPathPolicy
+	labels []string
+}
+
+// RecallDecision records how a source label was classified and whether it was allowed.
+type RecallDecision struct {
+	Source  string      `json:"source"`
+	Scope   RecallScope `json:"scope"`
+	Label   string      `json:"label"`
+	Allowed bool        `json:"allowed"`
+	Reason  string      `json:"reason"`
+}
+
+// NewRecallPolicy returns a conservative policy for the current chat context.
+func NewRecallPolicy(ctx RecallContext) *RecallPolicy {
+	p := &RecallPolicy{ctx: ctx, extra: map[string]ExtraPathPolicy{}}
+	for _, extra := range ctx.ExtraPaths {
+		label := sanitizeScopeID(extra.Label)
+		if label == "" {
+			continue
+		}
+		extra.Label = label
+		p.extra[label] = extra
+		p.labels = append(p.labels, label)
+	}
+	sort.Strings(p.labels)
+	return p
+}
+
+// Context returns the policy input used to make decisions.
+func (p *RecallPolicy) Context() RecallContext {
+	if p == nil {
+		return RecallContext{}
+	}
+	return p.ctx
+}
+
+// DecisionForSource classifies source and returns the current policy decision.
+func (p *RecallPolicy) DecisionForSource(source string) RecallDecision {
+	source = normalizeSourceLabel(source)
+	if p == nil {
+		return RecallDecision{Source: source, Scope: ScopeUnknown, Allowed: true, Reason: "no recall policy configured"}
+	}
+	if source == "" {
+		return RecallDecision{Source: source, Scope: ScopeUnknown, Allowed: false, Reason: "empty source label"}
+	}
+
+	scope, label := classifySource(source)
+	decision := RecallDecision{Source: source, Scope: scope, Label: label}
+
+	private := p.isPrivateChat()
+	group := p.isGroupChat()
+	userLabel := strconv.FormatInt(p.ctx.UserID, 10)
+	chatLabel := strconv.FormatInt(p.ctx.ChatID, 10)
+	sessionLabel := sanitizeScopeID(p.ctx.SessionKey)
+	roleLabel := sanitizeScopeID(p.ctx.Role)
+	jobLabel := sanitizeScopeID(p.ctx.JobID)
+
+	switch scope {
+	case ScopeUser:
+		if !private {
+			decision.Reason = "user-scoped memory is private-chat only"
+			return decision
+		}
+		if label == "" || label != userLabel {
+			decision.Reason = "user scope does not match current Telegram user"
+			return decision
+		}
+		decision.Allowed = true
+		decision.Reason = "matched current Telegram user scope"
+	case ScopeChat:
+		if label == "" || label != chatLabel {
+			decision.Reason = "chat scope does not match current Telegram chat"
+			return decision
+		}
+		if group && !p.ctx.AllowGroupRecall {
+			decision.Reason = "group chat recall is disabled by policy"
+			return decision
+		}
+		decision.Allowed = true
+		decision.Reason = "matched current Telegram chat scope"
+	case ScopeSession:
+		if label == "" || label != sessionLabel {
+			decision.Reason = "session scope does not match current session"
+			return decision
+		}
+		if group && !p.ctx.AllowGroupRecall {
+			decision.Reason = "group session recall is disabled by policy"
+			return decision
+		}
+		decision.Allowed = true
+		decision.Reason = "matched current session scope"
+	case ScopeRole:
+		if label == "" || label != roleLabel {
+			decision.Reason = "role scope does not match active role"
+			return decision
+		}
+		if group && !p.ctx.AllowGroupRecall {
+			decision.Reason = "group role recall is disabled by policy"
+			return decision
+		}
+		decision.Allowed = true
+		decision.Reason = "matched active role scope"
+	case ScopeJob:
+		if label == "" || label != jobLabel {
+			decision.Reason = "job scope does not match current job"
+			return decision
+		}
+		decision.Allowed = true
+		decision.Reason = "matched current job scope"
+	case ScopeExternalPath:
+		extra, ok := p.extra[label]
+		if !ok {
+			decision.Reason = "external path label is not configured"
+			return decision
+		}
+		if group && !extra.AllowGroups {
+			decision.Reason = "external path is not allowed for group chats"
+			return decision
+		}
+		if private && !extra.AllowPrivate {
+			decision.Reason = "external path is not allowed for private chats"
+			return decision
+		}
+		if !private && !group && !extra.AllowPrivate {
+			decision.Reason = "external path is not allowed for this chat type"
+			return decision
+		}
+		decision.Allowed = true
+		decision.Reason = "matched configured external path label"
+	case ScopeLegacyGlobal:
+		if private && p.ctx.IncludeLegacyPrivate {
+			decision.Allowed = true
+			decision.Reason = "legacy global private memory explicitly enabled"
+			return decision
+		}
+		decision.Reason = "legacy global memory is disabled by scoped recall policy"
+	default:
+		decision.Reason = "source label does not declare a supported memory scope"
+	}
+
+	return decision
+}
+
+// AllowsSource reports whether source may be recalled in the current context.
+func (p *RecallPolicy) AllowsSource(source string) bool {
+	return p.DecisionForSource(source).Allowed
+}
+
+// ResolveExternalSource maps external/<label>/... source labels to their configured root path.
+func (p *RecallPolicy) ResolveExternalSource(source string) (rootPath, relativePath string, ok bool) {
+	if p == nil {
+		return "", "", false
+	}
+	source = normalizeSourceLabel(source)
+	if label, rel, parsed := ParseExtraSourceLabel(source); parsed {
+		extra, exists := p.extra[sanitizeScopeID(label)]
+		if !exists || strings.TrimSpace(extra.Path) == "" {
+			return "", "", false
+		}
+		return strings.TrimSpace(extra.Path), rel, true
+	}
+	parts := strings.Split(source, "/")
+	if len(parts) < 3 || (parts[0] != "external" && parts[0] != "extra") {
+		return "", "", false
+	}
+	label := sanitizeScopeID(parts[1])
+	extra, exists := p.extra[label]
+	if !exists || strings.TrimSpace(extra.Path) == "" {
+		return "", "", false
+	}
+	return strings.TrimSpace(extra.Path), strings.Join(parts[2:], "/"), true
+}
+
+// Describe returns a compact status/debug string for the policy.
+func (p *RecallPolicy) Describe() string {
+	if p == nil {
+		return "memory recall policy: none"
+	}
+
+	chatType := strings.TrimSpace(p.ctx.ChatType)
+	if chatType == "" {
+		chatType = "unknown"
+	}
+
+	allowed := []string{}
+	if p.isPrivateChat() && p.ctx.UserID != 0 {
+		allowed = append(allowed, "user:"+strconv.FormatInt(p.ctx.UserID, 10))
+	}
+	if p.ctx.ChatID != 0 {
+		if !p.isGroupChat() || p.ctx.AllowGroupRecall {
+			allowed = append(allowed, "chat:"+strconv.FormatInt(p.ctx.ChatID, 10))
+		}
+	}
+	if p.ctx.SessionKey != "" && (!p.isGroupChat() || p.ctx.AllowGroupRecall) {
+		allowed = append(allowed, "session:"+sanitizeScopeID(p.ctx.SessionKey))
+	}
+	if p.ctx.Role != "" && (!p.isGroupChat() || p.ctx.AllowGroupRecall) {
+		allowed = append(allowed, "role:"+sanitizeScopeID(p.ctx.Role))
+	}
+	if p.ctx.JobID != "" {
+		allowed = append(allowed, "job:"+sanitizeScopeID(p.ctx.JobID))
+	}
+	for _, label := range p.labels {
+		extra := p.extra[label]
+		if (p.isPrivateChat() && extra.AllowPrivate) || (p.isGroupChat() && extra.AllowGroups) {
+			allowed = append(allowed, "external:"+label)
+		}
+	}
+	if p.ctx.IncludeLegacyPrivate && p.isPrivateChat() {
+		allowed = append(allowed, "legacy_global")
+	}
+	if len(allowed) == 0 {
+		allowed = append(allowed, "none")
+	}
+
+	return fmt.Sprintf("memory recall policy: chat_type=%s user=%d chat=%d group_recall=%t legacy_private=%t allowed=%s",
+		chatType,
+		p.ctx.UserID,
+		p.ctx.ChatID,
+		p.ctx.AllowGroupRecall,
+		p.ctx.IncludeLegacyPrivate,
+		strings.Join(allowed, ","),
+	)
+}
+
+func (p *RecallPolicy) isPrivateChat() bool {
+	if p == nil {
+		return false
+	}
+	chatType := strings.ToLower(strings.TrimSpace(p.ctx.ChatType))
+	return chatType == "private" || chatType == "direct" || (chatType == "" && p.ctx.ChatID > 0)
+}
+
+func (p *RecallPolicy) isGroupChat() bool {
+	if p == nil {
+		return false
+	}
+	chatType := strings.ToLower(strings.TrimSpace(p.ctx.ChatType))
+	return chatType == "group" || chatType == "supergroup" || chatType == "channel" || p.ctx.ChatID < 0
+}
+
+func classifySource(source string) (RecallScope, string) {
+	source = normalizeSourceLabel(source)
+	if label, _, ok := ParseExtraSourceLabel(source); ok {
+		return ScopeExternalPath, sanitizeScopeID(label)
+	}
+	parts := strings.Split(source, "/")
+	if source == "MEMORY.md" || strings.HasPrefix(source, "memory/") {
+		return ScopeLegacyGlobal, ""
+	}
+	if len(parts) >= 3 {
+		switch {
+		case parts[0] == "telegram" && parts[1] == "users":
+			return ScopeUser, sanitizeScopeID(parts[2])
+		case parts[0] == "telegram" && parts[1] == "chats":
+			return ScopeChat, sanitizeScopeID(parts[2])
+		case parts[0] == "sessions":
+			return ScopeSession, sanitizeScopeID(parts[1])
+		case parts[0] == "roles":
+			return ScopeRole, sanitizeScopeID(parts[1])
+		case parts[0] == "jobs":
+			return ScopeJob, sanitizeScopeID(parts[1])
+		case parts[0] == "external" || parts[0] == "extra":
+			return ScopeExternalPath, sanitizeScopeID(parts[1])
+		}
+	}
+	if len(parts) >= 2 {
+		switch parts[0] {
+		case "user", "users":
+			return ScopeUser, sanitizeScopeID(parts[1])
+		case "chat", "chats", "dm", "group", "groups":
+			return ScopeChat, sanitizeScopeID(parts[1])
+		case "session":
+			return ScopeSession, sanitizeScopeID(parts[1])
+		case "role":
+			return ScopeRole, sanitizeScopeID(parts[1])
+		case "job":
+			return ScopeJob, sanitizeScopeID(parts[1])
+		}
+	}
+	return ScopeUnknown, ""
+}
+
+func normalizeSourceLabel(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return ""
+	}
+	source = filepath.ToSlash(filepath.Clean(source))
+	source = strings.TrimPrefix(source, "./")
+	return source
+}
+
+// TelegramDailySource returns the scoped daily memory source label for a Telegram turn.
+func TelegramDailySource(chatType string, chatID, userID int64, date time.Time) string {
+	stamp := date.Format("2006-01-02")
+	if strings.EqualFold(strings.TrimSpace(chatType), "private") {
+		if userID == 0 {
+			userID = chatID
+		}
+		return fmt.Sprintf("telegram/users/%d/memory/%s.md", userID, stamp)
+	}
+	return fmt.Sprintf("telegram/chats/%d/memory/%s.md", chatID, stamp)
+}
+
+// RedactMemorySnippet removes common secret shapes before memory text enters prompts or output.
+func RedactMemorySnippet(text string) string {
+	redacted := text
+	for _, rule := range redactionRules {
+		redacted = rule.re.ReplaceAllString(redacted, rule.repl)
+	}
+	return redacted
+}
+
+type redactionRule struct {
+	re   *regexp.Regexp
+	repl string
+}
+
+var redactionRules = []redactionRule{
+	{regexp.MustCompile(`(?is)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`), "[REDACTED_PRIVATE_KEY]"},
+	{regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}`), "Bearer [REDACTED]"},
+	{regexp.MustCompile(`\b\d{6,12}:[A-Za-z0-9_-]{25,}\b`), "[REDACTED_TELEGRAM_TOKEN]"},
+	{regexp.MustCompile(`\b(sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,})\b`), "[REDACTED_SECRET]"},
+	{regexp.MustCompile(`(?i)\b(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*[^\s]+`), "$1=[REDACTED]"},
+}
+
+func sanitizeScopeID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	var out strings.Builder
+	lastUnderscore := false
+	for _, r := range value {
+		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_'
+		if valid {
+			out.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			out.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(out.String(), "_")
+}

--- a/internal/memory/policy_test.go
+++ b/internal/memory/policy_test.go
@@ -1,0 +1,83 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRecallPolicy_PrivateChatOnlyAllowsMatchingUserScope(t *testing.T) {
+	policy := NewRecallPolicy(RecallContext{
+		UserID:     1001,
+		ChatID:     1001,
+		ChatType:   "private",
+		SessionKey: "dm:1001",
+	})
+
+	if decision := policy.DecisionForSource("telegram/users/1001/memory/2026-04-30.md"); !decision.Allowed {
+		t.Fatalf("expected matching user source allowed, got %#v", decision)
+	}
+	if decision := policy.DecisionForSource("telegram/users/2002/memory/2026-04-30.md"); decision.Allowed {
+		t.Fatalf("expected other user source denied, got %#v", decision)
+	}
+	if decision := policy.DecisionForSource("MEMORY.md"); decision.Allowed {
+		t.Fatalf("expected legacy global memory denied by default, got %#v", decision)
+	}
+}
+
+func TestRecallPolicy_GroupRecallDisabledByDefault(t *testing.T) {
+	policy := NewRecallPolicy(RecallContext{
+		ChatID:     -100,
+		ChatType:   "group",
+		SessionKey: "group:-100",
+	})
+
+	if decision := policy.DecisionForSource("telegram/chats/-100/memory/2026-04-30.md"); decision.Allowed {
+		t.Fatalf("expected group chat source denied by default, got %#v", decision)
+	}
+
+	optIn := NewRecallPolicy(RecallContext{
+		ChatID:           -100,
+		ChatType:         "group",
+		SessionKey:       "group:-100",
+		AllowGroupRecall: true,
+	})
+	if decision := optIn.DecisionForSource("telegram/chats/-100/memory/2026-04-30.md"); !decision.Allowed {
+		t.Fatalf("expected matching group source allowed after opt-in, got %#v", decision)
+	}
+	if decision := optIn.DecisionForSource("telegram/users/1001/memory/2026-04-30.md"); decision.Allowed {
+		t.Fatalf("expected private user source denied in group, got %#v", decision)
+	}
+}
+
+func TestRecallPolicy_ExternalPathRequiresConfiguredLabel(t *testing.T) {
+	policy := NewRecallPolicy(RecallContext{
+		UserID:   1001,
+		ChatID:   1001,
+		ChatType: "private",
+		ExtraPaths: []ExtraPathPolicy{
+			{Label: "project", Path: "/tmp/project", AllowPrivate: true},
+		},
+	})
+
+	if decision := policy.DecisionForSource("external/project/notes.md"); !decision.Allowed {
+		t.Fatalf("expected configured external label allowed, got %#v", decision)
+	}
+	if decision := policy.DecisionForSource("external/other/notes.md"); decision.Allowed {
+		t.Fatalf("expected unconfigured external label denied, got %#v", decision)
+	}
+	root, rel, ok := policy.ResolveExternalSource("external/project/notes.md")
+	if !ok || root != "/tmp/project" || rel != "notes.md" {
+		t.Fatalf("unexpected external source resolution: root=%q rel=%q ok=%v", root, rel, ok)
+	}
+}
+
+func TestRedactMemorySnippet(t *testing.T) {
+	input := "token: 123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabc and Authorization: Bearer sk-testsecret1234567890"
+	got := RedactMemorySnippet(input)
+	if strings.Contains(got, "ABCDEFGHIJKLMNOPQRSTUVWXYZabc") || strings.Contains(got, "sk-testsecret") {
+		t.Fatalf("expected secrets redacted, got %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED") {
+		t.Fatalf("expected redaction marker, got %q", got)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -409,6 +409,28 @@ func (s *MemoryStore) SearchChunks(ctx context.Context, queryEmbedding []float32
 	return s.SearchHybrid(ctx, "", queryEmbedding, topK)
 }
 
+// SearchChunksScoped finds similar chunks after applying the recall source policy.
+func (s *MemoryStore) SearchChunksScoped(ctx context.Context, queryEmbedding []float32, topK int, policy *RecallPolicy) ([]MemoryResult, []RecallDecision, error) {
+	limit := normalizeMemoryTopK(topK)
+	candidateLimit := limit
+	if policy != nil {
+		candidateLimit = limit * 20
+		if candidateLimit < 50 {
+			candidateLimit = 50
+		}
+		if candidateLimit > 200 {
+			candidateLimit = 200
+		}
+	}
+
+	results, err := s.SearchHybrid(ctx, "", queryEmbedding, candidateLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+	filtered, decisions := filterRecallResults(results, limit, policy)
+	return filtered, decisions, nil
+}
+
 // GetBranchChunks loads all chunks for a specific (sourceFile, headerPath) branch,
 // ordered by chunk_ordinal. Used by branch expansion to reconstruct full sections.
 func (s *MemoryStore) GetBranchChunks(ctx context.Context, sourceFile, headerPath string) ([]MemoryResult, error) {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -549,6 +549,60 @@ func TestMemoryStoreSearchTextFindsExistingRowsAfterMigration(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreSearchChunksScopedFiltersOtherPrivateChats(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	store, err := NewMemoryStore(db)
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+
+	ctx := context.Background()
+	fixtures := []struct {
+		source  string
+		content string
+	}{
+		{"telegram/users/1001/memory/2026-04-30.md", "Alice private preference: tea."},
+		{"telegram/users/2002/memory/2026-04-30.md", "Bob private preference: coffee."},
+		{"external/project/notes.md", "Project notes should stay labeled external."},
+	}
+	for i, fixture := range fixtures {
+		if err := store.IndexChunk(ctx, fixture.source, "root", i+1, i+1, fixture.content, []float32{1, 0}); err != nil {
+			t.Fatalf("failed to index %s: %v", fixture.source, err)
+		}
+	}
+
+	policy := NewRecallPolicy(RecallContext{UserID: 1001, ChatID: 1001, ChatType: "private", SessionKey: "dm:1001"})
+	results, decisions, err := store.SearchChunksScoped(ctx, []float32{1, 0}, 10, policy)
+	if err != nil {
+		t.Fatalf("SearchChunksScoped failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 scoped result, got %d: %#v", len(results), results)
+	}
+	if results[0].SourceFile != "telegram/users/1001/memory/2026-04-30.md" {
+		t.Fatalf("unexpected scoped result source: %q", results[0].SourceFile)
+	}
+
+	foundDeniedUser := false
+	foundDeniedExternal := false
+	for _, decision := range decisions {
+		if decision.Source == "telegram/users/2002/memory/2026-04-30.md" && !decision.Allowed {
+			foundDeniedUser = true
+		}
+		if decision.Source == "external/project/notes.md" && !decision.Allowed {
+			foundDeniedExternal = true
+		}
+	}
+	if !foundDeniedUser {
+		t.Fatal("expected policy decisions to include denied other-user source")
+	}
+	if !foundDeniedExternal {
+		t.Fatal("expected policy decisions to include denied unconfigured external source")
+	}
+}
+
 func TestMemoryStoreLegacyMutationsAreDeprecated(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/tools/memory_get_tool.go
+++ b/internal/tools/memory_get_tool.go
@@ -16,6 +16,7 @@ var markdownHeaderRegexp = regexp.MustCompile(`^(#{1,6})\s+(.+?)\s*$`)
 type MemoryGetTool struct {
 	basePath string
 	extras   []memory.ExtraPath
+	policy   *memory.RecallPolicy
 }
 
 // NewMemoryGetTool creates a memory_get tool.
@@ -33,6 +34,21 @@ func (m *MemoryGetTool) WithExtraPaths(extras []memory.ExtraPath) *MemoryGetTool
 	clone := *m
 	clone.extras = append([]memory.ExtraPath(nil), extras...)
 	return &clone
+}
+
+// WithRecallPolicy returns a copy of the tool constrained by policy.
+func (m *MemoryGetTool) WithRecallPolicy(policy *memory.RecallPolicy) *MemoryGetTool {
+	if m == nil {
+		return nil
+	}
+	clone := *m
+	clone.policy = policy
+	return &clone
+}
+
+// NewScopedMemoryGetTool creates a memory_get tool constrained by policy.
+func NewScopedMemoryGetTool(basePath string, policy *memory.RecallPolicy) *MemoryGetTool {
+	return &MemoryGetTool{basePath: basePath, policy: policy}
 }
 
 func (m *MemoryGetTool) Name() string {
@@ -53,6 +69,12 @@ func (m *MemoryGetTool) Execute(ctx context.Context, args ...string) (string, er
 	if len(args) > 1 {
 		headerPath = strings.TrimSpace(args[1])
 	}
+	if m.policy != nil {
+		decision := m.policy.DecisionForSource(source)
+		if !decision.Allowed {
+			return "", fmt.Errorf("memory_get denied by recall policy for source %q: %s", source, decision.Reason)
+		}
+	}
 
 	fullPath, err := m.resolveSource(source)
 	if err != nil {
@@ -66,7 +88,7 @@ func (m *MemoryGetTool) Execute(ctx context.Context, args ...string) (string, er
 	content := string(contentBytes)
 
 	if headerPath == "" {
-		return content, nil
+		return memory.RedactMemorySnippet(content), nil
 	}
 
 	section, err := extractMarkdownSectionByHeaderPath(content, headerPath)
@@ -74,7 +96,7 @@ func (m *MemoryGetTool) Execute(ctx context.Context, args ...string) (string, er
 		return "", err
 	}
 
-	return section, nil
+	return memory.RedactMemorySnippet(section), nil
 }
 
 // resolveSource picks the right backing root for a given source label.
@@ -85,8 +107,16 @@ func (m *MemoryGetTool) resolveSource(source string) (string, error) {
 	if extra, rel, ok := memory.ExtraPathByLabel(m.extras, source); ok {
 		return memory.ResolveExtraPathFile(extra, rel)
 	}
+	if m.policy != nil {
+		if root, rel, ok := m.policy.ResolveExternalSource(source); ok {
+			return resolvePath(root, rel)
+		}
+	}
 	if strings.HasPrefix(source, memory.ExtraSourcePrefix) {
 		return "", fmt.Errorf("unknown extra memory collection in source %q", source)
+	}
+	if strings.HasPrefix(source, "external/") {
+		return "", fmt.Errorf("unknown external memory label in source %q", source)
 	}
 	return resolvePath(m.basePath, source)
 }

--- a/internal/tools/memory_search_tool.go
+++ b/internal/tools/memory_search_tool.go
@@ -12,11 +12,36 @@ import (
 // MemorySearchTool performs hybrid lexical and semantic search over indexed markdown memory chunks.
 type MemorySearchTool struct {
 	manager *memory.MemoryManager
+	policy  *memory.RecallPolicy
 }
 
 // NewMemorySearchTool creates a memory_search tool.
 func NewMemorySearchTool(manager *memory.MemoryManager) *MemorySearchTool {
 	return &MemorySearchTool{manager: manager}
+}
+
+// NewScopedMemorySearchTool creates a memory_search tool constrained by policy.
+func NewScopedMemorySearchTool(manager *memory.MemoryManager, policy *memory.RecallPolicy) *MemorySearchTool {
+	return &MemorySearchTool{manager: manager, policy: policy}
+}
+
+// ScopeMemoryTools returns a registry where memory_search and memory_get enforce policy.
+func ScopeMemoryTools(registry *Registry, policy *memory.RecallPolicy) *Registry {
+	if registry == nil || policy == nil {
+		return registry
+	}
+	scoped := registry.Child()
+	for _, tool := range registry.List() {
+		switch t := tool.(type) {
+		case *MemorySearchTool:
+			scoped.Register(NewScopedMemorySearchTool(t.manager, policy))
+		case *MemoryGetTool:
+			scoped.Register(t.WithRecallPolicy(policy))
+		default:
+			scoped.Register(tool)
+		}
+	}
+	return scoped
 }
 
 func (m *MemorySearchTool) Name() string {
@@ -49,19 +74,25 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 		expand = strings.EqualFold(strings.TrimSpace(args[2]), "true")
 	}
 
-	var results []memory.MemoryResult
+	var search memory.RecallSearchResult
 	var err error
 	if expand {
-		results, err = m.manager.SearchExpanded(ctx, query, limit)
+		search, err = m.manager.SearchExpandedScoped(ctx, query, limit, m.policy)
 	} else {
-		results, err = m.manager.Search(ctx, query, limit)
+		search, err = m.manager.SearchScoped(ctx, query, limit, m.policy)
 	}
 	if err != nil {
 		return "", fmt.Errorf("failed to search memory index: %w", err)
 	}
+	results := search.Results
 
+	var out strings.Builder
+	if m.policy != nil {
+		writeRecallPolicySummary(&out, m.policy, search.Decisions)
+	}
 	if len(results) == 0 {
-		return "No memory chunks found matching your query.", nil
+		out.WriteString("No memory chunks found matching your query.")
+		return out.String(), nil
 	}
 
 	label := "chunks"
@@ -69,7 +100,6 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 		label = "branches"
 	}
 
-	var out strings.Builder
 	out.WriteString(fmt.Sprintf("Found %d relevant memory %s:\n\n", len(results), label))
 	for i, result := range results {
 		headerPath := result.HeaderPath
@@ -86,10 +116,38 @@ func (m *MemorySearchTool) Execute(ctx context.Context, args ...string) (string,
 		if result.LexicalScore > 0 || result.VectorScore != 0 {
 			out.WriteString(fmt.Sprintf("   Score Components: lexical=%.2f vector=%.2f\n", result.LexicalScore, result.VectorScore))
 		}
-		out.WriteString(fmt.Sprintf("   %s\n\n", result.Content))
+		out.WriteString(fmt.Sprintf("   %s\n\n", memory.RedactMemorySnippet(result.Content)))
 	}
 
 	return out.String(), nil
+}
+
+func writeRecallPolicySummary(out *strings.Builder, policy *memory.RecallPolicy, decisions []memory.RecallDecision) {
+	allowed, denied := 0, 0
+	deniedReasons := make([]string, 0, len(decisions))
+	for _, decision := range decisions {
+		if decision.Allowed {
+			allowed++
+			continue
+		}
+		denied++
+		if len(deniedReasons) < 5 {
+			label := string(decision.Scope)
+			if decision.Label != "" {
+				label += ":" + decision.Label
+			}
+			deniedReasons = append(deniedReasons, fmt.Sprintf("%s (%s)", label, decision.Reason))
+		}
+	}
+
+	out.WriteString(policy.Describe())
+	out.WriteString("\n")
+	out.WriteString(fmt.Sprintf("policy decisions: allowed_sources=%d denied_sources=%d", allowed, denied))
+	if len(deniedReasons) > 0 {
+		out.WriteString(" denied=")
+		out.WriteString(strings.Join(deniedReasons, "; "))
+	}
+	out.WriteString("\n\n")
 }
 
 func (m *MemorySearchTool) GetSchema() map[string]interface{} {

--- a/internal/tools/memory_tools_test.go
+++ b/internal/tools/memory_tools_test.go
@@ -124,3 +124,42 @@ func TestMemoryGetTool_UnknownExtraCollectionFails(t *testing.T) {
 		t.Fatal("expected unknown collection error")
 	}
 }
+
+func TestMemoryGetTool_ScopedPolicyDeniesOtherUserSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "telegram", "users", "2002", "memory", "2026-04-30.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create fixture dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("other user secret"), 0644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	policy := memory.NewRecallPolicy(memory.RecallContext{UserID: 1001, ChatID: 1001, ChatType: "private", SessionKey: "dm:1001"})
+	tool := NewScopedMemoryGetTool(tmpDir, policy)
+	_, err := tool.Execute(context.Background(), "telegram/users/2002/memory/2026-04-30.md")
+	if err == nil || !strings.Contains(err.Error(), "denied by recall policy") {
+		t.Fatalf("expected recall policy denial, got %v", err)
+	}
+}
+
+func TestMemoryGetTool_RedactsAllowedSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "telegram", "users", "1001", "memory", "2026-04-30.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create fixture dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("api_key: sk-testsecret1234567890"), 0644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	policy := memory.NewRecallPolicy(memory.RecallContext{UserID: 1001, ChatID: 1001, ChatType: "private", SessionKey: "dm:1001"})
+	tool := NewScopedMemoryGetTool(tmpDir, policy)
+	got, err := tool.Execute(context.Background(), "telegram/users/1001/memory/2026-04-30.md")
+	if err != nil {
+		t.Fatalf("memory_get failed: %v", err)
+	}
+	if strings.Contains(got, "sk-testsecret") || !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("expected redacted output, got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #329

Maestro auto-created this PR because the worker pushed branch feat/bot-121-329-scoped-memory-privacy-and-recall-policy- but exited before opening a pull request.

Observed worker state: pid 837242 dead, tmux session "maestro-bot-121" missing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `RecallPolicy` layer that gates which memory sources (user-scoped, chat-scoped, session, role, job, external, legacy) can enter Telegram prompts and tool results based on chat type and operator config. It adds scoped daily-note writes, path-traversal guards, a `RedactMemorySnippet` pass on all recalled content, and conservative defaults (`group_recall: false`, `include_legacy_private: false`).

- The guard condition in `status.go` (`chatID >= 0 || chatID < -1`) is equivalent to `chatID != -1`, accidentally including `chatID == 0` rather than the likely-intended `chatID > 0 || chatID < -1`.
- The `writeRecallPolicySummary` helper unconditionally injects `user=<ID>`, `chat=<ID>`, and denied-source reasons into every scoped `memory_search` tool result with no debug/opt-out flag, leaking user and chat metadata into the LLM context on every call.

<h3>Confidence Score: 3/5</h3>

Largely safe; the policy enforcement is conservative by default, but the status guard bug and unconditional ID leakage into LLM context should be addressed before merge.

One P1 logic defect (status guard off-by-one), one P2 design issue (IDs leaked to LLM on every tool call), and redundant double-redaction across the recall path. Core security invariants (deny-by-default, path traversal protection, DM-only active memory gate) are correctly implemented.

internal/bot/status.go (guard condition), internal/tools/memory_search_tool.go (policy metadata in tool output)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/memory/policy.go | New file implementing RecallPolicy, source classification, ExtraPathPolicy, redaction rules, and TelegramDailySource — the core of the scoped recall feature; logic is sound but leaks policy metadata into LLM tool output unconditionally. |
| internal/bot/status.go | Adds memoryRecallStatus display; contains off-by-one in the guard condition (chatID >= 0 || chatID < -1) which admits chatID==0 instead of the likely intended chatID > 0 || chatID < -1. |
| internal/memory/manager.go | Adds SearchScoped/SearchExpandedScoped and filterRecallResults; correctly enforces policy and limits candidate pool, but redacts content here AND again in callers (redundant). |
| internal/agent/runtime.go | Wires RecallPolicy into RunRequest, scopes memory tools, and uses scopedMemorySearcher for context pack; propagates UserID and ChatType correctly through sub-agent and SubmitAndWait paths. |
| internal/bot/active_memory.go | Applies scoped recall policy to active memory recall; hardcoded ChatType:"private" is safe because the function has an early-return DM-only guard (isDMSession check) before policy construction. |
| internal/tools/memory_search_tool.go | Adds ScopeMemoryTools and scoped search; always prepends full policy metadata (user/chat IDs, denied reasons) to tool output with no opt-out mechanism. |
| internal/agent/memory.go | Adds scoped daily note read/write helpers and resolveRelativeSource with correct path-traversal guards (blocks absolute paths and ../ prefixes). |
| internal/memory/lifecycle.go | Extends ManagedSources to walk telegram/, sessions/, roles/, jobs/ scoped directories; isScopedManagedRelativePath correctly validates depth and structure. |
| internal/tools/memory_get_tool.go | Adds recall policy enforcement and redaction to memory_get; policy check happens before path resolution, and external/ source falls through to an explicit error rather than silently resolving. |
| internal/memory/policy_test.go | New test file covering private-user scoping, group recall opt-in, external path label allowlist, and redaction; good coverage of core policy paths. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/bot/status.go`, line 822-824 ([link](https://github.com/befeast/ok-gobot/blob/d506265cfefa61cc6c0270f3321859cac06e26bc/internal/bot/status.go#L822-L824)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Off-by-one in memory recall status guard**

   `chatID >= 0 || chatID < -1` is logically equivalent to `chatID != -1`, which means `chatID == 0` (the "no/unknown chat" sentinel) falls into the `true` branch and calls `memoryRecallStatus(0)`. The function then constructs a policy with `UserID=0, ChatID=0` and `chatType="private"`, which is misleading.

   If the intent is to show the status only for *valid* chat IDs (positive for private, negative-less-than-minus-one for groups — standard Telegram convention), the condition should be `chatID > 0 || chatID < -1`. As written, `chatID == 0` is included but `-1` is specifically excluded, which appears backwards.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/bot/status.go
   Line: 822-824

   Comment:
   **Off-by-one in memory recall status guard**

   `chatID >= 0 || chatID < -1` is logically equivalent to `chatID != -1`, which means `chatID == 0` (the "no/unknown chat" sentinel) falls into the `true` branch and calls `memoryRecallStatus(0)`. The function then constructs a policy with `UserID=0, ChatID=0` and `chatType="private"`, which is misleading.

   If the intent is to show the status only for *valid* chat IDs (positive for private, negative-less-than-minus-one for groups — standard Telegram convention), the condition should be `chatID > 0 || chatID < -1`. As written, `chatID == 0` is included but `-1` is specifically excluded, which appears backwards.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/tools/memory_search_tool.go`, line 83-109 ([link](https://github.com/befeast/ok-gobot/blob/d506265cfefa61cc6c0270f3321859cac06e26bc/internal/tools/memory_search_tool.go#L83-L109)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Recall policy metadata unconditionally injected into LLM context**

   `writeRecallPolicySummary` emits `user=<ID>`, `chat=<ID>`, denied source reasons, and the full allowed-scopes list into every scoped `memory_search` tool result — this becomes part of the LLM's context window on every tool call. There is no way to suppress it (no config flag, no `debug` mode gate).

   Leaking numeric user and chat IDs plus the full scope list into every tool response risks the LLM mentioning them in replies. Consider gating this output behind a `debug` flag or omitting it from tool results entirely while keeping it in server-side logs.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tools/memory_search_tool.go
   Line: 83-109

   Comment:
   **Recall policy metadata unconditionally injected into LLM context**

   `writeRecallPolicySummary` emits `user=<ID>`, `chat=<ID>`, denied source reasons, and the full allowed-scopes list into every scoped `memory_search` tool result — this becomes part of the LLM's context window on every tool call. There is no way to suppress it (no config flag, no `debug` mode gate).

   Leaking numeric user and chat IDs plus the full scope list into every tool response risks the LLM mentioning them in replies. Consider gating this output behind a `debug` flag or omitting it from tool results entirely while keeping it in server-side logs.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `internal/memory/manager.go`, line 1303-1304 ([link](https://github.com/befeast/ok-gobot/blob/d506265cfefa61cc6c0270f3321859cac06e26bc/internal/memory/manager.go#L1303-L1304)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Double redaction of memory content**

   `filterRecallResults` calls `RedactMemorySnippet(result.Content)` before appending to `filtered`. Both `memory_search_tool.go` and `active_memory.go` (`buildActiveMemoryContextPack`) then call `RedactMemorySnippet` again on the already-redacted content. The redaction rules are idempotent so this does not cause incorrect output, but the redundant work happens on every recall path. Downstream callers can rely on content from `SearchScoped`/`filterRecallResults` already being redacted and skip their own pass.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/memory/manager.go
   Line: 1303-1304

   Comment:
   **Double redaction of memory content**

   `filterRecallResults` calls `RedactMemorySnippet(result.Content)` before appending to `filtered`. Both `memory_search_tool.go` and `active_memory.go` (`buildActiveMemoryContextPack`) then call `RedactMemorySnippet` again on the already-redacted content. The redaction rules are idempotent so this does not cause incorrect output, but the redundant work happens on every recall path. Downstream callers can rely on content from `SearchScoped`/`filterRecallResults` already being redacted and skip their own pass.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/bot/status.go:822-824
**Off-by-one in memory recall status guard**

`chatID >= 0 || chatID < -1` is logically equivalent to `chatID != -1`, which means `chatID == 0` (the "no/unknown chat" sentinel) falls into the `true` branch and calls `memoryRecallStatus(0)`. The function then constructs a policy with `UserID=0, ChatID=0` and `chatType="private"`, which is misleading.

If the intent is to show the status only for *valid* chat IDs (positive for private, negative-less-than-minus-one for groups — standard Telegram convention), the condition should be `chatID > 0 || chatID < -1`. As written, `chatID == 0` is included but `-1` is specifically excluded, which appears backwards.

### Issue 2 of 3
internal/tools/memory_search_tool.go:83-109
**Recall policy metadata unconditionally injected into LLM context**

`writeRecallPolicySummary` emits `user=<ID>`, `chat=<ID>`, denied source reasons, and the full allowed-scopes list into every scoped `memory_search` tool result — this becomes part of the LLM's context window on every tool call. There is no way to suppress it (no config flag, no `debug` mode gate).

Leaking numeric user and chat IDs plus the full scope list into every tool response risks the LLM mentioning them in replies. Consider gating this output behind a `debug` flag or omitting it from tool results entirely while keeping it in server-side logs.

### Issue 3 of 3
internal/memory/manager.go:1303-1304
**Double redaction of memory content**

`filterRecallResults` calls `RedactMemorySnippet(result.Content)` before appending to `filtered`. Both `memory_search_tool.go` and `active_memory.go` (`buildActiveMemoryContextPack`) then call `RedactMemorySnippet` again on the already-redacted content. The redaction rules are idempotent so this does not cause incorrect output, but the redundant work happens on every recall path. Downstream callers can rely on content from `SearchScoped`/`filterRecallResults` already being redacted and skip their own pass.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(memory): add scoped Telegram recall..."](https://github.com/befeast/ok-gobot/commit/d506265cfefa61cc6c0270f3321859cac06e26bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30340869)</sub>

<!-- /greptile_comment -->