### PR TITLE
feat: add Mission Control proof artifact gallery (#331)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -267,9 +267,45 @@ List durable background jobs.
 
 ### GET /api/jobs/{id}
 
-Get job detail with events and artifacts.
+Get job detail with events and display-safe artifacts.
 
 **Requires authentication**
+
+Artifact objects include stable presentation fields for Mission Control and API
+clients:
+
+```json
+{
+  "id": 12,
+  "job_id": "job_abc",
+  "type": "screenshot",
+  "label": "Home page proof",
+  "mime_type": "image/png",
+  "path": "/home/user/.ok-gobot/screenshots/proof.png",
+  "created_at": "2026-04-30T10:00:00Z",
+  "display": {
+    "kind": "image",
+    "safe": true,
+    "preview": true,
+    "href": "/api/artifacts/12/content"
+  }
+}
+```
+
+Supported `display.kind` values include `image`, `url`, `text_report`, and
+`artifact`. Local file paths are only exposed when they are inside configured
+artifact roots. Unsafe local paths are redacted and returned with
+`display.safe=false` and a reason.
+
+### GET /api/artifacts/{id}/content
+
+Serve a local artifact file for read-only previews.
+
+**Requires authentication**
+
+Only files under configured artifact roots are served. The built-in roots are
+`~/.ok-gobot/screenshots` and `~/.ok-gobot/artifacts`; operators can add roots
+with `artifacts.roots` in config or `OK_GOBOT_ARTIFACT_ROOTS`.
 
 ### POST /api/jobs/{id}/cancel
 
@@ -348,7 +384,7 @@ Job records, events, and artifacts are stored in SQLite and retained indefinitel
 
 - **Jobs**: Persisted in the `jobs` table with full lifecycle metadata including role name, model/tier, tool call count, and duration.
 - **Job events**: Stored in the `job_events` table (up to 200 per job in API responses).
-- **Job artifacts**: Stored in the `job_artifacts` table with content, URIs, and metadata.
+- **Job artifacts**: Stored in the `job_artifacts` table with content, URIs, and metadata. API responses redact unsafe local paths outside artifact roots.
 - **Sessions**: Stored in `sessions_v2` with token accounting and message history.
 
 There is currently no automatic TTL or pruning. Operators who need to manage storage size can:

--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -8,7 +8,7 @@ The goal is not a full dashboard product. It is the minimum monitoring surface a
 
 ## Current State (April 2026)
 
-The Mission Control API exists on the authenticated HTTP API server. A dashboard UI is planned but not yet built.
+The Mission Control API exists on the authenticated HTTP API server. The local web UI provides a read-only jobs/workers view over the loopback control server.
 
 ### API Endpoints
 
@@ -30,6 +30,11 @@ api:
 | `/api/mission/providers` | GET | Active AI provider and model |
 | `/api/mission/memory` | GET | Memory health: enabled state, backend, watcher, counts, freshness, and last error |
 
+Job detail responses from `/api/jobs/{id}` include proof artifacts with `type`,
+`label`, `path` or `url`, `created_at`, and `display` metadata. Mission Control
+renders image/screenshot artifacts, URL artifacts, and inline text reports when
+they are present.
+
 Run query parameters: `limit` (1-200), `status` (filter by run status). Stats query parameters: `days` (1-90).
 
 ### What It Monitors
@@ -37,6 +42,7 @@ Run query parameters: `limit` (1-200), `status` (filter by run status). Stats qu
 - **Profiles** -- which agent profiles are loaded and what tools/models they use
 - **Schedules** -- when each role is next due to run
 - **Runs** -- whether recent job runs succeeded or failed, with summaries
+- **Proof artifacts** -- screenshots, URLs, and text reports linked from job and worker rows
 - **Stats** -- aggregate token usage and message counts
 - **Controls** -- emergency-stop state and active provider/model
 - **Memory** -- whether the memory index is enabled, fresh, watched, and error-free
@@ -66,7 +72,19 @@ Mission Control is a read-only API layer over existing runtime data. It does not
 
 ## Safety Notes
 
-Mission Control is read-only today. It does not modify roles, start jobs, or change configuration.
+Mission Control artifact browsing is read-only. It does not modify roles, start jobs, or change configuration.
+
+Local file previews are restricted to artifact roots. Defaults are
+`~/.ok-gobot/screenshots` and `~/.ok-gobot/artifacts`; add more with:
+
+```yaml
+artifacts:
+  roots:
+    - "~/proof-artifacts"
+```
+
+Paths outside these roots are redacted from API responses and are not served by
+the artifact preview endpoint.
 
 Scheduled roles execute with whatever tools and capabilities their manifest declares. Operators should:
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3,9 +3,11 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
+	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/runtime"
 )
 
@@ -95,17 +97,74 @@ func (s *APIServer) handleJobDetail(w http.ResponseWriter, jobID string) {
 		return
 	}
 
-	artifacts, err := s.data.GetJobArtifacts(jobID, 100)
+	artifactRows, err := s.data.GetJobArtifacts(jobID, 100)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	serializer := artifactview.NewSerializer(s.artifactRoots(), "/api/artifacts")
 
 	writeJSON(w, map[string]interface{}{
 		"job":       job,
 		"events":    events,
-		"artifacts": artifacts,
+		"artifacts": serializer.SerializeAll(artifactRows),
 	})
