### PR TITLE
feat: add reliability benchmark harness (#353)

### DIFF
--- a/benchmarks/reliability/fake-scenarios.yaml
+++ b/benchmarks/reliability/fake-scenarios.yaml
@@ -1,0 +1,201 @@
+name: autonomous-pr-lifecycle-fakes
+version: 1
+scenarios:
+  - id: fake-ci-pass-success
+    title: CI and review pass
+    provider: fake
+    repo: BeFeast/ok-gobot
+    issue_ref: BeFeast/ok-gobot#9001
+    pr_ref: BeFeast/ok-gobot#9101
+    description: Baseline path where the agent opens a PR and all gates pass.
+    fake:
+      outcome: merge_ready
+      failure_category: none
+      reason: all lifecycle gates passed
+      retry_attempts: 0
+      events:
+        - state: issue_selected
+          status: passed
+          detail: issue selected from manifest
+        - state: preflight_passed
+          status: passed
+          detail: local policy and repository checks passed
+        - state: branch_created
+          status: passed
+          detail: feature branch created
+        - state: pr_opened
+          status: passed
+          detail: pull request opened
+        - state: ci_checked
+          status: passed
+          detail: required status checks passed
+        - state: review_checked
+          status: passed
+          detail: no blocking review comments
+        - state: merge_ready_emitted
+          status: passed
+          detail: merge-ready signal emitted
+
+  - id: fake-ci-failure
+    title: CI failure blocks lifecycle
+    provider: fake
+    repo: BeFeast/ok-gobot
+    issue_ref: BeFeast/ok-gobot#9002
+    pr_ref: BeFeast/ok-gobot#9102
+    description: PR exists but a required CI check fails.
+    fake:
+      outcome: blocked
+      failure_category: ci_failure
+      reason: required CI check failed after PR creation
+      retry_attempts: 0
+      events:
+        - state: issue_selected
+          status: passed
+        - state: preflight_passed
+          status: passed
+        - state: branch_created
+          status: passed
+        - state: pr_opened
+          status: passed
+        - state: ci_checked
+          status: failed
+          detail: go test failed
+        - state: blocker_emitted
+          status: failed
+          detail: CI failure reported as blocker
+
+  - id: fake-review-comments
+    title: Review comments block lifecycle
+    provider: fake
+    repo: BeFeast/ok-gobot
+    issue_ref: BeFeast/ok-gobot#9003
+    pr_ref: BeFeast/ok-gobot#9103
+    description: CI passes but reviewer feedback remains unresolved.
+    fake:
+      outcome: blocked
+      failure_category: review_failure
+      reason: blocking review comments were still open
+      retry_attempts: 1
+      events:
+        - state: issue_selected
+          status: passed
+        - state: preflight_passed
+          status: passed
+        - state: branch_created
+          status: passed
+        - state: pr_opened
+          status: passed
+        - state: ci_checked
+          status: passed
+        - state: review_checked
+          status: failed
+          detail: reviewer requested changes
+        - state: retry_attempted
+          status: passed
+          detail: agent pushed a follow-up commit
+        - state: blocker_emitted
+          status: failed
+          detail: review thread remained unresolved
+
+  - id: fake-branch-without-pr
+    title: Branch created without PR
+    provider: fake
+    repo: BeFeast/ok-gobot
+    issue_ref: BeFeast/ok-gobot#9004
+    description: Worker created a branch but never opened a pull request.
+    fake:
+      outcome: blocked
+      failure_category: agent_failure
+      reason: branch was created but no pull request was opened
+      retry_attempts: 0
+      events:
+        - state: issue_selected
+          status: passed
+        - state: preflight_passed
+          status: passed
+        - state: branch_created
+          status: passed
+          detail: branch exists on remote
+        - state: blocker_emitted
+          status: failed
+          detail: expected PR was missing
+
+  - id: fake-stale-worker
+    title: Stale worker blocks lifecycle
+    provider: fake
+    repo: BeFeast/ok-gobot
+    issue_ref: BeFeast/ok-gobot#9005
+    description: Worker heartbeat goes stale before the PR lifecycle can finish.
+    fake:
+      outcome: blocked
+      failure_category: environment_failure
+      reason: worker heartbeat became stale before PR checks completed
+      retry_attempts: 1
+      events:
+        - state: issue_selected
+          status: passed
+        - state: preflight_passed
+          status: passed
+        - state: branch_created
+          status: passed
+        - state: retry_attempted
+          status: failed
+          detail: worker session was stale
+        - state: blocker_emitted
+          status: failed
+          detail: stale worker reported as environment blocker
+
+  - id: fake-retry-exhausted-pr-open
+    title: Retry exhausted with PR open
+    provider: fake
+    repo: BeFeast/ok-gobot
+    issue_ref: BeFeast/ok-gobot#9006
+    pr_ref: BeFeast/ok-gobot#9106
+    description: PR remains open but the agent exhausts its retry budget.
+    fake:
+      outcome: blocked
+      failure_category: agent_failure
+      reason: retry budget was exhausted while the pull request stayed open
+      retry_attempts: 3
+      events:
+        - state: issue_selected
+          status: passed
+        - state: preflight_passed
+          status: passed
+        - state: branch_created
+          status: passed
+        - state: pr_opened
+          status: passed
+        - state: ci_checked
+          status: failed
+          detail: checks still failing after retries
+        - state: retry_attempted
+          status: failed
+          detail: maximum retry count reached
+        - state: blocker_emitted
+          status: failed
+          detail: retry exhaustion reported
+
+  - id: fake-policy-gated-skip
+    title: Policy-gated skip
+    provider: fake
+    repo: BeFeast/ok-gobot
+    issue_ref: BeFeast/ok-gobot#9007
+    labels:
+      - benchmark-skip
+    description: Scenario is skipped before work starts because policy forbids it.
+    fake:
+      outcome: skipped
+      failure_category: policy_gated_skip
+      reason: issue matched benchmark skip policy
+      retry_attempts: 0
+      events:
+        - state: issue_selected
+          status: passed
+          detail: issue selected from manifest
+        - state: preflight_passed
+          status: skipped
+          detail: policy gate declined execution
+        - state: blocker_emitted
+          status: skipped
+          detail: policy-gated skip emitted

--- a/docs/RELIABILITY-BENCHMARK.md
+++ b/docs/RELIABILITY-BENCHMARK.md
@@ -1,0 +1,62 @@
+# Reliability Benchmark Harness
+
+The reliability benchmark checks the autonomous PR lifecycle with a small,
+manifest-driven harness. The default manifest is deterministic and uses fake
+scenarios, so it runs locally without GitHub credentials, Telegram credentials,
+or live LLM calls.
+
+Run the default fake scenario suite:
+
+```bash
+ok-gobot benchmark reliability
+```
+
+From a checkout, this also works without installing the binary:
+
+```bash
+go run ./cmd/ok-gobot benchmark reliability
+```
+
+The compact report prints pass, fail, and skip counts plus failure buckets:
+
+```text
+Reliability benchmark: autonomous-pr-lifecycle-fakes (7 scenarios)
+PASS 1  FAIL 5  SKIP 1
+Categories: agent_failure=2  environment_failure=1  ci_failure=1  review_failure=1  policy_gated_skip=1
+```
+
+Write machine-readable JSON and human-readable Markdown artifacts:
+
+```bash
+ok-gobot benchmark reliability \
+  --json-out reliability-report.json \
+  --markdown-out reliability-report.md
+```
+
+Use `--format json` or `--format markdown` to print either artifact to stdout.
+Use `--fail-on-failure` when wiring the benchmark into a gate that should exit
+non-zero if any scenario is blocked.
+
+## Manifest
+
+The default fake manifest lives at
+`benchmarks/reliability/fake-scenarios.yaml`. Each scenario records lifecycle
+events for these states:
+
+- `issue_selected`
+- `preflight_passed`
+- `branch_created`
+- `pr_opened`
+- `ci_checked`
+- `review_checked`
+- `retry_attempted`
+- `merge_ready_emitted`
+- `blocker_emitted`
+
+Terminal outcomes are `merge_ready`, `blocked`, or `skipped`. Blocked and
+skipped scenarios include one failure category: `agent_failure`,
+`environment_failure`, `ci_failure`, `review_failure`, or `policy_gated_skip`.
+
+The runner is provider-neutral. The bundled `fake` provider replays manifest
+events for local testing. A future GitHub-backed provider can implement the same
+`reliability.Evaluator` interface and use the existing report generation.

--- a/internal/cli/benchmark.go
+++ b/internal/cli/benchmark.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"ok-gobot/internal/reliability"
+)
+
+const defaultReliabilityManifest = "benchmarks/reliability/fake-scenarios.yaml"
+
+func newBenchmarkCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "benchmark",
+		Short: "Run local benchmark harnesses",
+	}
+	cmd.AddCommand(newReliabilityBenchmarkCommand())
+	return cmd
+}
+
+func newReliabilityBenchmarkCommand() *cobra.Command {
+	var (
+		manifestPath  string
+		format        string
+		jsonOut       string
+		markdownOut   string
+		failOnFailure bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "reliability",
+		Short: "Run the autonomous PR lifecycle reliability benchmark",
+		Long: `Run a manifest-driven reliability benchmark for the autonomous PR lifecycle.
+
+The default manifest uses deterministic fake scenarios, so it can run locally
+without GitHub credentials, Telegram credentials, or live LLM calls.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			manifest, err := reliability.LoadManifestFile(manifestPath)
+			if err != nil {
+				return err
+			}
+
+			report, err := reliability.NewRunner(nil).Run(cmd.Context(), manifest)
+			if err != nil {
+				return err
+			}
+
+			jsonBytes, err := report.JSON()
+			if err != nil {
+				return fmt.Errorf("render JSON report: %w", err)
+			}
+			if jsonOut != "" {
+				if err := os.WriteFile(jsonOut, jsonBytes, 0o644); err != nil {
+					return fmt.Errorf("write JSON report: %w", err)
+				}
+			}
+			if markdownOut != "" {
+				if err := os.WriteFile(markdownOut, []byte(report.Markdown()), 0o644); err != nil {
+					return fmt.Errorf("write Markdown report: %w", err)
+				}
+			}
+
+			out := cmd.OutOrStdout()
+			switch strings.ToLower(strings.TrimSpace(format)) {
+			case "", "compact":
+				fmt.Fprint(out, report.Compact())
+			case "markdown", "md":
+				fmt.Fprint(out, report.Markdown())
+			case "json":
+				fmt.Fprintln(out, string(jsonBytes))
+			default:
+				return fmt.Errorf("unsupported format %q (supported: compact, markdown, json)", format)
+			}
+
+			if failOnFailure && report.Summary.Failed > 0 {
+				return fmt.Errorf("reliability benchmark reported %d failure(s)", report.Summary.Failed)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&manifestPath, "manifest", defaultReliabilityManifest, "path to reliability benchmark manifest")
+	cmd.Flags().StringVar(&format, "format", "compact", "output format: compact, markdown, json")
+	cmd.Flags().StringVar(&jsonOut, "json-out", "", "write machine-readable JSON report to this path")
+	cmd.Flags().StringVar(&markdownOut, "markdown-out", "", "write human-readable Markdown report to this path")
+	cmd.Flags().BoolVar(&failOnFailure, "fail-on-failure", false, "exit non-zero when any scenario is blocked")
+
+	return cmd
+}

--- a/internal/cli/benchmark_test.go
+++ b/internal/cli/benchmark_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBenchmarkReliabilityCommandPrintsAndWritesReports(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.yaml")
+	jsonPath := filepath.Join(dir, "report.json")
+	markdownPath := filepath.Join(dir, "report.md")
+	manifest := `
+name: cli-fixture
+version: 1
+scenarios:
+  - id: cli-pass
+    provider: fake
+    fake:
+      outcome: merge_ready
+      events:
+        - state: issue_selected
+          status: passed
+        - state: preflight_passed
+          status: passed
+        - state: branch_created
+          status: passed
+        - state: pr_opened
+          status: passed
+        - state: ci_checked
+          status: passed
+        - state: review_checked
+          status: passed
+        - state: merge_ready_emitted
+          status: passed
+  - id: cli-ci-fail
+    provider: fake
+    fake:
+      outcome: blocked
+      failure_category: ci_failure
+      reason: ci failed in CLI fixture
+      events:
+        - state: issue_selected
+          status: passed
+        - state: preflight_passed
+          status: passed
+        - state: branch_created
+          status: passed
+        - state: pr_opened
+          status: passed
+        - state: ci_checked
+          status: failed
+        - state: blocker_emitted
+          status: failed
+`
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	cmd := newBenchmarkCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"reliability",
+		"--manifest", manifestPath,
+		"--json-out", jsonPath,
+		"--markdown-out", markdownPath,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	for _, want := range []string{"Reliability benchmark: cli-fixture", "PASS 1  FAIL 1  SKIP 0", "ci_failure=1"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+
+	jsonBytes, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read JSON report: %v", err)
+	}
+	if !strings.Contains(string(jsonBytes), `"failure_category": "ci_failure"`) {
+		t.Fatalf("JSON report missing failure category:\n%s", jsonBytes)
+	}
+
+	markdownBytes, err := os.ReadFile(markdownPath)
+	if err != nil {
+		t.Fatalf("read Markdown report: %v", err)
+	}
+	if !strings.Contains(string(markdownBytes), "# Reliability Benchmark Report") {
+		t.Fatalf("Markdown report missing heading:\n%s", markdownBytes)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -54,6 +54,7 @@ Supports Telegram bot integration with personality and memory.`,
 	root.AddCommand(newExportCommand(cfg))
 	root.AddCommand(newEvolutionCommand(cfg))
 	root.AddCommand(newRolesCommand(cfg))
+	root.AddCommand(newBenchmarkCommand())
 
 	return root
 }

--- a/internal/reliability/manifest.go
+++ b/internal/reliability/manifest.go
@@ -1,0 +1,139 @@
+package reliability
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadManifestFile reads a YAML or JSON benchmark manifest from disk.
+func LoadManifestFile(path string) (Manifest, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return Manifest{}, fmt.Errorf("manifest path is required")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("read manifest %s: %w", path, err)
+	}
+	manifest, err := ParseManifest(data)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("parse manifest %s: %w", path, err)
+	}
+	return manifest, nil
+}
+
+// ParseManifest decodes and validates a benchmark manifest.
+func ParseManifest(data []byte) (Manifest, error) {
+	var manifest Manifest
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&manifest); err != nil {
+		return Manifest{}, err
+	}
+	if err := ValidateManifest(manifest); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+// ValidateManifest checks the provider-neutral parts of a manifest. Provider
+// availability is checked by Runner because providers are supplied at runtime.
+func ValidateManifest(manifest Manifest) error {
+	if len(manifest.Scenarios) == 0 {
+		return fmt.Errorf("manifest must contain at least one scenario")
+	}
+
+	seen := make(map[string]bool, len(manifest.Scenarios))
+	for i, scenario := range manifest.Scenarios {
+		prefix := fmt.Sprintf("scenario %d", i+1)
+		if strings.TrimSpace(scenario.ID) == "" {
+			return fmt.Errorf("%s: id is required", prefix)
+		}
+		if seen[scenario.ID] {
+			return fmt.Errorf("%s: duplicate id %q", prefix, scenario.ID)
+		}
+		seen[scenario.ID] = true
+
+		provider := normalizedProvider(scenario.Provider)
+		if provider == ProviderFake {
+			if err := validateFakeScenario(prefix, scenario.Fake); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateFakeScenario(prefix string, fake FakeScenario) error {
+	if len(fake.Events) == 0 {
+		return fmt.Errorf("%s: fake.events must contain at least one lifecycle event", prefix)
+	}
+	if fake.Outcome != "" && !validOutcome(fake.Outcome) {
+		return fmt.Errorf("%s: invalid fake.outcome %q", prefix, fake.Outcome)
+	}
+	if fake.FailureCategory != "" && !validCategory(fake.FailureCategory) {
+		return fmt.Errorf("%s: invalid fake.failure_category %q", prefix, fake.FailureCategory)
+	}
+	if fake.RetryAttempts < 0 {
+		return fmt.Errorf("%s: fake.retry_attempts cannot be negative", prefix)
+	}
+	for i, event := range fake.Events {
+		eventPrefix := fmt.Sprintf("%s event %d", prefix, i+1)
+		if !validLifecycleState(event.State) {
+			return fmt.Errorf("%s: invalid state %q", eventPrefix, event.State)
+		}
+		if event.Status != "" && !validEventStatus(event.Status) {
+			return fmt.Errorf("%s: invalid status %q", eventPrefix, event.Status)
+		}
+	}
+	return nil
+}
+
+func normalizedProvider(provider string) string {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return ProviderFake
+	}
+	return provider
+}
+
+func validLifecycleState(state LifecycleState) bool {
+	for _, required := range RequiredLifecycleStates {
+		if state == required {
+			return true
+		}
+	}
+	return false
+}
+
+func validEventStatus(status EventStatus) bool {
+	switch status {
+	case EventStatusPassed, EventStatusFailed, EventStatusSkipped, EventStatusInfo:
+		return true
+	default:
+		return false
+	}
+}
+
+func validOutcome(outcome Outcome) bool {
+	switch outcome {
+	case OutcomeMergeReady, OutcomeBlocked, OutcomeSkipped:
+		return true
+	default:
+		return false
+	}
+}
+
+func validCategory(category FailureCategory) bool {
+	switch category {
+	case CategoryNone, CategoryAgentFailure, CategoryEnvironmentFailure, CategoryCIFailure, CategoryReviewFailure, CategoryPolicyGatedSkip:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/reliability/report.go
+++ b/internal/reliability/report.go
@@ -1,0 +1,127 @@
+package reliability
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var orderedCategories = []FailureCategory{
+	CategoryAgentFailure,
+	CategoryEnvironmentFailure,
+	CategoryCIFailure,
+	CategoryReviewFailure,
+	CategoryPolicyGatedSkip,
+}
+
+// JSON renders the report as stable, indented JSON.
+func (r Report) JSON() ([]byte, error) {
+	return json.MarshalIndent(r, "", "  ")
+}
+
+// Compact renders a terse operator-facing report for CLI output.
+func (r Report) Compact() string {
+	var sb strings.Builder
+	name := valueOrDefault(strings.TrimSpace(r.Name), "reliability-benchmark")
+	fmt.Fprintf(&sb, "Reliability benchmark: %s (%d scenarios)\n", name, r.Summary.Total)
+	fmt.Fprintf(&sb, "PASS %d  FAIL %d  SKIP %d\n", r.Summary.Passed, r.Summary.Failed, r.Summary.Skipped)
+
+	if categories := r.formatCategoryCounts(); categories != "" {
+		fmt.Fprintf(&sb, "Categories: %s\n", categories)
+	}
+
+	for _, result := range r.Results {
+		label := outcomeLabel(result.Outcome)
+		category := ""
+		if result.FailureCategory != "" && result.FailureCategory != CategoryNone {
+			category = fmt.Sprintf(" [%s]", result.FailureCategory)
+		}
+		fmt.Fprintf(&sb, "%s %s%s: %s\n", label, result.ID, category, result.Reason)
+	}
+	return sb.String()
+}
+
+// Markdown renders a human-readable benchmark artifact suitable for PRs or run
+// logs.
+func (r Report) Markdown() string {
+	var sb strings.Builder
+	name := valueOrDefault(strings.TrimSpace(r.Name), "reliability-benchmark")
+	fmt.Fprintf(&sb, "# Reliability Benchmark Report\n\n")
+	fmt.Fprintf(&sb, "- Manifest: `%s`\n", escapeInline(name))
+	if !r.GeneratedAt.IsZero() {
+		fmt.Fprintf(&sb, "- Generated: `%s`\n", r.GeneratedAt.UTC().Format(time.RFC3339))
+	}
+	fmt.Fprintf(&sb, "- Total: %d\n", r.Summary.Total)
+	fmt.Fprintf(&sb, "- Passed: %d\n", r.Summary.Passed)
+	fmt.Fprintf(&sb, "- Failed: %d\n", r.Summary.Failed)
+	fmt.Fprintf(&sb, "- Skipped: %d\n", r.Summary.Skipped)
+	if categories := r.formatCategoryCounts(); categories != "" {
+		fmt.Fprintf(&sb, "- Categories: %s\n", categories)
+	}
+
+	sb.WriteString("\n| Result | Scenario | Category | Reason | Lifecycle |\n")
+	sb.WriteString("|---|---|---|---|---|\n")
+	for _, result := range r.Results {
+		category := string(result.FailureCategory)
+		if category == "" {
+			category = string(CategoryNone)
+		}
+		fmt.Fprintf(&sb, "| %s | `%s` | `%s` | %s | %s |\n",
+			escapeCell(outcomeLabel(result.Outcome)),
+			escapeCell(result.ID),
+			escapeCell(category),
+			escapeCell(result.Reason),
+			escapeCell(formatLifecycle(result.Lifecycle)),
+		)
+	}
+	return sb.String()
+}
+
+func (r Report) formatCategoryCounts() string {
+	var parts []string
+	for _, category := range orderedCategories {
+		count := r.Summary.Categories[category]
+		if count == 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s=%d", category, count))
+	}
+	return strings.Join(parts, "  ")
+}
+
+func outcomeLabel(outcome Outcome) string {
+	switch outcome {
+	case OutcomeMergeReady:
+		return "PASS"
+	case OutcomeSkipped:
+		return "SKIP"
+	default:
+		return "FAIL"
+	}
+}
+
+func formatLifecycle(events []LifecycleEvent) string {
+	if len(events) == 0 {
+		return "not recorded"
+	}
+	parts := make([]string, 0, len(events))
+	for _, event := range events {
+		status := event.Status
+		if status == "" {
+			status = EventStatusPassed
+		}
+		parts = append(parts, fmt.Sprintf("%s:%s", event.State, status))
+	}
+	return strings.Join(parts, " -> ")
+}
+
+func escapeCell(value string) string {
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, "|", `\|`)
+	return strings.TrimSpace(value)
+}
+
+func escapeInline(value string) string {
+	return strings.ReplaceAll(value, "`", "'")
+}

--- a/internal/reliability/runner.go
+++ b/internal/reliability/runner.go
@@ -1,0 +1,239 @@
+package reliability
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Evaluator runs one scenario through a provider-specific backend.
+type Evaluator interface {
+	Evaluate(ctx context.Context, scenario Scenario) (ScenarioResult, error)
+}
+
+// Runner evaluates every scenario in a manifest and aggregates the report.
+type Runner struct {
+	Evaluators map[string]Evaluator
+	Clock      func() time.Time
+}
+
+// NewRunner builds a runner with the deterministic fake evaluator installed by
+// default. Callers can pass extra evaluators, for example a future GitHub-backed
+// provider keyed by "github".
+func NewRunner(evaluators map[string]Evaluator) Runner {
+	merged := map[string]Evaluator{ProviderFake: FakeEvaluator{}}
+	for name, evaluator := range evaluators {
+		if strings.TrimSpace(name) == "" || evaluator == nil {
+			continue
+		}
+		merged[name] = evaluator
+	}
+	return Runner{Evaluators: merged, Clock: time.Now}
+}
+
+// Run executes all manifest scenarios. Provider execution errors are recorded as
+// environment failures so one broken scenario does not hide the rest of the run.
+func (r Runner) Run(ctx context.Context, manifest Manifest) (Report, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ValidateManifest(manifest); err != nil {
+		return Report{}, err
+	}
+
+	clock := r.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	evaluators := r.Evaluators
+	if len(evaluators) == 0 {
+		defaults := NewRunner(nil)
+		evaluators = defaults.Evaluators
+	}
+
+	results := make([]ScenarioResult, 0, len(manifest.Scenarios))
+	for _, scenario := range manifest.Scenarios {
+		provider := normalizedProvider(scenario.Provider)
+		evaluator, ok := evaluators[provider]
+		if !ok {
+			return Report{}, fmt.Errorf("scenario %q: evaluator %q is not registered", scenario.ID, provider)
+		}
+
+		result, err := evaluator.Evaluate(ctx, scenario)
+		result = normalizeResult(scenario, provider, result, err)
+		results = append(results, result)
+	}
+
+	report := Report{
+		Name:        valueOrDefault(strings.TrimSpace(manifest.Name), "reliability-benchmark"),
+		Version:     manifest.Version,
+		GeneratedAt: clock().UTC(),
+		Results:     results,
+	}
+	report.Summary = summarize(results)
+	return report, nil
+}
+
+// FakeEvaluator replays deterministic lifecycle events from the manifest.
+type FakeEvaluator struct{}
+
+// Evaluate implements Evaluator.
+func (FakeEvaluator) Evaluate(ctx context.Context, scenario Scenario) (ScenarioResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ScenarioResult{}, err
+	}
+
+	fake := scenario.Fake
+	outcome := fake.Outcome
+	if outcome == "" {
+		outcome = inferOutcome(fake.Events)
+	}
+	if outcome == "" {
+		outcome = OutcomeBlocked
+	}
+
+	category := fake.FailureCategory
+	if category == "" {
+		category = inferCategory(outcome, fake.Events)
+	}
+
+	reason := strings.TrimSpace(fake.Reason)
+	if reason == "" {
+		reason = defaultReason(outcome, category)
+	}
+
+	return ScenarioResult{
+		Outcome:         outcome,
+		FailureCategory: category,
+		Reason:          reason,
+		RetryAttempts:   fake.RetryAttempts,
+		Lifecycle:       normalizeEvents(fake.Events),
+	}, nil
+}
+
+func normalizeResult(scenario Scenario, provider string, result ScenarioResult, evalErr error) ScenarioResult {
+	if result.ID == "" {
+		result.ID = scenario.ID
+	}
+	if result.Title == "" {
+		result.Title = valueOrDefault(strings.TrimSpace(scenario.Title), scenario.ID)
+	}
+	if result.Provider == "" {
+		result.Provider = provider
+	}
+	if result.Repo == "" {
+		result.Repo = scenario.Repo
+	}
+	if result.IssueRef == "" {
+		result.IssueRef = scenario.IssueRef
+	}
+	if result.PRRef == "" {
+		result.PRRef = scenario.PRRef
+	}
+
+	result.Lifecycle = normalizeEvents(result.Lifecycle)
+	if evalErr != nil {
+		result.Outcome = OutcomeBlocked
+		result.FailureCategory = CategoryEnvironmentFailure
+		result.Reason = evalErr.Error()
+	}
+	if result.Outcome == "" {
+		result.Outcome = inferOutcome(result.Lifecycle)
+		if result.Outcome == "" {
+			result.Outcome = OutcomeBlocked
+		}
+	}
+	if result.FailureCategory == "" {
+		result.FailureCategory = inferCategory(result.Outcome, result.Lifecycle)
+	}
+	if result.Reason == "" {
+		result.Reason = defaultReason(result.Outcome, result.FailureCategory)
+	}
+	return result
+}
+
+func normalizeEvents(events []LifecycleEvent) []LifecycleEvent {
+	normalized := make([]LifecycleEvent, 0, len(events))
+	for _, event := range events {
+		if event.Status == "" {
+			event.Status = EventStatusPassed
+		}
+		normalized = append(normalized, event)
+	}
+	return normalized
+}
+
+func inferOutcome(events []LifecycleEvent) Outcome {
+	for i := len(events) - 1; i >= 0; i-- {
+		switch events[i].State {
+		case StateMergeReadyEmitted:
+			return OutcomeMergeReady
+		case StateBlockerEmitted:
+			if events[i].Status == EventStatusSkipped {
+				return OutcomeSkipped
+			}
+			return OutcomeBlocked
+		}
+	}
+	return ""
+}
+
+func inferCategory(outcome Outcome, events []LifecycleEvent) FailureCategory {
+	switch outcome {
+	case OutcomeMergeReady:
+		return CategoryNone
+	case OutcomeSkipped:
+		return CategoryPolicyGatedSkip
+	}
+	for _, event := range events {
+		if event.Status != EventStatusFailed {
+			continue
+		}
+		switch event.State {
+		case StateCIChecked:
+			return CategoryCIFailure
+		case StateReviewChecked:
+			return CategoryReviewFailure
+		}
+	}
+	return CategoryAgentFailure
+}
+
+func defaultReason(outcome Outcome, category FailureCategory) string {
+	switch outcome {
+	case OutcomeMergeReady:
+		return "all lifecycle gates passed"
+	case OutcomeSkipped:
+		return "scenario skipped by policy gate"
+	}
+	if category == "" || category == CategoryNone {
+		category = CategoryAgentFailure
+	}
+	return fmt.Sprintf("scenario blocked with %s", category)
+}
+
+func summarize(results []ScenarioResult) Summary {
+	summary := Summary{Total: len(results), Categories: make(map[FailureCategory]int)}
+	for _, result := range results {
+		switch result.Outcome {
+		case OutcomeMergeReady:
+			summary.Passed++
+		case OutcomeSkipped:
+			summary.Skipped++
+		default:
+			summary.Failed++
+		}
+		if result.FailureCategory != "" && result.FailureCategory != CategoryNone {
+			summary.Categories[result.FailureCategory]++
+		}
+	}
+	return summary
+}
+
+func valueOrDefault(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}

--- a/internal/reliability/runner_test.go
+++ b/internal/reliability/runner_test.go
@@ -1,0 +1,207 @@
+package reliability
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFakeManifestSummaryAndLifecycleStates(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := LoadManifestFile(fixtureManifestPath(t))
+	if err != nil {
+		t.Fatalf("LoadManifestFile() error = %v", err)
+	}
+
+	runner := NewRunner(nil)
+	runner.Clock = func() time.Time { return time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC) }
+	report, err := runner.Run(context.Background(), manifest)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if report.Summary.Total != 7 || report.Summary.Passed != 1 || report.Summary.Failed != 5 || report.Summary.Skipped != 1 {
+		t.Fatalf("unexpected summary: %+v", report.Summary)
+	}
+	wantCategories := map[FailureCategory]int{
+		CategoryAgentFailure:       2,
+		CategoryEnvironmentFailure: 1,
+		CategoryCIFailure:          1,
+		CategoryReviewFailure:      1,
+		CategoryPolicyGatedSkip:    1,
+	}
+	for category, want := range wantCategories {
+		if got := report.Summary.Categories[category]; got != want {
+			t.Fatalf("category %s count = %d, want %d", category, got, want)
+		}
+	}
+
+	seenStates := map[LifecycleState]bool{}
+	for _, result := range report.Results {
+		for _, event := range result.Lifecycle {
+			seenStates[event.State] = true
+		}
+	}
+	for _, state := range RequiredLifecycleStates {
+		if !seenStates[state] {
+			t.Fatalf("fixture did not exercise lifecycle state %s", state)
+		}
+	}
+
+	branchOnly := findResult(t, report, "fake-branch-without-pr")
+	if branchOnly.FailureCategory != CategoryAgentFailure {
+		t.Fatalf("branch-without-pr category = %s, want %s", branchOnly.FailureCategory, CategoryAgentFailure)
+	}
+	if lifecycleHasState(branchOnly.Lifecycle, StatePROpened) {
+		t.Fatalf("branch-without-pr fixture unexpectedly recorded pr_opened")
+	}
+
+	retryExhausted := findResult(t, report, "fake-retry-exhausted-pr-open")
+	if retryExhausted.RetryAttempts != 3 {
+		t.Fatalf("retry attempts = %d, want 3", retryExhausted.RetryAttempts)
+	}
+}
+
+func TestReportArtifactsContainCountsAndReasons(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := LoadManifestFile(fixtureManifestPath(t))
+	if err != nil {
+		t.Fatalf("LoadManifestFile() error = %v", err)
+	}
+	runner := NewRunner(nil)
+	runner.Clock = func() time.Time { return time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC) }
+	report, err := runner.Run(context.Background(), manifest)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	compact := report.Compact()
+	for _, want := range []string{
+		"PASS 1  FAIL 5  SKIP 1",
+		"agent_failure=2",
+		"environment_failure=1",
+		"FAIL fake-ci-failure [ci_failure]: required CI check failed after PR creation",
+		"SKIP fake-policy-gated-skip [policy_gated_skip]: issue matched benchmark skip policy",
+	} {
+		if !strings.Contains(compact, want) {
+			t.Fatalf("compact report missing %q:\n%s", want, compact)
+		}
+	}
+
+	markdown := report.Markdown()
+	for _, want := range []string{
+		"# Reliability Benchmark Report",
+		"| FAIL | `fake-ci-failure` | `ci_failure` | required CI check failed after PR creation |",
+		"| SKIP | `fake-policy-gated-skip` | `policy_gated_skip` | issue matched benchmark skip policy |",
+	} {
+		if !strings.Contains(markdown, want) {
+			t.Fatalf("markdown report missing %q:\n%s", want, markdown)
+		}
+	}
+
+	jsonBytes, err := report.JSON()
+	if err != nil {
+		t.Fatalf("JSON() error = %v", err)
+	}
+	var decoded Report
+	if err := json.Unmarshal(jsonBytes, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, jsonBytes)
+	}
+	if decoded.Summary.Failed != 5 || len(decoded.Results) != 7 {
+		t.Fatalf("decoded report mismatch: summary=%+v results=%d", decoded.Summary, len(decoded.Results))
+	}
+	if got := findResult(t, decoded, "fake-review-comments").Reason; got != "blocking review comments were still open" {
+		t.Fatalf("decoded reason = %q", got)
+	}
+}
+
+func TestEvaluatorErrorBecomesEnvironmentFailure(t *testing.T) {
+	t.Parallel()
+
+	manifest := Manifest{
+		Name: "provider-error",
+		Scenarios: []Scenario{{
+			ID:       "github-network-down",
+			Title:    "GitHub unavailable",
+			Provider: "github",
+		}},
+	}
+	runner := NewRunner(map[string]Evaluator{"github": errEvaluator{err: errors.New("api unavailable")}})
+	report, err := runner.Run(context.Background(), manifest)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if report.Summary.Failed != 1 || report.Summary.Categories[CategoryEnvironmentFailure] != 1 {
+		t.Fatalf("unexpected summary: %+v", report.Summary)
+	}
+	result := findResult(t, report, "github-network-down")
+	if result.FailureCategory != CategoryEnvironmentFailure || result.Reason != "api unavailable" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestManifestValidationRejectsBadFakeLifecycle(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseManifest([]byte(`
+name: bad
+scenarios:
+  - id: invalid-state
+    provider: fake
+    fake:
+      outcome: blocked
+      events:
+        - state: unknown_state
+          status: passed
+`))
+	if err == nil {
+		t.Fatal("expected invalid state error")
+	}
+	if !strings.Contains(err.Error(), "invalid state") {
+		t.Fatalf("expected invalid state error, got %v", err)
+	}
+}
+
+type errEvaluator struct {
+	err error
+}
+
+func (e errEvaluator) Evaluate(context.Context, Scenario) (ScenarioResult, error) {
+	return ScenarioResult{}, e.err
+}
+
+func fixtureManifestPath(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(file), "..", "..", "benchmarks", "reliability", "fake-scenarios.yaml")
+}
+
+func findResult(t *testing.T, report Report, id string) ScenarioResult {
+	t.Helper()
+	for _, result := range report.Results {
+		if result.ID == id {
+			return result
+		}
+	}
+	t.Fatalf("result %q not found", id)
+	return ScenarioResult{}
+}
+
+func lifecycleHasState(events []LifecycleEvent, state LifecycleState) bool {
+	for _, event := range events {
+		if event.State == state {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/reliability/types.go
+++ b/internal/reliability/types.go
@@ -1,0 +1,140 @@
+package reliability
+
+import "time"
+
+// ProviderFake is the local, deterministic scenario evaluator used by tests and
+// by the default benchmark manifest. Real GitHub-backed evaluators can be added
+// behind the same Evaluator interface without changing the runner.
+const ProviderFake = "fake"
+
+// LifecycleState names the autonomous PR lifecycle gates tracked by the harness.
+type LifecycleState string
+
+const (
+	StateIssueSelected     LifecycleState = "issue_selected"
+	StatePreflightPassed   LifecycleState = "preflight_passed"
+	StateBranchCreated     LifecycleState = "branch_created"
+	StatePROpened          LifecycleState = "pr_opened"
+	StateCIChecked         LifecycleState = "ci_checked"
+	StateReviewChecked     LifecycleState = "review_checked"
+	StateRetryAttempted    LifecycleState = "retry_attempted"
+	StateMergeReadyEmitted LifecycleState = "merge_ready_emitted"
+	StateBlockerEmitted    LifecycleState = "blocker_emitted"
+)
+
+// RequiredLifecycleStates is the state vocabulary every reliability report uses.
+var RequiredLifecycleStates = []LifecycleState{
+	StateIssueSelected,
+	StatePreflightPassed,
+	StateBranchCreated,
+	StatePROpened,
+	StateCIChecked,
+	StateReviewChecked,
+	StateRetryAttempted,
+	StateMergeReadyEmitted,
+	StateBlockerEmitted,
+}
+
+// EventStatus records how a lifecycle gate resolved.
+type EventStatus string
+
+const (
+	EventStatusPassed  EventStatus = "passed"
+	EventStatusFailed  EventStatus = "failed"
+	EventStatusSkipped EventStatus = "skipped"
+	EventStatusInfo    EventStatus = "info"
+)
+
+// Outcome is the terminal reliability state for one scenario.
+type Outcome string
+
+const (
+	OutcomeMergeReady Outcome = "merge_ready"
+	OutcomeBlocked    Outcome = "blocked"
+	OutcomeSkipped    Outcome = "skipped"
+)
+
+// FailureCategory is the top-level bucket used for reliability accounting.
+type FailureCategory string
+
+const (
+	CategoryNone               FailureCategory = "none"
+	CategoryAgentFailure       FailureCategory = "agent_failure"
+	CategoryEnvironmentFailure FailureCategory = "environment_failure"
+	CategoryCIFailure          FailureCategory = "ci_failure"
+	CategoryReviewFailure      FailureCategory = "review_failure"
+	CategoryPolicyGatedSkip    FailureCategory = "policy_gated_skip"
+)
+
+// Manifest describes a repeatable set of PR lifecycle scenarios.
+type Manifest struct {
+	Name      string     `json:"name" yaml:"name"`
+	Version   int        `json:"version" yaml:"version"`
+	Scenarios []Scenario `json:"scenarios" yaml:"scenarios"`
+}
+
+// Scenario is intentionally provider-neutral. The fake block is used by the
+// local evaluator; GitHub-backed providers can use Repo, IssueRef, PRRef, and
+// Metadata later without changing report generation.
+type Scenario struct {
+	ID          string            `json:"id" yaml:"id"`
+	Title       string            `json:"title" yaml:"title"`
+	Provider    string            `json:"provider" yaml:"provider"`
+	Repo        string            `json:"repo,omitempty" yaml:"repo"`
+	IssueRef    string            `json:"issue_ref,omitempty" yaml:"issue_ref"`
+	PRRef       string            `json:"pr_ref,omitempty" yaml:"pr_ref"`
+	Description string            `json:"description,omitempty" yaml:"description"`
+	Labels      []string          `json:"labels,omitempty" yaml:"labels"`
+	Metadata    map[string]string `json:"metadata,omitempty" yaml:"metadata"`
+	Fake        FakeScenario      `json:"fake,omitempty" yaml:"fake"`
+}
+
+// FakeScenario is a deterministic fixture for exercising the harness without
+// secrets, live GitHub access, or live LLM calls.
+type FakeScenario struct {
+	Events          []LifecycleEvent `json:"events" yaml:"events"`
+	Outcome         Outcome          `json:"outcome" yaml:"outcome"`
+	FailureCategory FailureCategory  `json:"failure_category" yaml:"failure_category"`
+	Reason          string           `json:"reason" yaml:"reason"`
+	RetryAttempts   int              `json:"retry_attempts" yaml:"retry_attempts"`
+}
+
+// LifecycleEvent records one observed lifecycle gate.
+type LifecycleEvent struct {
+	State  LifecycleState `json:"state" yaml:"state"`
+	Status EventStatus    `json:"status" yaml:"status"`
+	Detail string         `json:"detail,omitempty" yaml:"detail"`
+}
+
+// ScenarioResult is the machine-readable outcome for one benchmark scenario.
+type ScenarioResult struct {
+	ID              string           `json:"id"`
+	Title           string           `json:"title"`
+	Provider        string           `json:"provider"`
+	Repo            string           `json:"repo,omitempty"`
+	IssueRef        string           `json:"issue_ref,omitempty"`
+	PRRef           string           `json:"pr_ref,omitempty"`
+	Outcome         Outcome          `json:"outcome"`
+	FailureCategory FailureCategory  `json:"failure_category"`
+	Reason          string           `json:"reason"`
+	RetryAttempts   int              `json:"retry_attempts"`
+	Lifecycle       []LifecycleEvent `json:"lifecycle"`
+}
+
+// Summary aggregates terminal outcomes across the manifest.
+type Summary struct {
+	Total      int                     `json:"total"`
+	Passed     int                     `json:"passed"`
+	Failed     int                     `json:"failed"`
+	Skipped    int                     `json:"skipped"`
+	Categories map[FailureCategory]int `json:"categories"`
+}
+
+// Report is the full benchmark artifact emitted as JSON and Markdown.
+type Report struct {
+	Name        string           `json:"name"`
+	Version     int              `json:"version"`
+	GeneratedAt time.Time        `json:"generated_at"`
+	Summary     Summary          `json:"summary"`
+	Results     []ScenarioResult `json:"results"`
+}


### PR DESCRIPTION
Implements #353

## Changes
- Added a manifest-driven reliability runner with fake provider support, lifecycle states, failure categories, and JSON/Markdown/compact reports.
- Added local fake scenarios for CI pass/fail, review comments, branch-without-PR, stale worker, retry exhaustion, and policy-gated skip.
- Added `ok-gobot benchmark reliability` plus docs for local runs and report artifact output.

## Testing
- `go run ./cmd/ok-gobot benchmark reliability`
- `bash .maestro/verify.sh`
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a manifest-driven reliability benchmark harness with a fake provider for deterministic local testing, a CLI subcommand (`ok-gobot benchmark reliability`), and JSON/Markdown/compact report generation. The implementation is well-structured and the test coverage exercises all lifecycle states and failure categories.

- **P1 — `Run()` absorbs context cancellation as environment failures**: when the context is cancelled mid-run, every remaining scenario is recorded as `CategoryEnvironmentFailure` and `Run()` returns `(Report, nil)`. A CI gate using `--fail-on-failure` cannot distinguish an interrupted benchmark from a legitimately failing one.

<h3>Confidence Score: 3/5</h3>

Safe to merge for local/fake-provider use; the context-cancellation issue becomes a real problem if --fail-on-failure is wired into a CI gate that can time out.

One P1 finding (context cancellation silently becomes environment failures) in the core Run loop, plus one P2 (unnecessary JSON marshaling on every invocation). The P1 directly affects the stated CI gate use case of --fail-on-failure.

internal/reliability/runner.go — the Run() loop needs a ctx.Err() check between iterations.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/reliability/runner.go | Core runner logic; FakeEvaluator replays manifest events correctly, but Run() absorbs context cancellation silently as environment failures rather than propagating it. |
| internal/cli/benchmark.go | CLI wiring for the benchmark subcommand; always marshals JSON regardless of format, which couples all output paths to JSON marshaling success. |
| internal/reliability/types.go | Clean type definitions with well-named constants for lifecycle states, outcomes, and failure categories; no issues found. |
| internal/reliability/manifest.go | Manifest loading and validation; correctly scopes fake-specific validation to fake provider scenarios and validates the full state/status vocabulary. |
| internal/reliability/report.go | Report rendering for compact, Markdown, and JSON formats; escaping helpers are correct for table cells and inline code. |
| internal/reliability/runner_test.go | Good coverage of the happy path, evaluator error fallback, manifest validation, and all lifecycle state exercises. |
| internal/cli/benchmark_test.go | Integration test for the CLI command verifying compact output, JSON artifact, and Markdown artifact; covers pass and fail scenarios. |
| benchmarks/reliability/fake-scenarios.yaml | Deterministic fixture covering all seven scenario types; exercises every lifecycle state in RequiredLifecycleStates. |
| internal/cli/root.go | Minimal change — registers the new benchmark subcommand with the root cobra command. |
| docs/RELIABILITY-BENCHMARK.md | Clear documentation for local runs, report flags, and manifest structure; no issues. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/reliability/runner.go`, line 832-842 ([link](https://github.com/befeast/ok-gobot/blob/3ab3a7d6eab69662661273ef17004f2b84af6f07/internal/reliability/runner.go#L832-L842)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Context cancellation silently becomes environment failures**

   `Run()` never checks `ctx.Err()` between loop iterations. When the context is cancelled (e.g., Ctrl+C or a CI timeout), `FakeEvaluator.Evaluate` returns the context error immediately, `normalizeResult` converts it to `CategoryEnvironmentFailure`, and the loop continues until every remaining scenario has been processed. `Run()` then returns `(Report, nil)` — a successful return containing false-positive environment failures.

   For any caller using `--fail-on-failure` as a CI gate, an interrupted benchmark looks identical to a legitimate run where all providers are down, making it impossible to distinguish a cancelled run from a real environment problem.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/reliability/runner.go
   Line: 832-842

   Comment:
   **Context cancellation silently becomes environment failures**

   `Run()` never checks `ctx.Err()` between loop iterations. When the context is cancelled (e.g., Ctrl+C or a CI timeout), `FakeEvaluator.Evaluate` returns the context error immediately, `normalizeResult` converts it to `CategoryEnvironmentFailure`, and the loop continues until every remaining scenario has been processed. `Run()` then returns `(Report, nil)` — a successful return containing false-positive environment failures.

   For any caller using `--fail-on-failure` as a CI gate, an interrupted benchmark looks identical to a legitimate run where all providers are down, making it impossible to distinguish a cancelled run from a real environment problem.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/cli/benchmark.go`, line 333-336 ([link](https://github.com/befeast/ok-gobot/blob/3ab3a7d6eab69662661273ef17004f2b84af6f07/internal/cli/benchmark.go#L333-L336)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **JSON always marshaled regardless of output format**

   `report.JSON()` is called unconditionally before the format switch, so every invocation marshals JSON even when only compact or Markdown output is needed. If a future change to the `Report` or `Summary` types introduces a field that is not JSON-serializable (e.g. a function, channel, or `interface{}` holding an unmarshallable value), the compact-only path silently breaks even though JSON was never requested. Marshaling should be deferred to where it is actually needed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/cli/benchmark.go
   Line: 333-336

   Comment:
   **JSON always marshaled regardless of output format**

   `report.JSON()` is called unconditionally before the format switch, so every invocation marshals JSON even when only compact or Markdown output is needed. If a future change to the `Report` or `Summary` types introduces a field that is not JSON-serializable (e.g. a function, channel, or `interface{}` holding an unmarshallable value), the compact-only path silently breaks even though JSON was never requested. Marshaling should be deferred to where it is actually needed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/reliability/runner.go:832-842
**Context cancellation silently becomes environment failures**

`Run()` never checks `ctx.Err()` between loop iterations. When the context is cancelled (e.g., Ctrl+C or a CI timeout), `FakeEvaluator.Evaluate` returns the context error immediately, `normalizeResult` converts it to `CategoryEnvironmentFailure`, and the loop continues until every remaining scenario has been processed. `Run()` then returns `(Report, nil)` — a successful return containing false-positive environment failures.

For any caller using `--fail-on-failure` as a CI gate, an interrupted benchmark looks identical to a legitimate run where all providers are down, making it impossible to distinguish a cancelled run from a real environment problem.

### Issue 2 of 2
internal/cli/benchmark.go:333-336
**JSON always marshaled regardless of output format**

`report.JSON()` is called unconditionally before the format switch, so every invocation marshals JSON even when only compact or Markdown output is needed. If a future change to the `Report` or `Summary` types introduces a field that is not JSON-serializable (e.g. a function, channel, or `interface{}` holding an unmarshallable value), the compact-only path silently breaks even though JSON was never requested. Marshaling should be deferred to where it is actually needed.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add reliability benchmark harness ..."](https://github.com/befeast/ok-gobot/commit/3ab3a7d6eab69662661273ef17004f2b84af6f07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30446256)</sub>

<!-- /greptile_comment -->