### PR TITLE
feat: persist role job proof artifacts (#342)

### DIFF
--- a/internal/agent/tool_agent.go
+++ b/internal/agent/tool_agent.go
@@ -28,12 +28,13 @@ const (
 
 // ToolEvent represents a tool lifecycle event fired during ProcessRequest
 type ToolEvent struct {
-	ToolName string
-	Type     string            // ToolEventStarted or ToolEventFinished
-	Input    string            // raw JSON arguments (populated on Started)
-	Output   string            // truncated result text (populated on Finished)
-	Err      error             // non-nil if Type is ToolEventFinished and tool failed
-	Denial   *tools.ToolDenial // non-nil when the tool was blocked by policy
+	ToolName   string
+	Type       string            // ToolEventStarted or ToolEventFinished
+	Input      string            // raw JSON arguments (populated on Started)
+	Output     string            // truncated result text for display (populated on Finished)
+	FullOutput string            // untruncated result text for internal consumers only
+	Err        error             // non-nil if Type is ToolEventFinished and tool failed
+	Denial     *tools.ToolDenial // non-nil when the tool was blocked by policy
 }
 
 // ToolTimeoutSpawnFunc is called when a tool execution exceeds ToolTimeout.
@@ -351,7 +352,7 @@ iterationLoop:
 					if len(out) > 300 {
 						out = out[:300] + "…"
 					}
-					a.onToolEvent(ToolEvent{ToolName: functionName, Type: ToolEventFinished, Output: out, Err: err, Denial: denial})
+					a.onToolEvent(ToolEvent{ToolName: functionName, Type: ToolEventFinished, Output: out, FullOutput: result, Err: err, Denial: denial})
 				}
 
 				// Fire PostToolUse lifecycle hook.

--- a/internal/agent/tool_agent_test.go
+++ b/internal/agent/tool_agent_test.go
@@ -181,6 +181,7 @@ type mockTool struct {
 	name        string
 	desc        string
 	schema      map[string]interface{}
+	output      string
 	executedCmd string
 	executedURL string
 	allArgs     []string
@@ -196,6 +197,9 @@ func (t *mockTool) Execute(ctx context.Context, args ...string) (string, error) 
 	}
 	if len(args) > 1 {
 		t.executedURL = args[1]
+	}
+	if t.output != "" {
+		return t.output, nil
 	}
 	return fmt.Sprintf("OK: executed %s with %v", t.name, args), nil
 }
