### PR TITLE
feat: add session evidence ledger (#357)

### DIFF
--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -29,11 +29,17 @@ api:
 | `/api/mission/estop` | GET | Current emergency-stop state |
 | `/api/mission/providers` | GET | Active AI provider and model |
 | `/api/mission/memory` | GET | Memory health: enabled state, backend, watcher, counts, freshness, and last error |
+| `/api/mission/evidence?session_key=...` | GET | Concise structured evidence timeline for a session, including Markdown rendering |
 
 Job detail responses from `/api/jobs/{id}` include proof artifacts with `type`,
 `label`, `path` or `url`, `created_at`, and `display` metadata. Mission Control
 renders image/screenshot artifacts, URL artifacts, and inline text reports when
 they are present.
+
+Evidence timelines are stored as append-only structured rows in the same SQLite
+store as durable jobs and session transcripts. Event summaries and payloads are
+redacted and capped before rendering so operators can diagnose sessions without
+using raw log tails as the only source of truth.
 
 Run query parameters: `limit` (1-200), `status` (filter by run status). Stats query parameters: `days` (1-90).
 
@@ -43,6 +49,7 @@ Run query parameters: `limit` (1-200), `status` (filter by run status). Stats qu
 - **Schedules** -- when each role is next due to run
 - **Runs** -- whether recent job runs succeeded, failed, or were refused by preflight, with summaries and errors
 - **Proof artifacts** -- screenshots, URLs, and text reports linked from job and worker rows
+- **Evidence timelines** -- redacted structured session ledger for preflight, commands, checks, reviews, retries, and final outcomes
 - **Stats** -- aggregate token usage and message counts
 - **Controls** -- emergency-stop state and active provider/model
 - **Memory** -- whether the memory index is enabled, fresh, watched, and error-free

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -551,6 +551,22 @@ func TestHandleMissionMemory(t *testing.T) {
 	}
 }
 
+func TestHandleMissionEvidence(t *testing.T) {
+	srv := NewAPIServer(config.APIConfig{
+		Enabled: true,
+		Port:    8080,
+		APIKey:  "test-key",
+	}, nil)
+	// Without bot, should return error.
+	req := httptest.NewRequest(http.MethodGet, "/api/mission/evidence?session_key=agent:test:main", nil)
+	w := httptest.NewRecorder()
+	srv.handleMissionEvidence(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("Expected 500 without bot, got %d", w.Code)
+	}
+}
+
 func TestHandleMissionEstop_WrongMethod(t *testing.T) {
 	srv := newTestServer(&mockDataProvider{})
 	req := httptest.NewRequest(http.MethodPost, "/api/mission/estop", nil)
@@ -578,6 +594,17 @@ func TestHandleMissionMemory_WrongMethod(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/mission/memory", nil)
 	w := httptest.NewRecorder()
 	srv.handleMissionMemory(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleMissionEvidence_WrongMethod(t *testing.T) {
+	srv := newTestServer(&mockDataProvider{})
+	req := httptest.NewRequest(http.MethodPost, "/api/mission/evidence", nil)
+	w := httptest.NewRecorder()
+	srv.handleMissionEvidence(w, req)
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("Expected 405, got %d", w.Code)

--- a/internal/api/mission.go
+++ b/internal/api/mission.go
@@ -318,7 +318,7 @@ func (s *APIServer) handleMissionEvidence(w http.ResponseWriter, r *http.Request
 	}
 	events, err := store.ListEvidenceEvents(sessionKey, limit)
 	if err != nil {
-		writeJSONError(w, "Failed to list evidence: "+err.Error(), http.StatusInternalServerError)
+		writeJSONError(w, "failed to list evidence", http.StatusInternalServerError)
 		return
 	}
 	writeJSON(w, map[string]interface{}{

--- a/internal/api/mission.go
+++ b/internal/api/mission.go
@@ -3,8 +3,10 @@ package api
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/storage"
 )
 
@@ -285,6 +287,45 @@ func (s *APIServer) handleMissionMemory(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	writeJSON(w, status)
+}
+
+// handleMissionEvidence returns the structured evidence timeline for a session.
+func (s *APIServer) handleMissionEvidence(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.bot == nil {
+		writeJSONError(w, "Bot not available", http.StatusInternalServerError)
+		return
+	}
+	store := s.bot.GetStore()
+	if store == nil {
+		writeJSONError(w, "Store not available", http.StatusInternalServerError)
+		return
+	}
+
+	sessionKey := strings.TrimSpace(r.URL.Query().Get("session_key"))
+	if sessionKey == "" {
+		writeJSONError(w, "session_key is required", http.StatusBadRequest)
+		return
+	}
+	limit := 25
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 200 {
+			limit = n
+		}
+	}
+	events, err := store.ListEvidenceEvents(sessionKey, limit)
+	if err != nil {
+		writeJSONError(w, "Failed to list evidence: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]interface{}{
+		"session_key": sessionKey,
+		"events":      events,
+		"markdown":    evidence.RenderMarkdown(events, evidence.RenderOptions{Limit: limit}),
+	})
 }
 
 // handleMissionStats returns daily aggregate statistics.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -86,6 +86,7 @@ func (s *APIServer) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/mission/estop", s.handleMissionEstop)
 	mux.HandleFunc("/api/mission/providers", s.handleMissionProviders)
 	mux.HandleFunc("/api/mission/memory", s.handleMissionMemory)
+	mux.HandleFunc("/api/mission/evidence", s.handleMissionEvidence)
 
 	// Apply middleware
 	handler := loggingMiddleware(mux)

--- a/internal/bot/role_commands.go
+++ b/internal/bot/role_commands.go
@@ -12,6 +12,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	artifactview "ok-gobot/internal/artifacts"
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/role"
 	"ok-gobot/internal/rolejob"
 	"ok-gobot/internal/runtime"
@@ -307,6 +308,11 @@ func (b *Bot) handleTGJobCommand(c telebot.Context) error {
 			errMsg = errMsg[:197] + "..."
 		}
 		sb.WriteString(fmt.Sprintf("\nError: %s\n", errMsg))
+	}
+	if events, err := b.store.ListEvidenceEventsForJob(job.JobID, 6); err == nil && len(events) > 0 {
+		sb.WriteString("\nEvidence:\n")
+		sb.WriteString(evidence.RenderMarkdown(events, evidence.RenderOptions{Limit: 6, MaxSummaryRune: 180}))
+		sb.WriteString("\n")
 	}
 
 	artifacts, err := b.store.ListJobArtifacts(job.JobID, 10)

--- a/internal/cli/jobs.go
+++ b/internal/cli/jobs.go
@@ -11,6 +11,7 @@ import (
 
 	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/config"
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/storage"
 )
 
@@ -162,6 +163,17 @@ func newJobsInspectCommand(cfg *config.Config) *cobra.Command {
 				fmt.Fprintf(out, "%-14s%s\n", reasonLabel+":", job.Error)
 			}
 
+			// Structured evidence timeline.
+			evidenceEvents, err := store.ListEvidenceEventsForJob(job.JobID, 12)
+			if err != nil {
+				return fmt.Errorf("failed to list evidence: %w", err)
+			}
+			if len(evidenceEvents) > 0 {
+				fmt.Fprintln(out)
+				fmt.Fprintln(out, "Evidence:")
+				fmt.Fprintln(out, evidence.RenderMarkdown(evidenceEvents, evidence.RenderOptions{Limit: 12}))
+			}
+
 			// Events
 			events, err := store.ListJobEvents(job.JobID, 100)
 			if err != nil {
@@ -310,6 +322,9 @@ picked up by the running bot instance.`,
 				Attempt:            attempt,
 				MaxAttempts:        job.MaxAttempts,
 				TimeoutSeconds:     job.TimeoutSeconds,
+				MaxToolCalls:       job.MaxToolCalls,
+				RoleName:           job.RoleName,
+				ModelTier:          job.ModelTier,
 			}); err != nil {
 				return fmt.Errorf("failed to create retry job: %w", err)
 			}

--- a/internal/cli/jobs.go
+++ b/internal/cli/jobs.go
@@ -166,9 +166,8 @@ func newJobsInspectCommand(cfg *config.Config) *cobra.Command {
 			// Structured evidence timeline.
 			evidenceEvents, err := store.ListEvidenceEventsForJob(job.JobID, 12)
 			if err != nil {
-				return fmt.Errorf("failed to list evidence: %w", err)
-			}
-			if len(evidenceEvents) > 0 {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to list evidence: %v\n", err)
+			} else if len(evidenceEvents) > 0 {
 				fmt.Fprintln(out)
 				fmt.Fprintln(out, "Evidence:")
 				fmt.Fprintln(out, evidence.RenderMarkdown(evidenceEvents, evidence.RenderOptions{Limit: 12}))

--- a/internal/cli/jobs_test.go
+++ b/internal/cli/jobs_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"strings"
@@ -158,6 +159,68 @@ func TestJobsInspect(t *testing.T) {
 
 	output := out.String()
 	for _, want := range []string{"job-inspect-1", "succeeded", "research", "agent-x", "deep research task", "1 / 3", "all done", "Events:", "created"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
+func TestJobsInspect_EvidenceFailureDoesNotAbort(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+
+	seedJob(t, store, storage.Job{
+		JobID:       "job-inspect-evidence-failure",
+		Kind:        "research",
+		Worker:      "agent-x",
+		Description: "inspect survives evidence failure",
+		Status:      "succeeded",
+	})
+	if err := store.AddJobEvent(storage.JobEvent{
+		JobID:     "job-inspect-evidence-failure",
+		EventType: "created",
+		Message:   "still visible",
+	}); err != nil {
+		t.Fatalf("AddJobEvent error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", cfg.StoragePath)
+	if err != nil {
+		t.Fatalf("sql.Open error = %v", err)
+	}
+	if _, err := db.Exec(`DROP TABLE evidence_events`); err != nil {
+		t.Fatalf("drop evidence_events: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE evidence_events (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_key TEXT NOT NULL DEFAULT '',
+		job_id TEXT NOT NULL DEFAULT '',
+		status TEXT NOT NULL DEFAULT '',
+		summary TEXT NOT NULL DEFAULT '',
+		payload TEXT NOT NULL DEFAULT '',
+		created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		t.Fatalf("create broken evidence_events: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("sql close error = %v", err)
+	}
+
+	cmd := newJobsCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"inspect", "job-inspect-evidence-failure"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	output := out.String()
+	for _, want := range []string{"Warning: failed to list evidence", "Events:", "created", "still visible"} {
 		if !strings.Contains(output, want) {
 			t.Errorf("expected %q in output: %q", want, output)
 		}

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"ok-gobot/internal/config"
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/memory"
 	"ok-gobot/internal/storage"
 )
@@ -23,6 +24,7 @@ func newSessionsCommand(cfg *config.Config) *cobra.Command {
 	cmd.AddCommand(newSessionsIndexCommand(cfg))
 	cmd.AddCommand(newSessionsSearchCommand(cfg))
 	cmd.AddCommand(newSessionsShowCommand(cfg))
+	cmd.AddCommand(newSessionsEvidenceCommand(cfg))
 
 	return cmd
 }
@@ -397,5 +399,41 @@ Without --around the most recent (1 + 2*span) messages are shown.`,
 	cmd.Flags().Int64Var(&around, "around", 0, "anchor message id to centre the window on")
 	cmd.Flags().IntVar(&span, "span", 2, "messages to show before/after the anchor")
 	cmd.Flags().IntVar(&limit, "limit", 0, "hard cap on messages to show (0 = no cap)")
+	return cmd
+}
+
+// --- sessions evidence ---
+
+func newSessionsEvidenceCommand(cfg *config.Config) *cobra.Command {
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "evidence <session-key>",
+		Short: "Show the structured evidence timeline for a session",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessionKey := strings.TrimSpace(args[0])
+			if sessionKey == "" {
+				return fmt.Errorf("session key must not be empty")
+			}
+
+			store, err := storage.New(cfg.StoragePath)
+			if err != nil {
+				return fmt.Errorf("open storage: %w", err)
+			}
+			defer store.Close() //nolint:errcheck
+
+			events, err := store.ListEvidenceEvents(sessionKey, limit)
+			if err != nil {
+				return fmt.Errorf("list evidence: %w", err)
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Session: %s (fingerprint=%s)\n", sessionKey, memory.SessionKeyFingerprint(sessionKey))
+			fmt.Fprintf(out, "Evidence events: %d\n\n", len(events))
+			fmt.Fprintln(out, evidence.RenderMarkdown(events, evidence.RenderOptions{Limit: limit}))
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 25, "maximum evidence events to show")
 	return cmd
 }

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/storage"
 )
 
@@ -77,6 +78,48 @@ func TestSessionsShowReturnsSpanAroundAnchor(t *testing.T) {
 	// Ensure the anchor row uses the highlight marker.
 	if !strings.Contains(output, "> msg "+strString(anchor)) {
 		t.Errorf("expected anchor marker, got: %q", output)
+	}
+}
+
+func TestSessionsEvidenceRendersTimeline(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+
+	sessionKey := "agent:maestro:main"
+	if err := store.UpsertSessionV2(&storage.SessionV2{SessionKey: sessionKey, AgentID: "maestro"}); err != nil {
+		t.Fatalf("UpsertSessionV2: %v", err)
+	}
+	if err := store.AddEvidenceEvent(evidence.Event{
+		SessionKey: sessionKey,
+		Type:       evidence.EventPreflight,
+		Status:     "passed",
+		Summary:    "go vet ./...",
+	}); err != nil {
+		t.Fatalf("AddEvidenceEvent: %v", err)
+	}
+	if err := store.AddEvidenceEvent(evidence.Event{
+		SessionKey: sessionKey,
+		Type:       evidence.EventFinalDecision,
+		Status:     "succeeded",
+		Summary:    "PR opened",
+	}); err != nil {
+		t.Fatalf("AddEvidenceEvent: %v", err)
+	}
+
+	cmd := newSessionsCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"evidence", sessionKey})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	output := out.String()
+	for _, want := range []string{"Evidence events: 2", "Preflight [passed]", "Final [succeeded]", "fingerprint="} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in output: %q", want, output)
+		}
 	}
 }
 

