### PR TITLE
fix: harden frontend verification (#343)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -398,7 +398,7 @@ func (a *App) Start(ctx context.Context) error {
 		log.Printf("⚠️ [memory] extra paths config error: %v", err)
 		memoryExtras = nil
 	}
-	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.config.Browser, a.config.STT, a.scheduler, a.memoryManager, memoryExtras, a.config.Memory.Sessions.Enabled, a.memoryStatus, a.config.Contacts)
+	b, err := bot.New(a.config.Telegram.Token, a.store, a.ai, aiCfg, a.personality, agentRegistry, a.config.Auth, a.config.Groups, a.config.TTS, a.config.Browser, a.config.Artifacts, a.config.STT, a.scheduler, a.memoryManager, memoryExtras, a.config.Memory.Sessions.Enabled, a.memoryStatus, a.config.Contacts)
 	if err != nil {
 		return fmt.Errorf("failed to create bot: %w", err)
 	}

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -84,7 +84,7 @@ type AIConfig struct {
 }
 
 // New creates a new bot instance
-func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, browserCfg config.BrowserConfig, sttCfg config.STTConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager, memoryExtraPaths []memory.ExtraPath, sessionMemoryEnabled bool, memoryStatus MemoryStatusProvider, contacts map[string]int64) (*Bot, error) {
+func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig, personality *agent.Personality, agentRegistry *agent.AgentRegistry, authCfg config.AuthConfig, groupsCfg config.GroupsConfig, ttsCfg config.TTSConfig, browserCfg config.BrowserConfig, artifactCfg config.ArtifactConfig, sttCfg config.STTConfig, scheduler tools.CronScheduler, memoryManager *memory.MemoryManager, memoryExtraPaths []memory.ExtraPath, sessionMemoryEnabled bool, memoryStatus MemoryStatusProvider, contacts map[string]int64) (*Bot, error) {
 	pref := telebot.Settings{
 		Token:  token,
 		Poller: &telebot.LongPoller{Timeout: 10 * time.Second},
@@ -107,6 +107,7 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		ChromePath:       browserCfg.ChromePath,
 		BrowserProfile:   browserCfg.ProfilePath,
 		BrowserDebugURL:  browserCfg.DebugURL,
+		ArtifactRoots:    artifactCfg.Roots,
 		MemoryManager:    memoryManager,
 		MemoryExtraPaths: memoryExtraPaths,
 		PatternStore:     store,

--- a/internal/tools/frontend_verify.go
+++ b/internal/tools/frontend_verify.go
@@ -9,14 +9,17 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/chromedp/chromedp"
 
 	"ok-gobot/internal/ai"
+	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/browser"
 	"ok-gobot/internal/logger"
+	jobruntime "ok-gobot/internal/runtime"
 )
 
 const (
@@ -25,6 +28,14 @@ const (
 	frontendVerifyRetryDelay         = 2 * time.Second
 	frontendVerifyOpTimeout          = 60 * time.Second
 	frontendVerifyHealthInterval     = 500 * time.Millisecond
+	frontendVerifyStartupGrace       = 500 * time.Millisecond
+	frontendVerifyOutputLimit        = 32 * 1024
+
+	frontendVerifyStatusPassed           = "passed"
+	frontendVerifyStatusFailed           = "failed"
+	frontendVerifyStatusUnreachable      = "unreachable"
+	frontendVerifyStatusScreenshotFailed = "screenshot_failed"
+	frontendVerifyStatusComparisonFailed = "comparison_failed"
 )
 
 // FrontendVerifyTool starts a local dev server, captures a screenshot via CDP,
@@ -35,24 +46,37 @@ type FrontendVerifyTool struct {
 	manager       *browser.Manager
 	aiClient      ai.Client // nil = no LLM comparison, returns screenshot path only
 	screenshotDir string
+	artifactRoots []string
 
 	mu         sync.Mutex
 	devServers map[string]*devServerProc // key: workDir
 }
 
 type devServerProc struct {
-	cmd    *exec.Cmd
-	cancel context.CancelFunc
+	cmd     *exec.Cmd
+	cancel  context.CancelFunc
+	command string
+	output  *boundedBuffer
+	done    chan struct{}
+
+	mu      sync.Mutex
+	exited  bool
+	exitErr error
 }
 
 // FrontendVerifyResult is the structured response from the tool.
 type FrontendVerifyResult struct {
-	Match          bool   `json:"match"`
-	Score          string `json:"score,omitempty"`
-	Feedback       string `json:"feedback"`
-	Suggestions    string `json:"suggestions,omitempty"`
-	ScreenshotPath string `json:"screenshot_path"`
-	ServerRunning  bool   `json:"server_running"`
+	Match              bool   `json:"match"`
+	Score              string `json:"score,omitempty"`
+	Feedback           string `json:"feedback"`
+	Suggestions        string `json:"suggestions,omitempty"`
+	ScreenshotPath     string `json:"screenshot_path"`
+	ScreenshotURI      string `json:"screenshot_uri,omitempty"`
+	TargetURL          string `json:"target_url,omitempty"`
+	VerificationStatus string `json:"verification_status,omitempty"`
+	TextReport         string `json:"text_report,omitempty"`
+	ServerRunning      bool   `json:"server_running"`
+	DevCommand         string `json:"dev_command,omitempty"`
 }
 
 // NewFrontendVerifyTool creates a FrontendVerifyTool with its own browser.Manager instance.
@@ -71,6 +95,13 @@ func NewFrontendVerifyTool(browserProfile, chromePath, debugURL string, aiClient
 		aiClient:   aiClient,
 		devServers: make(map[string]*devServerProc),
 	}
+}
+
+// SetArtifactRoots configures the safe local roots where screenshots may be
+// written. When unset, frontend_verify uses the same default artifact roots as
+// Mission Control/API artifact display.
+func (t *FrontendVerifyTool) SetArtifactRoots(roots []string) {
+	t.artifactRoots = artifactview.NormalizeRoots(roots)
 }
 
 func (t *FrontendVerifyTool) Name() string { return "frontend_verify" }
@@ -93,14 +124,18 @@ func (t *FrontendVerifyTool) Execute(ctx context.Context, args ...string) (strin
 }
 
 func (t *FrontendVerifyTool) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
-	rawURL := params["url"]
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	rawURL := strings.TrimSpace(params["url"])
 	if rawURL == "" {
 		return "", fmt.Errorf("url is required")
 	}
 
 	description := params["description"]
-	command := params["command"]
-	workDir := params["work_dir"]
+	command := strings.TrimSpace(params["command"])
+	workDir := strings.TrimSpace(params["work_dir"])
+	resolvedCommand := ""
 
 	waitTimeout := frontendVerifyDefaultWaitTimeout
 	if s := params["wait_timeout"]; s != "" {
@@ -126,21 +161,45 @@ func (t *FrontendVerifyTool) ExecuteJSON(ctx context.Context, params map[string]
 
 	// Start dev server if a command was provided.
 	if command != "" {
-		if err := t.ensureDevServer(ctx, command, workDir); err != nil {
+		if policy := NetworkPolicyFromContext(ctx); policy != nil && !policy.Shell {
+			return "", &ToolDenial{
+				ToolName:    t.Name(),
+				Family:      "shell",
+				Reason:      "frontend_verify dev server startup requires shell execution, which is denied by agent policy",
+				Remediation: "Ask the operator to allow shell execution or start the dev server outside frontend_verify.",
+			}
+		}
+
+		resolution, err := t.resolveDevCommand(command, workDir)
+		if err != nil {
+			return "", err
+		}
+		resolvedCommand = resolution.Command
+		if err := t.ensureDevServer(ctx, resolvedCommand, workDir); err != nil {
 			return "", fmt.Errorf("failed to start dev server: %w", err)
 		}
 	}
 
-	serverRunning := command != "" || t.isDevServerRunning(workDir)
+	serverRunning := t.isDevServerRunning(workDir)
 
 	// Wait for the URL to become accessible.
 	if err := t.waitForURL(ctx, rawURL, waitTimeout); err != nil {
-		result := FrontendVerifyResult{
-			Match:         false,
-			Feedback:      fmt.Sprintf("URL %s did not become accessible within %s: %v", rawURL, waitTimeout, err),
-			ServerRunning: serverRunning,
+		feedback := fmt.Sprintf("URL %s did not become accessible within %s: %v", rawURL, waitTimeout, err)
+		if exited, exitErr, output := t.devServerExit(workDir); exited && resolvedCommand != "" {
+			feedback = fmt.Sprintf("dev server command %q exited before %s became reachable: %v", resolvedCommand, rawURL, exitErr)
+			if output != "" {
+				feedback += fmt.Sprintf("; output: %s", output)
+			}
 		}
-		return marshalResult(result)
+		result := FrontendVerifyResult{
+			Match:              false,
+			Feedback:           feedback,
+			TargetURL:          rawURL,
+			VerificationStatus: frontendVerifyStatusUnreachable,
+			ServerRunning:      serverRunning,
+			DevCommand:         resolvedCommand,
+		}
+		return marshalResult(finalizeFrontendVerifyResult(result))
 	}
 
 	// Iterate: take screenshot(s), compare, retry if hot-reload is still settling.
@@ -158,21 +217,28 @@ func (t *FrontendVerifyTool) ExecuteJSON(ctx context.Context, params map[string]
 		imgData, path, err := t.captureScreenshot(ctx, rawURL)
 		if err != nil {
 			lastResult = FrontendVerifyResult{
-				Match:         false,
-				Feedback:      fmt.Sprintf("screenshot failed: %v", err),
-				ServerRunning: serverRunning,
+				Match:              false,
+				Feedback:           fmt.Sprintf("screenshot failed: %v", err),
+				TargetURL:          rawURL,
+				VerificationStatus: frontendVerifyStatusScreenshotFailed,
+				ServerRunning:      serverRunning,
+				DevCommand:         resolvedCommand,
 			}
 			continue
 		}
 
 		lastResult = FrontendVerifyResult{
 			ScreenshotPath: path,
+			ScreenshotURI:  path,
+			TargetURL:      rawURL,
 			ServerRunning:  serverRunning,
+			DevCommand:     resolvedCommand,
 		}
 
 		if description == "" || t.aiClient == nil {
 			// No comparison requested — just return the screenshot path.
 			lastResult.Match = true
+			lastResult.VerificationStatus = frontendVerifyStatusPassed
 			lastResult.Feedback = fmt.Sprintf("Screenshot saved to %s", path)
 			break
 		}
@@ -181,11 +247,17 @@ func (t *FrontendVerifyTool) ExecuteJSON(ctx context.Context, params map[string]
 		if err != nil {
 			logger.Debugf("frontend_verify: LLM comparison failed: %v", err)
 			lastResult.Match = false
+			lastResult.VerificationStatus = frontendVerifyStatusComparisonFailed
 			lastResult.Feedback = fmt.Sprintf("Visual comparison failed: %v", err)
 			continue
 		}
 
 		lastResult.Match = cmpResult.Match
+		if cmpResult.Match {
+			lastResult.VerificationStatus = frontendVerifyStatusPassed
+		} else {
+			lastResult.VerificationStatus = frontendVerifyStatusFailed
+		}
 		lastResult.Score = cmpResult.Score
 		lastResult.Feedback = cmpResult.Feedback
 		lastResult.Suggestions = cmpResult.Suggestions
@@ -195,7 +267,7 @@ func (t *FrontendVerifyTool) ExecuteJSON(ctx context.Context, params map[string]
 		}
 	}
 
-	return marshalResult(lastResult)
+	return marshalResult(finalizeFrontendVerifyResult(lastResult))
 }
 
 // ensureDevServer starts a dev server for the given command+workDir if one is not already running.
@@ -206,7 +278,7 @@ func (t *FrontendVerifyTool) ensureDevServer(ctx context.Context, command, workD
 	key := workDir
 	if proc, ok := t.devServers[key]; ok {
 		// Already running — check if process is still alive.
-		if proc.cmd.ProcessState == nil {
+		if proc.isRunning() {
 			logger.Debugf("frontend_verify: dev server already running for %s", key)
 			return nil
 		}
@@ -220,16 +292,49 @@ func (t *FrontendVerifyTool) ensureDevServer(ctx context.Context, command, workD
 	if workDir != "" {
 		cmd.Dir = workDir
 	}
-	// Discard output — agent should check via URL health check.
-	cmd.Stdout = nil
-	cmd.Stderr = nil
+	output := newBoundedBuffer(frontendVerifyOutputLimit)
+	cmd.Stdout = output
+	cmd.Stderr = output
 
 	if err := cmd.Start(); err != nil {
 		cancel()
 		return fmt.Errorf("failed to start dev server command %q: %w", command, err)
 	}
+	proc := &devServerProc{
+		cmd:     cmd,
+		cancel:  cancel,
+		command: command,
+		output:  output,
+		done:    make(chan struct{}),
+	}
+	go func() {
+		err := cmd.Wait()
+		proc.mu.Lock()
+		proc.exited = true
+		proc.exitErr = err
+		proc.mu.Unlock()
+		close(proc.done)
+	}()
 
-	t.devServers[key] = &devServerProc{cmd: cmd, cancel: cancel}
+	select {
+	case <-ctx.Done():
+		cancel()
+		return ctx.Err()
+	case <-proc.done:
+		cancel()
+		msg := fmt.Sprintf("dev server command %q exited immediately", command)
+		_, exitErr := proc.exitStatus()
+		if exitErr != nil {
+			msg = fmt.Sprintf("%s: %v", msg, exitErr)
+		}
+		if out := output.String(); out != "" {
+			msg = fmt.Sprintf("%s; output: %s", msg, out)
+		}
+		return fmt.Errorf("%s", msg)
+	case <-time.After(frontendVerifyStartupGrace):
+	}
+
+	t.devServers[key] = proc
 	logger.Debugf("frontend_verify: started dev server pid=%d for workDir=%q", cmd.Process.Pid, workDir)
 	return nil
 }
@@ -251,13 +356,53 @@ func (t *FrontendVerifyTool) stopDevServer(workDir string) {
 func (t *FrontendVerifyTool) isDevServerRunning(workDir string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	_, ok := t.devServers[workDir]
-	return ok
+	proc, ok := t.devServers[workDir]
+	if !ok {
+		return false
+	}
+	if proc.isRunning() {
+		return true
+	}
+	return false
+}
+
+func (t *FrontendVerifyTool) devServerExit(workDir string) (bool, error, string) {
+	t.mu.Lock()
+	proc, ok := t.devServers[workDir]
+	t.mu.Unlock()
+	if !ok {
+		return false, nil, ""
+	}
+	exited, err := proc.exitStatus()
+	return exited, err, proc.output.String()
+}
+
+func (p *devServerProc) isRunning() bool {
+	exited, _ := p.exitStatus()
+	return !exited
+}
+
+func (p *devServerProc) exitStatus() (bool, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.exited, p.exitErr
 }
 
 // waitForURL polls the URL with HTTP GET until it responds or timeout.
 func (t *FrontendVerifyTool) waitForURL(ctx context.Context, rawURL string, timeout time.Duration) error {
 	client := &http.Client{Timeout: 2 * time.Second}
+	if policy := NetworkPolicyFromContext(ctx); policy != nil {
+		if denial := CheckNetworkTarget(t.Name(), rawURL, policy); denial != nil {
+			return denial
+		}
+		client.Transport = SSRFSafeTransport(policy.AllowInternalNetworks)
+		client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+			if denial := CheckNetworkTarget(t.Name(), req.URL.String(), policy); denial != nil {
+				return denial
+			}
+			return nil
+		}
+	}
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for time.Now().Before(deadline) {
@@ -266,7 +411,11 @@ func (t *FrontendVerifyTool) waitForURL(ctx context.Context, rawURL string, time
 			return ctx.Err()
 		default:
 		}
-		resp, err := client.Get(rawURL) //nolint:noctx // intentional poll; context checked above
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
 		if err == nil {
 			resp.Body.Close()
 			return nil
@@ -281,8 +430,9 @@ func (t *FrontendVerifyTool) waitForURL(ctx context.Context, rawURL string, time
 }
 
 // captureScreenshot navigates to rawURL using the ephemeral browser profile and
-// captures a full-page screenshot, saving it to screenshotDir.
-// Localhost/loopback URLs are explicitly allowed for dev server use.
+// captures a full-page screenshot under a safe artifact root.
+// Localhost/loopback URLs are allowed unless an agent network policy disallows
+// internal networks.
 func (t *FrontendVerifyTool) captureScreenshot(ctx context.Context, rawURL string) ([]byte, string, error) {
 	if err := t.manager.StartProfile(browser.ProfileEphemeral); err != nil {
 		return nil, "", fmt.Errorf("failed to start ephemeral browser: %w", err)
@@ -306,22 +456,330 @@ func (t *FrontendVerifyTool) captureScreenshot(ctx context.Context, rawURL strin
 		return nil, "", fmt.Errorf("chromedp screenshot failed: %w", err)
 	}
 
-	dir := t.screenshotDir
-	if dir == "" {
-		homeDir, _ := os.UserHomeDir()
-		dir = filepath.Join(homeDir, ".ok-gobot", "screenshots")
+	path, err := t.nextScreenshotPath(time.Now())
+	if err != nil {
+		return nil, "", err
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, "", fmt.Errorf("failed to create screenshot dir: %w", err)
-	}
-
-	filename := fmt.Sprintf("frontend_verify_%s.png", time.Now().Format("20060102_150405"))
-	path := filepath.Join(dir, filename)
 	if err := os.WriteFile(path, buf, 0o644); err != nil {
 		return nil, "", fmt.Errorf("failed to save screenshot: %w", err)
 	}
 
 	return buf, path, nil
+}
+
+func (t *FrontendVerifyTool) nextScreenshotPath(now time.Time) (string, error) {
+	roots := t.screenshotRoots()
+	if len(roots) == 0 {
+		return "", fmt.Errorf("no safe artifact root is configured for frontend_verify screenshots")
+	}
+
+	dir := roots[0]
+	if strings.TrimSpace(t.screenshotDir) == "" && len(t.artifactRoots) > 0 {
+		dir = filepath.Join(dir, "frontend_verify")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create screenshot dir: %w", err)
+	}
+	safeDir, ok := artifactview.SafeLocalPath(dir, roots)
+	if !ok {
+		return "", fmt.Errorf("screenshot dir %q is outside configured artifact roots", dir)
+	}
+
+	filename := fmt.Sprintf("frontend_verify_%s_%d.png", now.Format("20060102_150405"), now.UnixNano())
+	return filepath.Join(safeDir, filename), nil
+}
+
+func (t *FrontendVerifyTool) screenshotRoots() []string {
+	if strings.TrimSpace(t.screenshotDir) != "" {
+		return artifactview.NormalizeRoots([]string{t.screenshotDir})
+	}
+	if len(t.artifactRoots) > 0 {
+		return artifactview.NormalizeRoots(t.artifactRoots)
+	}
+	return artifactview.DefaultRoots()
+}
+
+type devCommandResolution struct {
+	Command string
+	Source  string
+}
+
+func (t *FrontendVerifyTool) resolveDevCommand(command, workDir string) (devCommandResolution, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return devCommandResolution{}, fmt.Errorf("dev server command is required")
+	}
+	if isAutoDevCommand(command) {
+		return detectDevCommand(workDir)
+	}
+
+	executable := commandExecutable(command)
+	if executable == "" {
+		return devCommandResolution{}, fmt.Errorf("dev server command %q has no executable", command)
+	}
+	if _, err := exec.LookPath(executable); err == nil {
+		return devCommandResolution{Command: command, Source: "explicit"}, nil
+	}
+
+	manager := filepath.Base(executable)
+	if isSupportedPackageManager(manager) {
+		if detected, err := detectDevCommand(workDir); err == nil {
+			return devCommandResolution{Command: detected.Command, Source: "detected_fallback"}, nil
+		} else {
+			return devCommandResolution{}, fmt.Errorf("dev server command %q requires %q, but it was not found in PATH; install %s, pass another command, or use command=\"auto\" with an available package manager: %w", command, executable, executable, err)
+		}
+	}
+
+	return devCommandResolution{}, fmt.Errorf("dev server command executable %q was not found in PATH; install it or pass a supported frontend dev command such as command=\"auto\", \"npm run dev\", \"pnpm run dev\", \"yarn run dev\", or \"bun run dev\"", executable)
+}
+
+func isAutoDevCommand(command string) bool {
+	switch strings.ToLower(strings.TrimSpace(command)) {
+	case "auto", "detect", "detected":
+		return true
+	default:
+		return false
+	}
+}
+
+func commandExecutable(command string) string {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return ""
+	}
+	i := 0
+	if fields[i] == "env" {
+		i++
+	}
+	for i < len(fields) && isEnvAssignment(fields[i]) {
+		i++
+	}
+	if i >= len(fields) {
+		return ""
+	}
+	return fields[i]
+}
+
+func isEnvAssignment(token string) bool {
+	idx := strings.Index(token, "=")
+	return idx > 0 && !strings.HasPrefix(token, "-")
+}
+
+func detectDevCommand(workDir string) (devCommandResolution, error) {
+	dir := strings.TrimSpace(workDir)
+	if dir == "" {
+		dir = "."
+	}
+	scripts, err := readPackageScripts(dir)
+	if err != nil {
+		return devCommandResolution{}, err
+	}
+	script := preferredDevScript(scripts)
+	if script == "" {
+		return devCommandResolution{}, fmt.Errorf("package.json in %s has no supported frontend dev script (expected \"dev\" or \"start\"); add one or pass an explicit command", dir)
+	}
+
+	for _, manager := range packageManagerCandidates(dir) {
+		if _, err := exec.LookPath(manager); err == nil {
+			return devCommandResolution{Command: packageManagerCommand(manager, script), Source: "detected"}, nil
+		}
+	}
+	return devCommandResolution{}, fmt.Errorf("no supported frontend dev command is available in %s: package.json has script %q, but none of bun, pnpm, yarn, or npm were found in PATH; install one or pass an explicit command", dir, script)
+}
+
+func readPackageScripts(dir string) (map[string]string, error) {
+	path := filepath.Join(dir, "package.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("no package.json found in %s; pass an explicit dev server command or set command=\"auto\" in a frontend project directory", dir)
+		}
+		return nil, fmt.Errorf("read package.json in %s: %w", dir, err)
+	}
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, fmt.Errorf("parse package.json in %s: %w", dir, err)
+	}
+	return pkg.Scripts, nil
+}
+
+func preferredDevScript(scripts map[string]string) string {
+	if strings.TrimSpace(scripts["dev"]) != "" {
+		return "dev"
+	}
+	if strings.TrimSpace(scripts["start"]) != "" {
+		return "start"
+	}
+	return ""
+}
+
+func packageManagerCandidates(dir string) []string {
+	var candidates []string
+	add := func(manager string) {
+		for _, existing := range candidates {
+			if existing == manager {
+				return
+			}
+		}
+		candidates = append(candidates, manager)
+	}
+	if fileExists(filepath.Join(dir, "bun.lock")) || fileExists(filepath.Join(dir, "bun.lockb")) {
+		add("bun")
+	}
+	if fileExists(filepath.Join(dir, "pnpm-lock.yaml")) {
+		add("pnpm")
+	}
+	if fileExists(filepath.Join(dir, "yarn.lock")) {
+		add("yarn")
+	}
+	if fileExists(filepath.Join(dir, "package-lock.json")) || fileExists(filepath.Join(dir, "npm-shrinkwrap.json")) {
+		add("npm")
+	}
+	for _, manager := range []string{"npm", "pnpm", "yarn", "bun"} {
+		add(manager)
+	}
+	return candidates
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func isSupportedPackageManager(manager string) bool {
+	switch manager {
+	case "bun", "pnpm", "yarn", "npm":
+		return true
+	default:
+		return false
+	}
+}
+
+func packageManagerCommand(manager, script string) string {
+	return fmt.Sprintf("%s run %s", manager, script)
+}
+
+type boundedBuffer struct {
+	mu    sync.Mutex
+	limit int
+	buf   []byte
+}
+
+func newBoundedBuffer(limit int) *boundedBuffer {
+	return &boundedBuffer{limit: limit}
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, p...)
+	if b.limit > 0 && len(b.buf) > b.limit {
+		b.buf = append([]byte(nil), b.buf[len(b.buf)-b.limit:]...)
+	}
+	return len(p), nil
+}
+
+func (b *boundedBuffer) String() string {
+	if b == nil {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.TrimSpace(string(b.buf))
+}
+
+// JobArtifacts converts a frontend_verify result into durable artifacts that a
+// role job can persist when it wants to expose the proof in Mission Control.
+func (r FrontendVerifyResult) JobArtifacts() []jobruntime.JobArtifactSpec {
+	r = finalizeFrontendVerifyResult(r)
+	metadata := map[string]any{
+		"tool":                "frontend_verify",
+		"target_url":          r.TargetURL,
+		"verification_status": r.VerificationStatus,
+		"match":               r.Match,
+	}
+	if r.Score != "" {
+		metadata["score"] = r.Score
+	}
+
+	var out []jobruntime.JobArtifactSpec
+	if uri := strings.TrimSpace(firstNonEmpty(r.ScreenshotURI, r.ScreenshotPath)); uri != "" {
+		out = append(out, jobruntime.JobArtifactSpec{
+			Name:     "frontend_verify screenshot",
+			Type:     "screenshot",
+			MimeType: "image/png",
+			URI:      uri,
+			Metadata: metadata,
+		})
+	}
+	if strings.TrimSpace(r.TargetURL) != "" {
+		out = append(out, jobruntime.JobArtifactSpec{
+			Name:     "frontend_verify target",
+			Type:     artifactview.KindURL,
+			MimeType: "text/uri-list",
+			URI:      r.TargetURL,
+			Metadata: metadata,
+		})
+	}
+	if strings.TrimSpace(r.TextReport) != "" {
+		out = append(out, jobruntime.JobArtifactSpec{
+			Name:     "frontend_verify report",
+			Type:     artifactview.KindTextReport,
+			MimeType: "text/plain",
+			Content:  r.TextReport,
+			Metadata: metadata,
+		})
+	}
+	return out
+}
+
+func finalizeFrontendVerifyResult(r FrontendVerifyResult) FrontendVerifyResult {
+	if r.VerificationStatus == "" {
+		if r.Match {
+			r.VerificationStatus = frontendVerifyStatusPassed
+		} else {
+			r.VerificationStatus = frontendVerifyStatusFailed
+		}
+	}
+	if r.ScreenshotURI == "" {
+		r.ScreenshotURI = r.ScreenshotPath
+	}
+	if strings.TrimSpace(r.TextReport) == "" {
+		r.TextReport = frontendVerifyTextReport(r)
+	}
+	return r
+}
+
+func frontendVerifyTextReport(r FrontendVerifyResult) string {
+	var parts []string
+	parts = append(parts, fmt.Sprintf("frontend_verify %s", r.VerificationStatus))
+	if r.TargetURL != "" {
+		parts = append(parts, fmt.Sprintf("url: %s", r.TargetURL))
+	}
+	if r.Score != "" {
+		parts = append(parts, fmt.Sprintf("score: %s", r.Score))
+	}
+	if r.Feedback != "" {
+		parts = append(parts, fmt.Sprintf("feedback: %s", r.Feedback))
+	}
+	if r.Suggestions != "" {
+		parts = append(parts, fmt.Sprintf("suggestions: %s", r.Suggestions))
+	}
+	if r.ScreenshotURI != "" {
+		parts = append(parts, fmt.Sprintf("screenshot: %s", r.ScreenshotURI))
+	}
+	return strings.Join(parts, "\n")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 type llmCompareResult struct {
@@ -453,7 +911,7 @@ func (t *FrontendVerifyTool) GetSchema() map[string]interface{} {
 			},
 			"command": map[string]interface{}{
 				"type":        "string",
-				"description": "Shell command to start the dev server, e.g. 'bun run dev' or 'npm start'. Omit if server is already running.",
+				"description": "Shell command to start the dev server, e.g. 'npm run dev', 'pnpm run dev', 'yarn run dev', 'bun run dev', or 'auto' to detect from package.json. Omit if server is already running.",
 			},
 			"work_dir": map[string]interface{}{
 				"type":        "string",

--- a/internal/tools/frontend_verify_test.go
+++ b/internal/tools/frontend_verify_test.go
@@ -6,9 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	artifactview "ok-gobot/internal/artifacts"
 )
 
 // TestFrontendVerifyTool_Name verifies the tool name and schema.
@@ -106,6 +109,134 @@ func TestFrontendVerifyTool_URLTimeout(t *testing.T) {
 	}
 	if out.Feedback == "" {
 		t.Error("feedback should describe the timeout")
+	}
+	if out.TargetURL != "http://127.0.0.1:19876" {
+		t.Errorf("target_url = %q", out.TargetURL)
+	}
+	if out.VerificationStatus != frontendVerifyStatusUnreachable {
+		t.Errorf("verification_status = %q", out.VerificationStatus)
+	}
+	if out.TextReport == "" {
+		t.Error("text_report should be set")
+	}
+}
+
+func TestFrontendVerifyTool_ScreenshotPathUsesArtifactRoot(t *testing.T) {
+	root := t.TempDir()
+	tool := NewFrontendVerifyTool("", "", "", nil)
+	tool.SetArtifactRoots([]string{root})
+
+	path, err := tool.nextScreenshotPath(time.Date(2026, 5, 1, 12, 0, 0, 123, time.UTC))
+	if err != nil {
+		t.Fatalf("nextScreenshotPath: %v", err)
+	}
+
+	wantPrefix := filepath.Join(root, "frontend_verify") + string(os.PathSeparator)
+	if !strings.HasPrefix(path, wantPrefix) {
+		t.Fatalf("screenshot path %q is not under %q", path, wantPrefix)
+	}
+	if filepath.Ext(path) != ".png" {
+		t.Fatalf("screenshot path extension = %q", filepath.Ext(path))
+	}
+	if _, err := os.Stat(filepath.Dir(path)); err != nil {
+		t.Fatalf("screenshot directory was not created: %v", err)
+	}
+	if _, ok := artifactview.SafeLocalPath(filepath.Dir(path), []string{root}); !ok {
+		t.Fatalf("screenshot directory is not safe under artifact root: %s", filepath.Dir(path))
+	}
+}
+
+func TestFrontendVerifyTool_ScreenshotPathRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "frontend_verify")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	tool := NewFrontendVerifyTool("", "", "", nil)
+	tool.SetArtifactRoots([]string{root})
+	_, err := tool.nextScreenshotPath(time.Now())
+	if err == nil || !strings.Contains(err.Error(), "outside configured artifact roots") {
+		t.Fatalf("expected symlink escape error, got %v", err)
+	}
+}
+
+func TestFrontendVerifyResult_JobArtifacts(t *testing.T) {
+	shot := filepath.Join(t.TempDir(), "shot.png")
+	result := FrontendVerifyResult{
+		Match:              true,
+		Feedback:           "looks good",
+		ScreenshotPath:     shot,
+		ScreenshotURI:      shot,
+		TargetURL:          "http://localhost:5173",
+		VerificationStatus: frontendVerifyStatusPassed,
+	}
+
+	artifacts := result.JobArtifacts()
+	if len(artifacts) != 3 {
+		t.Fatalf("artifact count = %d, want 3: %+v", len(artifacts), artifacts)
+	}
+	if artifacts[0].Type != "screenshot" || artifacts[0].URI != shot || artifacts[0].MimeType != "image/png" {
+		t.Fatalf("unexpected screenshot artifact: %+v", artifacts[0])
+	}
+	if artifacts[1].Type != artifactview.KindURL || artifacts[1].URI != "http://localhost:5173" {
+		t.Fatalf("unexpected url artifact: %+v", artifacts[1])
+	}
+	if artifacts[2].Type != artifactview.KindTextReport || !strings.Contains(artifacts[2].Content, "frontend_verify passed") {
+		t.Fatalf("unexpected report artifact: %+v", artifacts[2])
+	}
+}
+
+func TestFrontendVerifyTool_MissingDevCommandFailsActionably(t *testing.T) {
+	tool := NewFrontendVerifyTool("", "", "", nil)
+	_, err := tool.ExecuteJSON(context.Background(), map[string]string{
+		"url":     "http://127.0.0.1:19876",
+		"command": "ok-gobot-missing-dev-command-343 run dev",
+	})
+	if err == nil {
+		t.Fatal("expected missing command error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "not found in PATH") || !strings.Contains(msg, "command=\"auto\"") {
+		t.Fatalf("missing command error is not actionable: %v", err)
+	}
+}
+
+func TestFrontendVerifyTool_ResolvesBunToAvailablePackageManager(t *testing.T) {
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, "package.json"), []byte(`{"scripts":{"dev":"vite --host 127.0.0.1"}}`), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "npm"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake npm: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	tool := NewFrontendVerifyTool("", "", "", nil)
+	resolved, err := tool.resolveDevCommand("bun run dev", workDir)
+	if err != nil {
+		t.Fatalf("resolveDevCommand: %v", err)
+	}
+	if resolved.Command != "npm run dev" {
+		t.Fatalf("resolved command = %q, want npm run dev", resolved.Command)
+	}
+}
+
+func TestFrontendVerifyTool_AutoCommandFailsWithoutPackageManager(t *testing.T) {
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, "package.json"), []byte(`{"scripts":{"dev":"vite"}}`), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	tool := NewFrontendVerifyTool("", "", "", nil)
+	_, err := tool.resolveDevCommand("auto", workDir)
+	if err == nil {
+		t.Fatal("expected auto command failure")
+	}
+	if !strings.Contains(err.Error(), "none of bun, pnpm, yarn, or npm") {
+		t.Fatalf("auto command error is not actionable: %v", err)
 	}
 }
 

--- a/internal/tools/network_policy_test.go
+++ b/internal/tools/network_policy_test.go
@@ -618,6 +618,52 @@ func TestNetworkPolicyGuard_BrowserTaskDeniedViaExecute(t *testing.T) {
 	}
 }
 
+func TestNetworkPolicyGuard_FrontendVerifyDeniedWithAllowlist(t *testing.T) {
+	t.Parallel()
+
+	reg := NewRegistry()
+	frontend := &stubJSONTool{stubTool: &stubTool{name: "frontend_verify"}}
+	reg.Register(frontend)
+
+	policy := &CapabilityPolicy{
+		Shell:            true,
+		Network:          true,
+		Cron:             true,
+		MemoryWrite:      true,
+		Spawn:            true,
+		NetworkAllowlist: []string{"github.com"},
+	}
+	result := ApplyPolicy(reg, policy)
+	tool, ok := result.Get("frontend_verify")
+	if !ok {
+		t.Fatal("frontend_verify missing")
+	}
+	je, ok := tool.(jsonExecutor)
+	if !ok {
+		t.Fatal("frontend_verify wrapper should preserve JSON execution")
+	}
+
+	_, err := je.ExecuteJSON(context.Background(), map[string]string{"url": "https://evil.com"})
+	if err == nil {
+		t.Fatal("frontend_verify to evil.com should be denied")
+	}
+	denial, ok := IsToolDenial(err)
+	if !ok {
+		t.Fatalf("expected ToolDenial, got %T: %v", err, err)
+	}
+	if denial.ToolName != "frontend_verify" || denial.Family != "network" {
+		t.Fatalf("unexpected denial: %+v", denial)
+	}
+
+	_, err = je.ExecuteJSON(context.Background(), map[string]string{"url": "https://github.com/BeFeast/ok-gobot"})
+	if err != nil {
+		t.Fatalf("frontend_verify to github.com should be allowed: %v", err)
+	}
+	if frontend.jsonCalled != 1 {
+		t.Fatalf("frontend_verify JSON call count = %d, want 1", frontend.jsonCalled)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Context propagation
 // ---------------------------------------------------------------------------

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -29,13 +29,14 @@ type CapabilityPolicy struct {
 // capabilitiesForTool maps tool names to the capabilities that govern them.
 // A tool requires ALL listed capabilities to be allowed.
 var capabilitiesForTool = map[string][]string{
-	"local":        {"shell"},
-	"ssh":          {"shell"},
-	"web_fetch":    {"network"},
-	"search":       {"network"},
-	"browser":      {"network"},
-	"browser_task": {"network", "spawn"},
-	"cron":         {"cron"},
+	"local":           {"shell"},
+	"ssh":             {"shell"},
+	"web_fetch":       {"network"},
+	"search":          {"network"},
+	"browser":         {"network"},
+	"frontend_verify": {"network"},
+	"browser_task":    {"network", "spawn"},
+	"cron":            {"cron"},
 }
 
 // CapabilityForTool returns the capabilities governing the named tool.
@@ -110,7 +111,7 @@ func wrapForPolicy(tool Tool, policy *CapabilityPolicy) Tool {
 	// Network-capable tools always get the policy context. Even with an empty
 	// allowlist, the policy controls internal network access and denial shape.
 	switch name {
-	case "web_fetch", "browser", "browser_task", "search":
+	case "web_fetch", "browser", "browser_task", "frontend_verify", "search":
 		tool = wrapToolWithNetworkPolicy(tool, policy)
 	}
 
@@ -579,6 +580,10 @@ func (g *networkPolicyGuard) checkExecArgs(args []string) *ToolDenial {
 				return CheckNetworkTarget(name, args[1], g.policy)
 			}
 		}
+	case "frontend_verify":
+		if len(args) > 0 {
+			return CheckNetworkTarget(name, args[0], g.policy)
+		}
 	case "search":
 		// Search engines make requests to their own APIs; we cannot guarantee
 		// that result URLs will stay within the allowlist. When an allowlist is
@@ -640,6 +645,10 @@ func (g *networkPolicyGuardWithJSON) checkJSONParams(params map[string]string) *
 		// will inherit the policy through context and enforce it per-navigation.
 		if len(g.policy.NetworkAllowlist) > 0 {
 			return browserTaskAllowlistDenial()
+		}
+	case "frontend_verify":
+		if u := params["url"]; u != "" {
+			return CheckNetworkTarget(name, u, g.policy)
 		}
 	case "search":
 		if len(g.policy.NetworkAllowlist) > 0 {

--- a/internal/tools/policy_test.go
+++ b/internal/tools/policy_test.go
@@ -19,6 +19,7 @@ func TestCapabilityPolicy_DeniedCapability(t *testing.T) {
 		{"network denied blocks web_fetch", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "web_fetch", "network"},
 		{"network denied blocks search", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "search", "network"},
 		{"network denied blocks browser", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "browser", "network"},
+		{"network denied blocks frontend_verify", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "frontend_verify", "network"},
 		{"network denied blocks browser_task", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true}, "browser_task", "network"},
 		{"spawn denied blocks browser_task", CapabilityPolicy{Shell: true, Network: true, Cron: true, MemoryWrite: true}, "browser_task", "spawn"},
 		{"cron denied blocks cron", CapabilityPolicy{Shell: true, Network: true, MemoryWrite: true, Spawn: true}, "cron", "cron"},

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -474,6 +474,7 @@ type ToolsConfig struct {
 	ChromePath           string // explicit path to Chrome/Chromium binary
 	BrowserProfile       string // user data directory for browser profiles
 	BrowserDebugURL      string // connect to existing browser CDP endpoint
+	ArtifactRoots        []string
 	CronScheduler        CronScheduler
 	MessageSender        MessageSender
 	Contacts             map[string]int64 // alias -> chatID for message tool allowlist
@@ -583,7 +584,11 @@ func LoadFromConfigWithOptions(basePath string, cfg *ToolsConfig) (*Registry, er
 	if cfg != nil {
 		aiClientForVerify = cfg.AIClient
 	}
-	registry.Register(NewFrontendVerifyTool(browserProfile, chromePath, browserDebugURL, aiClientForVerify))
+	frontendVerifyTool := NewFrontendVerifyTool(browserProfile, chromePath, browserDebugURL, aiClientForVerify)
+	if cfg != nil {
+		frontendVerifyTool.SetArtifactRoots(cfg.ArtifactRoots)
+	}
+	registry.Register(frontendVerifyTool)
 
 	// Register optional tools based on config
 	if cfg != nil {


### PR DESCRIPTION
Implements #343

## Changes
- Writes frontend_verify screenshots under configured artifact roots and returns artifact-ready structured fields.
- Adds dev command detection/fallback for npm/pnpm/yarn/bun and actionable failures for missing commands.
- Enforces network policy wrapping for frontend_verify and adds tests for safe paths, artifact conversion, command failures, and allowlist denial.

## Testing
- .maestro/verify.sh
- git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens `frontend_verify` by enforcing artifact-root path safety for screenshots, adding package-manager auto-detection with fallback logic, capturing bounded dev server output for actionable error messages, and wrapping the tool in the existing network policy infrastructure. The plumbing changes across `app.go`, `bot.go`, and `tools.go` are clean, and the new test suite covers the key new paths (symlink escape, artifact conversion, missing commands, allowlist denial).

- **P1 — `waitForURL` denial swallowed:** Any `*ToolDenial` returned by `waitForURL` — most critically one produced by `CheckRedirect` when a redirect targets a disallowed host — is caught by the generic error handler in `ExecuteJSON` and converted to a JSON `unreachable` result rather than propagated as an error. The agent receives a transient-failure signal instead of a permanent policy denial, which may cause unnecessary retries. Fix: check `errors.As(err, new(*ToolDenial))` before constructing the unreachable result and return the denial directly.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without addressing the denial-swallowing bug in the waitForURL error path.

One P1 logic bug: redirect-triggered ToolDenial errors are silently converted to "unreachable" JSON results in ExecuteJSON, meaning network policy violations from HTTP redirects are not surfaced as errors to the caller. The rest of the changes are well-structured with solid test coverage.

internal/tools/frontend_verify.go — waitForURL error handler at line 186.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tools/frontend_verify.go | Major overhaul adding artifact-root enforcement, bounded output buffering, auto-detection of package managers, and network policy checks; one P1 logic bug: ToolDenial from waitForURL (particularly redirect blocks) is converted to an "unreachable" JSON result instead of being propagated as an error. |
| internal/tools/policy.go | Adds frontend_verify to the capability map and network policy wrapper list; guard pre-checks the initial URL via checkJSONParams correctly. |
| internal/tools/tools.go | Adds ArtifactRoots to ToolsConfig and wires it into FrontendVerifyTool; straightforward plumbing. |
| internal/tools/frontend_verify_test.go | New tests for artifact root enforcement, symlink escape rejection, JobArtifacts conversion, missing command fallback, and auto-detection; good coverage of the new code paths. |
| internal/tools/network_policy_test.go | Adds test verifying frontend_verify is denied by allowlist (evil.com) and allowed for an allowlisted domain via the JSON guard path. |
| internal/tools/policy_test.go | Adds capability denial test case for frontend_verify under network=false; no issues. |
| internal/bot/bot.go | Threads ArtifactConfig through New() and maps it to ArtifactRoots in ToolsConfig; straightforward signature change. |
| internal/app/app.go | Single-line change adding a.config.Artifacts to bot.New() call; no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/tools/frontend_verify.go:186-202
**Network policy denial swallowed as "unreachable"**

`waitForURL` can return a `*ToolDenial` in two cases: (1) a direct denial from `CheckNetworkTarget` on the initial URL, and (2) a `*url.Error` wrapping a `*ToolDenial` when `CheckRedirect` blocks a redirect to a disallowed host. Both reach this catch-all error handler, which converts them into a JSON `unreachable` result and returns `nil` error. The policy violation is buried in `Feedback` text and the calling agent sees a transient failure rather than a permanent denial — it may retry or try alternative approaches.

The guard's `checkJSONParams` pre-checks the initial URL, so case (1) is usually preempted. Case (2) — a redirect that escapes to a disallowed host — is entirely in `waitForURL`'s hands and will always be swallowed here.

```go
// Wait for the URL to become accessible.
if err := t.waitForURL(ctx, rawURL, waitTimeout); err != nil {
    var denial *ToolDenial
    if errors.As(err, &denial) {
        return "", denial
    }
    feedback := fmt.Sprintf("URL %s did not become accessible within %s: %v", rawURL, waitTimeout, err)
    ...
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden frontend verification artifa..."](https://github.com/befeast/ok-gobot/commit/d036077628ea399a6d9f31e4ad5f4f4b336ebb4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30444669)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->