@@ -666,6 +670,49 @@ func TestToolCallingAgent_EventCallback(t *testing.T) {
 	}
 	if events[1].Err != nil {
 		t.Errorf("expected no error in finished event, got %v", events[1].Err)
+	}
+}
+
+func TestToolCallingAgent_EventCallbackIncludesFullOutput(t *testing.T) {
+	fullOutput := `{"match":true,"feedback":"` + strings.Repeat("verbose ", 60) + `","screenshot_path":"/tmp/proof.png"}`
+	registry := tools.NewRegistry()
+	registry.Register(&mockTool{
+		name:   "frontend_verify",
+		desc:   "Verify frontend",
+		schema: map[string]interface{}{"type": "object"},
+		output: fullOutput,
+	})
+
+	mockAI := &mockAIClient{
+		toolCallName: "frontend_verify",
+		toolCallArgs: `{"url":"http://localhost:3000"}`,
+		finalText:    "Done",
+	}
+
+	ta := NewToolCallingAgent(mockAI, registry, &Personality{
+		Files: map[string]string{"IDENTITY.md": "Test Bot"},
+	})
+	var events []ToolEvent
+	ta.SetToolEventCallback(func(e ToolEvent) {
+		events = append(events, e)
+	})
+
+	_, err := ta.ProcessRequest(context.Background(), "verify UI", "")
+	if err != nil {
+		t.Fatalf("ProcessRequest failed: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	finished := events[1]
+	if finished.Type != ToolEventFinished || finished.ToolName != "frontend_verify" {
+		t.Fatalf("unexpected finished event: %+v", finished)
+	}
+	if finished.Output == fullOutput || strings.Contains(finished.Output, "screenshot_path") {
+		t.Fatalf("display output was not truncated before screenshot path: %q", finished.Output)
+	}
+	if finished.FullOutput != fullOutput || !strings.Contains(finished.FullOutput, "screenshot_path") {
+		t.Fatalf("full output did not preserve raw tool result: %q", finished.FullOutput)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -403,6 +403,7 @@ func (a *App) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to create bot: %w", err)
 	}
 	a.bot = b
+	a.bot.SetArtifactRoots(a.config.Artifacts.Roots)
 
 	// Wire Active Memory pre-reply recall (DM-only, opt-in).
 	activeCfg := agent.ActiveMemoryConfig{

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -58,6 +58,7 @@ type Bot struct {
 	controlHub            *control.Hub // optional: emit run/tool/approval events over WebSocket
 	voiceTranscriber      *VoiceTranscriber
 	rolesPath             string // directory of role manifests; set via SetRolesPath
+	artifactRoots         []string
 	activeMemory          *agent.ActiveMemory
 	memoryStatus          MemoryStatusProvider
 	memoryExtraPathLabels []string
@@ -921,6 +922,11 @@ func (b *Bot) SetControlHub(h *control.Hub) {
 // SetRolesPath sets the directory for role manifest loading.
 func (b *Bot) SetRolesPath(path string) {
 	b.rolesPath = path
+}
+
+// SetArtifactRoots sets local roots allowed for role proof artifacts.
+func (b *Bot) SetArtifactRoots(roots []string) {
+	b.artifactRoots = append([]string(nil), roots...)
 }
 
 // SubagentHub returns the runtime Hub used for sub-agent completion routing.

--- a/internal/bot/role_commands.go
+++ b/internal/bot/role_commands.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/telebot.v4"
 
 	"ok-gobot/internal/agent"
+	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/role"
 	"ok-gobot/internal/rolejob"
 	"ok-gobot/internal/runtime"
@@ -193,6 +194,7 @@ func (b *Bot) handleRoleRunCommand(c telebot.Context) error {
 		DeliverySessionKey: deliverySessionKey,
 		Worker:             m.Worker,
 		ChatID:             chatID,
+		ArtifactRoots:      b.artifactRoots,
 	}
 	spec, err := rolejob.JobSpec(m, opts)
 	if err != nil {
@@ -305,6 +307,23 @@ func (b *Bot) handleTGJobCommand(c telebot.Context) error {
 			errMsg = errMsg[:197] + "..."
 		}
 		sb.WriteString(fmt.Sprintf("\nError: %s\n", errMsg))
+	}
+
+	artifacts, err := b.store.ListJobArtifacts(job.JobID, 10)
+	if err != nil {
+		log.Printf("[jobs] failed to list artifacts for %s: %v", job.JobID, err)
+	} else if len(artifacts) > 0 {
+		serializer := artifactview.NewSerializer(b.artifactRoots, "")
+		sb.WriteString("\nArtifacts:\n")
+		for _, info := range serializer.SerializeAll(artifacts) {
+			detail := ""
+			if info.URL != "" {
+				detail = " - " + info.URL
+			} else if !info.Display.Safe {
+				detail = " - unsafe local artifact hidden"
+			}
+			sb.WriteString(fmt.Sprintf("- `%s` (%s)%s\n", info.Label, info.Type, detail))
+		}
 	}
 
 	return c.Send(sb.String(), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})

--- a/internal/cli/jobs.go
+++ b/internal/cli/jobs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/config"
 	"ok-gobot/internal/storage"
 )
@@ -184,12 +185,13 @@ func newJobsInspectCommand(cfg *config.Config) *cobra.Command {
 				return fmt.Errorf("failed to list artifacts: %w", err)
 			}
 			if len(artifacts) > 0 {
+				serializer := artifactview.NewSerializer(cfg.Artifacts.Roots, "")
 				fmt.Fprintln(out)
 				fmt.Fprintln(out, "Artifacts:")
 				w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
 				fmt.Fprintln(w, "  NAME\tTYPE\tMIME\tURI")
 				for _, a := range artifacts {
-					fmt.Fprintf(w, "  %s\t%s\t%s\t%s\n", a.Name, a.ArtifactType, a.MimeType, a.URI)
+					fmt.Fprintf(w, "  %s\t%s\t%s\t%s\n", a.Name, a.ArtifactType, a.MimeType, artifactInspectURI(serializer, a))
 				}
 				w.Flush() //nolint:errcheck
 			}
@@ -558,6 +560,20 @@ func printEvent(out interface{ Write([]byte) (int, error) }, e storage.JobEvent)
 		msg = "-"
 	}
 	fmt.Fprintf(out, "%s  %-20s  %s\n", formatTime(e.CreatedAt), e.EventType, msg)
+}
+
+func artifactInspectURI(serializer artifactview.Serializer, artifact storage.JobArtifact) string {
+	info := serializer.Serialize(artifact)
+	if !info.Display.Safe {
+		if info.Display.Reason != "" {
+			return "[unsafe: " + info.Display.Reason + "]"
+		}
+		return "[unsafe]"
+	}
+	if info.URL != "" {
+		return info.URL
+	}
+	return info.URI
 }
 
 func isTerminalStatus(status string) bool {

--- a/internal/cli/jobs_test.go
+++ b/internal/cli/jobs_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -472,6 +473,58 @@ func TestJobsInspect_ShowsRoleAndModelTier(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Errorf("expected %q in output: %q", want, output)
 		}
+	}
+}
+
+func TestJobsInspect_ShowsArtifactsWithSafeURIs(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+
+	root := t.TempDir()
+	cfg.Artifacts.Roots = []string{root}
+	shotPath := filepath.Join(root, "shot.png")
+	if err := os.WriteFile(shotPath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write screenshot: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "secret.png")
+	if err := os.WriteFile(outside, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+
+	seedJob(t, store, storage.Job{
+		JobID:    "job-artifacts-1",
+		Kind:     "role",
+		Status:   "succeeded",
+		RoleName: "auditor",
+	})
+	if err := store.AddJobArtifact(storage.JobArtifact{JobID: "job-artifacts-1", Name: "PR", ArtifactType: "url", URI: "https://example.com/pr/1"}); err != nil {
+		t.Fatalf("AddJobArtifact url: %v", err)
+	}
+	if err := store.AddJobArtifact(storage.JobArtifact{JobID: "job-artifacts-1", Name: "Screenshot", ArtifactType: "screenshot", MimeType: "image/png", URI: shotPath}); err != nil {
+		t.Fatalf("AddJobArtifact screenshot: %v", err)
+	}
+	if err := store.AddJobArtifact(storage.JobArtifact{JobID: "job-artifacts-1", Name: "Outside", ArtifactType: "screenshot", MimeType: "image/png", URI: outside}); err != nil {
+		t.Fatalf("AddJobArtifact outside: %v", err)
+	}
+
+	cmd := newJobsCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"inspect", "job-artifacts-1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	output := out.String()
+	for _, want := range []string{"Artifacts:", "PR", "https://example.com/pr/1", "Screenshot", shotPath, "[unsafe:"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in output: %q", want, output)
+		}
+	}
+	if strings.Contains(output, outside) {
+		t.Fatalf("unsafe path leaked in output: %q", output)
 	}
 }
 

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -218,8 +218,9 @@ func newRolesRunCommand(cfg *config.Config, deps roleRunDeps) *cobra.Command {
 				worker = tier
 			}
 			opts := rolejob.Options{
-				SessionKey: fmt.Sprintf("cli:role:%s", m.Name),
-				Worker:     worker,
+				SessionKey:    fmt.Sprintf("cli:role:%s", m.Name),
+				Worker:        worker,
+				ArtifactRoots: cfg.Artifacts.Roots,
 			}
 			spec, err := rolejob.JobSpec(m, opts)
 			if err != nil {

--- a/internal/memory/qmd_test.go
+++ b/internal/memory/qmd_test.go
@@ -193,8 +193,19 @@ printf '%s\n' '[]'
 func writeQMDTestBinary(t *testing.T, script string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "qmd")
-	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o755)
+	if err != nil {
 		t.Fatalf("write fake qmd: %v", err)
+	}
+	if _, err := f.WriteString(script); err != nil {
+		_ = f.Close()
+		t.Fatalf("write fake qmd: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close fake qmd: %v", err)
+	}
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("chmod fake qmd: %v", err)
 	}
 	return path
 }

--- a/internal/rolejob/runner.go
+++ b/internal/rolejob/runner.go
@@ -2,7 +2,10 @@ package rolejob
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"mime"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -43,6 +46,7 @@ type Options struct {
 	OnToolEvent        func(agent.ToolEvent)
 	OnDelta            func(string)
 	OnDeltaReset       func()
+	ArtifactRoots      []string
 }
 
 // BuildTask combines the role manifest prompt with the operator's input.
@@ -89,6 +93,7 @@ func JobSpec(m *role.Manifest, opts Options) (jobruntime.JobSpec, error) {
 		RoleName:           strings.TrimSpace(m.Name),
 		Timeout:            timeout,
 		MaxToolCalls:       m.MaxToolCalls,
+		ArtifactRoots:      append([]string(nil), opts.ArtifactRoots...),
 	}, nil
 }
 