+}
+
+// handleArtifactContent serves safe local artifact files for read-only previews.
+func (s *APIServer) handleArtifactContent(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.data == nil {
+		writeJSONError(w, "Data provider not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	artifactID, ok := parseArtifactContentPath(r.URL.Path, "/api/artifacts/")
+	if !ok {
+		writeJSONError(w, "artifact ID is required", http.StatusBadRequest)
+		return
+	}
+
+	artifact, err := s.data.GetJobArtifact(artifactID)
+	if err != nil {
+		writeJSONError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if artifact == nil {
+		writeJSONError(w, "artifact not found", http.StatusNotFound)
+		return
+	}
+
+	path, err := artifactview.ContentPath(*artifact, s.artifactRoots())
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeJSONError(w, "artifact file not found", http.StatusNotFound)
+			return
+		}
+		writeJSONError(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	if artifact.MimeType != "" {
+		w.Header().Set("Content-Type", artifact.MimeType)
+	}
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	http.ServeFile(w, r, path)
+}
+
+func parseArtifactContentPath(path, prefix string) (int64, bool) {
+	trimmed := strings.TrimPrefix(path, prefix)
+	if trimmed == path || !strings.HasSuffix(trimmed, "/content") {
+		return 0, false
+	}
+	idPart := strings.TrimSuffix(trimmed, "/content")
+	if idPart == "" || strings.Contains(idPart, "/") {
+		return 0, false
+	}
+	id, err := strconv.ParseInt(idPart, 10, 64)
+	return id, err == nil && id > 0
 }
 
 // handleJobCancel requests cancellation of a background job.

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -46,6 +48,16 @@ func (m *mockDataProvider) GetJobEvents(jobID string, limit int) ([]storage.JobE
 
 func (m *mockDataProvider) GetJobArtifacts(jobID string, limit int) ([]storage.JobArtifact, error) {
 	return m.artifacts, nil
+}
+
+func (m *mockDataProvider) GetJobArtifact(artifactID int64) (*storage.JobArtifact, error) {
+	for _, artifact := range m.artifacts {
+		if artifact.ID == artifactID {
+			copy := artifact
+			return &copy, nil
+		}
+	}
+	return nil, nil
 }
 
 func (m *mockDataProvider) CancelJob(jobID string) error {
@@ -168,6 +180,139 @@ func TestHandleJobDetail(t *testing.T) {
 	}
 	if result["events"] == nil {
 		t.Error("Expected events in response")
+	}
+}
+
+func TestHandleJobDetailSerializesSafeArtifacts(t *testing.T) {
+	root := t.TempDir()
+	screenshotPath := filepath.Join(root, "proof.png")
+	if err := os.WriteFile(screenshotPath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write screenshot: %v", err)
+	}
+
+	dp := &mockDataProvider{
+		job: &storage.Job{JobID: "job-proof", Kind: "task", Status: "succeeded", Description: "proof job"},
+		artifacts: []storage.JobArtifact{
+			{ID: 1, JobID: "job-proof", Name: "Screenshot", ArtifactType: "screenshot", MimeType: "image/png", URI: screenshotPath, CreatedAt: "2026-04-30T10:00:00Z"},
+			{ID: 2, JobID: "job-proof", Name: "PR", ArtifactType: "url", URI: "https://github.com/BeFeast/ok-gobot/pull/331"},
+			{ID: 3, JobID: "job-proof", Name: "Report", ArtifactType: "text_report", MimeType: "text/markdown", Content: "tests passed"},
+		},
+	}
+	srv := newTestServer(dp)
+	srv.SetArtifactRoots([]string{root})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/jobs/job-proof", nil)
+	w := httptest.NewRecorder()
+	srv.handleJobByID(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d", w.Code)
+	}
+
+	var result struct {
+		Artifacts []struct {
+			Type    string `json:"type"`
+			Label   string `json:"label"`
+			Path    string `json:"path"`
+			URL     string `json:"url"`
+			Content string `json:"content"`
+			Display struct {
+				Kind string `json:"kind"`
+				Safe bool   `json:"safe"`
+				Href string `json:"href"`
+			} `json:"display"`
+		} `json:"artifacts"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+	if len(result.Artifacts) != 3 {
+		t.Fatalf("artifact count = %d, want 3", len(result.Artifacts))
+	}
+	if got := result.Artifacts[0]; got.Type != "screenshot" || got.Label != "Screenshot" || got.Path != screenshotPath || got.Display.Kind != "image" || !got.Display.Safe || got.Display.Href != "/api/artifacts/1/content" {
+		t.Fatalf("unexpected screenshot artifact: %+v", got)
+	}
+	if got := result.Artifacts[1]; got.URL == "" || got.Display.Kind != "url" || !got.Display.Safe {
+		t.Fatalf("unexpected URL artifact: %+v", got)
+	}
+	if got := result.Artifacts[2]; got.Content != "tests passed" || got.Display.Kind != "text_report" || !got.Display.Safe {
+		t.Fatalf("unexpected text report artifact: %+v", got)
+	}
+}
+
+func TestHandleJobDetailRedactsUnsafeArtifactPath(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.png")
+	if err := os.WriteFile(outside, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write outside artifact: %v", err)
+	}
+
+	dp := &mockDataProvider{
+		job:       &storage.Job{JobID: "job-proof", Kind: "task", Status: "succeeded", Description: "proof job"},
+		artifacts: []storage.JobArtifact{{ID: 9, JobID: "job-proof", Name: "Outside", ArtifactType: "screenshot", MimeType: "image/png", URI: outside}},
+	}
+	srv := newTestServer(dp)
+	srv.SetArtifactRoots([]string{root})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/jobs/job-proof", nil)
+	w := httptest.NewRecorder()
+	srv.handleJobByID(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d", w.Code)
+	}
+
+	var result struct {
+		Artifacts []struct {
+			Path    string `json:"path"`
+			URI     string `json:"uri"`
+			Display struct {
+				Safe   bool   `json:"safe"`
+				Reason string `json:"reason"`
+				Href   string `json:"href"`
+			} `json:"display"`
+		} `json:"artifacts"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+	if len(result.Artifacts) != 1 {
+		t.Fatalf("artifact count = %d, want 1", len(result.Artifacts))
+	}
+	artifact := result.Artifacts[0]
+	if artifact.Path != "" || artifact.URI != "" || artifact.Display.Href != "" || artifact.Display.Safe || artifact.Display.Reason == "" {
+		t.Fatalf("unsafe artifact path was exposed: %+v", artifact)
+	}
+}
+
+func TestHandleArtifactContentPathSafety(t *testing.T) {
+	root := t.TempDir()
+	safePath := filepath.Join(root, "proof.txt")
+	if err := os.WriteFile(safePath, []byte("safe proof"), 0o644); err != nil {
+		t.Fatalf("write safe artifact: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write outside artifact: %v", err)
+	}
+
+	dp := &mockDataProvider{artifacts: []storage.JobArtifact{
+		{ID: 1, JobID: "job-proof", Name: "safe", ArtifactType: "text_report", MimeType: "text/plain", URI: safePath},
+		{ID: 2, JobID: "job-proof", Name: "unsafe", ArtifactType: "text_report", MimeType: "text/plain", URI: outside},
+	}}
+	srv := newTestServer(dp)
+	srv.SetArtifactRoots([]string{root})
+
+	w := httptest.NewRecorder()
+	srv.handleArtifactContent(w, httptest.NewRequest(http.MethodGet, "/api/artifacts/1/content", nil))
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "safe proof") {
+		t.Fatalf("expected safe artifact content, code=%d body=%q", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	srv.handleArtifactContent(w, httptest.NewRequest(http.MethodGet, "/api/artifacts/2/content", nil))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected forbidden unsafe artifact content, got %d", w.Code)
 	}
 }
 

--- a/internal/api/mission.go
+++ b/internal/api/mission.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	"ok-gobot/internal/storage"
 )
 
 // handleMissionRoles returns all registered agent profiles.
@@ -156,6 +158,7 @@ func (s *APIServer) handleMissionRuns(w http.ResponseWriter, r *http.Request) {
 		RoleName      string `json:"role_name,omitempty"`
 		ModelTier     string `json:"model_tier,omitempty"`
 		ToolCallCount int    `json:"tool_call_count,omitempty"`
+		ArtifactCount int    `json:"artifact_count,omitempty"`
 		Attempt       int    `json:"attempt"`
 		MaxAttempts   int    `json:"max_attempts"`
 		CreatedAt     string `json:"created_at"`
@@ -179,6 +182,7 @@ func (s *APIServer) handleMissionRuns(w http.ResponseWriter, r *http.Request) {
 			RoleName:      job.RoleName,
 			ModelTier:     job.ModelTier,
 			ToolCallCount: job.ToolCallCount,
+			ArtifactCount: missionArtifactCount(store, job.JobID),
 			Attempt:       job.Attempt,
 			MaxAttempts:   job.MaxAttempts,
 			CreatedAt:     job.CreatedAt,
@@ -188,6 +192,16 @@ func (s *APIServer) handleMissionRuns(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, result)
+}
+
+func missionArtifactCount(store interface {
+	ListJobArtifacts(string, int) ([]storage.JobArtifact, error)
+}, jobID string) int {
+	artifacts, err := store.ListJobArtifacts(jobID, 100)
+	if err != nil {
+		return 0
+	}
+	return len(artifacts)
 }
 
 // handleMissionEstop returns the current emergency stop state.

--- a/internal/api/mission.go
+++ b/internal/api/mission.go
@@ -166,11 +166,19 @@ func (s *APIServer) handleMissionRuns(w http.ResponseWriter, r *http.Request) {
 		CompletedAt   string `json:"completed_at,omitempty"`
 	}
 
-	result := make([]runEntry, 0, len(jobs))
+	filteredJobs := make([]storage.Job, 0, len(jobs))
+	jobIDs := make([]string, 0, len(jobs))
 	for _, job := range jobs {
 		if statusFilter != "" && job.Status != statusFilter {
 			continue
 		}
+		filteredJobs = append(filteredJobs, job)
+		jobIDs = append(jobIDs, job.JobID)
+	}
+	artifactCounts := missionArtifactCounts(store, jobIDs)
+
+	result := make([]runEntry, 0, len(filteredJobs))
+	for _, job := range filteredJobs {
 		result = append(result, runEntry{
 			JobID:         job.JobID,
 			Kind:          job.Kind,
@@ -182,7 +190,7 @@ func (s *APIServer) handleMissionRuns(w http.ResponseWriter, r *http.Request) {
 			RoleName:      job.RoleName,
 			ModelTier:     job.ModelTier,
 			ToolCallCount: job.ToolCallCount,
-			ArtifactCount: missionArtifactCount(store, job.JobID),
+			ArtifactCount: artifactCounts[job.JobID],
 			Attempt:       job.Attempt,
 			MaxAttempts:   job.MaxAttempts,
 			CreatedAt:     job.CreatedAt,
@@ -194,14 +202,12 @@ func (s *APIServer) handleMissionRuns(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, result)
 }
 
-func missionArtifactCount(store interface {
-	ListJobArtifacts(string, int) ([]storage.JobArtifact, error)
-}, jobID string) int {
-	artifacts, err := store.ListJobArtifacts(jobID, 100)
+func missionArtifactCounts(store *storage.Store, jobIDs []string) map[string]int {
+	counts, err := store.CountJobArtifactsByJobIDs(jobIDs)
 	if err != nil {
-		return 0
+		return map[string]int{}
 	}
-	return len(artifacts)
+	return counts
 }
 
 // handleMissionEstop returns the current emergency stop state.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/bot"
 	"ok-gobot/internal/config"
 	"ok-gobot/internal/runtime"
@@ -21,6 +22,7 @@ type DataProvider interface {
 	GetJob(jobID string) (*storage.Job, error)
 	GetJobEvents(jobID string, limit int) ([]storage.JobEvent, error)
 	GetJobArtifacts(jobID string, limit int) ([]storage.JobArtifact, error)
+	GetJobArtifact(artifactID int64) (*storage.JobArtifact, error)
 	CancelJob(jobID string) error
 	WorkerSnapshots() []runtime.WorkerSnapshot
 }
@@ -32,6 +34,7 @@ type APIServer struct {
 	data   DataProvider
 	server *http.Server
 	uptime time.Time
+	roots  []string
 }
 
 // NewAPIServer creates a new API server instance
@@ -48,6 +51,18 @@ func (s *APIServer) SetDataProvider(dp DataProvider) {
 	s.data = dp
 }
 
+// SetArtifactRoots configures local roots that artifact file previews may read from.
+func (s *APIServer) SetArtifactRoots(roots []string) {
+	s.roots = artifactview.NormalizeRoots(roots)
+}
+
+func (s *APIServer) artifactRoots() []string {
+	if len(s.roots) > 0 {
+		return s.roots
+	}
+	return artifactview.DefaultRoots()
+}
+
 // Start initializes and starts the HTTP server
 func (s *APIServer) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
@@ -59,6 +74,7 @@ func (s *APIServer) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/webhook", s.handleWebhook)
 	mux.HandleFunc("/api/jobs", s.handleJobs)
 	mux.HandleFunc("/api/jobs/", s.handleJobByID)
+	mux.HandleFunc("/api/artifacts/", s.handleArtifactContent)
 	mux.HandleFunc("/api/workers", s.handleWorkers)
 	mux.HandleFunc("/api/route", s.handleRoute)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,6 +24,7 @@ import (
 	"ok-gobot/internal/role"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
+	"ok-gobot/internal/tools"
 )
 
 // App orchestrates all components
@@ -58,6 +59,18 @@ func (a *stateAdapter) GetStatus() map[string]interface{} {
 
 func (a *stateAdapter) GetMemoryStatus(ctx context.Context) (memory.IndexStatus, error) {
 	return a.b.GetMemoryStatus(ctx)
+}
+
+func (a *stateAdapter) GetStore() *storage.Store {
+	return a.b.GetStore()
+}
+
+func (a *stateAdapter) GetAgentRegistry() *agent.AgentRegistry {
+	return a.b.GetAgentRegistry()
+}
+
+func (a *stateAdapter) GetScheduler() tools.CronScheduler {
+	return a.b.GetScheduler()
 }
 
 func (a *stateAdapter) RespondToApproval(id string, approved bool) error {
@@ -100,6 +113,10 @@ func (d *dataProvider) GetJobEvents(jobID string, limit int) ([]storage.JobEvent
 
 func (d *dataProvider) GetJobArtifacts(jobID string, limit int) ([]storage.JobArtifact, error) {
 	return d.store.ListJobArtifacts(jobID, limit)
+}
+
+func (d *dataProvider) GetJobArtifact(artifactID int64) (*storage.JobArtifact, error) {
+	return d.store.GetJobArtifact(artifactID)
 }
 
 func (d *dataProvider) CancelJob(jobID string) error {
@@ -434,6 +451,7 @@ func (a *App) Start(ctx context.Context) error {
 		log.Printf("🌐 Initializing API server on port %d...", a.config.API.Port)
 		a.apiServer = api.NewAPIServer(a.config.API, a.bot)
 		a.apiServer.SetDataProvider(&dataProvider{store: a.store, bot: a.bot})
+		a.apiServer.SetArtifactRoots(a.config.Artifacts.Roots)
 
 		// Start API server in goroutine
 		go func() {
@@ -454,6 +472,7 @@ func (a *App) Start(ctx context.Context) error {
 		adapter := &stateAdapter{b: a.bot}
 		a.controlServer = control.New(ctrlCfg, adapter)
 		a.controlServer.SetStore(a.store)
+		a.controlServer.SetArtifactRoots(a.config.Artifacts.Roots)
 		a.bot.SetControlHub(a.controlServer.Hub())
 		go func() {
 			if err := a.controlServer.Start(ctx); err != nil {

--- a/internal/artifacts/display.go
+++ b/internal/artifacts/display.go
@@ -1,0 +1,360 @@
+package artifacts
+
+import (
+	"fmt"
+	"mime"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"ok-gobot/internal/storage"
+)
+
+const (
+	KindArtifact   = "artifact"
+	KindImage      = "image"
+	KindTextReport = "text_report"
+	KindURL        = "url"
+)
+
+// Info is the API-safe representation of a persisted job artifact.
+type Info struct {
+	ID           int64           `json:"id"`
+	JobID        string          `json:"job_id"`
+	Type         string          `json:"type"`
+	ArtifactType string          `json:"artifact_type,omitempty"`
+	Label        string          `json:"label"`
+	Name         string          `json:"name,omitempty"`
+	MimeType     string          `json:"mime_type,omitempty"`
+	Content      string          `json:"content,omitempty"`
+	Path         string          `json:"path,omitempty"`
+	URL          string          `json:"url,omitempty"`
+	URI          string          `json:"uri,omitempty"`
+	CreatedAt    string          `json:"created_at"`
+	Display      DisplayMetadata `json:"display"`
+}
+
+// DisplayMetadata tells Mission Control how an artifact can be displayed
+// without trusting arbitrary persisted paths or URI schemes.
+type DisplayMetadata struct {
+	Kind    string `json:"kind"`
+	Safe    bool   `json:"safe"`
+	Preview bool   `json:"preview,omitempty"`
+	Inline  bool   `json:"inline,omitempty"`
+	Href    string `json:"href,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// Serializer converts persisted artifact rows into display-safe API objects.
+type Serializer struct {
+	Roots            []string
+	ContentURLPrefix string
+}
+
+// NewSerializer builds a serializer using the supplied artifact roots and URL
+// prefix for safe local artifact content. The prefix should not include a
+// trailing slash, for example "/api/artifacts".
+func NewSerializer(roots []string, contentURLPrefix string) Serializer {
+	return Serializer{
+		Roots:            NormalizeRoots(roots),
+		ContentURLPrefix: strings.TrimRight(strings.TrimSpace(contentURLPrefix), "/"),
+	}
+}
+
+// DefaultRoots returns the built-in artifact roots used when config does not
+// provide explicit roots. OK_GOBOT_ARTIFACT_ROOTS may add roots using the OS
+// path-list separator.
+func DefaultRoots() []string {
+	var roots []string
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		roots = append(roots,
+			filepath.Join(home, ".ok-gobot", "screenshots"),
+			filepath.Join(home, ".ok-gobot", "artifacts"),
+		)
+	}
+	if env := strings.TrimSpace(os.Getenv("OK_GOBOT_ARTIFACT_ROOTS")); env != "" {
+		roots = append(roots, filepath.SplitList(env)...)
+	}
+	return NormalizeRoots(roots)
+}
+
+// NormalizeRoots expands and canonicalizes artifact root paths.
+func NormalizeRoots(roots []string) []string {
+	seen := make(map[string]struct{}, len(roots))
+	out := make([]string, 0, len(roots))
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		path, err := canonicalPath(root)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		out = append(out, path)
+	}
+	return out
+}
+
+// Serialize converts one persisted artifact to a display-safe API object.
+func (s Serializer) Serialize(artifact storage.JobArtifact) Info {
+	if len(s.Roots) == 0 {
+		s.Roots = DefaultRoots()
+	}
+
+	kind := displayKind(artifact)
+	info := Info{
+		ID:           artifact.ID,
+		JobID:        artifact.JobID,
+		Type:         artifact.ArtifactType,
+		ArtifactType: artifact.ArtifactType,
+		Label:        artifact.Name,
+		Name:         artifact.Name,
+		MimeType:     artifact.MimeType,
+		Content:      artifact.Content,
+		CreatedAt:    artifact.CreatedAt,
+		Display: DisplayMetadata{
+			Kind: kind,
+			Safe: artifact.URI == "",
+		},
+	}
+
+	if info.Type == "" {
+		info.Type = KindArtifact
+	}
+	if info.Label == "" {
+		info.Label = info.Type
+	}
+
+	rawURI := strings.TrimSpace(artifact.URI)
+	switch {
+	case rawURI == "":
+		if artifact.Content != "" {
+			info.Display.Safe = true
+			info.Display.Inline = true
+		}
+	case isSafeRemoteURL(rawURI) || isSafeImageDataURL(rawURI):
+		info.URL = rawURI
+		info.URI = rawURI
+		info.Display.Safe = true
+		info.Display.Href = rawURI
+		if kind == KindArtifact {
+			info.Display.Kind = KindURL
+		}
+		info.Display.Preview = info.Display.Kind == KindImage || info.Display.Kind == KindURL
+	case isLocalURI(rawURI):
+		path, ok := SafeLocalPath(rawURI, s.Roots)
+		if !ok {
+			info.Display.Safe = false
+			info.Display.Reason = "local artifact is outside configured artifact roots"
+			break
+		}
+		info.Path = path
+		info.URI = path
+		info.Display.Safe = true
+		info.Display.Href = s.contentHref(artifact.ID)
+		info.Display.Preview = info.Display.Kind == KindImage
+		info.Display.Inline = info.Display.Kind == KindTextReport
+	default:
+		info.Display.Safe = false
+		info.Display.Reason = "unsupported artifact URI scheme"
+	}
+
+	if artifact.Content != "" && info.Display.Kind == KindTextReport && info.Display.Safe {
+		info.Display.Inline = true
+	}
+
+	return info
+}
+
+// SerializeAll converts persisted artifact rows to display-safe API objects.
+func (s Serializer) SerializeAll(rows []storage.JobArtifact) []Info {
+	if rows == nil {
+		return []Info{}
+	}
+	out := make([]Info, len(rows))
+	for i, row := range rows {
+		out[i] = s.Serialize(row)
+	}
+	return out
+}
+
+// SafeLocalPath returns a canonical local path only when rawURI points inside
+// one of the configured roots.
+func SafeLocalPath(rawURI string, roots []string) (string, bool) {
+	local, ok := localPathFromURI(rawURI)
+	if !ok {
+		return "", false
+	}
+	path, err := canonicalPath(local)
+	if err != nil {
+		return "", false
+	}
+	for _, root := range NormalizeRoots(roots) {
+		if pathInsideRoot(path, root) {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+// ContentPath returns the safe local file path for an artifact content endpoint.
+func ContentPath(artifact storage.JobArtifact, roots []string) (string, error) {
+	path, ok := SafeLocalPath(artifact.URI, roots)
+	if !ok {
+		return "", fmt.Errorf("artifact file is outside configured artifact roots")
+	}
+	stat, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if stat.IsDir() {
+		return "", fmt.Errorf("artifact path is a directory")
+	}
+	return path, nil
+}
+
+func (s Serializer) contentHref(id int64) string {
+	if s.ContentURLPrefix == "" || id <= 0 {
+		return ""
+	}
+	return s.ContentURLPrefix + "/" + strconv.FormatInt(id, 10) + "/content"
+}
+
+func displayKind(artifact storage.JobArtifact) string {
+	typeName := strings.ToLower(strings.TrimSpace(artifact.ArtifactType))
+	mimeType := strings.ToLower(strings.TrimSpace(artifact.MimeType))
+	uri := strings.ToLower(strings.TrimSpace(artifact.URI))
+	name := strings.ToLower(strings.TrimSpace(artifact.Name))
+
+	if isImageType(typeName, mimeType, uri, name) {
+		return KindImage
+	}
+	if typeName == KindTextReport || typeName == "report" || strings.Contains(typeName, "report") || strings.HasPrefix(mimeType, "text/") {
+		return KindTextReport
+	}
+	if artifact.Content != "" {
+		return KindTextReport
+	}
+	if isSafeRemoteURL(artifact.URI) {
+		return KindURL
+	}
+	return KindArtifact
+}
+
+func isImageType(typeName, mimeType, uri, name string) bool {
+	if typeName == "screenshot" || typeName == "image" || strings.HasPrefix(typeName, "image_") {
+		return true
+	}
+	if strings.HasPrefix(mimeType, "image/") {
+		return true
+	}
+	if isImagePath(uri) || isImagePath(name) {
+		return true
+	}
+	return false
+}
+
+func isImagePath(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext == "" {
+		return false
+	}
+	if mt := mime.TypeByExtension(ext); strings.HasPrefix(mt, "image/") {
+		return true
+	}
+	switch ext {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp":
+		return true
+	}
+	return false
+}
+
+func isSafeRemoteURL(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u == nil {
+		return false
+	}
+	scheme := strings.ToLower(u.Scheme)
+	return (scheme == "http" || scheme == "https") && u.Host != ""
+}
+
+func isSafeImageDataURL(raw string) bool {
+	lower := strings.ToLower(strings.TrimSpace(raw))
+	allowed := []string{
+		"data:image/png;base64,",
+		"data:image/jpeg;base64,",
+		"data:image/jpg;base64,",
+		"data:image/gif;base64,",
+		"data:image/webp;base64,",
+	}
+	for _, prefix := range allowed {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isLocalURI(raw string) bool {
+	_, ok := localPathFromURI(raw)
+	return ok
+}
+
+func localPathFromURI(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+	if strings.HasPrefix(raw, "~/") {
+		return raw, true
+	}
+	if filepath.IsAbs(raw) {
+		return raw, true
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u == nil {
+		return "", false
+	}
+	if strings.ToLower(u.Scheme) != "file" {
+		return "", false
+	}
+	if u.Host != "" && u.Host != "localhost" {
+		return "", false
+	}
+	return u.Path, u.Path != ""
+}
+
+func canonicalPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(home, path[2:])
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	if evaluated, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = filepath.Clean(evaluated)
+	}
+	return abs, nil
+}
+
+func pathInsideRoot(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}

--- a/internal/artifacts/display_test.go
+++ b/internal/artifacts/display_test.go
@@ -1,0 +1,102 @@
+package artifacts
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"ok-gobot/internal/storage"
+)
+
+func TestSerializerAllowsLocalImageInsideRoot(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "shot.png")
+	if err := os.WriteFile(path, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	info := NewSerializer([]string{root}, "/api/artifacts").Serialize(storage.JobArtifact{
+		ID:           42,
+		JobID:        "job-1",
+		Name:         "Home page",
+		ArtifactType: "screenshot",
+		MimeType:     "image/png",
+		URI:          path,
+		CreatedAt:    "2026-04-30T10:00:00Z",
+	})
+
+	if info.Type != "screenshot" || info.Label != "Home page" || info.Path != path || info.URI != path {
+		t.Fatalf("unexpected artifact info: %+v", info)
+	}
+	if info.Display.Kind != KindImage || !info.Display.Safe || !info.Display.Preview {
+		t.Fatalf("unexpected display metadata: %+v", info.Display)
+	}
+	if info.Display.Href != "/api/artifacts/42/content" {
+		t.Fatalf("Display.Href = %q", info.Display.Href)
+	}
+}
+
+func TestSerializerBlocksLocalPathOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.png")
+	if err := os.WriteFile(outside, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write outside artifact: %v", err)
+	}
+
+	info := NewSerializer([]string{root}, "/api/artifacts").Serialize(storage.JobArtifact{
+		ID:           7,
+		JobID:        "job-1",
+		Name:         "outside",
+		ArtifactType: "screenshot",
+		MimeType:     "image/png",
+		URI:          outside,
+	})
+
+	if info.Path != "" || info.URI != "" || info.Display.Href != "" {
+		t.Fatalf("unsafe local path was exposed: %+v", info)
+	}
+	if info.Display.Safe || info.Display.Reason == "" {
+		t.Fatalf("expected unsafe display metadata, got %+v", info.Display)
+	}
+}
+
+func TestSerializerBlocksSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.png")
+	if err := os.WriteFile(outside, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write outside artifact: %v", err)
+	}
+	link := filepath.Join(root, "link.png")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	if path, ok := SafeLocalPath(link, []string{root}); ok {
+		t.Fatalf("symlink escape resolved as safe: %s", path)
+	}
+}
+
+func TestSerializerClassifiesURLAndTextReport(t *testing.T) {
+	serializer := NewSerializer([]string{t.TempDir()}, "/api/artifacts")
+
+	urlInfo := serializer.Serialize(storage.JobArtifact{
+		ID:           1,
+		Name:         "Pull request",
+		ArtifactType: "url",
+		URI:          "https://github.com/BeFeast/ok-gobot/pull/1",
+	})
+	if urlInfo.URL == "" || urlInfo.Display.Kind != KindURL || !urlInfo.Display.Safe || urlInfo.Display.Href != urlInfo.URL {
+		t.Fatalf("unexpected URL artifact info: %+v", urlInfo)
+	}
+
+	reportInfo := serializer.Serialize(storage.JobArtifact{
+		ID:           2,
+		Name:         "Verification",
+		ArtifactType: "text_report",
+		MimeType:     "text/markdown",
+		Content:      "tests passed",
+	})
+	if reportInfo.Display.Kind != KindTextReport || !reportInfo.Display.Safe || !reportInfo.Display.Inline || reportInfo.Content != "tests passed" {
+		t.Fatalf("unexpected text report artifact info: %+v", reportInfo)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,11 @@ type BrowserConfig struct {
 	DebugURL    string `mapstructure:"debug_url"`    // connect to existing browser (e.g. http://127.0.0.1:9222)
 }
 
+// ArtifactConfig holds local proof artifact display settings.
+type ArtifactConfig struct {
+	Roots []string `mapstructure:"roots"` // Local roots safe for Mission Control/API artifact previews
+}
+
 // SessionConfig holds session-key derivation behavior.
 type SessionConfig struct {
 	// DMScope controls how DM session keys are created:
@@ -111,6 +116,7 @@ type Config struct {
 	API          APIConfig         `mapstructure:"api"`
 	Control      ControlConfig     `mapstructure:"control"`
 	Browser      BrowserConfig     `mapstructure:"browser"`
+	Artifacts    ArtifactConfig    `mapstructure:"artifacts"`
 	Runtime      RuntimeConfig     `mapstructure:"runtime"`
 	Session      SessionConfig     `mapstructure:"session"`
 	Groups       GroupsConfig      `mapstructure:"groups"`
@@ -389,6 +395,7 @@ func Load() (*Config, error) {
 	v.SetDefault("api.bind_addr", "127.0.0.1")
 	v.SetDefault("api.api_key", "")
 	v.SetDefault("api.webhook_chat", int64(0))
+	v.SetDefault("artifacts.roots", []string{})
 	v.SetDefault("tts.provider", "openai")
 	v.SetDefault("tts.default_voice", "")
 	v.SetDefault("stt.base_url", "")
@@ -483,6 +490,7 @@ func Load() (*Config, error) {
 	cfg.StoragePath = expandPath(cfg.StoragePath)
 	cfg.SoulPath = expandPath(cfg.SoulPath)
 	cfg.RolesPath = expandPath(cfg.RolesPath)
+	cfg.Artifacts.Roots = expandPaths(cfg.Artifacts.Roots)
 	cfg.Memory.ExtraPaths = expandMemoryExtraPaths(cfg.Memory.ExtraPaths)
 	cfg.Evolution.BenchmarksDir = expandPath(cfg.Evolution.BenchmarksDir)
 	cfg.Evolution.EvolutionDir = expandPath(cfg.Evolution.EvolutionDir)
@@ -525,6 +533,7 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("api.bind_addr", "127.0.0.1")
 	v.SetDefault("api.api_key", "")
 	v.SetDefault("api.webhook_chat", int64(0))
+	v.SetDefault("artifacts.roots", []string{})
 	v.SetDefault("tts.provider", "openai")
 	v.SetDefault("tts.default_voice", "")
 	v.SetDefault("stt.base_url", "")
@@ -600,6 +609,7 @@ func LoadFrom(configPath string) (*Config, error) {
 	cfg.StoragePath = expandPath(cfg.StoragePath)
 	cfg.SoulPath = expandPath(cfg.SoulPath)
 	cfg.RolesPath = expandPath(cfg.RolesPath)
+	cfg.Artifacts.Roots = expandPaths(cfg.Artifacts.Roots)
 	cfg.Memory.ExtraPaths = expandMemoryExtraPaths(cfg.Memory.ExtraPaths)
 	cfg.Evolution.BenchmarksDir = expandPath(cfg.Evolution.BenchmarksDir)
 	cfg.Evolution.EvolutionDir = expandPath(cfg.Evolution.EvolutionDir)
@@ -770,6 +780,7 @@ func (c *Config) Save() error {
 	v.Set("api.bind_addr", c.API.BindAddr)
 	v.Set("api.api_key", c.API.APIKey)
 	v.Set("api.webhook_chat", c.API.WebhookChat)
+	v.Set("artifacts.roots", c.Artifacts.Roots)
 	v.Set("tts.provider", c.TTS.Provider)
 	v.Set("tts.default_voice", c.TTS.DefaultVoice)
 	v.Set("memory.enabled", c.Memory.Enabled)
@@ -860,6 +871,17 @@ func expandPath(path string) string {
 		return filepath.Join(homeDir, path[2:])
 	}
 	return path
+}
+
+func expandPaths(paths []string) []string {
+	if paths == nil {
+		return nil
+	}
+	out := make([]string, len(paths))
+	for i, path := range paths {
+		out[i] = expandPath(path)
+	}
+	return out
 }
 
 func expandMemoryExtraPaths(paths []MemoryExtraPathConfig) []MemoryExtraPathConfig {

--- a/internal/control/mission.go
+++ b/internal/control/mission.go
@@ -208,11 +208,19 @@ func missionRuns(mp MissionProvider) http.HandlerFunc {
 			CompletedAt   string `json:"completed_at,omitempty"`
 		}
 
-		result := make([]runEntry, 0, len(jobs))
+		filteredJobs := make([]storage.Job, 0, len(jobs))
+		jobIDs := make([]string, 0, len(jobs))
 		for _, job := range jobs {
 			if statusFilter != "" && job.Status != statusFilter {
 				continue
 			}
+			filteredJobs = append(filteredJobs, job)
+			jobIDs = append(jobIDs, job.JobID)
+		}
+		artifactCounts := missionArtifactCounts(store, jobIDs)
+
+		result := make([]runEntry, 0, len(filteredJobs))
+		for _, job := range filteredJobs {
 			result = append(result, runEntry{
 				JobID:         job.JobID,
 				Kind:          job.Kind,
@@ -224,7 +232,7 @@ func missionRuns(mp MissionProvider) http.HandlerFunc {
 				RoleName:      job.RoleName,
 				ModelTier:     job.ModelTier,
 				ToolCallCount: job.ToolCallCount,
-				ArtifactCount: countMissionArtifacts(store, job.JobID),
+				ArtifactCount: artifactCounts[job.JobID],
 				Attempt:       job.Attempt,
 				MaxAttempts:   job.MaxAttempts,
 				CreatedAt:     job.CreatedAt,
@@ -295,12 +303,12 @@ func parseMissionArtifactContentPath(path string) (int64, bool) {
 	return id, err == nil && id > 0
 }
 
-func countMissionArtifacts(store *storage.Store, jobID string) int {
-	artifacts, err := store.ListJobArtifacts(jobID, 100)
+func missionArtifactCounts(store *storage.Store, jobIDs []string) map[string]int {
+	counts, err := store.CountJobArtifactsByJobIDs(jobIDs)
 	if err != nil {
-		return 0
+		return map[string]int{}
 	}
-	return len(artifacts)
+	return counts
 }
 
 func missionStats(mp MissionProvider) http.HandlerFunc {

--- a/internal/control/mission.go
+++ b/internal/control/mission.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"ok-gobot/internal/agent"
+	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/memory"
 	"ok-gobot/internal/storage"
 	"ok-gobot/internal/tools"
@@ -36,6 +39,7 @@ func (s *Server) registerMissionRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/mission/estop", s.corsWrap(missionEstop(mp)))
 	mux.HandleFunc("/api/mission/providers", s.corsWrap(missionProviders(s)))
 	mux.HandleFunc("/api/mission/memory", s.corsWrap(missionMemory(mp)))
+	mux.HandleFunc("/api/mission/artifacts/", s.corsWrap(missionArtifactContent(mp, s.artifactRoots)))
 }
 
 // corsWrap adds permissive CORS headers for loopback origins.
@@ -196,6 +200,7 @@ func missionRuns(mp MissionProvider) http.HandlerFunc {
 			RoleName      string `json:"role_name,omitempty"`
 			ModelTier     string `json:"model_tier,omitempty"`
 			ToolCallCount int    `json:"tool_call_count,omitempty"`
+			ArtifactCount int    `json:"artifact_count,omitempty"`
 			Attempt       int    `json:"attempt"`
 			MaxAttempts   int    `json:"max_attempts"`
 			CreatedAt     string `json:"created_at"`
@@ -219,6 +224,7 @@ func missionRuns(mp MissionProvider) http.HandlerFunc {
 				RoleName:      job.RoleName,
 				ModelTier:     job.ModelTier,
 				ToolCallCount: job.ToolCallCount,
+				ArtifactCount: countMissionArtifacts(store, job.JobID),
 				Attempt:       job.Attempt,
 				MaxAttempts:   job.MaxAttempts,
 				CreatedAt:     job.CreatedAt,
@@ -228,6 +234,73 @@ func missionRuns(mp MissionProvider) http.HandlerFunc {
 		}
 		writeJSON(w, result)
 	}
+}
+
+func missionArtifactContent(mp MissionProvider, rootsFn func() []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeJSONErr(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		store := mp.GetStore()
+		if store == nil {
+			writeJSONErr(w, "store unavailable", http.StatusInternalServerError)
+			return
+		}
+
+		artifactID, ok := parseMissionArtifactContentPath(r.URL.Path)
+		if !ok {
+			writeJSONErr(w, "artifact ID is required", http.StatusBadRequest)
+			return
+		}
+
+		artifact, err := store.GetJobArtifact(artifactID)
+		if err != nil {
+			writeJSONErr(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if artifact == nil {
+			writeJSONErr(w, "artifact not found", http.StatusNotFound)
+			return
+		}
+
+		path, err := artifactview.ContentPath(*artifact, rootsFn())
+		if err != nil {
+			if os.IsNotExist(err) {
+				writeJSONErr(w, "artifact file not found", http.StatusNotFound)
+				return
+			}
+			writeJSONErr(w, err.Error(), http.StatusForbidden)
+			return
+		}
+		if artifact.MimeType != "" {
+			w.Header().Set("Content-Type", artifact.MimeType)
+		}
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		http.ServeFile(w, r, path)
+	}
+}
+
+func parseMissionArtifactContentPath(path string) (int64, bool) {
+	const prefix = "/api/mission/artifacts/"
+	trimmed := strings.TrimPrefix(path, prefix)
+	if trimmed == path || !strings.HasSuffix(trimmed, "/content") {
+		return 0, false
+	}
+	idPart := strings.TrimSuffix(trimmed, "/content")
+	if idPart == "" || strings.Contains(idPart, "/") {
+		return 0, false
+	}
+	id, err := strconv.ParseInt(idPart, 10, 64)
+	return id, err == nil && id > 0
+}
+
+func countMissionArtifacts(store *storage.Store, jobID string) int {
+	artifacts, err := store.ListJobArtifacts(jobID, 100)
+	if err != nil {
+		return 0
+	}
+	return len(artifacts)
 }
 
 func missionStats(mp MissionProvider) http.HandlerFunc {

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gobwas/ws"
 
+	artifactview "ok-gobot/internal/artifacts"
 	runtimepkg "ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -71,6 +72,7 @@ type Server struct {
 	runtimeHub *runtimepkg.Hub
 	tuiMu      sync.Mutex
 	tuiState   *tuiSessionStore
+	roots      []string
 }
 
 // New creates a new Server.  Call Start to begin accepting connections.
@@ -89,6 +91,18 @@ func New(cfg Config, state StateProvider) *Server {
 // SetStore attaches a storage.Store for job/artifact queries.
 func (s *Server) SetStore(store *storage.Store) {
 	s.store = store
+}
+
+// SetArtifactRoots configures local roots that artifact file previews may read from.
+func (s *Server) SetArtifactRoots(roots []string) {
+	s.roots = artifactview.NormalizeRoots(roots)
+}
+
+func (s *Server) artifactRoots() []string {
+	if len(s.roots) > 0 {
+		return s.roots
+	}
+	return artifactview.DefaultRoots()
 }
 
 // Hub returns the event hub so callers can emit events from elsewhere in the

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -952,10 +952,15 @@ func (s *Server) handleListJobs(c *client, cmd ClientMsg) {
 		c.sendTUIError("list jobs: " + err.Error())
 		return
 	}
+	jobIDs := make([]string, 0, len(jobs))
+	for _, j := range jobs {
+		jobIDs = append(jobIDs, j.JobID)
+	}
+	artifactCounts := s.artifactCounts(jobIDs)
 	infos := make([]JobInfo, len(jobs))
 	for i, j := range jobs {
 		infos[i] = jobToInfo(j)
-		infos[i].ArtifactCount = s.artifactCount(j.JobID)
+		infos[i].ArtifactCount = artifactCounts[j.JobID]
 	}
 	c.sendTUIMsg(ServerMsg{Type: MsgTypeJobs, Jobs: infos})
 }
@@ -1100,11 +1105,22 @@ func (s *Server) artifactCount(jobID string) int {
 	if s.store == nil || strings.TrimSpace(jobID) == "" {
 		return 0
 	}
-	artifacts, err := s.store.ListJobArtifacts(jobID, 100)
+	count, err := s.store.CountJobArtifacts(jobID)
 	if err != nil {
 		return 0
 	}
-	return len(artifacts)
+	return count
+}
+
+func (s *Server) artifactCounts(jobIDs []string) map[string]int {
+	if s.store == nil {
+		return map[string]int{}
+	}
+	counts, err := s.store.CountJobArtifactsByJobIDs(jobIDs)
+	if err != nil {
+		return map[string]int{}
+	}
+	return counts
 }
 
 func (s *Server) latestProofsBySession() map[string]proofLink {
@@ -1116,8 +1132,13 @@ func (s *Server) latestProofsBySession() map[string]proofLink {
 	if err != nil {
 		return proofs
 	}
+	jobIDs := make([]string, 0, len(jobs))
 	for _, job := range jobs {
-		count := s.artifactCount(job.JobID)
+		jobIDs = append(jobIDs, job.JobID)
+	}
+	artifactCounts := s.artifactCounts(jobIDs)
+	for _, job := range jobs {
+		count := artifactCounts[job.JobID]
 		if count == 0 {
 			continue
 		}

--- a/internal/control/server_tui.go
+++ b/internal/control/server_tui.go
@@ -13,6 +13,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/ai"
+	artifactview "ok-gobot/internal/artifacts"
 	runtimepkg "ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -954,6 +955,7 @@ func (s *Server) handleListJobs(c *client, cmd ClientMsg) {
 	infos := make([]JobInfo, len(jobs))
 	for i, j := range jobs {
 		infos[i] = jobToInfo(j)
+		infos[i].ArtifactCount = s.artifactCount(j.JobID)
 	}
 	c.sendTUIMsg(ServerMsg{Type: MsgTypeJobs, Jobs: infos})
 }
@@ -978,6 +980,7 @@ func (s *Server) handleGetJob(c *client, cmd ClientMsg) {
 		return
 	}
 	info := jobToInfo(*job)
+	info.ArtifactCount = s.artifactCount(job.JobID)
 	c.sendTUIMsg(ServerMsg{Type: MsgTypeJobDetail, Job: &info})
 }
 
@@ -1033,20 +1036,8 @@ func (s *Server) handleListJobArtifacts(c *client, cmd ClientMsg) {
 		c.sendTUIError("list job artifacts: " + err.Error())
 		return
 	}
-	infos := make([]ArtifactInfo, len(artifacts))
-	for i, a := range artifacts {
-		infos[i] = ArtifactInfo{
-			ID:           a.ID,
-			JobID:        a.JobID,
-			Name:         a.Name,
-			ArtifactType: a.ArtifactType,
-			MimeType:     a.MimeType,
-			Content:      a.Content,
-			URI:          a.URI,
-			Metadata:     a.Metadata,
-			CreatedAt:    a.CreatedAt,
-		}
-	}
+	serializer := artifactview.NewSerializer(s.artifactRoots(), "/api/mission/artifacts")
+	infos := serializer.SerializeAll(artifacts)
 	c.sendTUIMsg(ServerMsg{Type: MsgTypeJobArtifacts, Artifacts: infos})
 }
 
@@ -1075,6 +1066,7 @@ func (s *Server) handleCancelJob(c *client, cmd ClientMsg) {
 		return
 	}
 	info := jobToInfo(*job)
+	info.ArtifactCount = s.artifactCount(job.JobID)
 	c.sendTUIMsg(ServerMsg{Type: MsgTypeJobDetail, Job: &info})
 }
 
@@ -1084,15 +1076,62 @@ func (s *Server) handleListWorkers(c *client) {
 		return
 	}
 	snapshots := s.runtimeHub.ListWorkers()
+	proofs := s.latestProofsBySession()
 	infos := make([]WorkerInfo, len(snapshots))
 	for i, w := range snapshots {
+		proof := proofs[w.SessionKey]
 		infos[i] = WorkerInfo{
-			SessionKey: w.SessionKey,
-			Running:    w.Running,
-			QueueDepth: w.QueueDepth,
+			SessionKey:         w.SessionKey,
+			Running:            w.Running,
+			QueueDepth:         w.QueueDepth,
+			ProofJobID:         proof.jobID,
+			ProofArtifactCount: proof.count,
 		}
 	}
 	c.sendTUIMsg(ServerMsg{Type: MsgTypeWorkers, Workers: infos})
+}
+
+type proofLink struct {
+	jobID string
+	count int
+}
+
+func (s *Server) artifactCount(jobID string) int {
+	if s.store == nil || strings.TrimSpace(jobID) == "" {
+		return 0
+	}
+	artifacts, err := s.store.ListJobArtifacts(jobID, 100)
+	if err != nil {
+		return 0
+	}
+	return len(artifacts)
+}
+
+func (s *Server) latestProofsBySession() map[string]proofLink {
+	proofs := map[string]proofLink{}
+	if s.store == nil {
+		return proofs
+	}
+	jobs, err := s.store.ListJobs(100)
+	if err != nil {
+		return proofs
+	}
+	for _, job := range jobs {
+		count := s.artifactCount(job.JobID)
+		if count == 0 {
+			continue
+		}
+		for _, key := range []string{job.SessionKey, job.DeliverySessionKey} {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			if _, exists := proofs[key]; !exists {
+				proofs[key] = proofLink{jobID: job.JobID, count: count}
+			}
+		}
+	}
+	return proofs
 }
 
 func jobToInfo(j storage.Job) JobInfo {

--- a/internal/control/server_tui_test.go
+++ b/internal/control/server_tui_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/control"
+	"ok-gobot/internal/storage"
 	"ok-gobot/internal/tools"
 )
 
@@ -143,6 +145,36 @@ func startServerWithHandle(t *testing.T, state control.StateProvider) (*control.
 	return srv, addr, cancel
 }
 
+func startServerWithStore(t *testing.T, state control.StateProvider, store *storage.Store) (*control.Server, string, context.CancelFunc) {
+	t.Helper()
+	port := freePort(t)
+	cfg := control.Config{
+		Enabled:                   true,
+		Port:                      port,
+		AllowLoopbackWithoutToken: true,
+	}
+	srv := control.New(cfg, state)
+	srv.SetStore(store)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		if err := srv.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Errorf("server error: %v", err)
+		}
+	}()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond); err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	return srv, addr, cancel
+}
+
 func sendTUIRequest(t *testing.T, conn net.Conn, msg control.ClientMsg) {
 	t.Helper()
 	data, err := json.Marshal(msg)
@@ -239,6 +271,46 @@ func TestControlServerHandlesTUISessionCommands(t *testing.T) {
 	defer state.mu.Unlock()
 	if len(state.modelSet) != 0 {
 		t.Fatalf("expected no Telegram SetModel calls for TUI sessions, got %d", len(state.modelSet))
+	}
+}
+
+func TestControlServerListsJobArtifactsWithDisplayMetadata(t *testing.T) {
+	store, err := storage.New(filepath.Join(t.TempDir(), "jobs.db"))
+	if err != nil {
+		t.Fatalf("storage.New: %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	if err := store.CreateJob(storage.Job{JobID: "job-proof", Kind: "task", Status: "succeeded", Description: "proof job"}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if err := store.AddJobArtifact(storage.JobArtifact{JobID: "job-proof", Name: "PR", ArtifactType: "url", URI: "https://github.com/BeFeast/ok-gobot/pull/331"}); err != nil {
+		t.Fatalf("AddJobArtifact url: %v", err)
+	}
+	if err := store.AddJobArtifact(storage.JobArtifact{JobID: "job-proof", Name: "Report", ArtifactType: "text_report", MimeType: "text/plain", Content: "proof passed"}); err != nil {
+		t.Fatalf("AddJobArtifact report: %v", err)
+	}
+
+	state := &mockTUIState{}
+	_, addr, cancel := startServerWithStore(t, state, store)
+	defer cancel()
+
+	conn := wsConnect(t, addr)
+	sendTUIRequest(t, conn, control.ClientMsg{Type: control.CmdListJobArtifacts, JobID: "job-proof"})
+	_ = readTUIMessage(t, conn) // connected
+	msg := readTUIMessage(t, conn)
+
+	if msg.Type != control.MsgTypeJobArtifacts {
+		t.Fatalf("expected %q, got %q", control.MsgTypeJobArtifacts, msg.Type)
+	}
+	if len(msg.Artifacts) != 2 {
+		t.Fatalf("artifact count = %d, want 2", len(msg.Artifacts))
+	}
+	if got := msg.Artifacts[0]; got.Type != "url" || got.Label != "PR" || got.Display.Kind != "url" || !got.Display.Safe || got.URL == "" {
+		t.Fatalf("unexpected URL artifact: %+v", got)
+	}
+	if got := msg.Artifacts[1]; got.Type != "text_report" || got.Display.Kind != "text_report" || !got.Display.Safe || got.Content != "proof passed" {
+		t.Fatalf("unexpected text report artifact: %+v", got)
 	}
 }
 

--- a/internal/control/tui_types.go
+++ b/internal/control/tui_types.go
@@ -1,5 +1,7 @@
 package control
 
+import artifactview "ok-gobot/internal/artifacts"
+
 // Message type constants for server→client messages.
 const (
 	MsgTypeEvent        = "event"
@@ -104,6 +106,7 @@ type JobInfo struct {
 	RoleName           string `json:"role_name,omitempty"`
 	ModelTier          string `json:"model_tier,omitempty"`
 	ToolCallCount      int    `json:"tool_call_count,omitempty"`
+	ArtifactCount      int    `json:"artifact_count,omitempty"`
 	CreatedAt          string `json:"created_at"`
 	StartedAt          string `json:"started_at,omitempty"`
 	CompletedAt        string `json:"completed_at,omitempty"`
@@ -121,23 +124,15 @@ type JobEventInfo struct {
 }
 
 // ArtifactInfo is the JSON-friendly representation of a job artifact.
-type ArtifactInfo struct {
-	ID           int64  `json:"id"`
-	JobID        string `json:"job_id"`
-	Name         string `json:"name"`
-	ArtifactType string `json:"artifact_type"`
-	MimeType     string `json:"mime_type,omitempty"`
-	Content      string `json:"content,omitempty"`
-	URI          string `json:"uri,omitempty"`
-	Metadata     string `json:"metadata,omitempty"`
-	CreatedAt    string `json:"created_at"`
-}
+type ArtifactInfo = artifactview.Info
 
 // WorkerInfo describes an active session worker for the dashboard.
 type WorkerInfo struct {
-	SessionKey string `json:"session_key"`
-	Running    bool   `json:"running"`
-	QueueDepth int    `json:"queue_depth"`
+	SessionKey         string `json:"session_key"`
+	Running            bool   `json:"running"`
+	QueueDepth         int    `json:"queue_depth"`
+	ProofJobID         string `json:"proof_job_id,omitempty"`
+	ProofArtifactCount int    `json:"proof_artifact_count,omitempty"`
 }
 
 // ClientMsg is sent from TUI clients to the control server.

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -1895,6 +1895,38 @@ func (s *Store) ListJobArtifacts(jobID string, limit int) ([]JobArtifact, error)
 	return artifacts, rows.Err()
 }
 
+// GetJobArtifact loads one artifact by its durable artifact ID.
+// It returns (nil, nil) when the row does not exist.
+func (s *Store) GetJobArtifact(id int64) (*JobArtifact, error) {
+	if id <= 0 {
+		return nil, nil
+	}
+
+	var artifact JobArtifact
+	err := s.db.QueryRow(`
+		SELECT id, job_id, name, artifact_type, mime_type, content, uri, metadata, created_at
+		FROM job_artifacts
+		WHERE id = ?
+	`, id).Scan(
+		&artifact.ID,
+		&artifact.JobID,
+		&artifact.Name,
+		&artifact.ArtifactType,
+		&artifact.MimeType,
+		&artifact.Content,
+		&artifact.URI,
+		&artifact.Metadata,
+		&artifact.CreatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &artifact, nil
+}
+
 // ─── v2 session helpers ──────────────────────────────────────────────────────
 
 // SessionV2 holds the data stored in sessions_v2.

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -1895,6 +1895,68 @@ func (s *Store) ListJobArtifacts(jobID string, limit int) ([]JobArtifact, error)
 	return artifacts, rows.Err()
 }
 
+// CountJobArtifacts returns the full artifact count for one job.
+func (s *Store) CountJobArtifacts(jobID string) (int, error) {
+	var count int
+	err := s.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM job_artifacts
+		WHERE job_id = ?
+	`, strings.TrimSpace(jobID)).Scan(&count)
+	return count, err
+}
+
+// CountJobArtifactsByJobIDs returns full artifact counts grouped by job ID.
+func (s *Store) CountJobArtifactsByJobIDs(jobIDs []string) (map[string]int, error) {
+	counts := make(map[string]int, len(jobIDs))
+	unique := make([]string, 0, len(jobIDs))
+	seen := make(map[string]struct{}, len(jobIDs))
+	for _, jobID := range jobIDs {
+		jobID = strings.TrimSpace(jobID)
+		if jobID == "" {
+			continue
+		}
+		if _, ok := seen[jobID]; ok {
+			continue
+		}
+		seen[jobID] = struct{}{}
+		unique = append(unique, jobID)
+		counts[jobID] = 0
+	}
+	if len(unique) == 0 {
+		return counts, nil
+	}
+
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(unique)), ",")
+	args := make([]interface{}, len(unique))
+	for i, jobID := range unique {
+		args[i] = jobID
+	}
+
+	rows, err := s.db.Query(`
+		SELECT job_id, COUNT(*)
+		FROM job_artifacts
+		WHERE job_id IN (`+placeholders+`)
+		GROUP BY job_id
+	`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			jobID string
+			count int
+		)
+		if err := rows.Scan(&jobID, &count); err != nil {
+			return nil, err
+		}
+		counts[jobID] = count
+	}
+	return counts, rows.Err()
+}
+
 // GetJobArtifact loads one artifact by its durable artifact ID.
 // It returns (nil, nil) when the row does not exist.
 func (s *Store) GetJobArtifact(id int64) (*JobArtifact, error) {

--- a/internal/storage/sqlite_schema_test.go
+++ b/internal/storage/sqlite_schema_test.go
@@ -422,6 +422,52 @@ func TestJobCRUDAndLinkedArtifacts(t *testing.T) {
 	}
 }
 
+func TestJobArtifactCountsAreAccurateAndBatchable(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	for _, jobID := range []string{"job-count-a", "job-count-b"} {
+		if err := store.CreateJob(Job{JobID: jobID, Kind: "task", Status: "succeeded"}); err != nil {
+			t.Fatalf("CreateJob(%s) failed: %v", jobID, err)
+		}
+	}
+
+	for i := 0; i < 105; i++ {
+		if err := store.AddJobArtifact(JobArtifact{JobID: "job-count-a", Name: "artifact-a", ArtifactType: "text_report"}); err != nil {
+			t.Fatalf("AddJobArtifact job-count-a #%d failed: %v", i, err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := store.AddJobArtifact(JobArtifact{JobID: "job-count-b", Name: "artifact-b", ArtifactType: "url", URI: "https://example.com"}); err != nil {
+			t.Fatalf("AddJobArtifact job-count-b #%d failed: %v", i, err)
+		}
+	}
+
+	count, err := store.CountJobArtifacts(" job-count-a ")
+	if err != nil {
+		t.Fatalf("CountJobArtifacts failed: %v", err)
+	}
+	if count != 105 {
+		t.Fatalf("CountJobArtifacts = %d, want 105", count)
+	}
+
+	counts, err := store.CountJobArtifactsByJobIDs([]string{"job-count-a", "job-count-b", "job-missing", "job-count-a", ""})
+	if err != nil {
+		t.Fatalf("CountJobArtifactsByJobIDs failed: %v", err)
+	}
+	if counts["job-count-a"] != 105 {
+		t.Fatalf("job-count-a count = %d, want 105", counts["job-count-a"])
+	}
+	if counts["job-count-b"] != 2 {
+		t.Fatalf("job-count-b count = %d, want 2", counts["job-count-b"])
+	}
+	if counts["job-missing"] != 0 {
+		t.Fatalf("job-missing count = %d, want 0", counts["job-missing"])
+	}
+}
+
 func TestJobRoleMetadataFields(t *testing.T) {
 	t.Parallel()
 	store := newTestStore(t)

--- a/internal/storage/sqlite_schema_test.go
+++ b/internal/storage/sqlite_schema_test.go
@@ -405,6 +405,13 @@ func TestJobCRUDAndLinkedArtifacts(t *testing.T) {
 	if artifacts[0].Name != "result.md" || artifacts[0].ArtifactType != "report" {
 		t.Fatalf("unexpected artifact row: %+v", artifacts[0])
 	}
+	artifact, err := store.GetJobArtifact(artifacts[0].ID)
+	if err != nil {
+		t.Fatalf("GetJobArtifact failed: %v", err)
+	}
+	if artifact == nil || artifact.Name != "result.md" || artifact.JobID != job.JobID {
+		t.Fatalf("unexpected artifact detail: %+v", artifact)
+	}
 
 	jobs, err := store.ListJobs(10)
 	if err != nil {

--- a/web/index.html
+++ b/web/index.html
@@ -109,7 +109,13 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Ar
 .artifact-card { background: var(--bg2); border: 1px solid var(--border); border-radius: 6px; padding: 12px 16px; margin-bottom: 8px; }
 .artifact-card .art-name { font-weight: 600; font-size: 13px; }
 .artifact-card .art-meta { font-size: 12px; color: var(--fg2); margin-top: 2px; }
-.artifact-card .art-content { font-size: 12px; background: var(--bg3); border-radius: 4px; padding: 8px; margin-top: 8px; max-height: 200px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
+.artifact-card .art-content { font-size: 12px; background: var(--bg3); border-radius: 4px; padding: 8px; margin-top: 8px; max-height: 260px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; }
+.artifact-gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px; }
+.artifact-preview { margin-top: 10px; }
+.artifact-preview img { display: block; width: 100%; max-height: 360px; object-fit: contain; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); }
+.artifact-link { display: inline-flex; align-items: center; gap: 6px; margin-top: 8px; color: var(--accent); text-decoration: none; font-size: 13px; word-break: break-all; }
+.artifact-link:hover { text-decoration: underline; }
+.artifact-warning { margin-top: 8px; font-size: 12px; color: var(--orange); }
 
 /* Workers */
 .worker-card { background: var(--bg2); border: 1px solid var(--border); border-radius: 6px; padding: 12px 16px; margin-bottom: 8px; display: flex; align-items: center; gap: 12px; }
@@ -470,17 +476,19 @@ function renderJobsTable() {
   }
 
   let html = `<table class="data-table"><thead><tr>
-    <th>Status</th><th>Kind</th><th>Role</th><th>Description</th><th>Worker</th><th>Model/Tier</th><th>Duration</th><th>Created</th>
+    <th>Status</th><th>Kind</th><th>Role</th><th>Description</th><th>Worker</th><th>Proof</th><th>Model/Tier</th><th>Duration</th><th>Created</th>
   </tr></thead><tbody>`;
 
   for (const j of filtered) {
     const duration = jobDuration(j);
+    const proof = j.artifact_count ? `<a href="#" onclick="event.stopPropagation();openJobDetail('${esc(j.job_id)}');return false" style="color:var(--accent)">${j.artifact_count} artifact${j.artifact_count === 1 ? '' : 's'}</a>` : '-';
     html += `<tr class="clickable" onclick="openJobDetail('${esc(j.job_id)}')">
       <td><span class="status-badge ${j.status}">${j.status}</span></td>
       <td>${esc(j.kind)}</td>
       <td>${esc(j.role_name || '-')}</td>
       <td>${esc(truncate(j.description, 60))}</td>
       <td>${esc(j.worker || '-')}</td>
+      <td>${proof}</td>
       <td>${esc(j.model_tier || '-')}</td>
       <td>${duration}</td>
       <td>${formatTime(j.created_at)}</td>
@@ -537,6 +545,7 @@ function renderJobDetail(job) {
     { label: 'Duration', value: jobDuration(job) },
   );
   if (job.tool_call_count) meta.push({ label: 'Tool Calls', value: String(job.tool_call_count) });
+  if (job.artifact_count) meta.push({ label: 'Proof Artifacts', value: String(job.artifact_count) });
   if (job.summary) meta.push({ label: 'Summary', value: esc(job.summary) });
   if (job.error) {
     const errLabel = job.status === 'cancelled' ? 'Cancel Reason' : job.status === 'timed_out' ? 'Timeout Reason' : 'Error';
@@ -571,23 +580,70 @@ function renderJobArtifacts(artifacts) {
     container.innerHTML = '<div style="color:var(--fg3);font-size:13px;">No artifacts</div>';
     return;
   }
-  container.innerHTML = artifacts.map(a => {
-    let contentHtml = '';
-    if (a.content) {
-      const truncated = a.content.length > 2000 ? a.content.slice(0, 2000) + '\n... (truncated)' : a.content;
-      contentHtml = `<div class="art-content">${esc(truncated)}</div>`;
-    }
-    let uriHtml = '';
-    if (a.uri) {
-      uriHtml = `<div class="art-meta">URI: ${esc(a.uri)}</div>`;
-    }
-    return `<div class="artifact-card">
-      <div class="art-name">${esc(a.name)}</div>
-      <div class="art-meta">${esc(a.artifact_type)}${a.mime_type ? ' \u00B7 ' + esc(a.mime_type) : ''} \u00B7 ${formatTime(a.created_at)}</div>
-      ${uriHtml}
-      ${contentHtml}
-    </div>`;
-  }).join('');
+  container.innerHTML = `<div class="artifact-gallery">${artifacts.map(renderArtifactCard).join('')}</div>`;
+}
+
+function renderArtifactCard(a) {
+  const display = a.display || {};
+  const kind = display.kind || artifactKind(a);
+  const label = a.label || a.name || 'artifact';
+  const type = a.type || a.artifact_type || kind;
+  const meta = [type, a.mime_type, formatTime(a.created_at)].filter(Boolean).map(esc).join(' &middot; ');
+  const body = renderArtifactPreview(a, display, kind);
+  return `<div class="artifact-card">
+    <div class="art-name">${esc(label)}</div>
+    <div class="art-meta">${meta}</div>
+    ${body}
+  </div>`;
+}
+
+function renderArtifactPreview(a, display, kind) {
+  const href = artifactHref(display.href || a.url || a.uri || '');
+  if (display.safe === false) {
+    const warning = `<div class="artifact-warning">Preview blocked: ${esc(display.reason || 'unsafe artifact location')}</div>`;
+    return a.content ? warning + renderTextArtifact(a.content) : warning;
+  }
+  if (kind === 'image' && href) {
+    const label = a.label || a.name || 'artifact image';
+    return `<div class="artifact-preview"><a href="${esc(href)}" target="_blank" rel="noopener noreferrer"><img src="${esc(href)}" alt="${esc(label)}" loading="lazy"></a></div>`;
+  }
+  if (kind === 'url' && href) {
+    return `<a class="artifact-link" href="${esc(href)}" target="_blank" rel="noopener noreferrer">Open ${esc(a.label || a.name || 'artifact URL')}</a>`;
+  }
+  if ((kind === 'text_report' || a.content) && a.content) {
+    return renderTextArtifact(a.content);
+  }
+  if (href) {
+    return `<a class="artifact-link" href="${esc(href)}" target="_blank" rel="noopener noreferrer">Open artifact</a>`;
+  }
+  return '<div class="art-meta">No preview available</div>';
+}
+
+function renderTextArtifact(content) {
+  const truncated = content.length > 4000 ? content.slice(0, 4000) + '\n... (truncated)' : content;
+  return `<div class="art-content">${esc(truncated)}</div>`;
+}
+
+function artifactKind(a) {
+  const type = (a.type || a.artifact_type || '').toLowerCase();
+  const mime = (a.mime_type || '').toLowerCase();
+  if (type === 'screenshot' || type === 'image' || mime.startsWith('image/')) return 'image';
+  if (type === 'text_report' || type.includes('report') || mime.startsWith('text/')) return 'text_report';
+  if (a.url || /^https?:\/\//i.test(a.uri || '')) return 'url';
+  if (a.content) return 'text_report';
+  return 'artifact';
+}
+
+function artifactHref(href) {
+  if (!href) return '';
+  if (/^(https?:|data:image\/)/i.test(href)) return href;
+  if (href.startsWith('/')) {
+    const proto = location.protocol === 'https:' ? 'https' : 'http';
+    const host = location.hostname || '127.0.0.1';
+    const port = window.CONTROL_PORT || location.port || '8787';
+    return `${proto}://${host}:${port}${href}`;
+  }
+  return '';
 }
 
 function cancelSelectedJob() {
@@ -620,13 +676,14 @@ function renderWorkers(workers) {
   // Sort: running first, then by session key
   workers.sort((a, b) => (b.running ? 1 : 0) - (a.running ? 1 : 0) || a.session_key.localeCompare(b.session_key));
 
-  container.innerHTML = workers.map(w =>
-    `<div class="worker-card">
+  container.innerHTML = workers.map(w => {
+    const proof = w.proof_job_id ? `<a href="#" class="artifact-link" onclick="switchTab('jobs');openJobDetail('${esc(w.proof_job_id)}');return false">proof: ${w.proof_artifact_count || 1} artifact${w.proof_artifact_count === 1 ? '' : 's'}</a>` : '';
+    return `<div class="worker-card">
       <div class="w-dot ${w.running ? 'active' : 'idle'}"></div>
-      <div class="w-key">${esc(w.session_key)}</div>
-      <div class="w-queue">${w.running ? 'running' : 'idle'}${w.queue_depth > 0 ? ' \u00B7 queue: ' + w.queue_depth : ''}</div>
-    </div>`
-  ).join('');
+      <div class="w-key">${esc(w.session_key)}${proof}</div>
+      <div class="w-queue">${w.running ? 'running' : 'idle'}${w.queue_depth > 0 ? ' &middot; queue: ' + w.queue_depth : ''}</div>
+    </div>`;
+  }).join('');
 }
 
 // ─── Chat (secondary) ───────────────────────────────────────────────

--- a/web/index_test.go
+++ b/web/index_test.go
@@ -1,0 +1,22 @@
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIndexIncludesArtifactGalleryRenderers(t *testing.T) {
+	html := string(IndexHTML)
+	for _, want := range []string{
+		"function renderArtifactPreview",
+		"kind === 'image'",
+		"kind === 'url'",
+		"kind === 'text_report'",
+		"function artifactHref",
+		"proof_artifact_count",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("index.html missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Implements #331

## Changes
- Adds display-safe artifact serialization for jobs, including type, label, path/url, created time, and preview metadata.
- Adds local artifact content endpoints that only serve files under configured artifact roots, with API/control tests for unsafe path blocking.
- Renders image/screenshot, URL, and text report proof artifacts in the web Mission Control job detail view, and links proof artifacts from job/worker rows.

## Testing
- `./.maestro/verify.sh` passed
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/` passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a proof artifact gallery to Mission Control: a new `artifacts` package handles display-safe serialization with path allowlisting and symlink resolution, new storage methods batch artifact counts in a single `GROUP BY` query (addressing the previously flagged N+1 patterns), a new `/api/artifacts/{id}/content` endpoint serves local files under configured roots, and the web UI renders image/URL/text-report artifacts in a gallery layout. Auth for the API endpoint is correctly covered by the existing global `authMiddleware`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0 or P1 issues found; path-traversal and symlink-escape defenses are solid.

All previously flagged N+1 DB queries are resolved. The artifact path safety model (EvalSymlinks + root prefix check, URI scheme allowlist, separate content endpoint) is correctly implemented and well-tested. Auth coverage is confirmed via the global middleware. No logic bugs found in the new code paths.

No files require special attention. The previously noted Metadata field drop in tui_types.go and single-quote escaping in web/index.html are carry-over P2 items documented in prior review threads.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/artifacts/display.go | New file: display-safe artifact serialization. Path validation uses EvalSymlinks to block traversal/symlink escapes; URI scheme allowlist covers http/https and whitelisted data:image/ prefixes. Logic is sound. |
| internal/api/handlers.go | Adds handleArtifactContent endpoint and path parser. Auth is applied via global authMiddleware wrapping the mux, so the new route is covered. Path-safety check delegated to artifacts.ContentPath before ServeFile. |
| internal/control/server_tui.go | Replaces inline ArtifactInfo construction with Serializer and adds batched artifact counts. latestProofsBySession uses a single ListJobs + CountJobArtifactsByJobIDs call (2 queries total). |
| internal/storage/sqlite.go | Adds CountJobArtifacts, CountJobArtifactsByJobIDs (batched GROUP BY query with IN clause), and GetJobArtifact. Placeholder construction uses strings.Repeat+TrimRight, which is correct and safe. |
| web/index.html | Renders proof artifact gallery with image/url/text_report previews. artifactHref validates schemes and builds full URLs for relative paths. esc() does not encode single quotes in JS onclick context (previously flagged). |
| internal/control/tui_types.go | ArtifactInfo replaced with type alias to artifactview.Info, dropping the Metadata field from TUI responses (previously flagged). WorkerInfo gains proof link fields. |
| internal/api/mission.go | N+1 artifact count queries replaced with single batched CountJobArtifactsByJobIDs call. |
| internal/config/config.go | Adds ArtifactConfig with roots slice, wired into both Load and LoadFrom with expandPaths. Default is empty slice (DefaultRoots() provides built-in fallbacks at runtime). |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `web/index.html`, line 1622 ([link](https://github.com/befeast/ok-gobot/blob/56a53f37bcfb0a6c6dd6c51f8d9d29ab3bc045af/web/index.html#L1622)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`esc()` does not encode single quotes in JS event handler context**

   The `esc()` helper (`div.textContent` → `div.innerHTML`) encodes `<`, `>`, and `&` but not `'`. When the escaped value is interpolated into a single-quoted JS string inside an `onclick` attribute, a job_id containing a single quote (e.g. `'; doSomething(); var x='`) would break out of the string literal. The same pattern is in `renderWorkers` for `w.proof_job_id`. While job IDs are server-generated, the safer approach is to pass the ID via a `data-` attribute and read it in a non-inline event listener, or at minimum use `encodeURIComponent` / `JSON.stringify` for the JS string context.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/index.html
   Line: 1622

   Comment:
   **`esc()` does not encode single quotes in JS event handler context**

   The `esc()` helper (`div.textContent` → `div.innerHTML`) encodes `<`, `>`, and `&` but not `'`. When the escaped value is interpolated into a single-quoted JS string inside an `onclick` attribute, a job_id containing a single quote (e.g. `'; doSomething(); var x='`) would break out of the string literal. The same pattern is in `renderWorkers` for `w.proof_job_id`. While job IDs are server-generated, the safer approach is to pass the ID via a `data-` attribute and read it in a non-inline event listener, or at minimum use `encodeURIComponent` / `JSON.stringify` for the JS string context.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/control/tui_types.go`, line 1517 ([link](https://github.com/befeast/ok-gobot/blob/56a53f37bcfb0a6c6dd6c51f8d9d29ab3bc045af/internal/control/tui_types.go#L1517)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`metadata` field silently dropped from TUI artifact responses**

   The old `ArtifactInfo` struct included `Metadata string \`json:"metadata,omitempty"\``, which was copied directly from the storage row and sent to TUI clients. The new `artifactview.Info` type alias has no `Metadata` field, so any TUI consumer that reads `metadata` will silently receive an empty value without a schema version bump or migration note.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/control/tui_types.go
   Line: 1517

   Comment:
   **`metadata` field silently dropped from TUI artifact responses**

   The old `ArtifactInfo` struct included `Metadata string \`json:"metadata,omitempty"\``, which was copied directly from the storage row and sent to TUI clients. The new `artifactview.Info` type alias has no `Metadata` field, so any TUI consumer that reads `metadata` will silently receive an empty value without a schema version bump or migration note.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: batch mission artifact counts"](https://github.com/befeast/ok-gobot/commit/cea8f40da596afed4049e9f90b394c08686acfd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30369406)</sub>

<!-- /greptile_comment -->