--- a/internal/control/mission.go
+++ b/internal/control/mission.go
@@ -11,6 +11,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	artifactview "ok-gobot/internal/artifacts"
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/memory"
 	"ok-gobot/internal/storage"
 	"ok-gobot/internal/tools"
@@ -39,6 +40,7 @@ func (s *Server) registerMissionRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/mission/estop", s.corsWrap(missionEstop(mp)))
 	mux.HandleFunc("/api/mission/providers", s.corsWrap(missionProviders(s)))
 	mux.HandleFunc("/api/mission/memory", s.corsWrap(missionMemory(mp)))
+	mux.HandleFunc("/api/mission/evidence", s.corsWrap(missionEvidence(mp)))
 	mux.HandleFunc("/api/mission/artifacts/", s.corsWrap(missionArtifactContent(mp, s.artifactRoots)))
 }
 
@@ -405,5 +407,40 @@ func missionMemory(mp MissionProvider) http.HandlerFunc {
 			return
 		}
 		writeJSON(w, status)
+	}
+}
+
+func missionEvidence(mp MissionProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeJSONErr(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		store := mp.GetStore()
+		if store == nil {
+			writeJSONErr(w, "store unavailable", http.StatusInternalServerError)
+			return
+		}
+		sessionKey := strings.TrimSpace(r.URL.Query().Get("session_key"))
+		if sessionKey == "" {
+			writeJSONErr(w, "session_key is required", http.StatusBadRequest)
+			return
+		}
+		limit := 25
+		if v := r.URL.Query().Get("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 200 {
+				limit = n
+			}
+		}
+		events, err := store.ListEvidenceEvents(sessionKey, limit)
+		if err != nil {
+			writeJSONErr(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]interface{}{
+			"session_key": sessionKey,
+			"events":      events,
+			"markdown":    evidence.RenderMarkdown(events, evidence.RenderOptions{Limit: limit}),
+		})
 	}
 }