@@ -111,6 +116,13 @@ func AgentJobRunner(hub AgentSubmitter, m *role.Manifest, input string, opts Opt
 		budget := m.ToDelegationJob()
 		runKey := roleRunSessionKey(job, m, opts)
 		memScope := roleMemoryScope(job, m, opts)
+		var toolArtifacts []jobruntime.JobArtifactSpec
+		onToolEvent := func(event agent.ToolEvent) {
+			if opts.OnToolEvent != nil {
+				opts.OnToolEvent(event)
+			}
+			toolArtifacts = append(toolArtifacts, extractToolArtifacts(event)...)
+		}
 
 		if svc != nil {
 			_ = svc.AppendEvent(job.JobID, jobruntime.JobEventProgress, fmt.Sprintf("running role %s", m.Name), nil)
@@ -121,7 +133,7 @@ func AgentJobRunner(hub AgentSubmitter, m *role.Manifest, input string, opts Opt
 			ChatID:       opts.ChatID,
 			Content:      task,
 			Context:      ctx,
-			OnToolEvent:  opts.OnToolEvent,
+			OnToolEvent:  onToolEvent,
 			OnDelta:      opts.OnDelta,
 			OnDeltaReset: opts.OnDeltaReset,
 			Job:          &budget,
@@ -139,16 +151,7 @@ func AgentJobRunner(hub AgentSubmitter, m *role.Manifest, input string, opts Opt
 					return jobruntime.JobRunResult{}, fmt.Errorf("role agent runtime returned nil result")
 				}
 				summary := strings.TrimSpace(ev.Result.Message)
-				result := jobruntime.JobRunResult{Summary: summary}
-				if summary != "" {
-					result.Artifacts = []jobruntime.JobArtifactSpec{{
-						Name:     "output",
-						Type:     "text",
-						MimeType: "text/plain",
-						Content:  summary,
-					}}
-				}
-				return result, nil
+				return jobruntime.JobRunResult{Summary: summary, Artifacts: toolArtifacts}, nil
 			case agent.RunEventError:
 				if ev.Err != nil {
 					return jobruntime.JobRunResult{}, ev.Err
@@ -164,6 +167,35 @@ func AgentJobRunner(hub AgentSubmitter, m *role.Manifest, input string, opts Opt
 			return jobruntime.JobRunResult{}, ctx.Err()
 		}
 	}
+}
+
+func extractToolArtifacts(event agent.ToolEvent) []jobruntime.JobArtifactSpec {
+	if event.Type != agent.ToolEventFinished || event.Err != nil {
+		return nil
+	}
+	if event.ToolName != "frontend_verify" {
+		return nil
+	}
+
+	var out struct {
+		ScreenshotPath string `json:"screenshot_path"`
+	}
+	if err := json.Unmarshal([]byte(event.Output), &out); err != nil || strings.TrimSpace(out.ScreenshotPath) == "" {
+		return nil
+	}
+
+	path := strings.TrimSpace(out.ScreenshotPath)
+	mimeType := mime.TypeByExtension(strings.ToLower(filepath.Ext(path)))
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+	return []jobruntime.JobArtifactSpec{{
+		Name:     "frontend-verify-screenshot",
+		Type:     jobruntime.JobArtifactTypeScreenshot,
+		MimeType: mimeType,
+		URI:      path,
+		Metadata: map[string]any{"source": "frontend_verify"},
+	}}
 }
 
 func roleRunSessionKey(job *storage.Job, m *role.Manifest, opts Options) agent.SessionKey {

--- a/internal/rolejob/runner.go
+++ b/internal/rolejob/runner.go
@@ -180,7 +180,11 @@ func extractToolArtifacts(event agent.ToolEvent) []jobruntime.JobArtifactSpec {
 	var out struct {
 		ScreenshotPath string `json:"screenshot_path"`
 	}
-	if err := json.Unmarshal([]byte(event.Output), &out); err != nil || strings.TrimSpace(out.ScreenshotPath) == "" {
+	output := strings.TrimSpace(event.FullOutput)
+	if output == "" {
+		output = event.Output
+	}
+	if err := json.Unmarshal([]byte(output), &out); err != nil || strings.TrimSpace(out.ScreenshotPath) == "" {
 		return nil
 	}
 

--- a/internal/rolejob/runner.go
+++ b/internal/rolejob/runner.go
@@ -151,7 +151,11 @@ func AgentJobRunner(hub AgentSubmitter, m *role.Manifest, input string, opts Opt
 					return jobruntime.JobRunResult{}, fmt.Errorf("role agent runtime returned nil result")
 				}
 				summary := strings.TrimSpace(ev.Result.Message)
-				return jobruntime.JobRunResult{Summary: summary, Artifacts: toolArtifacts}, nil
+				return jobruntime.JobRunResult{
+					Summary:       summary,
+					Artifacts:     toolArtifacts,
+					ArtifactRoots: append([]string(nil), opts.ArtifactRoots...),
+				}, nil
 			case agent.RunEventError:
 				if ev.Err != nil {
 					return jobruntime.JobRunResult{}, ev.Err

--- a/internal/rolejob/runner_test.go
+++ b/internal/rolejob/runner_test.go
@@ -163,14 +163,17 @@ func TestAgentJobRunnerPersistsFrontendVerifyScreenshot(t *testing.T) {
 	if err := os.WriteFile(shotPath, []byte("png"), 0o644); err != nil {
 		t.Fatalf("write screenshot: %v", err)
 	}
+	fullOutput := `{"match":true,"feedback":"` + strings.Repeat("verbose ", 60) + `","screenshot_path":"` + shotPath + `"}`
+	truncatedOutput := fullOutput[:300] + "…"
 
 	manifest := &role.Manifest{Name: "prototype", Prompt: "Build and verify UI", Worker: "standard"}
 	hub := &fakeAgentHub{
 		content: "verified",
 		events: []agent.ToolEvent{{
-			ToolName: "frontend_verify",
-			Type:     agent.ToolEventFinished,
-			Output:   `{"match":true,"screenshot_path":"` + shotPath + `"}`,
+			ToolName:   "frontend_verify",
+			Type:       agent.ToolEventFinished,
+			Output:     truncatedOutput,
+			FullOutput: fullOutput,
 		}},
 	}
 	opts := Options{ArtifactRoots: []string{root}}

--- a/internal/rolejob/runner_test.go
+++ b/internal/rolejob/runner_test.go
@@ -3,6 +3,7 @@ package rolejob
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -22,6 +23,7 @@ type fakeAgentHub struct {
 	err      error
 	block    bool
 	cancel   agent.SessionKey
+	events   []agent.ToolEvent
 }
 
 func (h *fakeAgentHub) Submit(req agent.RunRequest) <-chan agent.RunEvent {
@@ -32,6 +34,11 @@ func (h *fakeAgentHub) Submit(req agent.RunRequest) <-chan agent.RunEvent {
 	ch := make(chan agent.RunEvent, 1)
 	if h.block {
 		return ch
+	}
+	for _, event := range h.events {
+		if req.OnToolEvent != nil {
+			req.OnToolEvent(event)
+		}
 	}
 	if h.err != nil {
 		ch <- agent.RunEvent{Type: agent.RunEventError, Err: h.err, ProfileName: "test"}
@@ -77,7 +84,7 @@ func TestAgentJobRunnerPersistsWorkerResultAndMetadata(t *testing.T) {
 		MaxToolCalls: 7,
 		MaxDuration:  90 * time.Second,
 	}
-	hub := &fakeAgentHub{content: "real worker result"}
+	hub := &fakeAgentHub{content: "real worker result\n\nProof: https://example.com/report"}
 	opts := Options{SessionKey: routeKey, DeliverySessionKey: routeKey, ChatID: 42}
 	spec, err := JobSpec(manifest, opts)
 	if err != nil {
@@ -91,7 +98,7 @@ func TestAgentJobRunnerPersistsWorkerResultAndMetadata(t *testing.T) {
 	}
 
 	finished := waitForRoleJobStatus(t, store, job.JobID, string(jobruntime.JobStatusSucceeded))
-	if finished.Summary != "real worker result" {
+	if finished.Summary != "real worker result\n\nProof: https://example.com/report" {
 		t.Fatalf("Summary = %q, want worker result", finished.Summary)
 	}
 	if strings.Contains(finished.Summary, "prompt length") {
@@ -128,6 +135,72 @@ func TestAgentJobRunnerPersistsWorkerResultAndMetadata(t *testing.T) {
 	}
 	if string(req.SessionKey) == routeKey {
 		t.Fatalf("runtime session key should be isolated from delivery session key")
+	}
+
+	artifacts, err := store.ListJobArtifacts(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	if len(artifacts) != 2 {
+		t.Fatalf("artifact count = %d, want text report and URL: %+v", len(artifacts), artifacts)
+	}
+	if artifacts[0].ArtifactType != jobruntime.JobArtifactTypeTextReport || !strings.Contains(artifacts[0].Content, "real worker result") {
+		t.Fatalf("artifact[0] = %+v, want text report", artifacts[0])
+	}
+	if artifacts[1].ArtifactType != jobruntime.JobArtifactTypeURL || artifacts[1].URI != "https://example.com/report" {
+		t.Fatalf("artifact[1] = %+v, want URL", artifacts[1])
+	}
+}
+
+func TestAgentJobRunnerPersistsFrontendVerifyScreenshot(t *testing.T) {
+	t.Parallel()
+
+	store := newRoleJobTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	root := t.TempDir()
+	shotPath := filepath.Join(root, "proof.png")
+	if err := os.WriteFile(shotPath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write screenshot: %v", err)
+	}
+
+	manifest := &role.Manifest{Name: "prototype", Prompt: "Build and verify UI", Worker: "standard"}
+	hub := &fakeAgentHub{
+		content: "verified",
+		events: []agent.ToolEvent{{
+			ToolName: "frontend_verify",
+			Type:     agent.ToolEventFinished,
+			Output:   `{"match":true,"screenshot_path":"` + shotPath + `"}`,
+		}},
+	}
+	opts := Options{ArtifactRoots: []string{root}}
+	spec, err := JobSpec(manifest, opts)
+	if err != nil {
+		t.Fatalf("JobSpec failed: %v", err)
+	}
+
+	svc := jobruntime.NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), spec, AgentJobRunner(hub, manifest, "", opts))
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+	waitForRoleJobStatus(t, store, job.JobID, string(jobruntime.JobStatusSucceeded))
+
+	artifacts, err := store.ListJobArtifacts(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	found := false
+	for _, artifact := range artifacts {
+		if artifact.ArtifactType == jobruntime.JobArtifactTypeScreenshot {
+			found = true
+			if artifact.URI != shotPath || artifact.Content != "" {
+				t.Fatalf("unexpected screenshot artifact: %+v", artifact)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("missing screenshot artifact: %+v", artifacts)
 	}
 }
 

--- a/internal/runtime/artifacts.go
+++ b/internal/runtime/artifacts.go
@@ -1,0 +1,334 @@
+package runtime
+
+import (
+	"mime"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	artifactview "ok-gobot/internal/artifacts"
+	"ok-gobot/internal/storage"
+)
+
+const (
+	JobArtifactTypeScreenshot = "screenshot"
+	JobArtifactTypeURL        = "url"
+	JobArtifactTypeFile       = "file"
+	JobArtifactTypeTextReport = "text_report"
+)
+
+var (
+	roleURLRE     = regexp.MustCompile(`https?://[^\s<>"']+`)
+	roleFileURIRE = regexp.MustCompile(`file:///[^\s<>"']+`)
+	rolePathRE    = regexp.MustCompile(`(?i)(^|[\s"'(\[])(/[A-Za-z0-9._~!$&+,;=:@%/-]+\.(png|jpe?g|gif|webp|html?|md|json|txt|log|pdf|csv))`)
+)
+
+func isRoleJob(job *storage.Job) bool {
+	if job == nil {
+		return false
+	}
+	return strings.TrimSpace(job.Kind) == "role" || strings.TrimSpace(job.RoleName) != ""
+}
+
+func roleProofArtifacts(result JobRunResult, roots []string) []JobArtifactSpec {
+	raw := append([]JobArtifactSpec(nil), result.Artifacts...)
+	if !hasRoleTextReport(raw) {
+		report := strings.TrimSpace(result.Summary)
+		if report == "" {
+			report = "role job completed with no final output"
+		}
+		raw = append([]JobArtifactSpec{{
+			Name:     "final-report",
+			Type:     JobArtifactTypeTextReport,
+			MimeType: "text/markdown",
+			Content:  report,
+		}}, raw...)
+	}
+
+	raw = append(raw, extractArtifactsFromRoleText(result.Summary)...)
+	for _, artifact := range result.Artifacts {
+		if standardRoleArtifactType(artifact) == JobArtifactTypeTextReport {
+			raw = append(raw, extractArtifactsFromRoleText(artifact.Content)...)
+		}
+	}
+
+	return sanitizeRoleArtifactSpecs(raw, roots)
+}
+
+func hasRoleTextReport(artifacts []JobArtifactSpec) bool {
+	for _, artifact := range artifacts {
+		if standardRoleArtifactType(artifact) == JobArtifactTypeTextReport && strings.TrimSpace(artifact.Content) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func extractArtifactsFromRoleText(text string) []JobArtifactSpec {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	var artifacts []JobArtifactSpec
+	for _, match := range roleURLRE.FindAllString(text, -1) {
+		raw := cleanRoleArtifactMatch(match)
+		if raw == "" {
+			continue
+		}
+		artifacts = append(artifacts, JobArtifactSpec{
+			Name: "url",
+			Type: JobArtifactTypeURL,
+			URI:  raw,
+		})
+	}
+
+	for _, match := range roleFileURIRE.FindAllString(text, -1) {
+		raw := cleanRoleArtifactMatch(match)
+		if raw == "" {
+			continue
+		}
+		artifacts = append(artifacts, JobArtifactSpec{
+			Name: artifactNameForPath(artifactPathValue(raw)),
+			Type: localArtifactType(raw),
+			URI:  raw,
+		})
+	}
+
+	for _, match := range rolePathRE.FindAllStringSubmatch(text, -1) {
+		if len(match) < 3 {
+			continue
+		}
+		raw := cleanRoleArtifactMatch(match[2])
+		if raw == "" {
+			continue
+		}
+		artifacts = append(artifacts, JobArtifactSpec{
+			Name: artifactNameForPath(raw),
+			Type: localArtifactType(raw),
+			URI:  raw,
+		})
+	}
+
+	return artifacts
+}
+
+func sanitizeRoleArtifactSpecs(raw []JobArtifactSpec, roots []string) []JobArtifactSpec {
+	if len(raw) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]JobArtifactSpec, 0, len(raw))
+	for _, artifact := range raw {
+		safe, ok := sanitizeRoleArtifactSpec(artifact, roots)
+		if !ok {
+			continue
+		}
+		key := roleArtifactKey(safe)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, safe)
+	}
+	return out
+}
+
+func sanitizeRoleArtifactSpec(artifact JobArtifactSpec, roots []string) (JobArtifactSpec, bool) {
+	artifactType := standardRoleArtifactType(artifact)
+	if artifactType == "" {
+		return JobArtifactSpec{}, false
+	}
+
+	name := strings.TrimSpace(artifact.Name)
+	mimeType := strings.TrimSpace(artifact.MimeType)
+	safe := JobArtifactSpec{
+		Name:     name,
+		Type:     artifactType,
+		MimeType: mimeType,
+		Metadata: artifact.Metadata,
+	}
+
+	switch artifactType {
+	case JobArtifactTypeTextReport:
+		content := strings.TrimSpace(artifact.Content)
+		if content == "" {
+			return JobArtifactSpec{}, false
+		}
+		if safe.Name == "" {
+			safe.Name = "final-report"
+		}
+		if safe.MimeType == "" {
+			safe.MimeType = "text/markdown"
+		}
+		safe.Content = content
+		return safe, true
+	case JobArtifactTypeURL:
+		raw := firstArtifactValue(artifact)
+		normalized, ok := safeRemoteURL(raw)
+		if !ok {
+			return JobArtifactSpec{}, false
+		}
+		if safe.Name == "" {
+			safe.Name = "url"
+		}
+		safe.URI = normalized
+		return safe, true
+	case JobArtifactTypeScreenshot, JobArtifactTypeFile:
+		raw := firstArtifactValue(artifact)
+		path, ok := safeLocalArtifactPath(raw, roots)
+		if !ok {
+			return JobArtifactSpec{}, false
+		}
+		if artifactType == JobArtifactTypeScreenshot && !isImagePath(path) && !strings.HasPrefix(strings.ToLower(safe.MimeType), "image/") {
+			return JobArtifactSpec{}, false
+		}
+		if safe.Name == "" {
+			safe.Name = artifactNameForPath(path)
+		}
+		if safe.MimeType == "" {
+			safe.MimeType = mimeTypeForPath(path)
+		}
+		safe.URI = path
+		return safe, true
+	default:
+		return JobArtifactSpec{}, false
+	}
+}
+
+func standardRoleArtifactType(artifact JobArtifactSpec) string {
+	typeName := strings.ToLower(strings.TrimSpace(artifact.Type))
+	mimeType := strings.ToLower(strings.TrimSpace(artifact.MimeType))
+	value := firstArtifactValue(artifact)
+
+	switch {
+	case typeName == JobArtifactTypeScreenshot || typeName == "image" || strings.HasPrefix(typeName, "image_") || strings.HasPrefix(mimeType, "image/"):
+		return JobArtifactTypeScreenshot
+	case typeName == JobArtifactTypeURL || typeName == "link":
+		return JobArtifactTypeURL
+	case typeName == JobArtifactTypeFile || typeName == "artifact":
+		return JobArtifactTypeFile
+	case typeName == JobArtifactTypeTextReport || typeName == "text" || typeName == "markdown" || typeName == "report" || strings.Contains(typeName, "report") || strings.HasPrefix(mimeType, "text/"):
+		return JobArtifactTypeTextReport
+	}
+
+	if _, ok := safeRemoteURL(value); ok {
+		return JobArtifactTypeURL
+	}
+	if isImagePath(value) || isImagePath(artifact.Name) {
+		return JobArtifactTypeScreenshot
+	}
+	if looksLikeLocalArtifactPath(value) {
+		return JobArtifactTypeFile
+	}
+	if strings.TrimSpace(artifact.Content) != "" {
+		return JobArtifactTypeTextReport
+	}
+	return ""
+}
+
+func firstArtifactValue(artifact JobArtifactSpec) string {
+	if raw := strings.TrimSpace(artifact.URI); raw != "" {
+		return raw
+	}
+	return strings.TrimSpace(artifact.Content)
+}
+
+func roleArtifactKey(artifact JobArtifactSpec) string {
+	switch artifact.Type {
+	case JobArtifactTypeTextReport:
+		return artifact.Type + ":" + artifact.Name + ":" + artifact.Content
+	case JobArtifactTypeURL, JobArtifactTypeScreenshot, JobArtifactTypeFile:
+		return artifact.Type + ":" + artifact.URI
+	default:
+		return artifact.Type + ":" + artifact.Name
+	}
+}
+
+func safeRemoteURL(raw string) (string, bool) {
+	raw = cleanRoleArtifactMatch(raw)
+	if raw == "" {
+		return "", false
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u == nil {
+		return "", false
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if (scheme != "http" && scheme != "https") || u.Host == "" {
+		return "", false
+	}
+	return raw, true
+}
+
+func safeLocalArtifactPath(raw string, roots []string) (string, bool) {
+	raw = cleanRoleArtifactMatch(raw)
+	if raw == "" {
+		return "", false
+	}
+	normalizedRoots := artifactview.NormalizeRoots(roots)
+	if len(normalizedRoots) == 0 {
+		normalizedRoots = artifactview.DefaultRoots()
+	}
+	path, err := artifactview.ContentPath(storage.JobArtifact{URI: raw}, normalizedRoots)
+	if err != nil {
+		return "", false
+	}
+	return path, true
+}
+
+func localArtifactType(raw string) string {
+	if isImagePath(raw) {
+		return JobArtifactTypeScreenshot
+	}
+	return JobArtifactTypeFile
+}
+
+func looksLikeLocalArtifactPath(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	return strings.HasPrefix(strings.ToLower(raw), "file://") || filepath.IsAbs(raw)
+}
+
+func artifactPathValue(raw string) string {
+	if strings.HasPrefix(strings.ToLower(raw), "file://") {
+		if u, err := url.Parse(raw); err == nil && u != nil && u.Path != "" {
+			return u.Path
+		}
+	}
+	return raw
+}
+
+func artifactNameForPath(path string) string {
+	base := filepath.Base(path)
+	if base == "." || base == "/" || base == "" {
+		return "artifact"
+	}
+	return base
+}
+
+func isImagePath(path string) bool {
+	ext := strings.ToLower(filepath.Ext(artifactPathValue(path)))
+	switch ext {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp":
+		return true
+	default:
+		return strings.HasPrefix(mime.TypeByExtension(ext), "image/")
+	}
+}
+
+func mimeTypeForPath(path string) string {
+	if mt := mime.TypeByExtension(strings.ToLower(filepath.Ext(path))); mt != "" {
+		return mt
+	}
+	if isImagePath(path) {
+		return "image/png"
+	}
+	return "application/octet-stream"
+}
+
+func cleanRoleArtifactMatch(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.Trim(raw, "`'\"")
+	return strings.TrimRight(raw, ".,;:)]}")
+}

--- a/internal/runtime/artifacts.go
+++ b/internal/runtime/artifacts.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"mime"
 	"net/url"
 	"path/filepath"
@@ -238,7 +240,8 @@ func firstArtifactValue(artifact JobArtifactSpec) string {
 func roleArtifactKey(artifact JobArtifactSpec) string {
 	switch artifact.Type {
 	case JobArtifactTypeTextReport:
-		return artifact.Type + ":" + artifact.Name + ":" + artifact.Content
+		sum := sha256.Sum256([]byte(artifact.Content))
+		return artifact.Type + ":" + artifact.Name + ":" + hex.EncodeToString(sum[:])
 	case JobArtifactTypeURL, JobArtifactTypeScreenshot, JobArtifactTypeFile:
 		return artifact.Type + ":" + artifact.URI
 	default:
@@ -330,5 +333,28 @@ func mimeTypeForPath(path string) string {
 func cleanRoleArtifactMatch(raw string) string {
 	raw = strings.TrimSpace(raw)
 	raw = strings.Trim(raw, "`'\"")
-	return strings.TrimRight(raw, ".,;:)]}")
+	raw = strings.TrimRight(raw, ".,;:")
+	return trimUnmatchedClosingDelimiters(raw)
+}
+
+func trimUnmatchedClosingDelimiters(raw string) string {
+	for raw != "" {
+		last := raw[len(raw)-1]
+		open := byte(0)
+		switch last {
+		case ')':
+			open = '('
+		case ']':
+			open = '['
+		case '}':
+			open = '{'
+		default:
+			return raw
+		}
+		if strings.Count(raw, string(last)) <= strings.Count(raw, string(open)) {
+			return raw
+		}
+		raw = strings.TrimSpace(raw[:len(raw)-1])
+	}
+	return raw
 }

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -75,8 +75,9 @@ type JobArtifactSpec struct {
 
 // JobRunResult is the structured outcome of a background job.
 type JobRunResult struct {
-	Summary   string
-	Artifacts []JobArtifactSpec
+	Summary       string
+	Artifacts     []JobArtifactSpec
+	ArtifactRoots []string
 }
 
 // JobRunner executes one durable job.
@@ -141,6 +142,9 @@ func (s *JobService) RetryDetached(parentCtx context.Context, jobID string, runn
 		Attempt:            existing.Attempt + 1,
 		MaxAttempts:        existing.MaxAttempts,
 		Timeout:            time.Duration(existing.TimeoutSeconds) * time.Second,
+		MaxToolCalls:       existing.MaxToolCalls,
+		RoleName:           existing.RoleName,
+		ModelTier:          existing.ModelTier,
 	}, runner)
 	if err != nil {
 		return nil, err
@@ -328,7 +332,11 @@ func (s *JobService) run(parentCtx context.Context, job *storage.Job, spec JobSp
 	result, runErr := runner(ctx, job, s)
 	if runErr == nil {
 		if isRoleJob(job) {
-			result.Artifacts = roleProofArtifacts(result, spec.ArtifactRoots)
+			artifactRoots := spec.ArtifactRoots
+			if len(result.ArtifactRoots) > 0 {
+				artifactRoots = result.ArtifactRoots
+			}
+			result.Artifacts = roleProofArtifacts(result, artifactRoots)
 		}
 		for _, artifact := range result.Artifacts {
 			if err := s.AddArtifact(job.JobID, artifact); err != nil {

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -60,6 +60,7 @@ type JobSpec struct {
 	MaxAttempts        int
 	Timeout            time.Duration
 	MaxToolCalls       int
+	ArtifactRoots      []string
 }
 
 // JobArtifactSpec describes one durable artifact emitted by a job.
@@ -108,7 +109,7 @@ func (s *JobService) StartDetached(parentCtx context.Context, spec JobSpec, runn
 		return nil, err
 	}
 
-	go s.run(parentCtx, job, spec.Timeout, runner)
+	go s.run(parentCtx, job, spec, runner)
 	return job, nil
 }
 
@@ -296,7 +297,7 @@ func (s *JobService) createJob(spec JobSpec) (*storage.Job, error) {
 	return s.store.GetJob(jobID)
 }
 
-func (s *JobService) run(parentCtx context.Context, job *storage.Job, timeout time.Duration, runner JobRunner) {
+func (s *JobService) run(parentCtx context.Context, job *storage.Job, spec JobSpec, runner JobRunner) {
 	if parentCtx == nil {
 		parentCtx = context.Background()
 	}
@@ -305,8 +306,8 @@ func (s *JobService) run(parentCtx context.Context, job *storage.Job, timeout ti
 		ctx    context.Context
 		cancel context.CancelFunc
 	)
-	if timeout > 0 {
-		ctx, cancel = context.WithTimeout(parentCtx, timeout)
+	if spec.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(parentCtx, spec.Timeout)
 	} else {
 		ctx, cancel = context.WithCancel(parentCtx)
 	}
@@ -326,6 +327,9 @@ func (s *JobService) run(parentCtx context.Context, job *storage.Job, timeout ti
 
 	result, runErr := runner(ctx, job, s)
 	if runErr == nil {
+		if isRoleJob(job) {
+			result.Artifacts = roleProofArtifacts(result, spec.ArtifactRoots)
+		}
 		for _, artifact := range result.Artifacts {
 			if err := s.AddArtifact(job.JobID, artifact); err != nil {
 				runErr = fmt.Errorf("persist artifact %q: %w", artifact.Name, err)

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -128,6 +128,50 @@ func TestJobServiceRoleSuccessExtractsReportAndURLArtifacts(t *testing.T) {
 	}
 }
 
+func TestJobServiceRoleSuccessPreservesBalancedURLDelimiters(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	svc := NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:        "role",
+		Worker:      "test_runner",
+		Description: "role:proof",
+		RoleName:    "proof",
+		Timeout:     2 * time.Second,
+	}, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{
+			Summary: "Proof: https://en.wikipedia.org/wiki/Foo_(band) and https://example.com/docs/[draft]. Wrapped: https://example.com/trailing).",
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+	waitForJobStatus(t, store, job.JobID, string(JobStatusSucceeded))
+
+	artifacts, err := store.ListJobArtifacts(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	gotURLs := map[string]bool{}
+	for _, artifact := range artifacts {
+		if artifact.ArtifactType == JobArtifactTypeURL {
+			gotURLs[artifact.URI] = true
+		}
+	}
+	for _, want := range []string{
+		"https://en.wikipedia.org/wiki/Foo_(band)",
+		"https://example.com/docs/[draft]",
+		"https://example.com/trailing",
+	} {
+		if !gotURLs[want] {
+			t.Fatalf("missing URL %q in artifacts: %+v", want, artifacts)
+		}
+	}
+}
+
 func TestJobServiceRoleSuccessPersistsSafeScreenshotArtifact(t *testing.T) {
 	t.Parallel()
 
@@ -380,6 +424,64 @@ func TestJobServiceRetryDetachedClonesAttempt(t *testing.T) {
 	if events[len(events)-1].EventType != string(JobEventRetryRequested) {
 		t.Fatalf("expected final original event retry_requested, got %+v", events)
 	}
+}
+
+func TestJobServiceRetryDetachedUsesRunnerArtifactRoots(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	root := t.TempDir()
+	shotPath := filepath.Join(root, "retry-shot.png")
+	if err := os.WriteFile(shotPath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write screenshot: %v", err)
+	}
+
+	svc := NewJobService(store)
+	original, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:          "role",
+		Worker:        "retry_runner",
+		Description:   "role:proof",
+		RoleName:      "proof",
+		MaxAttempts:   2,
+		ArtifactRoots: []string{root},
+	}, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{}, errors.New("boom")
+	})
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	waitForJobStatus(t, store, original.JobID, string(JobStatusFailed))
+
+	retry, err := svc.RetryDetached(context.Background(), original.JobID, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{
+			Summary:       "retried proof",
+			ArtifactRoots: []string{root},
+			Artifacts: []JobArtifactSpec{{
+				Name:     "retry screenshot",
+				Type:     JobArtifactTypeScreenshot,
+				MimeType: "image/png",
+				URI:      shotPath,
+			}},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("RetryDetached failed: %v", err)
+	}
+
+	waitForJobStatus(t, store, retry.JobID, string(JobStatusSucceeded))
+	artifacts, err := store.ListJobArtifacts(retry.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	for _, artifact := range artifacts {
+		if artifact.ArtifactType == JobArtifactTypeScreenshot && artifact.URI == shotPath {
+			return
+		}
+	}
+	t.Fatalf("missing retry screenshot artifact rooted at %q: %+v", root, artifacts)
 }
 
 func TestJobServiceBudgetExceededMarksBudgetExceeded(t *testing.T) {

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -3,10 +3,13 @@ package runtime
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/storage"
 )
@@ -86,6 +89,139 @@ func TestJobServiceStartDetachedPersistsSuccess(t *testing.T) {
 	}
 	if artifacts[0].Name != "result.md" || artifacts[0].ArtifactType != "report" {
 		t.Fatalf("unexpected artifact row: %+v", artifacts[0])
+	}
+}
+
+func TestJobServiceRoleSuccessExtractsReportAndURLArtifacts(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	svc := NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:        "role",
+		Worker:      "test_runner",
+		Description: "role:proof",
+		RoleName:    "proof",
+		Timeout:     2 * time.Second,
+	}, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{Summary: "Proof complete: https://example.com/proof."}, nil
+	})
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+	waitForJobStatus(t, store, job.JobID, string(JobStatusSucceeded))
+
+	artifacts, err := store.ListJobArtifacts(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	if len(artifacts) != 2 {
+		t.Fatalf("artifact count = %d, want 2: %+v", len(artifacts), artifacts)
+	}
+	if artifacts[0].ArtifactType != JobArtifactTypeTextReport || artifacts[0].Content == "" {
+		t.Fatalf("artifact[0] = %+v, want final text report", artifacts[0])
+	}
+	if artifacts[1].ArtifactType != JobArtifactTypeURL || artifacts[1].URI != "https://example.com/proof" {
+		t.Fatalf("artifact[1] = %+v, want safe URL", artifacts[1])
+	}
+}
+
+func TestJobServiceRoleSuccessPersistsSafeScreenshotArtifact(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	root := t.TempDir()
+	shotPath := filepath.Join(root, "shot.png")
+	if err := os.WriteFile(shotPath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write screenshot: %v", err)
+	}
+
+	svc := NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:          "role",
+		Description:   "role:screenshot",
+		RoleName:      "screenshot",
+		Timeout:       2 * time.Second,
+		ArtifactRoots: []string{root},
+	}, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{Summary: "Screenshot saved to " + shotPath}, nil
+	})
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+	waitForJobStatus(t, store, job.JobID, string(JobStatusSucceeded))
+
+	artifacts, err := store.ListJobArtifacts(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	var screenshot *storage.JobArtifact
+	for i := range artifacts {
+		if artifacts[i].ArtifactType == JobArtifactTypeScreenshot {
+			screenshot = &artifacts[i]
+			break
+		}
+	}
+	if screenshot == nil {
+		t.Fatalf("missing screenshot artifact: %+v", artifacts)
+	}
+	info := artifactview.NewSerializer([]string{root}, "/api/artifacts").Serialize(*screenshot)
+	if info.Display.Kind != artifactview.KindImage || !info.Display.Safe || !info.Display.Preview || info.Path != shotPath {
+		t.Fatalf("screenshot is not display-safe: %+v", info)
+	}
+}
+
+func TestJobServiceRoleSuccessRejectsUnsafeLocalArtifact(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.png")
+	if err := os.WriteFile(outside, []byte("secret image bytes"), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	svc := NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:          "role",
+		Description:   "role:unsafe",
+		RoleName:      "unsafe",
+		Timeout:       2 * time.Second,
+		ArtifactRoots: []string{root},
+	}, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{
+			Summary: "done",
+			Artifacts: []JobArtifactSpec{{
+				Name:     "outside screenshot",
+				Type:     JobArtifactTypeScreenshot,
+				MimeType: "image/png",
+				Content:  "secret image bytes",
+				URI:      outside,
+			}},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+	waitForJobStatus(t, store, job.JobID, string(JobStatusSucceeded))
+
+	artifacts, err := store.ListJobArtifacts(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	for _, artifact := range artifacts {
+		if artifact.ArtifactType == JobArtifactTypeScreenshot {
+			t.Fatalf("unsafe screenshot was persisted: %+v", artifact)
+		}
+		if strings.Contains(artifact.URI, outside) || strings.Contains(artifact.Content, "secret image bytes") {
+			t.Fatalf("unsafe artifact leaked path or content: %+v", artifact)
+		}
 	}
 }
 


### PR DESCRIPTION
Implements #342

## Changes
- Adds role-job proof artifact normalization for final text reports, safe URLs, safe local screenshots, and files.
- Validates local role artifacts against configured artifact roots before persistence.
- Shows persisted artifacts in Telegram `/job` and display-safe CLI `jobs inspect` output.

## Testing
- `go test ./internal/runtime/...` passed
- `go test ./internal/rolejob/...` passed
- `go test ./internal/cli/...` passed
- `go test ./internal/artifacts/...` passed
- `./.maestro/verify.sh` hit a flaky cron delivery timeout; `go test -count=1 ./internal/cron/...` passed immediately after
- Required pre-PR sequence passed: `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements persistent artifact storage for role jobs: the final text report, URLs extracted from role output, safe local screenshots (validated against configured artifact roots), and files. It also surfaces those artifacts in the Telegram `/job` command and the CLI `jobs inspect` output behind a display-safety gate.

Two issues raised in the previous review are resolved: the URL trailing-delimiter stripping bug is fixed by the new `trimUnmatchedClosingDelimiters` function (which correctly handles balanced parentheses like Wikipedia `/wiki/Foo_(band)` URLs), and the full-content deduplication key for text reports is replaced with a SHA-256 hash. The `ArtifactRoots`-on-retry concern is mitigated: `run()` now prefers `result.ArtifactRoots` over `spec.ArtifactRoots`, and `AgentJobRunner` propagates its `opts.ArtifactRoots` through the result, so a retry caller that supplies a fresh runner with the correct opts will work correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — previous P1/P2 findings are resolved and the new artifact normalization path is well-tested.

Both prior P1 issues (URL delimiter trimming, ArtifactRoots lost on retry) and the prior P2 (full-content dedup key) are addressed in this PR. Test coverage is thorough across the runtime, rolejob, CLI, and agent layers. No new definitive logic defects were identified.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/runtime/artifacts.go | New file: artifact normalization for role jobs — URL extraction with balanced-delimiter trimming (fixes prior P1), SHA-256 dedup key for text reports (fixes prior P2), local path validation against configured roots. |
| internal/runtime/jobs.go | Passes full JobSpec to run(), adds ArtifactRoots to spec and result, calls roleProofArtifacts post-run for role jobs with result.ArtifactRoots fallback — mitigates prior P1 about roots being lost on retry. |
| internal/rolejob/runner.go | Captures tool events via onToolEvent wrapper; extractToolArtifacts currently scoped to frontend_verify only; returns ArtifactRoots in result so retry callers can recover the correct roots. |
| internal/agent/tool_agent.go | Adds FullOutput field to ToolEvent to carry the untruncated result alongside the 300-char display Output; backward-compatible struct extension. |
| internal/bot/role_commands.go | Appends persisted artifacts to the Telegram /job reply; unsafe local artifacts are hidden with a reason string; uses artifactview.Serializer correctly. |
| internal/cli/jobs.go | artifactInspectURI uses Serializer to gate local paths behind root check; unsafe artifacts show [unsafe: reason] instead of raw paths. |
| internal/app/app.go | Wires config artifact roots to bot via SetArtifactRoots after bot creation. |
| internal/cli/roles.go | Passes cfg.Artifacts.Roots into rolejob.Options so CLI role runs carry the correct artifact roots. |
| internal/memory/qmd_test.go | Replaces WriteFile with OpenFile+O_EXCL to avoid implicit truncation on the test binary, adds explicit chmod — defensive test hygiene fix. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/runtime/jobs.go`, line 134-144 ([link](https://github.com/befeast/ok-gobot/blob/aeaa92fe77bc1fc4370c9f8f57dda91e890d3fe2/internal/runtime/jobs.go#L134-L144)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`ArtifactRoots` lost on retry**

   `RetryDetached` reconstructs a `JobSpec` from the stored `storage.Job` record, but `ArtifactRoots` is never persisted to the DB — so the retried spec always has an empty slice. `run()` then calls `roleProofArtifacts(result, spec.ArtifactRoots)` with no roots, falling back to `DefaultRoots()`. Any local-path artifacts (e.g. screenshots outside the user home directories) that were accepted on the first run will be silently dropped on retry, since the path-inside-root check uses different directories.

   The runner closure still carries `opts.ArtifactRoots` for tool-event capture, but `roleProofArtifacts` only sees `spec.ArtifactRoots`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/runtime/jobs.go
   Line: 134-144

   Comment:
   **`ArtifactRoots` lost on retry**

   `RetryDetached` reconstructs a `JobSpec` from the stored `storage.Job` record, but `ArtifactRoots` is never persisted to the DB — so the retried spec always has an empty slice. `run()` then calls `roleProofArtifacts(result, spec.ArtifactRoots)` with no roots, falling back to `DefaultRoots()`. Any local-path artifacts (e.g. screenshots outside the user home directories) that were accepted on the first run will be silently dropped on retry, since the path-inside-root check uses different directories.

   The runner closure still carries `opts.ArtifactRoots` for tool-event capture, but `roleProofArtifacts` only sees `spec.ArtifactRoots`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/runtime/artifacts.go`, line 782-786 ([link](https://github.com/befeast/ok-gobot/blob/aeaa92fe77bc1fc4370c9f8f57dda91e890d3fe2/internal/runtime/artifacts.go#L782-L786)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Trailing `)` / `]` stripped from URLs**

   `cleanRoleArtifactMatch` uses `strings.TrimRight(raw, ".,;:)]}")` to strip punctuation. This damages legitimate URLs that end with a closing parenthesis or bracket — a common pattern in Wikipedia links (e.g. `https://en.wikipedia.org/wiki/Foo_(band)` becomes `https://en.wikipedia.org/wiki/Foo_(band`). The key deduplication in `sanitizeRoleArtifactSpecs` then stores the malformed URI, so any downstream consumer sees a broken URL.

   A safer approach is to only strip trailing punctuation that has no matching open delimiter within the URL.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/runtime/artifacts.go
   Line: 782-786

   Comment:
   **Trailing `)` / `]` stripped from URLs**

   `cleanRoleArtifactMatch` uses `strings.TrimRight(raw, ".,;:)]}")` to strip punctuation. This damages legitimate URLs that end with a closing parenthesis or bracket — a common pattern in Wikipedia links (e.g. `https://en.wikipedia.org/wiki/Foo_(band)` becomes `https://en.wikipedia.org/wiki/Foo_(band`). The key deduplication in `sanitizeRoleArtifactSpecs` then stores the malformed URI, so any downstream consumer sees a broken URL.

   A safer approach is to only strip trailing punctuation that has no matching open delimiter within the URL.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `internal/runtime/artifacts.go`, line 690-699 ([link](https://github.com/befeast/ok-gobot/blob/aeaa92fe77bc1fc4370c9f8f57dda91e890d3fe2/internal/runtime/artifacts.go#L690-L699)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Full text content used as deduplication key**

   `roleArtifactKey` concatenates the full report content into the map key for `text_report` artifacts:

   ```go
   case JobArtifactTypeTextReport:
       return artifact.Type + ":" + artifact.Name + ":" + artifact.Content
   ```

   For role jobs that produce multi-kilobyte (or larger) markdown reports, every call to `sanitizeRoleArtifactSpecs` allocates this string in the `seen` map. A short hash (e.g. `fmt.Sprintf("%x", sha256.Sum256([]byte(artifact.Content)))`) of the content would bound the key size without losing uniqueness.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/runtime/artifacts.go
   Line: 690-699

   Comment:
   **Full text content used as deduplication key**

   `roleArtifactKey` concatenates the full report content into the map key for `text_report` artifacts:

   ```go
   case JobArtifactTypeTextReport:
       return artifact.Type + ":" + artifact.Name + ":" + artifact.Content
   ```

   For role jobs that produce multi-kilobyte (or larger) markdown reports, every call to `sanitizeRoleArtifactSpecs` allocates this string in the `seen` map. A short hash (e.g. `fmt.Sprintf("%x", sha256.Sum256([]byte(artifact.Content)))`) of the content would bound the key size without losing uniqueness.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: address role artifact review findin..."](https://github.com/befeast/ok-gobot/commit/61f4522b4b0597f1ef76ebf8088bb21708a7138f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30411605)</sub>

<!-- /greptile_comment -->