### PR TITLE
feat: add Telegram memory curation review workflow (#330)

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -289,6 +289,7 @@ func (b *Bot) registerCommands() {
 		{Text: "abort", Description: "Abort the current run"},
 		{Text: "memory", Description: "Show today's memory"},
 		{Text: "memory_status", Description: "Show memory index health"},
+		{Text: "memory_curate", Description: "Review memory curation drafts"},
 		{Text: "qmd", Description: "Show QMD sidecar status"},
 		{Text: "tools", Description: "List available tools"},
 		{Text: "model", Description: "Show or set AI model"},
@@ -361,6 +362,7 @@ func (b *Bot) Start(ctx context.Context) error {
 /note <text> - Quick note to today's memory
 /memory - Show today's memory
 /memory_status - Show memory index health
+/memory_curate - Review memory curation drafts (admin only)
 /qmd - Show QMD sidecar status
 /tools - List available tools
 /model - Manage AI model (list/set/clear)

--- a/internal/bot/memory_curate.go
+++ b/internal/bot/memory_curate.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 	"gopkg.in/telebot.v4"
 
+	"ok-gobot/internal/logger"
 	"ok-gobot/internal/memory/curate"
 )
 
@@ -22,22 +24,28 @@ import (
 //	/memory_curate draft [N]       — draft from the last N days (default 7)
 //	/memory_curate range YYYY-MM-DD YYYY-MM-DD
 //	/memory_curate list
-//	/memory_curate show <id>
-//	/memory_curate apply <id> yes  — admin only, requires the literal "yes"
+//	/memory_curate show <id>       — alias: preview
+//	/memory_curate apply <id> yes  — alias: approve; requires literal "yes"
 //	/memory_curate reject <id> [notes]
-//	/memory_curate delete <id>
+//	/memory_curate delete <id> yes — requires literal "yes"
 func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 	args := strings.Fields(strings.TrimSpace(c.Message().Payload))
+	senderID := int64(0)
+	if sender := c.Sender(); sender != nil {
+		senderID = sender.ID
+	}
+	if b.authManager == nil || !b.authManager.IsAdmin(senderID) {
+		return c.Send("🔒 /memory_curate is admin-only.")
+	}
 	if len(args) == 0 {
 		return c.Send(memoryCurateUsage(), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 	}
-
-	soul := b.memory.BasePath
+	soul := ""
+	if b.memory != nil {
+		soul = b.memory.BasePath
+	}
 	if soul == "" {
 		return c.Send("❌ Memory base path not configured.")
-	}
-	if !b.authManager.IsAdmin(c.Sender().ID) {
-		return c.Send("🔒 /memory_curate is admin-only.")
 	}
 	store := curate.NewDraftStore(soul)
 
@@ -87,9 +95,9 @@ func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 		}
 		return c.Send(sb.String(), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 
-	case "show":
+	case "show", "preview":
 		if len(args) < 2 {
-			return c.Send("Usage: `/memory_curate show <id>`", &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+			return c.Send("Usage: `/memory_curate preview <id>`", &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 		}
 		if err := curate.ValidateDraftID(args[1]); err != nil {
 			return c.Send(fmt.Sprintf("❌ %v", err))
@@ -99,12 +107,12 @@ func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 			return c.Send(fmt.Sprintf("❌ %v", err))
 		}
 		audit := curate.AuditDraft(d)
-		body := curate.RenderDraftMarkdown(d, audit)
+		body := renderMemoryCuratePreview(d, audit)
 		return sendChunked(c, body)
 
-	case "apply":
+	case "apply", "approve":
 		if len(args) < 3 || strings.ToLower(args[2]) != "yes" {
-			return c.Send("Usage: `/memory_curate apply <id> yes`\n\n"+
+			return c.Send("Usage: `/memory_curate approve <id> yes`\n\n"+
 				"The literal `yes` is required as explicit confirmation that you want "+
 				"to modify MEMORY.md.",
 				&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
@@ -131,6 +139,7 @@ func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 		case err != nil:
 			return c.Send(fmt.Sprintf("❌ %v", err))
 		}
+		logMemoryCurateAudit("apply", c, d.ID, d.Status)
 		return c.Send(fmt.Sprintf("✅ Applied draft `%s` to MEMORY.md.", d.ID),
 			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 
@@ -143,21 +152,35 @@ func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 		if len(args) > 2 {
 			notes = strings.Join(args[2:], " ")
 		}
+		label := senderLabel(c)
+		if notes == "" {
+			notes = "rejected by " + label
+		} else {
+			notes = "rejected by " + label + ": " + notes
+		}
 		d, err := store.SetStatus(args[1], curate.StatusRejected, notes)
 		if err != nil {
 			return c.Send(fmt.Sprintf("❌ %v", err))
 		}
-		return c.Send(fmt.Sprintf("Draft `%s` rejected. Use `/memory_curate delete %s` to remove from disk.",
+		logMemoryCurateAudit("reject", c, d.ID, d.Status)
+		return c.Send(fmt.Sprintf("Draft `%s` rejected. Use `/memory_curate delete %s yes` to remove from disk.",
 			d.ID, d.ID), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 
 	case "delete":
-		if len(args) < 2 {
-			return c.Send("Usage: `/memory_curate delete <id>`",
+		if len(args) < 3 || strings.ToLower(args[2]) != "yes" {
+			return c.Send("Usage: `/memory_curate delete <id> yes`\n\n"+
+				"The literal `yes` is required as explicit confirmation that you want "+
+				"to remove the draft files.",
 				&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+		}
+		d, err := store.Load(args[1])
+		if err != nil {
+			return c.Send(fmt.Sprintf("❌ %v", err))
 		}
 		if err := store.Delete(args[1]); err != nil {
 			return c.Send(fmt.Sprintf("❌ %v", err))
 		}
+		logMemoryCurateAudit("delete", c, d.ID, d.Status)
 		return c.Send(fmt.Sprintf("Draft `%s` deleted.", args[1]),
 			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 
@@ -171,10 +194,10 @@ func memoryCurateUsage() string {
 		"`/memory_curate draft [days]` — draft from last N days (default 7, admin)\n" +
 		"`/memory_curate range YYYY-MM-DD YYYY-MM-DD` — draft from a date range (admin)\n" +
 		"`/memory_curate list` — list drafts\n" +
-		"`/memory_curate show <id>` — show full draft + audit\n" +
-		"`/memory_curate apply <id> yes` — apply to MEMORY.md (admin, explicit confirm)\n" +
+		"`/memory_curate preview <id>` — show candidates, source dates, and audit findings\n" +
+		"`/memory_curate approve <id> yes` — apply to MEMORY.md (admin, explicit confirm)\n" +
 		"`/memory_curate reject <id> [notes]` — reject but keep on disk (admin)\n" +
-		"`/memory_curate delete <id>` — remove from disk (admin)\n"
+		"`/memory_curate delete <id> yes` — remove from disk (admin, explicit confirm)\n"
 }
 
 func runBotCurateDraft(c telebot.Context, soul string, since, until time.Time) error {
@@ -193,11 +216,11 @@ func runBotCurateDraft(c telebot.Context, soul string, since, until time.Time) e
 			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 	}
 	audit := curate.AuditDraft(draft)
-	body := curate.RenderDraftMarkdown(draft, audit)
+	body := renderMemoryCuratePreview(draft, audit)
 	if err := sendChunked(c, body); err != nil {
 		return err
 	}
-	return c.Send(fmt.Sprintf("Apply with `/memory_curate apply %s yes` (admin).", draft.ID),
+	return c.Send(fmt.Sprintf("Apply with `/memory_curate approve %s yes` (admin).", draft.ID),
 		&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 }
 
@@ -223,21 +246,164 @@ func parseDaysArg(s string) (int, error) {
 // stay under the per-message limit.
 func sendChunked(c telebot.Context, body string) error {
 	const limit = 3500
-	for len(body) > limit {
-		// Try to break on a newline within the last 200 chars of the limit.
-		cut := limit
-		if idx := strings.LastIndex(body[:limit], "\n"); idx > limit-300 {
-			cut = idx
-		}
-		if err := c.Send(body[:cut]); err != nil {
+	for _, chunk := range splitTelegramChunks(body, limit) {
+		if err := c.Send(chunk); err != nil {
 			return err
 		}
-		body = body[cut:]
-	}
-	if strings.TrimSpace(body) != "" {
-		return c.Send(body)
 	}
 	return nil
+}
+
+func splitTelegramChunks(body string, limit int) []string {
+	if limit <= 0 || strings.TrimSpace(body) == "" {
+		return nil
+	}
+
+	var chunks []string
+	for len([]rune(body)) > limit {
+		runes := []rune(body)
+		cut := limit
+		windowStart := limit - 300
+		if windowStart < 0 {
+			windowStart = 0
+		}
+		for i := limit; i > windowStart; i-- {
+			if runes[i-1] == '\n' {
+				cut = i
+				break
+			}
+		}
+		chunk := strings.TrimRight(string(runes[:cut]), "\n")
+		if strings.TrimSpace(chunk) != "" {
+			chunks = append(chunks, chunk)
+		}
+		body = strings.TrimLeft(string(runes[cut:]), "\n")
+	}
+	if strings.TrimSpace(body) != "" {
+		chunks = append(chunks, body)
+	}
+	return chunks
+}
+
+func renderMemoryCuratePreview(d *curate.Draft, audit curate.AuditReport) string {
+	if d == nil {
+		return ""
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Memory curation draft `%s`\n\n", d.ID)
+	fmt.Fprintf(&sb, "Status: `%s`\n", d.Status)
+	fmt.Fprintf(&sb, "Source dates: %s -> %s (%d notes)\n", d.Since, d.Until, d.SourceCount)
+	fmt.Fprintf(&sb, "Candidates: %d\n", len(d.Candidates))
+	if d.Notes != "" {
+		fmt.Fprintf(&sb, "Reviewer notes: %s\n", compactLine(d.Notes, 240))
+	}
+	sb.WriteString("\nCandidates:\n")
+	if d.IsEmpty() {
+		sb.WriteString("- none\n")
+	} else {
+		grouped := d.CandidatesBySection()
+		for _, section := range curate.AllSections() {
+			candidates := grouped[section]
+			if len(candidates) == 0 {
+				continue
+			}
+			fmt.Fprintf(&sb, "\n%s:\n", curate.SectionTitle(section))
+			for _, candidate := range candidates {
+				fmt.Fprintf(&sb, "- `%s` [%s, conf %.2f] %s\n", candidate.ID, candidate.Section, candidate.Confidence, compactLine(candidate.Text, 280))
+				fmt.Fprintf(&sb, "  source dates: %s\n", strings.Join(candidateSourceDates(candidate), ", "))
+				if len(candidate.Conflicts) > 0 {
+					fmt.Fprintf(&sb, "  risk: conflicts with %s\n", strings.Join(candidate.Conflicts, ", "))
+				}
+			}
+		}
+	}
+
+	sb.WriteString("\nAudit findings:\n")
+	if len(audit.Findings) == 0 {
+		sb.WriteString("- none\n")
+	} else {
+		for _, finding := range audit.Findings {
+			fmt.Fprintf(&sb, "- %s\n", compactLine(finding.String(), 240))
+		}
+	}
+
+	fmt.Fprintf(&sb, "\nApprove with `/memory_curate approve %s yes`.\n", d.ID)
+	fmt.Fprintf(&sb, "Reject with `/memory_curate reject %s [notes]`. Delete with `/memory_curate delete %s yes`.\n", d.ID, d.ID)
+	return sb.String()
+}
+
+func candidateSourceDates(candidate curate.Candidate) []string {
+	seen := make(map[string]bool)
+	var dates []string
+	for _, source := range candidate.Sources {
+		date := strings.TrimSpace(source.Date)
+		if date == "" {
+			date = dateFromSourcePath(source.Path)
+		}
+		if date == "" || seen[date] {
+			continue
+		}
+		seen[date] = true
+		dates = append(dates, date)
+	}
+	if len(dates) == 0 {
+		return []string{"unknown"}
+	}
+	return dates
+}
+
+func dateFromSourcePath(path string) string {
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		path = path[idx+1:]
+	}
+	path = strings.TrimSuffix(path, ".md")
+	if len(path) == len("2006-01-02") && path[4] == '-' && path[7] == '-' {
+		return path
+	}
+	return ""
+}
+
+func compactLine(s string, limit int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if limit <= 3 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= limit {
+		return s
+	}
+	return string(runes[:limit-3]) + "..."
+}
+
+type memoryCurateAuditEntry struct {
+	Timestamp int64  `json:"ts"`
+	Action    string `json:"action"`
+	DraftID   string `json:"draft_id"`
+	Status    string `json:"status"`
+	SenderID  int64  `json:"sender_id"`
+	Username  string `json:"username"`
+	ChatID    int64  `json:"chat_id"`
+	ChatType  string `json:"chat_type"`
+}
+
+func logMemoryCurateAudit(action string, c telebot.Context, draftID string, status curate.Status) {
+	entry := memoryCurateAuditEntry{
+		Timestamp: time.Now().Unix(),
+		Action:    action,
+		DraftID:   draftID,
+		Status:    string(status),
+	}
+	if sender := c.Sender(); sender != nil {
+		entry.SenderID = sender.ID
+		entry.Username = sender.Username
+	}
+	if chat := c.Chat(); chat != nil {
+		entry.ChatID = chat.ID
+		entry.ChatType = string(chat.Type)
+	}
+	data, _ := json.Marshal(entry)
+	logger.Infof("[AUDIT] memory_curate %s", data)
 }
 
 func senderLabel(c telebot.Context) string {

--- a/internal/bot/memory_curate.go
+++ b/internal/bot/memory_curate.go
@@ -173,14 +173,14 @@ func (b *Bot) handleMemoryCurateCommand(c telebot.Context) error {
 				"to remove the draft files.",
 				&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 		}
-		d, err := store.Load(args[1])
-		if err != nil {
-			return c.Send(fmt.Sprintf("❌ %v", err))
+		status := curate.Status("unknown")
+		if d, err := store.Load(args[1]); err == nil && d != nil {
+			status = d.Status
 		}
 		if err := store.Delete(args[1]); err != nil {
 			return c.Send(fmt.Sprintf("❌ %v", err))
 		}
-		logMemoryCurateAudit("delete", c, d.ID, d.Status)
+		logMemoryCurateAudit("delete", c, args[1], status)
 		return c.Send(fmt.Sprintf("Draft `%s` deleted.", args[1]),
 			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 

--- a/internal/bot/memory_curate_test.go
+++ b/internal/bot/memory_curate_test.go
@@ -1,8 +1,18 @@
 package bot
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+	"unicode/utf8"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/memory/curate"
 )
 
 func TestParseDaysArg(t *testing.T) {
@@ -38,7 +48,7 @@ func TestParseDaysArg(t *testing.T) {
 
 func TestMemoryCurateUsage_DescribesAllSubcommands(t *testing.T) {
 	usage := memoryCurateUsage()
-	for _, want := range []string{"draft", "range", "list", "show", "apply", "reject", "delete"} {
+	for _, want := range []string{"draft", "range", "list", "preview", "approve", "reject", "delete"} {
 		if !strings.Contains(usage, want) {
 			t.Errorf("usage missing subcommand %q:\n%s", want, usage)
 		}
@@ -47,5 +57,265 @@ func TestMemoryCurateUsage_DescribesAllSubcommands(t *testing.T) {
 	// it is required.
 	if !strings.Contains(usage, "yes") {
 		t.Error("usage should mention the explicit `yes` confirmation token")
+	}
+}
+
+func TestMemoryCurateCommand_AdminCanListAndPreviewDrafts(t *testing.T) {
+	bot, soul := newMemoryCurateCommandTestBot(t, 101)
+	draft := saveMemoryCurateTestDraft(t, soul, "20260430-120000-abcdef", []curate.Candidate{
+		{
+			ID:         "c001",
+			Section:    curate.SectionDecision,
+			Text:       "decision: use Telegram for memory draft reviews",
+			Confidence: 0.91,
+			Sources: []curate.Source{{
+				Date: "2026-04-29",
+				Path: "memory/2026-04-29.md",
+				Line: 12,
+			}},
+		},
+		{
+			ID:         "c002",
+			Section:    curate.SectionStale,
+			Text:       "host is old-box",
+			Confidence: 0.75,
+			Sources: []curate.Source{{
+				Date: "2026-04-30",
+				Path: "memory/2026-04-30.md",
+				Line: 3,
+			}},
+			Conflicts: []string{"c003"},
+		},
+	})
+
+	listCtx := newMemoryCurateCommandContext("list", 101, "admin")
+	if err := bot.handleMemoryCurateCommand(listCtx); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	assertSentContains(t, listCtx, draft.ID)
+	assertSentContains(t, listCtx, string(curate.StatusPending))
+
+	previewCtx := newMemoryCurateCommandContext("preview "+draft.ID, 101, "admin")
+	if err := bot.handleMemoryCurateCommand(previewCtx); err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	assertSentContains(t, previewCtx, "Source dates: 2026-04-28 -> 2026-04-30")
+	assertSentContains(t, previewCtx, "decision: use Telegram for memory draft reviews")
+	assertSentContains(t, previewCtx, "source dates: 2026-04-29")
+	assertSentContains(t, previewCtx, "risk: conflicts with c003")
+	assertSentContains(t, previewCtx, "Audit findings:")
+	assertSentContains(t, previewCtx, "conflicting values")
+}
+
+func TestMemoryCurateCommand_NonAdminCannotListOrReadDrafts(t *testing.T) {
+	bot, soul := newMemoryCurateCommandTestBot(t, 101)
+	draft := saveMemoryCurateTestDraft(t, soul, "20260430-120000-abcdef", []curate.Candidate{
+		{
+			ID:         "c001",
+			Section:    curate.SectionPreference,
+			Text:       "preference: keep this private",
+			Confidence: 0.9,
+			Sources:    []curate.Source{{Date: "2026-04-29", Path: "memory/2026-04-29.md"}},
+		},
+	})
+
+	for _, payload := range []string{"list", "preview " + draft.ID} {
+		t.Run(payload, func(t *testing.T) {
+			ctx := newMemoryCurateCommandContext(payload, 202, "notadmin")
+			if err := bot.handleMemoryCurateCommand(ctx); err != nil {
+				t.Fatalf("handleMemoryCurateCommand: %v", err)
+			}
+			assertSentContains(t, ctx, "admin-only")
+			if strings.Contains(strings.Join(ctx.sent, "\n"), "keep this private") {
+				t.Fatalf("non-admin response leaked draft content: %#v", ctx.sent)
+			}
+		})
+	}
+}
+
+func TestMemoryCurateCommand_InvalidDraftID(t *testing.T) {
+	bot, _ := newMemoryCurateCommandTestBot(t, 101)
+
+	ctx := newMemoryCurateCommandContext("preview ../../MEMORY.md", 101, "admin")
+	if err := bot.handleMemoryCurateCommand(ctx); err != nil {
+		t.Fatalf("handleMemoryCurateCommand: %v", err)
+	}
+	assertSentContains(t, ctx, "invalid draft id")
+}
+
+func TestMemoryCurateCommand_ApproveRequiresConfirmationAndAuditPass(t *testing.T) {
+	bot, soul := newMemoryCurateCommandTestBot(t, 101)
+	draft := saveMemoryCurateTestDraft(t, soul, "20260430-120000-abcdef", []curate.Candidate{
+		{
+			ID:         "c001",
+			Section:    curate.SectionDecision,
+			Text:       "decision: retain the Telegram review flow",
+			Confidence: 0.9,
+			Sources:    []curate.Source{{Date: "2026-04-29", Path: "memory/2026-04-29.md"}},
+		},
+	})
+
+	missingYesCtx := newMemoryCurateCommandContext("approve "+draft.ID, 101, "admin")
+	if err := bot.handleMemoryCurateCommand(missingYesCtx); err != nil {
+		t.Fatalf("approve without yes: %v", err)
+	}
+	assertSentContains(t, missingYesCtx, "literal `yes`")
+	if _, err := os.Stat(filepath.Join(soul, "MEMORY.md")); !os.IsNotExist(err) {
+		t.Fatalf("MEMORY.md should not exist without confirmation: %v", err)
+	}
+
+	blocked := saveMemoryCurateTestDraft(t, soul, "20260430-120100-fedcba", []curate.Candidate{
+		{
+			ID:         "c001",
+			Section:    curate.SectionInfra,
+			Text:       "infra: api_key = should-not-be-promoted",
+			Confidence: 0.9,
+			Sources:    []curate.Source{{Date: "2026-04-30", Path: "memory/2026-04-30.md"}},
+		},
+	})
+	blockedCtx := newMemoryCurateCommandContext("approve "+blocked.ID+" yes", 101, "admin")
+	if err := bot.handleMemoryCurateCommand(blockedCtx); err != nil {
+		t.Fatalf("approve audit-blocked draft: %v", err)
+	}
+	assertSentContains(t, blockedCtx, "Apply blocked by audit")
+	if _, err := os.Stat(filepath.Join(soul, "MEMORY.md")); !os.IsNotExist(err) {
+		t.Fatalf("MEMORY.md should not exist when audit blocks apply: %v", err)
+	}
+
+	approvedCtx := newMemoryCurateCommandContext("approve "+draft.ID+" yes", 101, "admin")
+	if err := bot.handleMemoryCurateCommand(approvedCtx); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	assertSentContains(t, approvedCtx, "Applied draft")
+	memoryBytes, err := os.ReadFile(filepath.Join(soul, "MEMORY.md"))
+	if err != nil {
+		t.Fatalf("read MEMORY.md: %v", err)
+	}
+	if !strings.Contains(string(memoryBytes), draft.ID) {
+		t.Fatalf("MEMORY.md missing applied draft id %s:\n%s", draft.ID, memoryBytes)
+	}
+}
+
+func TestMemoryCurateCommand_RejectAndDeleteAreAuditableAndDeleteRequiresConfirmation(t *testing.T) {
+	bot, soul := newMemoryCurateCommandTestBot(t, 101)
+	draft := saveMemoryCurateTestDraft(t, soul, "20260430-120000-abcdef", []curate.Candidate{
+		{
+			ID:         "c001",
+			Section:    curate.SectionMisc,
+			Text:       "misc: candidate to reject",
+			Confidence: 0.6,
+			Sources:    []curate.Source{{Date: "2026-04-29", Path: "memory/2026-04-29.md"}},
+		},
+	})
+	store := curate.NewDraftStore(soul)
+
+	rejectCtx := newMemoryCurateCommandContext("reject "+draft.ID+" not durable", 101, "admin")
+	rejectLogs := captureLogs(t, func() {
+		if err := bot.handleMemoryCurateCommand(rejectCtx); err != nil {
+			t.Fatalf("reject: %v", err)
+		}
+	})
+	assertSentContains(t, rejectCtx, "rejected")
+	if !strings.Contains(rejectLogs, "[AUDIT] memory_curate") || !strings.Contains(rejectLogs, `"action":"reject"`) {
+		t.Fatalf("reject audit log missing action: %q", rejectLogs)
+	}
+	loaded, err := store.Load(draft.ID)
+	if err != nil {
+		t.Fatalf("load rejected draft: %v", err)
+	}
+	if loaded.Status != curate.StatusRejected {
+		t.Fatalf("status = %s, want rejected", loaded.Status)
+	}
+	if !strings.Contains(loaded.Notes, "rejected by @admin: not durable") {
+		t.Fatalf("reject notes missing reviewer label: %q", loaded.Notes)
+	}
+
+	missingYesCtx := newMemoryCurateCommandContext("delete "+draft.ID, 101, "admin")
+	if err := bot.handleMemoryCurateCommand(missingYesCtx); err != nil {
+		t.Fatalf("delete without yes: %v", err)
+	}
+	assertSentContains(t, missingYesCtx, "literal `yes`")
+	if _, err := store.Load(draft.ID); err != nil {
+		t.Fatalf("draft should remain without delete confirmation: %v", err)
+	}
+
+	deleteCtx := newMemoryCurateCommandContext("delete "+draft.ID+" yes", 101, "admin")
+	deleteLogs := captureLogs(t, func() {
+		if err := bot.handleMemoryCurateCommand(deleteCtx); err != nil {
+			t.Fatalf("delete: %v", err)
+		}
+	})
+	assertSentContains(t, deleteCtx, "deleted")
+	if !strings.Contains(deleteLogs, "[AUDIT] memory_curate") || !strings.Contains(deleteLogs, `"action":"delete"`) {
+		t.Fatalf("delete audit log missing action: %q", deleteLogs)
+	}
+	if _, err := store.Load(draft.ID); err == nil {
+		t.Fatal("expected deleted draft to be gone")
+	}
+}
+
+func TestSplitTelegramChunksPreservesUTF8AndLimit(t *testing.T) {
+	body := strings.Repeat("a", 3499) + "🙂" + strings.Repeat("b", 50)
+	chunks := splitTelegramChunks(body, 3500)
+	if len(chunks) != 2 {
+		t.Fatalf("chunks = %d, want 2", len(chunks))
+	}
+	for i, chunk := range chunks {
+		if !utf8.ValidString(chunk) {
+			t.Fatalf("chunk %d is not valid UTF-8", i)
+		}
+		if got := len([]rune(chunk)); got > 3500 {
+			t.Fatalf("chunk %d has %d runes, want <= 3500", i, got)
+		}
+	}
+	if got := strings.Join(chunks, ""); got != body {
+		t.Fatalf("chunks did not preserve body")
+	}
+}
+
+func newMemoryCurateCommandTestBot(t *testing.T, adminID int64) (*Bot, string) {
+	t.Helper()
+	soul := t.TempDir()
+	bot := &Bot{
+		memory: agent.NewMemory(soul),
+		authManager: &AuthManager{
+			config: config.AuthConfig{AdminID: adminID},
+		},
+	}
+	return bot, soul
+}
+
+func newMemoryCurateCommandContext(payload string, senderID int64, username string) *fakeContext {
+	return &fakeContext{
+		msg: &telebot.Message{
+			Payload: payload,
+			Chat:    &telebot.Chat{ID: senderID, Type: telebot.ChatPrivate},
+			Sender:  &telebot.User{ID: senderID, Username: username},
+		},
+	}
+}
+
+func saveMemoryCurateTestDraft(t *testing.T, soul, id string, candidates []curate.Candidate) *curate.Draft {
+	t.Helper()
+	draft := &curate.Draft{
+		ID:          id,
+		CreatedAt:   time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC),
+		Since:       "2026-04-28",
+		Until:       "2026-04-30",
+		SourceCount: 2,
+		Candidates:  candidates,
+		Status:      curate.StatusPending,
+	}
+	if err := curate.NewDraftStore(soul).Save(draft); err != nil {
+		t.Fatalf("save draft: %v", err)
+	}
+	return draft
+}
+
+func assertSentContains(t *testing.T, ctx *fakeContext, want string) {
+	t.Helper()
+	got := strings.Join(ctx.sent, "\n")
+	if !strings.Contains(got, want) {
+		t.Fatalf("sent response missing %q:\n%s", want, got)
 	}
 }

--- a/internal/bot/memory_curate_test.go
+++ b/internal/bot/memory_curate_test.go
@@ -254,6 +254,39 @@ func TestMemoryCurateCommand_RejectAndDeleteAreAuditableAndDeleteRequiresConfirm
 	}
 }
 
+func TestMemoryCurateCommand_DeleteRemovesCorruptDraft(t *testing.T) {
+	bot, soul := newMemoryCurateCommandTestBot(t, 101)
+	draftID := "20260430-120200-badbad"
+	draftsDir := filepath.Join(soul, "memory", "drafts")
+	if err := os.MkdirAll(draftsDir, 0o755); err != nil {
+		t.Fatalf("create drafts dir: %v", err)
+	}
+	jsonPath := filepath.Join(draftsDir, draftID+".json")
+	markdownPath := filepath.Join(draftsDir, draftID+".md")
+	if err := os.WriteFile(jsonPath, []byte("{"), 0o644); err != nil {
+		t.Fatalf("write corrupt draft json: %v", err)
+	}
+	if err := os.WriteFile(markdownPath, []byte("corrupt draft"), 0o644); err != nil {
+		t.Fatalf("write draft markdown: %v", err)
+	}
+
+	deleteCtx := newMemoryCurateCommandContext("delete "+draftID+" yes", 101, "admin")
+	deleteLogs := captureLogs(t, func() {
+		if err := bot.handleMemoryCurateCommand(deleteCtx); err != nil {
+			t.Fatalf("delete corrupt draft: %v", err)
+		}
+	})
+	assertSentContains(t, deleteCtx, "deleted")
+	if !strings.Contains(deleteLogs, "[AUDIT] memory_curate") || !strings.Contains(deleteLogs, `"status":"unknown"`) {
+		t.Fatalf("delete audit log missing unknown status: %q", deleteLogs)
+	}
+	for _, path := range []string{jsonPath, markdownPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("draft artifact should be deleted at %s: %v", path, err)
+		}
+	}
+}
+
 func TestSplitTelegramChunksPreservesUTF8AndLimit(t *testing.T) {
 	body := strings.Repeat("a", 3499) + "🙂" + strings.Repeat("b", 50)
 	chunks := splitTelegramChunks(body, 3500)
@@ -268,8 +301,9 @@ func TestSplitTelegramChunksPreservesUTF8AndLimit(t *testing.T) {
 			t.Fatalf("chunk %d has %d runes, want <= 3500", i, got)
 		}
 	}
+	// This input has no newlines, so boundary newline trimming should not alter it.
 	if got := strings.Join(chunks, ""); got != body {
-		t.Fatalf("chunks did not preserve body")
+		t.Fatalf("chunks did not preserve newline-free body")
 	}
 }
 

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -132,8 +132,24 @@ func TestJobServiceCancelMarksCancelled(t *testing.T) {
 	}
 
 	events := waitForJobEvents(t, store, job.JobID, 4)
-	if events[len(events)-2].EventType != string(JobEventCancelRequested) {
-		t.Fatalf("expected penultimate event cancel_requested, got %+v", events)
+	cancelRequestedIndex := -1
+	cancelledIndex := -1
+	for i, event := range events {
+		switch event.EventType {
+		case string(JobEventCancelRequested):
+			cancelRequestedIndex = i
+		case string(JobEventCancelled):
+			cancelledIndex = i
+		}
+	}
+	if cancelRequestedIndex == -1 {
+		t.Fatalf("expected cancel_requested event, got %+v", events)
+	}
+	if cancelledIndex == -1 {
+		t.Fatalf("expected cancelled event, got %+v", events)
+	}
+	if cancelRequestedIndex > cancelledIndex {
+		t.Fatalf("expected cancel_requested before cancelled, got %+v", events)
 	}
 	if events[len(events)-1].EventType != string(JobEventCancelled) {
 		t.Fatalf("expected final event cancelled, got %+v", events)


### PR DESCRIPTION
Implements #330

## Changes
- Adds admin-only Telegram review subcommands for listing, previewing, approving, rejecting, and deleting memory curation drafts.
- Adds concise draft previews with candidate source dates, conflict risk, audit findings, and UTF-8-safe Telegram chunking.
- Requires explicit `yes` confirmation for approving durable memory writes and deleting draft files, and emits audit logs for apply/reject/delete actions.
- Registers `/memory_curate` in Telegram command/help surfaces and covers routing, admin checks, invalid IDs, confirmation, audit blocking, and chunking in tests.

## Testing
- `.maestro/verify.sh` passed
- `git fetch origin` passed
- `git rebase origin/main` passed
- `go fmt ./...` passed
- `go vet ./...` passed
- `go test ./...` passed
- `go build ./cmd/ok-gobot/` passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an admin-only `/memory_curate` Telegram workflow for listing, previewing, approving, rejecting, and deleting memory curation drafts, with JSON audit logging, rune-safe message chunking, and explicit `yes` confirmation guards on destructive actions. Also tightens a flaky job-cancellation test in `jobs_test.go` that was sensitive to event ordering.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no new P0/P1 logic issues found; all existing concerns are already tracked in prior review threads.

All changed code paths are guarded by admin checks, explicit confirmation tokens, and internal store-level ID validation (`ValidateDraftID` is called inside `Load`/`Delete`/`Save`). The only open concern — inconsistent handler-layer `ValidateDraftID` calls — was flagged in a prior review comment and is a P2 consistency point, not a real security hole. Test coverage is thorough.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/bot/memory_curate.go | Core implementation of memory curation review workflow — adds admin gate, `preview`/`approve` aliases, confirmation requirements for delete, audit logging, rune-safe chunking, and a rich preview renderer; logic is sound. |
| internal/bot/memory_curate_test.go | Adds comprehensive handler tests covering admin gate, invalid IDs, confirmation guards, audit log output, corrupt-draft deletion, and UTF-8 chunk splitting; coverage is thorough. |
| internal/bot/bot.go | Registers `/memory_curate` in command list and help text; trivial, correct change. |
| internal/runtime/jobs_test.go | Fixes a flaky assertion that assumed `cancel_requested` was always the penultimate event; replaced with a positional search that only requires ordering, not exact index. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/bot/memory_curate.go`, line 146-165 ([link](https://github.com/befeast/ok-gobot/blob/c70d911d7a009c4fe84bf1deaace1af1c8c07e0e/internal/bot/memory_curate.go#L146-L165)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing explicit `ValidateDraftID` in `reject` handler**

   The `preview` case calls `curate.ValidateDraftID(args[1])` before touching the store, providing a uniform "invalid draft id" error at the handler layer. The `reject` case skips that check and passes the raw `args[1]` directly to `store.SetStatus`. The store does validate internally (via `Load`), so there is no path-traversal risk, but the defensive pattern is inconsistent and makes the code harder to audit. Adding the same guard here (and in `apply`/`approve`) would make every mutating subcommand consistently reject invalid IDs at the handler boundary.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/bot/memory_curate.go
   Line: 146-165

   Comment:
   **Missing explicit `ValidateDraftID` in `reject` handler**

   The `preview` case calls `curate.ValidateDraftID(args[1])` before touching the store, providing a uniform "invalid draft id" error at the handler layer. The `reject` case skips that check and passes the raw `args[1]` directly to `store.SetStatus`. The store does validate internally (via `Load`), so there is no path-traversal risk, but the defensive pattern is inconsistent and makes the code harder to audit. Adding the same guard here (and in `apply`/`approve`) would make every mutating subcommand consistently reject invalid IDs at the handler boundary.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(runtime): stabilize cancel event ass..."](https://github.com/befeast/ok-gobot/commit/099b445b3433fc7c1bc3a8e69dcc46abff7f4249) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30355498)</sub>

<!-- /greptile_comment -->