--- a/internal/control/mission.go
+++ b/internal/control/mission.go
@@ -434,7 +434,7 @@ func missionEvidence(mp MissionProvider) http.HandlerFunc {
 		}
 		events, err := store.ListEvidenceEvents(sessionKey, limit)
 		if err != nil {
-			writeJSONErr(w, err.Error(), http.StatusInternalServerError)
+			writeJSONErr(w, "failed to list evidence", http.StatusInternalServerError)
 			return
 		}
 		writeJSON(w, map[string]interface{}{

--- a/internal/control/mission_test.go
+++ b/internal/control/mission_test.go
@@ -80,3 +80,30 @@ func TestMissionEvidenceRequiresSessionKey(t *testing.T) {
 		t.Fatalf("status = %d, want 400", w.Code)
 	}
 }
+
+func TestMissionEvidenceListFailureUsesGenericError(t *testing.T) {
+	t.Parallel()
+
+	store, err := storage.New(filepath.Join(t.TempDir(), "mission-evidence-closed.db"))
+	if err != nil {
+		t.Fatalf("storage.New failed: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mission/evidence?session_key=agent:maestro:main", nil)
+	w := httptest.NewRecorder()
+	missionEvidence(missionEvidenceProvider{store: store})(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "failed to list evidence") {
+		t.Fatalf("expected generic evidence error in body: %s", body)
+	}
+	if strings.Contains(body, "database") || strings.Contains(body, "evidence_events") {
+		t.Fatalf("raw storage detail leaked in body: %s", body)
+	}
+}

--- a/internal/control/mission_test.go
+++ b/internal/control/mission_test.go
@@ -1,0 +1,82 @@
+package control
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/evidence"
+	"ok-gobot/internal/memory"
+	"ok-gobot/internal/storage"
+	"ok-gobot/internal/tools"
+)
+
+type missionEvidenceProvider struct {
+	store *storage.Store
+}
+
+func (m missionEvidenceProvider) GetStore() *storage.Store { return m.store }
+
+func (m missionEvidenceProvider) GetAgentRegistry() *agent.AgentRegistry { return nil }
+
+func (m missionEvidenceProvider) GetScheduler() tools.CronScheduler { return nil }
+
+func (m missionEvidenceProvider) GetMemoryStatus(context.Context) (memory.IndexStatus, error) {
+	return memory.IndexStatus{}, nil
+}
+
+func TestMissionEvidenceRendersSessionTimeline(t *testing.T) {
+	t.Parallel()
+
+	store, err := storage.New(filepath.Join(t.TempDir(), "mission-evidence.db"))
+	if err != nil {
+		t.Fatalf("storage.New failed: %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	const sessionKey = "agent:maestro:main"
+	if err := store.AddEvidenceEvent(evidence.Event{
+		SessionKey: sessionKey,
+		Type:       evidence.EventPreflight,
+		Status:     "passed",
+		Summary:    "preflight passed",
+	}); err != nil {
+		t.Fatalf("AddEvidenceEvent failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mission/evidence?session_key="+sessionKey, nil)
+	w := httptest.NewRecorder()
+	missionEvidence(missionEvidenceProvider{store: store})(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{"\"session_key\"", "Preflight", "preflight passed", "markdown"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in body: %s", want, body)
+		}
+	}
+}
+
+func TestMissionEvidenceRequiresSessionKey(t *testing.T) {
+	t.Parallel()
+
+	store, err := storage.New(filepath.Join(t.TempDir(), "mission-evidence-missing.db"))
+	if err != nil {
+		t.Fatalf("storage.New failed: %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mission/evidence", nil)
+	w := httptest.NewRecorder()
+	missionEvidence(missionEvidenceProvider{store: store})(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1,0 +1,367 @@
+package evidence
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"ok-gobot/internal/redact"
+)
+
+const (
+	EventPreflight      = "preflight"
+	EventBackendModel   = "backend_model"
+	EventWorkspace      = "workspace"
+	EventCommand        = "command"
+	EventPullRequest    = "pull_request"
+	EventCheckRollup    = "check_rollup"
+	EventReviewFeedback = "review_feedback"
+	EventRetryDecision  = "retry_decision"
+	EventFinalDecision  = "final_decision"
+	EventJob            = "job_event"
+	EventArtifact       = "artifact"
+)
+
+const (
+	MaxSummaryRunes       = 320
+	MaxPayloadStringRunes = 1200
+	MaxPayloadKeys        = 64
+	MaxPayloadItems       = 32
+)
+
+// Event is one structured, append-only evidence ledger entry for a session.
+type Event struct {
+	ID         int64          `json:"id,omitempty"`
+	SessionKey string         `json:"session_key,omitempty"`
+	JobID      string         `json:"job_id,omitempty"`
+	Type       string         `json:"type"`
+	Status     string         `json:"status,omitempty"`
+	Summary    string         `json:"summary,omitempty"`
+	Payload    map[string]any `json:"payload,omitempty"`
+	CreatedAt  string         `json:"created_at,omitempty"`
+}
+
+// RenderOptions controls compact Markdown rendering for Mission Control and Telegram.
+type RenderOptions struct {
+	Limit          int
+	Heading        string
+	MaxSummaryRune int
+}
+
+// SanitizeEvent redacts secrets and caps large raw fields before persistence or rendering.
+func SanitizeEvent(event Event) Event {
+	event.SessionKey = strings.TrimSpace(event.SessionKey)
+	event.JobID = strings.TrimSpace(event.JobID)
+	event.Type = strings.TrimSpace(event.Type)
+	event.Status = clipOneLine(redact.Redact(strings.TrimSpace(event.Status)), MaxSummaryRunes)
+	event.Summary = clipOneLine(redact.Redact(strings.TrimSpace(event.Summary)), MaxSummaryRunes)
+	if event.Payload != nil {
+		if payload, ok := sanitizeValue(event.Payload, "").(map[string]any); ok {
+			event.Payload = payload
+		}
+	}
+	return event
+}
+
+// PayloadMap converts arbitrary structured payloads into a map suitable for an Event.
+func PayloadMap(payload any) (map[string]any, error) {
+	if payload == nil {
+		return nil, nil
+	}
+	switch v := payload.(type) {
+	case map[string]any:
+		return v, nil
+	case map[string]string:
+		out := make(map[string]any, len(v))
+		for k, value := range v {
+			out[k] = value
+		}
+		return out, nil
+	case string:
+		return payloadFromJSONOrValue([]byte(v), v), nil
+	case []byte:
+		return payloadFromJSONOrValue(v, string(v)), nil
+	case json.RawMessage:
+		return payloadFromJSONOrValue(v, string(v)), nil
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("marshal evidence payload: %w", err)
+		}
+		return payloadFromJSONOrValue(b, string(b)), nil
+	}
+}
+
+// MarshalPayload sanitizes and serializes an event payload for storage.
+func MarshalPayload(payload map[string]any) (string, error) {
+	if len(payload) == 0 {
+		return "", nil
+	}
+	clean, ok := sanitizeValue(payload, "").(map[string]any)
+	if !ok || len(clean) == 0 {
+		return "", nil
+	}
+	b, err := json.Marshal(clean)
+	if err != nil {
+		return "", fmt.Errorf("marshal evidence payload: %w", err)
+	}
+	return string(b), nil
+}
+
+// DecodePayload deserializes a stored payload string. Invalid legacy values are preserved.
+func DecodePayload(payload string) map[string]any {
+	payload = strings.TrimSpace(payload)
+	if payload == "" {
+		return nil
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		return map[string]any{"payload": clipOneLine(redact.Redact(payload), MaxPayloadStringRunes)}
+	}
+	if m, ok := decoded.(map[string]any); ok {
+		return m
+	}
+	return map[string]any{"payload": decoded}
+}
+
+// JSONLine returns an append-friendly JSONL representation of one sanitized event.
+func JSONLine(event Event) ([]byte, error) {
+	clean := SanitizeEvent(event)
+	b, err := json.Marshal(clean)
+	if err != nil {
+		return nil, fmt.Errorf("marshal evidence event: %w", err)
+	}
+	return append(b, '\n'), nil
+}
+
+// RenderMarkdown renders a concise evidence timeline suitable for compact UIs.
+func RenderMarkdown(events []Event, opts RenderOptions) string {
+	limit := opts.Limit
+	if limit <= 0 || limit > len(events) {
+		limit = len(events)
+	}
+	maxSummary := opts.MaxSummaryRune
+	if maxSummary <= 0 {
+		maxSummary = MaxSummaryRunes
+	}
+
+	var b strings.Builder
+	if opts.Heading != "" {
+		b.WriteString(opts.Heading)
+		b.WriteString("\n")
+	}
+	if limit == 0 {
+		b.WriteString("No evidence recorded.")
+		return b.String()
+	}
+	for i := 0; i < limit; i++ {
+		line := CompactLine(SanitizeEvent(events[i]), maxSummary)
+		b.WriteString("- ")
+		b.WriteString(line)
+		if i < limit-1 {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+// CompactLine renders a single event as one Markdown-safe timeline line.
+func CompactLine(event Event, maxSummaryRunes int) string {
+	if maxSummaryRunes <= 0 {
+		maxSummaryRunes = MaxSummaryRunes
+	}
+	parts := []string{eventLabel(event.Type)}
+	if ts := formatTime(event.CreatedAt); ts != "" {
+		parts = append([]string{ts}, parts...)
+	}
+	if event.Status != "" {
+		parts = append(parts, "["+event.Status+"]")
+	}
+
+	summary := event.Summary
+	if summary == "" {
+		summary = deriveSummary(event)
+	}
+	if summary == "" {
+		summary = "recorded"
+	}
+	return strings.Join(parts, " ") + ": " + clipOneLine(summary, maxSummaryRunes)
+}
+
+func payloadFromJSONOrValue(raw []byte, fallback string) map[string]any {
+	var decoded any
+	if len(strings.TrimSpace(string(raw))) > 0 && json.Unmarshal(raw, &decoded) == nil {
+		if m, ok := decoded.(map[string]any); ok {
+			return m
+		}
+		return map[string]any{"value": decoded}
+	}
+	return map[string]any{"value": fallback}
+}
+
+func sanitizeValue(value any, key string) any {
+	if isSensitiveKey(key) {
+		return "***"
+	}
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case string:
+		return clipOneLine(redact.Redact(v), MaxPayloadStringRunes)
+	case []byte:
+		return clipOneLine(redact.Redact(string(v)), MaxPayloadStringRunes)
+	case json.RawMessage:
+		return clipOneLine(redact.Redact(string(v)), MaxPayloadStringRunes)
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		out := make(map[string]any, min(len(keys), MaxPayloadKeys))
+		for i, k := range keys {
+			if i >= MaxPayloadKeys {
+				out["_truncated_keys"] = len(keys) - MaxPayloadKeys
+				break
+			}
+			cleanKey := clipOneLine(redact.Redact(strings.TrimSpace(k)), 96)
+			if cleanKey == "" {
+				continue
+			}
+			out[cleanKey] = sanitizeValue(v[k], k)
+		}
+		return out
+	case map[string]string:
+		converted := make(map[string]any, len(v))
+		for k, item := range v {
+			converted[k] = item
+		}
+		return sanitizeValue(converted, key)
+	case []any:
+		limit := min(len(v), MaxPayloadItems)
+		out := make([]any, 0, limit+1)
+		for i := 0; i < limit; i++ {
+			out = append(out, sanitizeValue(v[i], key))
+		}
+		if len(v) > limit {
+			out = append(out, map[string]any{"_truncated_items": len(v) - limit})
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func isSensitiveKey(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	for _, marker := range []string{"api_key", "apikey", "token", "secret", "password", "credential", "authorization"} {
+		if strings.Contains(key, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func deriveSummary(event Event) string {
+	switch event.Type {
+	case EventBackendModel:
+		return joinPayloadFields(event.Payload, "backend", "model", "model_tier", "role")
+	case EventWorkspace:
+		return joinPayloadFields(event.Payload, "branch", "worktree", "worktree_path")
+	case EventCommand:
+		return joinPayloadFields(event.Payload, "command", "exit_status")
+	case EventPullRequest:
+		return joinPayloadFields(event.Payload, "url", "pr_url")
+	case EventCheckRollup:
+		return joinPayloadFields(event.Payload, "conclusion", "failed", "pending", "passed")
+	case EventReviewFeedback:
+		return joinPayloadFields(event.Payload, "state", "author", "body")
+	case EventRetryDecision:
+		return joinPayloadFields(event.Payload, "decision", "retry_job_id", "reason")
+	case EventFinalDecision:
+		return joinPayloadFields(event.Payload, "outcome", "blocker", "limit_reason")
+	default:
+		return ""
+	}
+}
+
+func joinPayloadFields(payload map[string]any, keys ...string) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		value, ok := payload[key]
+		if !ok || value == nil {
+			continue
+		}
+		text := strings.TrimSpace(fmt.Sprint(value))
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, " - ")
+}
+
+func eventLabel(eventType string) string {
+	switch eventType {
+	case EventPreflight:
+		return "Preflight"
+	case EventBackendModel:
+		return "Backend/model"
+	case EventWorkspace:
+		return "Workspace"
+	case EventCommand:
+		return "Command"
+	case EventPullRequest:
+		return "PR"
+	case EventCheckRollup:
+		return "Checks"
+	case EventReviewFeedback:
+		return "Review"
+	case EventRetryDecision:
+		return "Retry"
+	case EventFinalDecision:
+		return "Final"
+	case EventArtifact:
+		return "Artifact"
+	case EventJob:
+		return "Job"
+	default:
+		if eventType == "" {
+			return "Evidence"
+		}
+		return strings.ReplaceAll(eventType, "_", " ")
+	}
+}
+
+func formatTime(ts string) string {
+	ts = strings.TrimSpace(ts)
+	if ts == "" {
+		return ""
+	}
+	for _, layout := range []string{
+		"2006-01-02 15:04:05",
+		"2006-01-02T15:04:05Z",
+		time.RFC3339,
+	} {
+		if t, err := time.Parse(layout, ts); err == nil {
+			return t.Format("15:04:05")
+		}
+	}
+	return ts
+}
+
+func clipOneLine(s string, maxRunes int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if maxRunes <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return string(runes[:maxRunes]) + "... [truncated]"
+}

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -1,0 +1,91 @@
+package evidence
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeEventRedactsSecretsAndTruncatesPayload(t *testing.T) {
+	longOutput := strings.Repeat("line ", 400)
+	event := SanitizeEvent(Event{
+		Type:    EventCommand,
+		Status:  "failed",
+		Summary: "command failed with sk-1234567890abcdefghijklmnop",
+		Payload: map[string]any{
+			"command":   "go test ./...",
+			"api_token": "plain-local-token",
+			"stdout":    longOutput,
+			"nested": map[string]any{
+				"authorization": "Bearer abc.def.ghi",
+			},
+		},
+	})
+
+	if strings.Contains(event.Summary, "abcdefghijklmnop") {
+		t.Fatalf("summary leaked secret: %q", event.Summary)
+	}
+	if !strings.Contains(event.Summary, "sk-123456***") {
+		t.Fatalf("summary did not keep redacted prefix: %q", event.Summary)
+	}
+	if got := event.Payload["api_token"]; got != "***" {
+		t.Fatalf("api_token = %v, want redacted", got)
+	}
+	stdout, ok := event.Payload["stdout"].(string)
+	if !ok || !strings.Contains(stdout, "[truncated]") {
+		t.Fatalf("stdout was not truncated: %#v", event.Payload["stdout"])
+	}
+	nested := event.Payload["nested"].(map[string]any)
+	if nested["authorization"] != "***" {
+		t.Fatalf("authorization = %v, want redacted", nested["authorization"])
+	}
+}
+
+func TestRenderMarkdownCompactsEvidenceTimeline(t *testing.T) {
+	events := []Event{
+		{
+			Type:      EventPreflight,
+			Status:    "passed",
+			Summary:   "go vet ./... completed",
+			CreatedAt: "2026-05-01 12:00:00",
+		},
+		{
+			Type:   EventCommand,
+			Status: "failed",
+			Payload: map[string]any{
+				"command":     "go test ./...",
+				"exit_status": 1,
+			},
+			CreatedAt: "2026-05-01 12:01:00",
+		},
+	}
+
+	md := RenderMarkdown(events, RenderOptions{Heading: "Evidence", Limit: 2})
+	for _, want := range []string{
+		"Evidence",
+		"- 12:00:00 Preflight [passed]: go vet ./... completed",
+		"- 12:01:00 Command [failed]: go test ./... - 1",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("expected %q in markdown:\n%s", want, md)
+		}
+	}
+	if strings.Contains(md, "\n  -") {
+		t.Fatalf("expected flat markdown bullets, got:\n%s", md)
+	}
+}
+
+func TestJSONLineSanitizesEvent(t *testing.T) {
+	line, err := JSONLine(Event{
+		Type:    EventPullRequest,
+		Summary: "opened with Bearer secret-token",
+	})
+	if err != nil {
+		t.Fatalf("JSONLine error = %v", err)
+	}
+	if !strings.HasSuffix(string(line), "\n") {
+		t.Fatalf("JSONLine missing newline: %q", string(line))
+	}
+	if strings.Contains(string(line), "secret-token") {
+		t.Fatalf("JSONLine leaked secret: %s", string(line))
+	}
+}

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -368,7 +368,8 @@ func (s *JobService) createJob(spec JobSpec) (*storage.Job, error) {
 		return nil, err
 	}
 
-	if strings.TrimSpace(spec.Worker) != "" || strings.TrimSpace(spec.ModelTier) != "" || strings.TrimSpace(spec.RoleName) != "" {
+	hasEvidenceSession := strings.TrimSpace(spec.SessionKey) != "" || strings.TrimSpace(spec.DeliverySessionKey) != ""
+	if hasEvidenceSession && (strings.TrimSpace(spec.Worker) != "" || strings.TrimSpace(spec.ModelTier) != "" || strings.TrimSpace(spec.RoleName) != "") {
 		if err := s.AppendEvidence(jobID, evidence.EventBackendModel, "selected", "selected backend/model", map[string]any{
 			"backend":    strings.TrimSpace(spec.Worker),
 			"model_tier": strings.TrimSpace(spec.ModelTier),
@@ -377,7 +378,7 @@ func (s *JobService) createJob(spec JobSpec) (*storage.Job, error) {
 			return nil, err
 		}
 	}
-	if strings.TrimSpace(spec.Branch) != "" || strings.TrimSpace(spec.WorktreePath) != "" {
+	if hasEvidenceSession && (strings.TrimSpace(spec.Branch) != "" || strings.TrimSpace(spec.WorktreePath) != "") {
 		if err := s.AppendEvidence(jobID, evidence.EventWorkspace, "selected", "selected branch/worktree", map[string]any{
 			"branch":        strings.TrimSpace(spec.Branch),
 			"worktree_path": strings.TrimSpace(spec.WorktreePath),

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"ok-gobot/internal/delegation"
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/storage"
 )
 
@@ -58,6 +59,8 @@ type JobSpec struct {
 	Description        string
 	RoleName           string
 	ModelTier          string
+	Branch             string
+	WorktreePath       string
 	Attempt            int
 	MaxAttempts        int
 	Timeout            time.Duration
@@ -174,12 +177,12 @@ func (s *JobService) RetryDetached(parentCtx context.Context, jobID string, runn
 		DeliverySessionKey: existing.DeliverySessionKey,
 		RetryOfJobID:       existing.JobID,
 		Description:        existing.Description,
+		RoleName:           existing.RoleName,
+		ModelTier:          existing.ModelTier,
 		Attempt:            nextAttempt,
 		MaxAttempts:        existing.MaxAttempts,
 		Timeout:            time.Duration(existing.TimeoutSeconds) * time.Second,
 		MaxToolCalls:       existing.MaxToolCalls,
-		RoleName:           existing.RoleName,
-		ModelTier:          existing.ModelTier,
 	}, runner)
 	if err != nil {
 		return nil, err
@@ -239,6 +242,36 @@ func (s *JobService) AppendEvent(jobID string, eventType JobEventType, message s
 		EventType: string(eventType),
 		Message:   message,
 		Payload:   payloadJSON,
+	})
+}
+
+// AppendEvidence persists one structured evidence ledger entry for a job.
+func (s *JobService) AppendEvidence(jobID, eventType, status, summary string, payload any) error {
+	if s == nil || s.store == nil {
+		return fmt.Errorf("job storage is required")
+	}
+	payloadMap, err := evidence.PayloadMap(payload)
+	if err != nil {
+		return err
+	}
+	job, err := s.store.GetJob(jobID)
+	if err != nil {
+		return err
+	}
+	if job == nil {
+		return fmt.Errorf("job %q not found", jobID)
+	}
+	sessionKey := strings.TrimSpace(job.SessionKey)
+	if sessionKey == "" {
+		sessionKey = strings.TrimSpace(job.DeliverySessionKey)
+	}
+	return s.store.AddEvidenceEvent(evidence.Event{
+		SessionKey: sessionKey,
+		JobID:      job.JobID,
+		Type:       eventType,
+		Status:     status,
+		Summary:    summary,
+		Payload:    payloadMap,
 	})
 }
 
@@ -326,11 +359,31 @@ func (s *JobService) createJob(spec JobSpec) (*storage.Job, error) {
 		"worker":               strings.TrimSpace(spec.Worker),
 		"delivery_session_key": strings.TrimSpace(spec.DeliverySessionKey),
 		"retry_of_job_id":      strings.TrimSpace(spec.RetryOfJobID),
+		"role_name":            strings.TrimSpace(spec.RoleName),
+		"model_tier":           strings.TrimSpace(spec.ModelTier),
 		"attempt":              attempt,
 		"max_attempts":         maxAttempts,
 		"timeout_seconds":      timeoutSeconds,
 	}); err != nil {
 		return nil, err
+	}
+
+	if strings.TrimSpace(spec.Worker) != "" || strings.TrimSpace(spec.ModelTier) != "" || strings.TrimSpace(spec.RoleName) != "" {
+		if err := s.AppendEvidence(jobID, evidence.EventBackendModel, "selected", "selected backend/model", map[string]any{
+			"backend":    strings.TrimSpace(spec.Worker),
+			"model_tier": strings.TrimSpace(spec.ModelTier),
+			"role":       strings.TrimSpace(spec.RoleName),
+		}); err != nil {
+			return nil, err
+		}
+	}
+	if strings.TrimSpace(spec.Branch) != "" || strings.TrimSpace(spec.WorktreePath) != "" {
+		if err := s.AppendEvidence(jobID, evidence.EventWorkspace, "selected", "selected branch/worktree", map[string]any{
+			"branch":        strings.TrimSpace(spec.Branch),
+			"worktree_path": strings.TrimSpace(spec.WorktreePath),
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	return s.store.GetJob(jobID)

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -375,7 +375,7 @@ func (s *JobService) createJob(spec JobSpec) (*storage.Job, error) {
 			"model_tier": strings.TrimSpace(spec.ModelTier),
 			"role":       strings.TrimSpace(spec.RoleName),
 		}); err != nil {
-			return nil, err
+			log.Printf("[evidence] failed to append backend/model evidence for job %s: %v", jobID, err)
 		}
 	}
 	if hasEvidenceSession && (strings.TrimSpace(spec.Branch) != "" || strings.TrimSpace(spec.WorktreePath) != "") {
@@ -383,7 +383,7 @@ func (s *JobService) createJob(spec JobSpec) (*storage.Job, error) {
 			"branch":        strings.TrimSpace(spec.Branch),
 			"worktree_path": strings.TrimSpace(spec.WorktreePath),
 		}); err != nil {
-			return nil, err
+			log.Printf("[evidence] failed to append workspace evidence for job %s: %v", jobID, err)
 		}
 	}
 

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
@@ -89,6 +90,58 @@ func TestJobServiceStartDetachedPersistsSuccess(t *testing.T) {
 	}
 	if artifacts[0].Name != "result.md" || artifacts[0].ArtifactType != "report" {
 		t.Fatalf("unexpected artifact row: %+v", artifacts[0])
+	}
+}
+
+func TestJobServiceStartDetachedIgnoresInitialEvidenceFailure(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "runtime-jobs-evidence-fail.db")
+	store, err := storage.New(dbPath)
+	if err != nil {
+		t.Fatalf("storage.New failed: %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	if _, err := db.Exec(`DROP TABLE evidence_events`); err != nil {
+		t.Fatalf("drop evidence_events failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sql db failed: %v", err)
+	}
+
+	svc := NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:         "background_task",
+		Worker:       "test_runner",
+		SessionKey:   "agent:test:main",
+		Description:  "collect diagnostics",
+		ModelTier:    "fast",
+		Branch:       "feature/test",
+		WorktreePath: "/tmp/ok-gobot-test",
+		Timeout:      2 * time.Second,
+	}, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{Summary: "done"}, nil
+	})
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	waitForJobStatus(t, store, job.JobID, string(JobStatusSucceeded))
+	events := waitForJobEvents(t, store, job.JobID, 3)
+	wantEvents := []string{
+		string(JobEventCreated),
+		string(JobEventStarted),
+		string(JobEventSucceeded),
+	}
+	for i, want := range wantEvents {
+		if events[i].EventType != want {
+			t.Fatalf("event[%d] = %q want %q", i, events[i].EventType, want)
+		}
 	}
 }
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
+
+	"ok-gobot/internal/evidence"
 )
 
 // Store provides data persistence
@@ -345,6 +348,18 @@ func (s *Store) migrateCanonicalSchema() error {
 			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_job_events_job_id ON job_events(job_id, created_at);`,
+		`CREATE TABLE IF NOT EXISTS evidence_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_key TEXT NOT NULL DEFAULT '',
+			job_id TEXT NOT NULL DEFAULT '',
+			event_type TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT '',
+			summary TEXT NOT NULL DEFAULT '',
+			payload TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);`,
+		`CREATE INDEX IF NOT EXISTS idx_evidence_events_session ON evidence_events(session_key, created_at);`,
+		`CREATE INDEX IF NOT EXISTS idx_evidence_events_job ON evidence_events(job_id, created_at);`,
 		`CREATE TABLE IF NOT EXISTS job_artifacts (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			job_id TEXT NOT NULL,
@@ -1802,7 +1817,15 @@ func (s *Store) AddJobEvent(event JobEvent) error {
 		INSERT INTO job_events (job_id, event_type, message, payload)
 		VALUES (?, ?, ?, ?)
 	`, jobID, eventType, event.Message, event.Payload)
-	return err
+	if err != nil {
+		return err
+	}
+	return s.addEvidenceForJobEvent(JobEvent{
+		JobID:     jobID,
+		EventType: eventType,
+		Message:   event.Message,
+		Payload:   event.Payload,
+	})
 }
 
 // ListJobEvents returns job lifecycle events in chronological order.
@@ -1835,6 +1858,233 @@ func (s *Store) ListJobEvents(jobID string, limit int) ([]JobEvent, error) {
 		events = append(events, event)
 	}
 	return events, rows.Err()
+}
+
+// AddEvidenceEvent appends one structured evidence ledger row.
+func (s *Store) AddEvidenceEvent(event evidence.Event) error {
+	event = evidence.SanitizeEvent(event)
+	if strings.TrimSpace(event.Type) == "" {
+		return fmt.Errorf("evidence event type is required")
+	}
+	payload, err := evidence.MarshalPayload(event.Payload)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(event.CreatedAt) != "" {
+		_, err = s.db.Exec(`
+			INSERT INTO evidence_events (session_key, job_id, event_type, status, summary, payload, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+		`, event.SessionKey, event.JobID, event.Type, event.Status, event.Summary, payload, event.CreatedAt)
+		return err
+	}
+	_, err = s.db.Exec(`
+		INSERT INTO evidence_events (session_key, job_id, event_type, status, summary, payload)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, event.SessionKey, event.JobID, event.Type, event.Status, event.Summary, payload)
+	return err
+}
+
+// ListEvidenceEvents returns the newest evidence rows for a session in chronological order.
+func (s *Store) ListEvidenceEvents(sessionKey string, limit int) ([]evidence.Event, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.Query(`
+		SELECT id, session_key, job_id, event_type, status, summary, payload, created_at
+		FROM (
+			SELECT id, session_key, job_id, event_type, status, summary, payload, created_at
+			FROM evidence_events
+			WHERE session_key = ?
+			ORDER BY created_at DESC, id DESC
+			LIMIT ?
+		)
+		ORDER BY created_at ASC, id ASC
+	`, strings.TrimSpace(sessionKey), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanEvidenceEvents(rows)
+}
+
+// ListEvidenceEventsForJob returns the newest evidence rows for a job in chronological order.
+func (s *Store) ListEvidenceEventsForJob(jobID string, limit int) ([]evidence.Event, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.Query(`
+		SELECT id, session_key, job_id, event_type, status, summary, payload, created_at
+		FROM (
+			SELECT id, session_key, job_id, event_type, status, summary, payload, created_at
+			FROM evidence_events
+			WHERE job_id = ?
+			ORDER BY created_at DESC, id DESC
+			LIMIT ?
+		)
+		ORDER BY created_at ASC, id ASC
+	`, strings.TrimSpace(jobID), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanEvidenceEvents(rows)
+}
+
+func scanEvidenceEvents(rows *sql.Rows) ([]evidence.Event, error) {
+	var events []evidence.Event
+	for rows.Next() {
+		var (
+			event   evidence.Event
+			payload string
+		)
+		if err := rows.Scan(
+			&event.ID,
+			&event.SessionKey,
+			&event.JobID,
+			&event.Type,
+			&event.Status,
+			&event.Summary,
+			&payload,
+			&event.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		event.Payload = evidence.DecodePayload(payload)
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+func (s *Store) addEvidenceForJobEvent(event JobEvent) error {
+	job, err := s.GetJob(event.JobID)
+	if err != nil {
+		return err
+	}
+	if job == nil {
+		return nil
+	}
+
+	payload := payloadMapFromJobEvent(event.Payload)
+	payload["job_event_type"] = event.EventType
+	payload["attempt"] = job.Attempt
+	payload["max_attempts"] = job.MaxAttempts
+	if job.Worker != "" {
+		payload["backend"] = job.Worker
+	}
+	if job.RoleName != "" {
+		payload["role"] = job.RoleName
+	}
+	if job.ModelTier != "" {
+		payload["model_tier"] = job.ModelTier
+	}
+	if job.LimitReason != "" {
+		payload["limit_reason"] = job.LimitReason
+	}
+
+	eventType := evidenceTypeForJobEvent(event.EventType)
+	status := evidenceStatusForJobEvent(job, event.EventType)
+	if eventType == evidence.EventFinalDecision {
+		payload["outcome"] = job.Status
+		payload["blocker"] = blockerForJob(*job)
+	}
+	if eventType == evidence.EventRetryDecision && payload["decision"] == nil {
+		payload["decision"] = "retry queued"
+	}
+
+	sessionKey := strings.TrimSpace(job.SessionKey)
+	if sessionKey == "" {
+		sessionKey = strings.TrimSpace(job.DeliverySessionKey)
+	}
+	return s.AddEvidenceEvent(evidence.Event{
+		SessionKey: sessionKey,
+		JobID:      job.JobID,
+		Type:       eventType,
+		Status:     status,
+		Summary:    event.Message,
+		Payload:    payload,
+	})
+}
+
+func payloadMapFromJobEvent(payload string) map[string]any {
+	payload = strings.TrimSpace(payload)
+	if payload == "" {
+		return map[string]any{}
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		return map[string]any{"raw_payload": payload}
+	}
+	if m, ok := decoded.(map[string]any); ok {
+		return m
+	}
+	return map[string]any{"payload": decoded}
+}
+
+func evidenceTypeForJobEvent(eventType string) string {
+	switch strings.TrimSpace(eventType) {
+	case evidence.EventPreflight,
+		evidence.EventBackendModel,
+		evidence.EventWorkspace,
+		evidence.EventCommand,
+		evidence.EventPullRequest,
+		evidence.EventCheckRollup,
+		evidence.EventReviewFeedback,
+		evidence.EventRetryDecision,
+		evidence.EventFinalDecision:
+		return eventType
+	case "retry_requested":
+		return evidence.EventRetryDecision
+	case "succeeded", "failed", "cancelled", "timed_out", "budget_exceeded":
+		return evidence.EventFinalDecision
+	case "artifact_added":
+		return evidence.EventArtifact
+	default:
+		return evidence.EventJob
+	}
+}
+
+func evidenceStatusForJobEvent(job *Job, eventType string) string {
+	switch eventType {
+	case "succeeded":
+		return "succeeded"
+	case "failed":
+		return "failed"
+	case "cancelled":
+		return "cancelled"
+	case "timed_out":
+		return "timed_out"
+	case "budget_exceeded":
+		return "blocked"
+	case "retry_requested":
+		return "retry"
+	}
+	if job == nil {
+		return ""
+	}
+	return job.Status
+}
+
+func blockerForJob(job Job) string {
+	switch job.Status {
+	case "succeeded":
+		return "none"
+	case "timed_out":
+		return "timeout"
+	case "cancelled":
+		return "cancelled"
+	case "budget_exceeded":
+		if job.LimitReason != "" {
+			return job.LimitReason
+		}
+		return "budget"
+	case "failed":
+		if job.Error != "" {
+			return "runtime_error"
+		}
+		return "failed"
+	default:
+		return job.Status
+	}
 }
 
 // AddJobArtifact persists one durable job artifact.

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1820,12 +1821,15 @@ func (s *Store) AddJobEvent(event JobEvent) error {
 	if err != nil {
 		return err
 	}
-	return s.addEvidenceForJobEvent(JobEvent{
+	if err := s.addEvidenceForJobEvent(JobEvent{
 		JobID:     jobID,
 		EventType: eventType,
 		Message:   event.Message,
 		Payload:   event.Payload,
-	})
+	}); err != nil {
+		log.Printf("[evidence] failed to mirror job event evidence for job %s: %v", jobID, err)
+	}
+	return nil
 }
 
 // ListJobEvents returns job lifecycle events in chronological order.

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -1995,6 +1995,14 @@ func (s *Store) addEvidenceForJobEvent(event JobEvent) error {
 	if sessionKey == "" {
 		sessionKey = strings.TrimSpace(job.DeliverySessionKey)
 	}
+	if sessionKey == "" {
+		if value, ok := payload["session_key"].(string); ok {
+			sessionKey = strings.TrimSpace(value)
+		}
+	}
+	if sessionKey == "" {
+		return nil
+	}
 	return s.AddEvidenceEvent(evidence.Event{
 		SessionKey: sessionKey,
 		JobID:      job.JobID,

--- a/internal/storage/sqlite_schema_test.go
+++ b/internal/storage/sqlite_schema_test.go
@@ -3,7 +3,10 @@ package storage
 import (
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"ok-gobot/internal/evidence"
 )
 
 func TestCanonicalSchemaTablesCreated(t *testing.T) {
@@ -12,7 +15,7 @@ func TestCanonicalSchemaTablesCreated(t *testing.T) {
 	store := newTestStore(t)
 	defer store.Close() //nolint:errcheck
 
-	for _, table := range []string{"sessions_v2", "session_routes", "session_messages_v2", "run_queue_state", "subagent_runs", "jobs", "job_events", "job_artifacts", "app_state"} {
+	for _, table := range []string{"sessions_v2", "session_routes", "session_messages_v2", "run_queue_state", "subagent_runs", "jobs", "job_events", "evidence_events", "job_artifacts", "app_state"} {
 		if !tableExists(t, store.DB(), table) {
 			t.Fatalf("expected table %q to exist", table)
 		}
@@ -419,6 +422,79 @@ func TestJobCRUDAndLinkedArtifacts(t *testing.T) {
 	}
 	if len(jobs) != 1 || jobs[0].JobID != job.JobID {
 		t.Fatalf("unexpected jobs list: %+v", jobs)
+	}
+}
+
+func TestEvidenceLedgerAppendListAndJobEventMirror(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	job := Job{
+		JobID:       "job-evidence-1",
+		Kind:        "maestro",
+		Worker:      "codex",
+		SessionKey:  "agent:maestro:main",
+		Description: "implement issue",
+		Status:      "pending",
+		Attempt:     1,
+		MaxAttempts: 2,
+		ModelTier:   "gpt-5.5",
+	}
+	if err := store.CreateJob(job); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+	if err := store.AddEvidenceEvent(evidence.Event{
+		SessionKey: job.SessionKey,
+		JobID:      job.JobID,
+		Type:       evidence.EventCommand,
+		Status:     "failed",
+		Summary:    "go test failed with sk-1234567890abcdefghijklmnop",
+		Payload: map[string]any{
+			"command":     "go test ./...",
+			"exit_status": 1,
+			"stdout":      strings.Repeat("failure ", 300),
+		},
+	}); err != nil {
+		t.Fatalf("AddEvidenceEvent failed: %v", err)
+	}
+	if err := store.AddJobEvent(JobEvent{
+		JobID:     job.JobID,
+		EventType: "retry_requested",
+		Message:   "retry queued as job-evidence-2",
+		Payload:   `{"retry_job_id":"job-evidence-2"}`,
+	}); err != nil {
+		t.Fatalf("AddJobEvent failed: %v", err)
+	}
+
+	events, err := store.ListEvidenceEvents(job.SessionKey, 10)
+	if err != nil {
+		t.Fatalf("ListEvidenceEvents failed: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("evidence count = %d, want 2: %+v", len(events), events)
+	}
+	if events[0].Type != evidence.EventCommand {
+		t.Fatalf("first event type = %q, want command", events[0].Type)
+	}
+	if strings.Contains(events[0].Summary, "abcdefghijklmnop") {
+		t.Fatalf("evidence summary leaked secret: %q", events[0].Summary)
+	}
+	stdout, _ := events[0].Payload["stdout"].(string)
+	if !strings.Contains(stdout, "[truncated]") {
+		t.Fatalf("expected truncated stdout payload, got %q", stdout)
+	}
+	if events[1].Type != evidence.EventRetryDecision {
+		t.Fatalf("second event type = %q, want retry_decision", events[1].Type)
+	}
+
+	jobEvents, err := store.ListEvidenceEventsForJob(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListEvidenceEventsForJob failed: %v", err)
+	}
+	if len(jobEvents) != 2 {
+		t.Fatalf("job evidence count = %d, want 2", len(jobEvents))
 	}
 }
 

--- a/internal/worker/bridge.go
+++ b/internal/worker/bridge.go
@@ -3,7 +3,9 @@ package worker
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -29,6 +31,17 @@ func AdapterJobRunner(adapter Adapter, req Request) runtime.JobRunner {
 			})
 		}
 
+		if strings.TrimSpace(req.Model) != "" || strings.TrimSpace(job.Worker) != "" {
+			_ = svc.AppendEvidence(job.JobID, evidence.EventBackendModel, "selected", "selected worker backend/model", map[string]any{
+				"backend": job.Worker,
+				"model":   req.Model,
+			})
+		}
+		if strings.TrimSpace(req.WorkDir) != "" {
+			_ = svc.AppendEvidence(job.JobID, evidence.EventWorkspace, "selected", "selected worktree", map[string]any{
+				"worktree_path": req.WorkDir,
+			})
+		}
 		_ = svc.AppendEvent(job.JobID, runtime.JobEventProgress, fmt.Sprintf("running %s task", job.Worker), nil)
 
 		result, err := adapter.Run(ctx, req)

--- a/internal/worker/bridge.go
+++ b/internal/worker/bridge.go
@@ -3,9 +3,7 @@ package worker
 import (
 	"context"
 	"fmt"
-	"strings"
 
-	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -31,17 +29,6 @@ func AdapterJobRunner(adapter Adapter, req Request) runtime.JobRunner {
 			})
 		}
 
-		if strings.TrimSpace(req.Model) != "" || strings.TrimSpace(job.Worker) != "" {
-			_ = svc.AppendEvidence(job.JobID, evidence.EventBackendModel, "selected", "selected worker backend/model", map[string]any{
-				"backend": job.Worker,
-				"model":   req.Model,
-			})
-		}
-		if strings.TrimSpace(req.WorkDir) != "" {
-			_ = svc.AppendEvidence(job.JobID, evidence.EventWorkspace, "selected", "selected worktree", map[string]any{
-				"worktree_path": req.WorkDir,
-			})
-		}
 		_ = svc.AppendEvent(job.JobID, runtime.JobEventProgress, fmt.Sprintf("running %s task", job.Worker), nil)
 
 		result, err := adapter.Run(ctx, req)

--- a/internal/worker/bridge_test.go
+++ b/internal/worker/bridge_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -74,7 +75,8 @@ func TestAdapterJobRunnerSuccess(t *testing.T) {
 	adapter := &stubAdapter{
 		runResult: &Result{Content: "task completed", SessionID: "sess-42"},
 	}
-	runner := AdapterJobRunner(adapter, Request{Task: "build project", Model: "test-model"})
+	workDir := t.TempDir()
+	runner := AdapterJobRunner(adapter, Request{Task: "build project", Model: "test-model", WorkDir: workDir})
 
 	svc := runtime.NewJobService(store)
 	job, err := svc.StartDetached(context.Background(), runtime.JobSpec{
@@ -83,6 +85,9 @@ func TestAdapterJobRunnerSuccess(t *testing.T) {
 		SessionKey:         "agent:test:main",
 		DeliverySessionKey: routeKey,
 		Description:        "test bridge",
+		ModelTier:          "test-tier",
+		Branch:             "test-branch",
+		WorktreePath:       workDir,
 		Timeout:            2 * time.Second,
 	}, runner)
 	if err != nil {
@@ -103,6 +108,17 @@ func TestAdapterJobRunnerSuccess(t *testing.T) {
 	}
 	if artifacts[0].Name != "output" || artifacts[0].Content != "task completed" {
 		t.Fatalf("unexpected artifact: %+v", artifacts[0])
+	}
+
+	events, err := store.ListEvidenceEventsForJob(job.JobID, 20)
+	if err != nil {
+		t.Fatalf("ListEvidenceEventsForJob failed: %v", err)
+	}
+	if got := countBridgeEvidenceEvents(events, evidence.EventBackendModel); got != 1 {
+		t.Fatalf("backend/model evidence count = %d, want 1: %+v", got, events)
+	}
+	if got := countBridgeEvidenceEvents(events, evidence.EventWorkspace); got != 1 {
+		t.Fatalf("workspace evidence count = %d, want 1: %+v", got, events)
 	}
 }
 
@@ -235,4 +251,14 @@ func hasJobEvent(events []storage.JobEvent, eventType string) bool {
 		}
 	}
 	return false
+}
+
+func countBridgeEvidenceEvents(events []evidence.Event, eventType string) int {
+	count := 0
+	for _, event := range events {
+		if event.Type == eventType {
+			count++
+		}
+	}
+	return count
 }


### PR DESCRIPTION
Implements #357

## Changes
- Adds an append-only structured evidence ledger for session/job evidence with secret redaction and bounded payloads.
- Mirrors session-scoped job lifecycle evidence, captures backend/model and workspace context, and renders compact Markdown for CLI, Mission Control, and Telegram job detail.
- Exposes `/api/mission/evidence?session_key=...` and `sessions evidence <session-key>` while preserving existing raw job event tails.

## Testing
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/`
- `bash .maestro/verify.sh`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements an append-only structured evidence ledger for session/job lifecycle events, backed by a new `evidence_events` SQLite table, with secret redaction, bounded payloads, compact Markdown rendering, and exposure via two API endpoints, a CLI subcommand, and Telegram job detail. The implementation is well-tested, and the previously flagged issues around error propagation (AppendEvidence swallowing evidence failures, AddJobEvent mirroring errors being logged-not-returned) and generic API error messages are all correctly addressed in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the single P2 finding is a defensive coding gap with no live impact given the guarded call sites.

All prior P1 findings (error propagation, raw DB errors in API responses, CLI abort on evidence failure) are resolved. The only new finding is a P2 inconsistency in AppendEvidence not guarding against empty session_key, which the primary caller already prevents via hasEvidenceSession. Test coverage is thorough across schema, storage, runtime, CLI, and API layers.

internal/runtime/jobs.go (AppendEvidence empty session_key guard), internal/storage/sqlite.go (extra GetJob per AddJobEvent is an existing P2)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/evidence/evidence.go | New evidence package: Event struct, SanitizeEvent with secret redaction/payload bounding, PayloadMap/MarshalPayload/DecodePayload, RenderMarkdown, and CompactLine for compact timeline rendering. Logic is sound; sanitizeValue recursion correctly handles all JSON-compatible types and sensitive key detection. |
| internal/storage/sqlite.go | Adds evidence_events table, AddEvidenceEvent, ListEvidenceEvents, ListEvidenceEventsForJob, and addEvidenceForJobEvent (called from AddJobEvent). Evidence mirroring errors are logged-and-swallowed, not propagated. AppendEvidence can store events with empty session_key for sessionless jobs, making them unqueryable. |
| internal/runtime/jobs.go | Adds AppendEvidence (with GetJob lookup), wires EventBackendModel and EventWorkspace emission into createJob guarded by hasEvidenceSession. Evidence errors are logged and swallowed. AppendEvidence doesn't guard against empty session_key before calling AddEvidenceEvent. |
| internal/api/mission.go | Adds handleMissionEvidence endpoint with method check, store nil guard, session_key validation, and bounded limit. Error messages are generic (no DB details exposed). RenderMarkdown included in response. |
| internal/control/mission.go | Adds missionEvidence handler mirroring the api/mission.go handler. Generic error messages confirmed; both endpoints are consistent. |
| internal/cli/sessions.go | Adds sessions evidence subcommand with session fingerprint display and RenderMarkdown output. Clean implementation with proper store lifecycle management. |
| internal/cli/jobs.go | Evidence listing in jobs inspect now prints a warning on failure and continues rather than aborting. Retry job creation now also propagates RoleName, ModelTier, and MaxToolCalls. |
| internal/worker/bridge_test.go | Bridge test updated to verify exactly 1 EventBackendModel and 1 EventWorkspace evidence event per adapter job. bridge.go doesn't write AppendEvidence directly, so count-1 assertion is correct and will pass. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/storage/sqlite.go`, line 1105-1111 ([link](https://github.com/befeast/ok-gobot/blob/75cde6f601e337382598be994c47664dece18eba/internal/storage/sqlite.go#L1105-L1111)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Evidence mirroring error propagated from `AddJobEvent` breaks job event recording**

   `addEvidenceForJobEvent` performs a `GetJob` query and then calls `AddEvidenceEvent`. If either fails (transient DB error, schema mismatch, etc.), `AddJobEvent` returns an error even though the `job_events` row was already committed. Callers such as `createJob` that check this error will surface a failure, but the job record and its `JobEventCreated` event are already in the database — creating an orphaned job with no coordinated rollback.

   Evidence mirroring is observability, not job-critical. The error from `addEvidenceForJobEvent` should be logged and swallowed rather than propagated, so a mirroring failure cannot break core job lifecycle recording.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/storage/sqlite.go
   Line: 1105-1111

   Comment:
   **Evidence mirroring error propagated from `AddJobEvent` breaks job event recording**

   `addEvidenceForJobEvent` performs a `GetJob` query and then calls `AddEvidenceEvent`. If either fails (transient DB error, schema mismatch, etc.), `AddJobEvent` returns an error even though the `job_events` row was already committed. Callers such as `createJob` that check this error will surface a failure, but the job record and its `JobEventCreated` event are already in the database — creating an orphaned job with no coordinated rollback.

   Evidence mirroring is observability, not job-critical. The error from `addEvidenceForJobEvent` should be logged and swallowed rather than propagated, so a mirroring failure cannot break core job lifecycle recording.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/api/mission.go`, line 121-124 ([link](https://github.com/befeast/ok-gobot/blob/75cde6f601e337382598be994c47664dece18eba/internal/api/mission.go#L121-L124)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Raw DB error string exposed in API response**

   `err.Error()` is concatenated into the client-facing error message. Internal database error text (table names, column names, SQLite driver details) is now visible to API consumers.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/api/mission.go
   Line: 121-124

   Comment:
   **Raw DB error string exposed in API response**

   `err.Error()` is concatenated into the client-facing error message. Internal database error text (table names, column names, SQLite driver details) is now visible to API consumers.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `internal/storage/sqlite.go`, line 1213-1270 ([link](https://github.com/befeast/ok-gobot/blob/75cde6f601e337382598be994c47664dece18eba/internal/storage/sqlite.go#L1213-L1270)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`addEvidenceForJobEvent` is called on every `AddJobEvent` — extra `GetJob` query per event**

   Every job lifecycle event (created, progress, succeeded, failed, etc.) now issues an additional `SELECT` query via `GetJob`. For jobs with many progress events this is a notable increase in write-path DB traffic. Consider caching the `sessionKey` on first lookup (e.g., pass it in, or look it up once and store it on the `JobService`), or at minimum accepting the already-fetched `*Job` as a parameter to avoid the round-trip.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/storage/sqlite.go
   Line: 1213-1270

   Comment:
   **`addEvidenceForJobEvent` is called on every `AddJobEvent` — extra `GetJob` query per event**

   Every job lifecycle event (created, progress, succeeded, failed, etc.) now issues an additional `SELECT` query via `GetJob`. For jobs with many progress events this is a notable increase in write-path DB traffic. Consider caching the `sessionKey` on first lookup (e.g., pass it in, or look it up once and store it on the `JobService`), or at minimum accepting the already-fetched `*Job` as a parameter to avoid the round-trip.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/runtime/jobs.go:1116-1124
**`AppendEvidence` stores evidence with empty `session_key` for sessionless jobs**

When both `job.SessionKey` and `job.DeliverySessionKey` are empty, `sessionKey` is `""` and `AddEvidenceEvent` is called unconditionally with `SessionKey: ""`. This writes a row to `evidence_events` with `session_key = ''` — a row that can't be retrieved by any API or CLI query (both reject empty `session_key`), but will be matched by any future `ListEvidenceEvents("", limit)` call.

`addEvidenceForJobEvent` in the store layer handles this correctly with an explicit guard:
```go
if sessionKey == "" {
    return nil
}
```
The same early-return should be applied here to keep behaviour consistent and avoid silently accumulating unreachable rows.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: harden evidence failure handling (#..."](https://github.com/befeast/ok-gobot/commit/ffe6d8090ed802ec58ee160d7200ffa1ca339b6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30450166)</sub>

<!-- /greptile_comment -->