### PR TITLE
feat: bridge role runs to real agent runtime (#341)

### DIFF
--- a/internal/bot/role_commands.go
+++ b/internal/bot/role_commands.go
@@ -12,6 +12,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/role"
+	"ok-gobot/internal/rolejob"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -153,35 +154,75 @@ func (b *Bot) handleRoleRunCommand(c telebot.Context) error {
 	if err != nil {
 		return c.Send(fmt.Sprintf("Role %q not found.", name))
 	}
+	if b.hub == nil {
+		return c.Send("Role runtime is not available.")
+	}
+
+	chat := c.Chat()
+	message := c.Message()
+	sender := c.Sender()
+	chatID := int64(0)
+	sessionKey := agent.SessionKey(fmt.Sprintf("role:%s", m.Name))
+	if chat != nil {
+		chatID = chat.ID
+		sessionKey = sessionKeyForChat(chat)
+	}
+	deliverySessionKey := ""
+	if chat != nil {
+		route := storage.SessionRoute{
+			SessionKey: string(sessionKey),
+			Channel:    "telegram",
+			ChatID:     chat.ID,
+		}
+		if message != nil {
+			route.ReplyToMessageID = message.ID
+		}
+		if sender != nil {
+			route.UserID = sender.ID
+			route.Username = sender.Username
+		}
+		if err := b.store.SaveSessionRoute(route); err != nil {
+			log.Printf("[roles] failed to persist delivery route for %s: %v", sessionKey, err)
+		} else {
+			deliverySessionKey = string(sessionKey)
+		}
+	}
+
+	opts := rolejob.Options{
+		SessionKey:         string(sessionKey),
+		DeliverySessionKey: deliverySessionKey,
+		Worker:             m.Worker,
+		ChatID:             chatID,
+	}
+	spec, err := rolejob.JobSpec(m, opts)
+	if err != nil {
+		return c.Send(fmt.Sprintf("Failed to build role job: %v", err))
+	}
 
 	js := runtime.NewJobService(b.store)
 	flusher := b.lifecycleFlush
 	roleName := m.Name
-	job, err := js.StartDetached(context.Background(), runtime.JobSpec{
-		Kind:        "role",
-		Worker:      m.Worker,
-		Description: fmt.Sprintf("role:%s", m.Name),
-		RoleName:    m.Name,
-		Timeout:     5 * time.Minute,
-	}, func(ctx context.Context, job *storage.Job, svc *runtime.JobService) (result runtime.JobRunResult, runErr error) {
+	runner := rolejob.AgentJobRunner(b.hub, m, input, opts)
+	parentCtx := b.ctx
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	job, err := js.StartDetached(parentCtx, spec, func(ctx context.Context, job *storage.Job, svc *runtime.JobService) (result runtime.JobRunResult, runErr error) {
 		defer func() {
 			runLifecycleJobFlush(ctx, flusher, job, roleName, result, runErr)
 		}()
-		prompt := m.Prompt
-		if input != "" {
-			prompt = prompt + "\n\nUser input: " + input
-		}
-		result = runtime.JobRunResult{
-			Summary: fmt.Sprintf("role %q executed (prompt length: %d chars)", m.Name, len(prompt)),
-		}
-		return result, nil
+		return runner(ctx, job, svc)
 	})
 	if err != nil {
 		return c.Send(fmt.Sprintf("Failed to start role job: %v", err))
 	}
 
+	worker := spec.Worker
+	if worker == "" {
+		worker = "(default)"
+	}
 	return c.Send(fmt.Sprintf("Job started: `%s`\nRole: *%s*\nWorker: %s\n\nUse `/job %s` to check status.",
-		job.JobID, m.Name, m.Worker, job.JobID),
+		job.JobID, m.Name, worker, job.JobID),
 		&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 }
 

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -9,13 +9,33 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/ai"
 	"ok-gobot/internal/config"
 	"ok-gobot/internal/role"
+	"ok-gobot/internal/rolejob"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
+	"ok-gobot/internal/tools"
 )
 
 func newRolesCommand(cfg *config.Config) *cobra.Command {
+	return newRolesCommandWithDeps(cfg, roleRunDeps{})
+}
+
+type roleRunDeps struct {
+	newSubmitter func(*config.Config, *storage.Store) (rolejob.AgentSubmitter, error)
+	waitPoll     time.Duration
+}
+
+func newRolesCommandWithDeps(cfg *config.Config, deps roleRunDeps) *cobra.Command {
+	if deps.newSubmitter == nil {
+		deps.newSubmitter = newRoleRunSubmitter
+	}
+	if deps.waitPoll <= 0 {
+		deps.waitPoll = 200 * time.Millisecond
+	}
+
 	cmd := &cobra.Command{
 		Use:   "roles",
 		Short: "List, inspect, run, and manage roles",
@@ -23,7 +43,7 @@ func newRolesCommand(cfg *config.Config) *cobra.Command {
 
 	cmd.AddCommand(newRolesListCommand(cfg))
 	cmd.AddCommand(newRolesShowCommand(cfg))
-	cmd.AddCommand(newRolesRunCommand(cfg))
+	cmd.AddCommand(newRolesRunCommand(cfg, deps))
 	cmd.AddCommand(newRolesEnableCommand(cfg))
 	cmd.AddCommand(newRolesDisableCommand(cfg))
 
@@ -167,7 +187,7 @@ func newRolesShowCommand(cfg *config.Config) *cobra.Command {
 
 // --- run ---
 
-func newRolesRunCommand(cfg *config.Config) *cobra.Command {
+func newRolesRunCommand(cfg *config.Config, deps roleRunDeps) *cobra.Command {
 	var (
 		input string
 		tier  string
@@ -197,33 +217,173 @@ func newRolesRunCommand(cfg *config.Config) *cobra.Command {
 			if tier != "" {
 				worker = tier
 			}
+			opts := rolejob.Options{
+				SessionKey: fmt.Sprintf("cli:role:%s", m.Name),
+				Worker:     worker,
+			}
+			spec, err := rolejob.JobSpec(m, opts)
+			if err != nil {
+				return err
+			}
+
+			submitter, err := deps.newSubmitter(cfg, store)
+			if err != nil {
+				return fmt.Errorf("failed to initialize role runtime: %w", err)
+			}
 
 			js := runtime.NewJobService(store)
-			job, err := js.StartDetached(context.Background(), runtime.JobSpec{
-				Kind:        "role",
-				Worker:      worker,
-				Description: fmt.Sprintf("role:%s", m.Name),
-				Timeout:     5 * time.Minute,
-			}, func(ctx context.Context, job *storage.Job, svc *runtime.JobService) (runtime.JobRunResult, error) {
-				prompt := m.Prompt
-				if input != "" {
-					prompt = prompt + "\n\nUser input: " + input
-				}
-				return runtime.JobRunResult{
-					Summary: fmt.Sprintf("role %q executed (prompt length: %d chars)", m.Name, len(prompt)),
-				}, nil
-			})
+			job, err := js.StartDetached(cmd.Context(), spec, rolejob.AgentJobRunner(submitter, m, input, opts))
 			if err != nil {
 				return fmt.Errorf("failed to start job: %w", err)
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Job started: %s\n", job.JobID)
+			finished, err := waitForRoleJobCompletion(cmd.Context(), store, job.JobID, deps.waitPoll)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Job finished: %s (%s)\n", finished.JobID, finished.Status)
+			if finished.Status != string(runtime.JobStatusSucceeded) {
+				detail := strings.TrimSpace(finished.Error)
+				if detail == "" {
+					detail = strings.TrimSpace(finished.Summary)
+				}
+				if detail == "" {
+					detail = finished.Status
+				}
+				return fmt.Errorf("role job %s ended with status %s: %s", finished.JobID, finished.Status, detail)
+			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&input, "input", "", "additional input for the role")
 	cmd.Flags().StringVar(&tier, "tier", "", "override worker tier (cheap, standard, premium, local)")
 	return cmd
+}
+
+func newRoleRunSubmitter(cfg *config.Config, store *storage.Store) (rolejob.AgentSubmitter, error) {
+	provider := strings.TrimSpace(cfg.AI.Provider)
+	if provider == "" {
+		provider = "openrouter"
+	}
+	apiKey := strings.TrimSpace(cfg.AI.APIKey)
+	if apiKey == "" && provider == "anthropic" {
+		if creds, err := ai.LoadAnthropicOAuthCredentials(""); err == nil && creds != nil {
+			apiKey = "oauth:" + creds.AccessToken
+		}
+	}
+
+	aiClient, err := ai.NewClientWithDroid(ai.ProviderConfig{
+		Name:    provider,
+		APIKey:  apiKey,
+		BaseURL: cfg.AI.BaseURL,
+		Model:   cfg.AI.Model,
+	}, ai.DroidConfig{
+		BinaryPath: cfg.AI.Droid.BinaryPath,
+		AutoLevel:  cfg.AI.Droid.AutoLevel,
+		WorkDir:    cfg.AI.Droid.WorkDir,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	soulPath := cfg.GetSoulPath()
+	personality, err := agent.NewPersonality(soulPath)
+	if err != nil {
+		personality = &agent.Personality{}
+	}
+	personality.SetScoreProvider(store)
+
+	var agentRegistry *agent.AgentRegistry
+	if len(cfg.Agents) > 0 {
+		agentRegistry, err = agent.NewAgentRegistry(cfg.Agents, cfg.AI.Model, soulPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	toolRegistry, err := tools.LoadFromConfigWithOptions(soulPath, &tools.ToolsConfig{
+		OpenAIAPIKey:    apiKey,
+		OpenAIBaseURL:   cfg.AI.BaseURL,
+		TTSProvider:     cfg.TTS.Provider,
+		TTSVoice:        cfg.TTS.DefaultVoice,
+		ChromePath:      cfg.Browser.ChromePath,
+		BrowserProfile:  cfg.Browser.ProfilePath,
+		BrowserDebugURL: cfg.Browser.DebugURL,
+		PatternStore:    store,
+		EmergencyStop:   store,
+		AIClient:        aiClient,
+		Contacts:        cfg.Contacts,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var modelRouter *ai.Router
+	if len(cfg.AI.Routing.Routes) > 0 {
+		modelRouter = ai.NewRouter(cfg.AI.Routing.Routes, cfg.AI.Model)
+	}
+
+	resolver := &agent.RunResolver{
+		Store:              store,
+		Registry:           agentRegistry,
+		DefaultPersonality: personality,
+		AIConfig: agent.AIResolverConfig{
+			Provider:        provider,
+			Model:           cfg.AI.Model,
+			APIKey:          apiKey,
+			BaseURL:         cfg.AI.BaseURL,
+			DefaultThinking: cfg.AI.DefaultThinking,
+			DefaultClient:   aiClient,
+			ModelAliases:    cfg.ModelAliases,
+			MemoryMode:      config.NormalizeMemoryMode(cfg.Memory.Mode),
+		},
+		ToolRegistry: toolRegistry,
+		Router:       modelRouter,
+	}
+	hub := agent.NewRuntimeHub(resolver)
+	resolver.SubagentSubmitter = hub
+	return hub, nil
+}
+
+func waitForRoleJobCompletion(ctx context.Context, store *storage.Store, jobID string, poll time.Duration) (*storage.Job, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if poll <= 0 {
+		poll = 200 * time.Millisecond
+	}
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+
+	for {
+		job, err := store.GetJob(jobID)
+		if err != nil {
+			return nil, err
+		}
+		if job != nil && isRoleJobTerminal(job.Status) {
+			return job, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func isRoleJobTerminal(status string) bool {
+	switch status {
+	case string(runtime.JobStatusSucceeded),
+		string(runtime.JobStatusFailed),
+		string(runtime.JobStatusCancelled),
+		string(runtime.JobStatusTimedOut),
+		string(runtime.JobStatusBudgetExceeded):
+		return true
+	default:
+		return false
+	}
 }
 
 // --- enable ---

--- a/internal/cli/roles_test.go
+++ b/internal/cli/roles_test.go
@@ -6,6 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/rolejob"
+	"ok-gobot/internal/storage"
 )
 
 func TestRolesList_ShowsBundled(t *testing.T) {
@@ -113,9 +119,10 @@ func TestRolesShow_NotFound(t *testing.T) {
 
 func TestRolesRun(t *testing.T) {
 	t.Parallel()
-	_, cfg := newTestStore(t)
+	store, cfg := newTestStore(t)
+	deps, _ := newRolesRunTestDeps("role completed from worker")
 
-	cmd := newRolesCommand(cfg)
+	cmd := newRolesCommandWithDeps(cfg, deps)
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -132,13 +139,28 @@ func TestRolesRun(t *testing.T) {
 	if !strings.Contains(output, "job-") {
 		t.Errorf("expected job ID in output: %q", output)
 	}
+
+	jobs, err := store.ListJobs(1)
+	if err != nil {
+		t.Fatalf("ListJobs error = %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("job count = %d, want 1", len(jobs))
+	}
+	if jobs[0].Summary != "role completed from worker" {
+		t.Fatalf("Summary = %q, want worker result", jobs[0].Summary)
+	}
+	if jobs[0].RoleName != "researcher" || jobs[0].Kind != "role" || jobs[0].MaxToolCalls == 0 {
+		t.Fatalf("unexpected role metadata: %+v", jobs[0])
+	}
 }
 
 func TestRolesRun_WithInput(t *testing.T) {
 	t.Parallel()
 	_, cfg := newTestStore(t)
+	deps, hub := newRolesRunTestDeps("input result")
 
-	cmd := newRolesCommand(cfg)
+	cmd := newRolesCommandWithDeps(cfg, deps)
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -151,13 +173,18 @@ func TestRolesRun_WithInput(t *testing.T) {
 	if !strings.Contains(out.String(), "Job started:") {
 		t.Errorf("expected 'Job started:' in output: %q", out.String())
 	}
+	req := hub.request(t)
+	if !strings.Contains(req.Content, "User input: Go programming news") {
+		t.Fatalf("role input not passed to runner: %q", req.Content)
+	}
 }
 
 func TestRolesRun_WithTier(t *testing.T) {
 	t.Parallel()
-	_, cfg := newTestStore(t)
+	store, cfg := newTestStore(t)
+	deps, _ := newRolesRunTestDeps("tier result")
 
-	cmd := newRolesCommand(cfg)
+	cmd := newRolesCommandWithDeps(cfg, deps)
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -169,6 +196,16 @@ func TestRolesRun_WithTier(t *testing.T) {
 
 	if !strings.Contains(out.String(), "Job started:") {
 		t.Errorf("expected 'Job started:' in output: %q", out.String())
+	}
+	jobs, err := store.ListJobs(1)
+	if err != nil {
+		t.Fatalf("ListJobs error = %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("job count = %d, want 1", len(jobs))
+	}
+	if jobs[0].Worker != "premium" {
+		t.Fatalf("Worker = %q, want premium", jobs[0].Worker)
 	}
 }
 
@@ -261,4 +298,38 @@ func TestRolesEnable_WithCronJob(t *testing.T) {
 	if !strings.Contains(out.String(), "enabled") {
 		t.Errorf("expected 'enabled' in output: %q", out.String())
 	}
+}
+
+type rolesRunTestHub struct {
+	content string
+	reqs    chan agent.RunRequest
+}
+
+func (h *rolesRunTestHub) Submit(req agent.RunRequest) <-chan agent.RunEvent {
+	h.reqs <- req
+	ch := make(chan agent.RunEvent, 1)
+	ch <- agent.RunEvent{Type: agent.RunEventDone, Result: &agent.AgentResponse{Message: h.content}}
+	close(ch)
+	return ch
+}
+
+func (h *rolesRunTestHub) request(t *testing.T) agent.RunRequest {
+	t.Helper()
+	select {
+	case req := <-h.reqs:
+		return req
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for role request")
+		return agent.RunRequest{}
+	}
+}
+
+func newRolesRunTestDeps(content string) (roleRunDeps, *rolesRunTestHub) {
+	hub := &rolesRunTestHub{content: content, reqs: make(chan agent.RunRequest, 1)}
+	return roleRunDeps{
+		newSubmitter: func(_ *config.Config, _ *storage.Store) (rolejob.AgentSubmitter, error) {
+			return hub, nil
+		},
+		waitPoll: 10 * time.Millisecond,
+	}, hub
 }

--- a/internal/rolejob/runner.go
+++ b/internal/rolejob/runner.go
@@ -177,9 +177,6 @@ func roleRunSessionKey(job *storage.Job, m *role.Manifest, opts Options) agent.S
 	if job != nil && strings.TrimSpace(job.JobID) != "" {
 		return agent.SessionKey(fmt.Sprintf("role:%s:%s", roleName, job.JobID))
 	}
-	if job != nil && strings.TrimSpace(job.SessionKey) != "" {
-		return agent.SessionKey(job.SessionKey)
-	}
 	return agent.SessionKey("role:" + roleName)
 }
 

--- a/internal/rolejob/runner.go
+++ b/internal/rolejob/runner.go
@@ -1,0 +1,201 @@
+package rolejob
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/memory"
+	"ok-gobot/internal/role"
+	jobruntime "ok-gobot/internal/runtime"
+	"ok-gobot/internal/storage"
+)
+
+const (
+	// DefaultTimeout preserves the bounded lifecycle for role jobs whose manifest
+	// does not declare max_duration.
+	DefaultTimeout = 5 * time.Minute
+)
+
+// AgentSubmitter is the RuntimeHub surface needed by role jobs.
+type AgentSubmitter interface {
+	Submit(agent.RunRequest) <-chan agent.RunEvent
+}
+
+// AgentCanceller is implemented by RuntimeHub and lets a waiting role job
+// cancel an in-flight agent run when the durable job context is done first.
+type AgentCanceller interface {
+	Cancel(agent.SessionKey)
+}
+
+// Options carries transport/runtime metadata for one role job.
+type Options struct {
+	SessionKey         string
+	DeliverySessionKey string
+	Worker             string
+	ModelTier          string
+	ChatID             int64
+	RunSessionKey      string
+	Timeout            time.Duration
+	MemoryScope        memory.RecallContext
+	OnToolEvent        func(agent.ToolEvent)
+	OnDelta            func(string)
+	OnDeltaReset       func()
+}
+
+// BuildTask combines the role manifest prompt with the operator's input.
+func BuildTask(m *role.Manifest, input string) (string, error) {
+	if m == nil {
+		return "", fmt.Errorf("role manifest is required")
+	}
+
+	var sb strings.Builder
+	sb.WriteString(strings.TrimSpace(m.Prompt))
+	if trimmed := strings.TrimSpace(input); trimmed != "" {
+		sb.WriteString("\n\nUser input: ")
+		sb.WriteString(trimmed)
+	}
+	return strings.TrimSpace(sb.String()), nil
+}
+
+// JobSpec builds the durable metadata for a role run.
+func JobSpec(m *role.Manifest, opts Options) (jobruntime.JobSpec, error) {
+	if m == nil {
+		return jobruntime.JobSpec{}, fmt.Errorf("role manifest is required")
+	}
+
+	worker := strings.TrimSpace(opts.Worker)
+	if worker == "" {
+		worker = strings.TrimSpace(m.Worker)
+	}
+
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = m.MaxDuration
+	}
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
+	return jobruntime.JobSpec{
+		Kind:               "role",
+		Worker:             worker,
+		ModelTier:          strings.TrimSpace(opts.ModelTier),
+		SessionKey:         strings.TrimSpace(opts.SessionKey),
+		DeliverySessionKey: strings.TrimSpace(opts.DeliverySessionKey),
+		Description:        fmt.Sprintf("role:%s", m.Name),
+		RoleName:           strings.TrimSpace(m.Name),
+		Timeout:            timeout,
+		MaxToolCalls:       m.MaxToolCalls,
+	}, nil
+}
+
+// AgentJobRunner returns a durable JobRunner that executes the role through the
+// existing agent RuntimeHub path and persists the agent's final content.
+func AgentJobRunner(hub AgentSubmitter, m *role.Manifest, input string, opts Options) jobruntime.JobRunner {
+	return func(ctx context.Context, job *storage.Job, svc *jobruntime.JobService) (jobruntime.JobRunResult, error) {
+		if hub == nil {
+			return jobruntime.JobRunResult{}, fmt.Errorf("role agent runtime is required")
+		}
+		if job == nil {
+			return jobruntime.JobRunResult{}, fmt.Errorf("job is required")
+		}
+
+		task, err := BuildTask(m, input)
+		if err != nil {
+			return jobruntime.JobRunResult{}, err
+		}
+
+		budget := m.ToDelegationJob()
+		runKey := roleRunSessionKey(job, m, opts)
+		memScope := roleMemoryScope(job, m, opts)
+
+		if svc != nil {
+			_ = svc.AppendEvent(job.JobID, jobruntime.JobEventProgress, fmt.Sprintf("running role %s", m.Name), nil)
+		}
+
+		events := hub.Submit(agent.RunRequest{
+			SessionKey:   runKey,
+			ChatID:       opts.ChatID,
+			Content:      task,
+			Context:      ctx,
+			OnToolEvent:  opts.OnToolEvent,
+			OnDelta:      opts.OnDelta,
+			OnDeltaReset: opts.OnDeltaReset,
+			Job:          &budget,
+			MemoryScope:  memScope,
+		})
+
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				return jobruntime.JobRunResult{}, fmt.Errorf("role agent runtime ended without a result")
+			}
+			switch ev.Type {
+			case agent.RunEventDone:
+				if ev.Result == nil {
+					return jobruntime.JobRunResult{}, fmt.Errorf("role agent runtime returned nil result")
+				}
+				summary := strings.TrimSpace(ev.Result.Message)
+				result := jobruntime.JobRunResult{Summary: summary}
+				if summary != "" {
+					result.Artifacts = []jobruntime.JobArtifactSpec{{
+						Name:     "output",
+						Type:     "text",
+						MimeType: "text/plain",
+						Content:  summary,
+					}}
+				}
+				return result, nil
+			case agent.RunEventError:
+				if ev.Err != nil {
+					return jobruntime.JobRunResult{}, ev.Err
+				}
+				return jobruntime.JobRunResult{}, fmt.Errorf("role agent runtime failed")
+			default:
+				return jobruntime.JobRunResult{}, fmt.Errorf("unexpected role agent event: %s", ev.Type)
+			}
+		case <-ctx.Done():
+			if canceller, ok := hub.(AgentCanceller); ok {
+				canceller.Cancel(runKey)
+			}
+			return jobruntime.JobRunResult{}, ctx.Err()
+		}
+	}
+}
+
+func roleRunSessionKey(job *storage.Job, m *role.Manifest, opts Options) agent.SessionKey {
+	if key := strings.TrimSpace(opts.RunSessionKey); key != "" {
+		return agent.SessionKey(key)
+	}
+	roleName := "role"
+	if m != nil && strings.TrimSpace(m.Name) != "" {
+		roleName = strings.TrimSpace(m.Name)
+	}
+	if job != nil && strings.TrimSpace(job.JobID) != "" {
+		return agent.SessionKey(fmt.Sprintf("role:%s:%s", roleName, job.JobID))
+	}
+	if job != nil && strings.TrimSpace(job.SessionKey) != "" {
+		return agent.SessionKey(job.SessionKey)
+	}
+	return agent.SessionKey("role:" + roleName)
+}
+
+func roleMemoryScope(job *storage.Job, m *role.Manifest, opts Options) memory.RecallContext {
+	scope := opts.MemoryScope
+	if scope.ChatID == 0 {
+		scope.ChatID = opts.ChatID
+	}
+	if scope.SessionKey == "" && job != nil {
+		scope.SessionKey = job.SessionKey
+	}
+	if scope.RoleName == "" && m != nil {
+		scope.RoleName = m.Name
+	}
+	if scope.JobID == "" && job != nil {
+		scope.JobID = job.JobID
+	}
+	return scope
+}

--- a/internal/rolejob/runner_test.go
+++ b/internal/rolejob/runner_test.go
@@ -1,0 +1,214 @@
+package rolejob
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/role"
+	jobruntime "ok-gobot/internal/runtime"
+	"ok-gobot/internal/storage"
+)
+
+type fakeAgentHub struct {
+	mu       sync.Mutex
+	requests []agent.RunRequest
+	content  string
+	err      error
+	block    bool
+	cancel   agent.SessionKey
+}
+
+func (h *fakeAgentHub) Submit(req agent.RunRequest) <-chan agent.RunEvent {
+	h.mu.Lock()
+	h.requests = append(h.requests, req)
+	h.mu.Unlock()
+
+	ch := make(chan agent.RunEvent, 1)
+	if h.block {
+		return ch
+	}
+	if h.err != nil {
+		ch <- agent.RunEvent{Type: agent.RunEventError, Err: h.err, ProfileName: "test"}
+	} else {
+		ch <- agent.RunEvent{Type: agent.RunEventDone, Result: &agent.AgentResponse{Message: h.content}, ProfileName: "test"}
+	}
+	close(ch)
+	return ch
+}
+
+func (h *fakeAgentHub) Cancel(key agent.SessionKey) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.cancel = key
+}
+
+func (h *fakeAgentHub) firstRequest(t *testing.T) agent.RunRequest {
+	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.requests) == 0 {
+		t.Fatal("expected one agent request")
+	}
+	return h.requests[0]
+}
+
+func TestAgentJobRunnerPersistsWorkerResultAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	store := newRoleJobTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const routeKey = "dm:42"
+	if err := store.SaveSessionRoute(storage.SessionRoute{SessionKey: routeKey, Channel: "telegram", ChatID: 42}); err != nil {
+		t.Fatalf("SaveSessionRoute failed: %v", err)
+	}
+
+	manifest := &role.Manifest{
+		Name:         "researcher",
+		Prompt:       "Research the topic and produce a brief.",
+		Worker:       "standard",
+		Tools:        []string{"web_fetch"},
+		MaxToolCalls: 7,
+		MaxDuration:  90 * time.Second,
+	}
+	hub := &fakeAgentHub{content: "real worker result"}
+	opts := Options{SessionKey: routeKey, DeliverySessionKey: routeKey, ChatID: 42}
+	spec, err := JobSpec(manifest, opts)
+	if err != nil {
+		t.Fatalf("JobSpec failed: %v", err)
+	}
+
+	svc := jobruntime.NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), spec, AgentJobRunner(hub, manifest, "Go programming news", opts))
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	finished := waitForRoleJobStatus(t, store, job.JobID, string(jobruntime.JobStatusSucceeded))
+	if finished.Summary != "real worker result" {
+		t.Fatalf("Summary = %q, want worker result", finished.Summary)
+	}
+	if strings.Contains(finished.Summary, "prompt length") {
+		t.Fatalf("summary still looks like the old stub: %q", finished.Summary)
+	}
+	if finished.Kind != "role" {
+		t.Fatalf("Kind = %q, want role", finished.Kind)
+	}
+	if finished.RoleName != "researcher" {
+		t.Fatalf("RoleName = %q, want researcher", finished.RoleName)
+	}
+	if finished.Worker != "standard" {
+		t.Fatalf("Worker = %q, want standard", finished.Worker)
+	}
+	if finished.SessionKey != routeKey || finished.DeliverySessionKey != routeKey {
+		t.Fatalf("session metadata = (%q, %q), want %q", finished.SessionKey, finished.DeliverySessionKey, routeKey)
+	}
+	if finished.MaxToolCalls != 7 {
+		t.Fatalf("MaxToolCalls = %d, want 7", finished.MaxToolCalls)
+	}
+	if finished.TimeoutSeconds != 90 {
+		t.Fatalf("TimeoutSeconds = %d, want 90", finished.TimeoutSeconds)
+	}
+
+	req := hub.firstRequest(t)
+	if !strings.Contains(req.Content, manifest.Prompt) || !strings.Contains(req.Content, "User input: Go programming news") {
+		t.Fatalf("agent request content did not include prompt and input: %q", req.Content)
+	}
+	if req.Job == nil || req.Job.MaxToolCalls != 7 || len(req.Job.ToolAllowlist) != 1 || req.Job.ToolAllowlist[0] != "web_fetch" {
+		t.Fatalf("unexpected delegation job: %+v", req.Job)
+	}
+	if req.MemoryScope.RoleName != "researcher" || req.MemoryScope.JobID != job.JobID || req.MemoryScope.SessionKey != routeKey {
+		t.Fatalf("unexpected memory scope: %+v", req.MemoryScope)
+	}
+	if string(req.SessionKey) == routeKey {
+		t.Fatalf("runtime session key should be isolated from delivery session key")
+	}
+}
+
+func TestAgentJobRunnerPropagatesWorkerError(t *testing.T) {
+	t.Parallel()
+
+	store := newRoleJobTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	manifest := &role.Manifest{Name: "researcher", Prompt: "Do work", Worker: "standard"}
+	hub := &fakeAgentHub{err: errors.New("worker failed")}
+	spec, err := JobSpec(manifest, Options{})
+	if err != nil {
+		t.Fatalf("JobSpec failed: %v", err)
+	}
+
+	svc := jobruntime.NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), spec, AgentJobRunner(hub, manifest, "", Options{}))
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	finished := waitForRoleJobStatus(t, store, job.JobID, string(jobruntime.JobStatusFailed))
+	if !strings.Contains(finished.Error, "worker failed") {
+		t.Fatalf("Error = %q, want worker failure", finished.Error)
+	}
+}
+
+func TestAgentJobRunnerPropagatesTimeout(t *testing.T) {
+	t.Parallel()
+
+	store := newRoleJobTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	manifest := &role.Manifest{Name: "researcher", Prompt: "Do work", Worker: "standard", MaxDuration: 30 * time.Millisecond}
+	hub := &fakeAgentHub{block: true}
+	spec, err := JobSpec(manifest, Options{})
+	if err != nil {
+		t.Fatalf("JobSpec failed: %v", err)
+	}
+
+	svc := jobruntime.NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), spec, AgentJobRunner(hub, manifest, "", Options{}))
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	finished := waitForRoleJobStatus(t, store, job.JobID, string(jobruntime.JobStatusTimedOut))
+	if finished.Error == "" {
+		t.Fatal("expected timeout error to be stored")
+	}
+	hub.mu.Lock()
+	cancelled := hub.cancel
+	hub.mu.Unlock()
+	if cancelled == "" {
+		t.Fatal("expected blocked agent run to be cancelled")
+	}
+}
+
+func newRoleJobTestStore(t *testing.T) *storage.Store {
+	t.Helper()
+	store, err := storage.New(filepath.Join(t.TempDir(), "rolejob.db"))
+	if err != nil {
+		t.Fatalf("storage.New failed: %v", err)
+	}
+	return store
+}
+
+func waitForRoleJobStatus(t *testing.T, store *storage.Store, jobID, want string) *storage.Job {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		job, err := store.GetJob(jobID)
+		if err != nil {
+			t.Fatalf("GetJob failed: %v", err)
+		}
+		if job != nil && job.Status == want {
+			return job
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for job %s to reach status %s", jobID, want)
+	return nil
+}


### PR DESCRIPTION
Implements #341

## Changes
- Adds a shared role job runner that builds role tasks from manifest prompt plus input and executes them through the existing agent runtime path.
- Wires both `ok-gobot roles run` and `/role_run` to the shared runner and persists real result content into durable job summaries.
- Persists role job metadata including kind, role name, session/delivery session keys, worker tier, timeout, and max tool calls.
- Adds focused tests for success, worker error propagation, timeout propagation, CLI metadata, and real summary persistence.

## Testing
- `.maestro/verify.sh` (initial run hit a transient `internal/memory` qmd temp-script `text file busy`; affected test passed on rerun)
- `go test ./internal/memory -run TestQMDBackendPassesConfiguredCollections -count=1`
- `go test ./internal/rolejob ./internal/cli ./internal/bot`
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the stub role-run implementations in both the CLI and the bot with a shared `rolejob.AgentJobRunner` that executes roles through the existing `RuntimeHub` path and persists real result content, metadata, and artifacts into durable job records. The dep-injection pattern via `roleRunDeps` keeps the CLI fully testable without a live agent stack.

<h3>Confidence Score: 5/5</h3>

PR is safe to merge — no logic bugs found across the new runner, bot wiring, or CLI path.

All five changed files are well-implemented with no P1/P0 issues. The single-event channel contract in AgentJobRunner matches the runtime's documented behaviour. Cancellation, timeout propagation, metadata persistence, and error handling are all correctly handled and covered by focused tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/rolejob/runner.go | New shared runner: BuildTask, JobSpec, and AgentJobRunner are well-structured; single-event channel contract aligns with the runtime; cancellation via AgentCanceller is properly guarded with a type assertion. |
| internal/rolejob/runner_test.go | Good test coverage for success path, worker-error propagation, timeout cancellation, and metadata persistence; fakeAgentHub correctly implements both AgentSubmitter and AgentCanceller. |
| internal/cli/roles.go | Wired to rolejob runner with proper dep-injection for testability; waitForRoleJobCompletion polls correctly and exits on ctx cancellation; newRoleRunSubmitter initialises the full agent stack consistently with the bot path. |
| internal/cli/roles_test.go | Updated tests use injected deps; covers summary persistence, metadata fields, tier override, and input forwarding with a buffered stub hub. |
| internal/bot/role_commands.go | Replaces stub role run with real agent runner; session/delivery key plumbing and nil-hub guard are correct; worker fallback display is a nice UX improvement. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: remove dead role session fallback (..."](https://github.com/befeast/ok-gobot/commit/44f2acc039fbe6dc2bbffa9a0c8473639860e18c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30408974)</sub>

<!-- /greptile_comment -->