### PR TITLE
feat: add strict Maestro intake policy (#355)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -188,6 +188,13 @@ runtime:
 session:
   dm_scope: "main"  # main or per_user
 
+# Maestro issue intake (read-only dry-run/status checks; workers are not started automatically)
+maestro:
+  repo: ""                 # Optional owner/name; empty lets gh infer from the current repo
+  ready_label: "ready"     # Only issues with this label are eligible by default
+  hard_exclude_labels: ["blocked", "epic", "meta", "question", "wontfix", "duplicate", "invalid"]
+  limit: 50                # Open issues inspected by ok-gobot maestro dry-run/status
+
 # Optional model alias overrides (empty = built-in defaults)
 model_aliases: {}
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -306,6 +306,47 @@
       ],
       "type": "string"
     },
+    "maestro": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Strict GitHub issue intake settings for worker selection dry-runs and status.",
+      "properties": {
+        "hard_exclude_labels": {
+          "default": [
+            "blocked",
+            "epic",
+            "meta",
+            "question",
+            "wontfix",
+            "duplicate",
+            "invalid"
+          ],
+          "description": "Labels that are hard-excluded by default during Maestro issue intake.",
+          "items": {
+            "default": "",
+            "description": "Hard-exclude label.",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "limit": {
+          "default": 50,
+          "description": "Number of open issues inspected by maestro dry-run/status commands.",
+          "type": "integer"
+        },
+        "ready_label": {
+          "default": "ready",
+          "description": "Required label for default Maestro issue eligibility. Keep non-empty to avoid all-open-issues intake.",
+          "type": "string"
+        },
+        "repo": {
+          "default": "",
+          "description": "GitHub repository in owner/name form. Empty lets the gh CLI infer the current repository.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "memory": {
       "additionalProperties": false,
       "default": {},

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -352,6 +352,38 @@ single source of truth for configuration keys, types, defaults, and descriptions
         }
       }
     },
+    "maestro": {
+      "type": "object",
+      "default": {},
+      "description": "Strict GitHub issue intake settings for worker selection dry-runs and status.",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "default": "",
+          "description": "GitHub repository in owner/name form. Empty lets the gh CLI infer the current repository."
+        },
+        "ready_label": {
+          "type": "string",
+          "default": "ready",
+          "description": "Required label for default Maestro issue eligibility. Keep non-empty to avoid all-open-issues intake."
+        },
+        "hard_exclude_labels": {
+          "type": "array",
+          "default": ["blocked", "epic", "meta", "question", "wontfix", "duplicate", "invalid"],
+          "description": "Labels that are hard-excluded by default during Maestro issue intake.",
+          "items": {
+            "type": "string",
+            "default": "",
+            "description": "Hard-exclude label."
+          }
+        },
+        "limit": {
+          "type": "integer",
+          "default": 50,
+          "description": "Number of open issues inspected by maestro dry-run/status commands."
+        }
+      }
+    },
     "runtime": {
       "type": "object",
       "default": {},

--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -74,6 +74,14 @@ Mission Control is a read-only API layer over existing runtime data. It does not
 
 Mission Control artifact browsing is read-only. It does not modify roles, start jobs, or change configuration.
 
+### Maestro Intake Status
+
+Use `ok-gobot maestro dry-run` before starting a worker from GitHub issues. The command reports the next eligible issue and every skipped candidate with a reason. By default, only issues with `maestro.ready_label` are eligible, and issues labeled `blocked`, `epic`, `meta`, `question`, `wontfix`, `duplicate`, or `invalid` are skipped.
+
+Use `ok-gobot maestro status` when no worker is running. It explains whether a worker is idle because there is no eligible issue, or which issue would be selected next. Dependency lines such as `Depends on: #353` block intake until the dependency is closed or a referenced PR is merge-ready. Inline-code snippets, fenced examples, and example sections are ignored.
+
+Maintainers can use `--override --override-reason "..."` to force the first open issue through the dry-run/status selection. The output and logs show that the maintainer override was used and list the gates it bypassed.
+
 Local file previews are restricted to artifact roots. Defaults are
 `~/.ok-gobot/screenshots` and `~/.ok-gobot/artifacts`; add more with:
 

--- a/internal/cli/maestro.go
+++ b/internal/cli/maestro.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/maestro"
+)
+
+type maestroOptions struct {
+	repo              string
+	readyLabel        string
+	hardExcludeLabels []string
+	limit             int
+	override          bool
+	overrideReason    string
+}
+
+func newMaestroCommand(cfg *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "maestro",
+		Short: "Inspect strict GitHub issue intake for worker selection",
+	}
+	cmd.AddCommand(newMaestroDryRunCommand(cfg))
+	cmd.AddCommand(newMaestroStatusCommand(cfg))
+	return cmd
+}
+
+func newMaestroDryRunCommand(cfg *config.Config) *cobra.Command {
+	opts := defaultMaestroOptions(cfg)
+	cmd := &cobra.Command{
+		Use:   "dry-run",
+		Short: "Show the next eligible issue and skipped candidates",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			decision, err := runMaestroDryRun(cmd, opts)
+			if err != nil {
+				return err
+			}
+			renderMaestroDecision(cmd.OutOrStdout(), decision, "dry-run")
+			return nil
+		},
+	}
+	bindMaestroFlags(cmd, &opts)
+	return cmd
+}
+
+func newMaestroStatusCommand(cfg *config.Config) *cobra.Command {
+	opts := defaultMaestroOptions(cfg)
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Explain why no Maestro worker is running",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			decision, err := runMaestroDryRun(cmd, opts)
+			if err != nil {
+				return err
+			}
+			renderMaestroDecision(cmd.OutOrStdout(), decision, "status")
+			return nil
+		},
+	}
+	bindMaestroFlags(cmd, &opts)
+	return cmd
+}
+
+func defaultMaestroOptions(cfg *config.Config) maestroOptions {
+	opts := maestroOptions{
+		readyLabel:        maestro.DefaultReadyLabel,
+		hardExcludeLabels: maestro.DefaultHardExcludeLabels(),
+		limit:             maestro.DefaultLimit,
+	}
+	if cfg == nil {
+		return opts
+	}
+	if cfg.Maestro.Repo != "" {
+		opts.repo = cfg.Maestro.Repo
+	}
+	if cfg.Maestro.ReadyLabel != "" {
+		opts.readyLabel = cfg.Maestro.ReadyLabel
+	}
+	if len(cfg.Maestro.HardExcludeLabels) > 0 {
+		opts.hardExcludeLabels = append([]string(nil), cfg.Maestro.HardExcludeLabels...)
+	}
+	if cfg.Maestro.Limit > 0 {
+		opts.limit = cfg.Maestro.Limit
+	}
+	return opts
+}
+
+func bindMaestroFlags(cmd *cobra.Command, opts *maestroOptions) {
+	cmd.Flags().StringVar(&opts.repo, "repo", opts.repo, "GitHub repo owner/name (default: gh infers from cwd)")
+	cmd.Flags().StringVar(&opts.readyLabel, "ready-label", opts.readyLabel, "label required for default issue eligibility")
+	cmd.Flags().StringSliceVar(&opts.hardExcludeLabels, "hard-exclude-label", opts.hardExcludeLabels, "hard-exclude label; repeat or comma-separate")
+	cmd.Flags().IntVar(&opts.limit, "limit", opts.limit, "number of open issues to inspect")
+	cmd.Flags().BoolVar(&opts.override, "override", false, "maintainer override: select the first open issue despite intake gates")
+	cmd.Flags().StringVar(&opts.overrideReason, "override-reason", "", "visible reason for maintainer override")
+}
+
+func runMaestroDryRun(cmd *cobra.Command, opts maestroOptions) (maestro.Decision, error) {
+	policy := maestro.Policy{
+		Repo:              opts.repo,
+		ReadyLabel:        opts.readyLabel,
+		HardExcludeLabels: opts.hardExcludeLabels,
+		Limit:             opts.limit,
+		Override:          opts.override,
+		OverrideReason:    opts.overrideReason,
+	}
+	if opts.override {
+		reason := strings.TrimSpace(opts.overrideReason)
+		if reason == "" {
+			reason = "no reason supplied"
+		}
+		log.Printf("[maestro] maintainer override enabled for intake dry-run: %s", reason)
+	}
+	return maestro.DryRun(cmd.Context(), maestro.NewGHClient(""), policy)
+}
+
+func renderMaestroDecision(out io.Writer, decision maestro.Decision, mode string) {
+	policy := maestro.NormalizePolicy(decision.Policy)
+	fmt.Fprintf(out, "Maestro intake %s\n", mode)
+	fmt.Fprintf(out, "Ready label: %q\n", policy.ReadyLabel)
+	fmt.Fprintf(out, "Hard excludes: %s\n", strings.Join(policy.HardExcludeLabels, ", "))
+	if strings.TrimSpace(policy.Repo) != "" {
+		fmt.Fprintf(out, "Repo: %s\n", policy.Repo)
+	}
+	if policy.Override {
+		reason := strings.TrimSpace(policy.OverrideReason)
+		if reason == "" {
+			reason = "no reason supplied"
+		}
+		fmt.Fprintf(out, "Override: ENABLED (maintainer override: %s)\n", reason)
+	} else {
+		fmt.Fprintln(out, "Override: disabled")
+	}
+
+	if decision.Next == nil {
+		fmt.Fprintln(out, "No worker running: no eligible issue after strict intake policy.")
+	} else {
+		fmt.Fprintf(out, "No worker running: next eligible issue is #%d %s.\n", decision.Next.Issue.Number, decision.Next.Issue.Title)
+		if decision.Next.OverrideUsed {
+			fmt.Fprintln(out, "Selected by maintainer override.")
+			if len(decision.Next.OverrideReasons) > 0 {
+				fmt.Fprintf(out, "Override bypassed: %s\n", strings.Join(decision.Next.OverrideReasons, "; "))
+			}
+		}
+	}
+
+	if len(decision.Skipped) == 0 {
+		fmt.Fprintln(out, "Skipped candidates: none")
+		return
+	}
+	fmt.Fprintln(out, "Skipped candidates:")
+	for _, skipped := range decision.Skipped {
+		reasons := strings.Join(skipped.SkipReasons, "; ")
+		if reasons == "" {
+			reasons = "unknown"
+		}
+		fmt.Fprintf(out, "  #%d %s - %s\n", skipped.Issue.Number, skipped.Issue.Title, reasons)
+	}
+}

--- a/internal/cli/maestro.go
+++ b/internal/cli/maestro.go
@@ -55,6 +55,7 @@ func newMaestroStatusCommand(cfg *config.Config) *cobra.Command {
 		Use:   "status",
 		Short: "Explain why no Maestro worker is running",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Status reuses the intake dry-run until worker runtime state is tracked.
 			decision, err := runMaestroDryRun(cmd, opts)
 			if err != nil {
 				return err

--- a/internal/cli/maestro_test.go
+++ b/internal/cli/maestro_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/maestro"
+)
+
+func TestRenderMaestroDecisionExplainsNoWorker(t *testing.T) {
+	t.Parallel()
+
+	decision := maestro.Decision{
+		Policy: maestro.Policy{ReadyLabel: "ready"},
+		Skipped: []maestro.CandidateDecision{{
+			Issue:       maestro.Issue{Number: 7, Title: "blocked task"},
+			SkipReasons: []string{`hard-exclude label "blocked"`},
+		}},
+	}
+	var out bytes.Buffer
+	renderMaestroDecision(&out, decision, "status")
+
+	got := out.String()
+	for _, want := range []string{
+		"No worker running: no eligible issue after strict intake policy.",
+		"Skipped candidates:",
+		`#7 blocked task - hard-exclude label "blocked"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestRenderMaestroDecisionShowsOverride(t *testing.T) {
+	t.Parallel()
+
+	decision := maestro.Decision{
+		Policy: maestro.Policy{ReadyLabel: "ready", Override: true, OverrideReason: "ops reviewed"},
+		Next: &maestro.CandidateDecision{
+			Issue:           maestro.Issue{Number: 8, Title: "force task"},
+			OverrideUsed:    true,
+			OverrideReasons: []string{`missing ready label "ready"`},
+		},
+	}
+	var out bytes.Buffer
+	renderMaestroDecision(&out, decision, "dry-run")
+
+	got := out.String()
+	for _, want := range []string{
+		"Override: ENABLED (maintainer override: ops reviewed)",
+		"Selected by maintainer override.",
+		`Override bypassed: missing ready label "ready"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q: %q", want, got)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -48,6 +48,7 @@ Supports Telegram bot integration with personality and memory.`,
 	root.AddCommand(newSessionsCommand(cfg))
 	root.AddCommand(newWorkCommand(cfg))
 	root.AddCommand(newWorktreesCommand(cfg))
+	root.AddCommand(newMaestroCommand(cfg))
 	root.AddCommand(newBabysitCommand(cfg))
 	root.AddCommand(newBatchCommand(cfg))
 	root.AddCommand(newVoiceCommand(cfg))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,14 @@ type WorktreeConfig struct {
 	Model        string `mapstructure:"model"`          // Model override for worker
 }
 
+// MaestroConfig holds strict GitHub issue intake settings for worker selection.
+type MaestroConfig struct {
+	Repo              string   `mapstructure:"repo"`                // GitHub repo, e.g. owner/name. Empty lets gh infer from cwd.
+	ReadyLabel        string   `mapstructure:"ready_label"`         // Required label for default eligibility.
+	HardExcludeLabels []string `mapstructure:"hard_exclude_labels"` // Labels that block intake by default.
+	Limit             int      `mapstructure:"limit"`               // Number of open issues to inspect in dry-runs/status.
+}
+
 // EvolutionConfig holds self-evolution loop configuration.
 type EvolutionConfig struct {
 	Enabled        bool    `mapstructure:"enabled"`          // Enable automatic self-evolution (default false)
@@ -124,6 +132,7 @@ type Config struct {
 	STT          STTConfig         `mapstructure:"stt"`
 	Memory       MemoryConfig      `mapstructure:"memory"`
 	Worktree     WorktreeConfig    `mapstructure:"worktree"`
+	Maestro      MaestroConfig     `mapstructure:"maestro"`
 	Evolution    EvolutionConfig   `mapstructure:"evolution"`
 	Agents       []AgentConfig     `mapstructure:"agents"`
 	Models       []string          `mapstructure:"models"` // list of models for TUI/web picker
@@ -443,6 +452,10 @@ func Load() (*Config, error) {
 	v.SetDefault("worktree.stale_age_days", 7)
 	v.SetDefault("worktree.worker", "claude")
 	v.SetDefault("worktree.model", "")
+	v.SetDefault("maestro.repo", "")
+	v.SetDefault("maestro.ready_label", "ready")
+	v.SetDefault("maestro.hard_exclude_labels", []string{"blocked", "epic", "meta", "question", "wontfix", "duplicate", "invalid"})
+	v.SetDefault("maestro.limit", 50)
 	v.SetDefault("evolution.enabled", false)
 	v.SetDefault("evolution.tasks_per_cycle", 50)
 	v.SetDefault("evolution.pass_threshold", 0.8)
@@ -581,6 +594,10 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("worktree.stale_age_days", 7)
 	v.SetDefault("worktree.worker", "claude")
 	v.SetDefault("worktree.model", "")
+	v.SetDefault("maestro.repo", "")
+	v.SetDefault("maestro.ready_label", "ready")
+	v.SetDefault("maestro.hard_exclude_labels", []string{"blocked", "epic", "meta", "question", "wontfix", "duplicate", "invalid"})
+	v.SetDefault("maestro.limit", 50)
 	v.SetDefault("evolution.enabled", false)
 	v.SetDefault("evolution.tasks_per_cycle", 50)
 	v.SetDefault("evolution.pass_threshold", 0.8)
@@ -699,6 +716,13 @@ func (c *Config) Validate() error {
 	validDMScope := map[string]bool{"main": true, "per_user": true}
 	if c.Session.DMScope != "" && !validDMScope[c.Session.DMScope] {
 		return fmt.Errorf("invalid session.dm_scope: %s (must be 'main' or 'per_user')", c.Session.DMScope)
+	}
+
+	if strings.TrimSpace(c.Maestro.ReadyLabel) == "" && (strings.TrimSpace(c.Maestro.Repo) != "" || len(c.Maestro.HardExcludeLabels) > 0 || c.Maestro.Limit != 0) {
+		return fmt.Errorf("invalid maestro.ready_label: must not be empty")
+	}
+	if c.Maestro.Limit < 0 {
+		return fmt.Errorf("invalid maestro.limit: %d (must be >= 0)", c.Maestro.Limit)
 	}
 
 	// Validate memory prompt mode

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -854,6 +854,10 @@ func (c *Config) Save() error {
 		v.Set("runtime.roles", c.Runtime.Roles)
 	}
 	v.Set("session.dm_scope", c.Session.DMScope)
+	v.Set("maestro.repo", c.Maestro.Repo)
+	v.Set("maestro.ready_label", c.Maestro.ReadyLabel)
+	v.Set("maestro.hard_exclude_labels", c.Maestro.HardExcludeLabels)
+	v.Set("maestro.limit", c.Maestro.Limit)
 
 	// Persist fields that were previously omitted causing lossy round-trips.
 	if len(c.Models) > 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -718,7 +718,7 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid session.dm_scope: %s (must be 'main' or 'per_user')", c.Session.DMScope)
 	}
 
-	if strings.TrimSpace(c.Maestro.ReadyLabel) == "" && (strings.TrimSpace(c.Maestro.Repo) != "" || len(c.Maestro.HardExcludeLabels) > 0 || c.Maestro.Limit != 0) {
+	if strings.TrimSpace(c.Maestro.ReadyLabel) == "" {
 		return fmt.Errorf("invalid maestro.ready_label: must not be empty")
 	}
 	if c.Maestro.Limit < 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -287,6 +287,7 @@ func TestValidateRejectsInvalidQMDSearchMode(t *testing.T) {
 		Telegram:    TelegramConfig{Token: "test-token"},
 		AI:          AIConfig{APIKey: "test-key", Model: "test-model"},
 		StoragePath: "/tmp/test.db",
+		Maestro:     MaestroConfig{ReadyLabel: "ready"},
 		Memory: MemoryConfig{
 			Backend: "qmd",
 			QMD:     MemoryQMDConfig{SearchMode: "bad", Timeout: "1s", FallbackCooldown: "1m"},
@@ -295,6 +296,21 @@ func TestValidateRejectsInvalidQMDSearchMode(t *testing.T) {
 
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("expected invalid qmd search mode error")
+	}
+}
+
+func TestValidateRejectsBlankMaestroReadyLabel(t *testing.T) {
+	cfg := &Config{
+		Telegram:    TelegramConfig{Token: "test-token"},
+		AI:          AIConfig{APIKey: "test-key", Model: "test-model"},
+		Auth:        AuthConfig{Mode: "open"},
+		StoragePath: "/tmp/test.db",
+		Maestro:     MaestroConfig{ReadyLabel: " "},
+	}
+
+	err := cfg.Validate()
+	if err == nil || err.Error() != "invalid maestro.ready_label: must not be empty" {
+		t.Fatalf("Validate error = %v, want invalid maestro.ready_label", err)
 	}
 }
 
@@ -600,6 +616,7 @@ func TestValidateAcceptsCaseVariantMemoryMode(t *testing.T) {
 			AI:          AIConfig{APIKey: "k", Model: "m", Provider: "openrouter"},
 			Auth:        AuthConfig{Mode: "open"},
 			Memory:      MemoryConfig{Mode: mode},
+			Maestro:     MaestroConfig{ReadyLabel: "ready"},
 			StoragePath: "/tmp/x",
 		}
 		if err := cfg.Validate(); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -314,6 +314,42 @@ func TestValidateRejectsBlankMaestroReadyLabel(t *testing.T) {
 	}
 }
 
+func TestSavePersistsMaestroConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("{}\n"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := &Config{
+		ConfigPath:  configPath,
+		Telegram:    TelegramConfig{Token: "test-token"},
+		AI:          AIConfig{APIKey: "test-key", Model: "test-model", Provider: "openrouter"},
+		Auth:        AuthConfig{Mode: "open"},
+		StoragePath: "/tmp/test.db",
+		Maestro: MaestroConfig{
+			Repo:              "BeFeast/ok-gobot",
+			ReadyLabel:        "ready-for-maestro",
+			HardExcludeLabels: []string{"blocked", "meta"},
+			Limit:             17,
+		},
+	}
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	if loaded.Maestro.Repo != cfg.Maestro.Repo || loaded.Maestro.ReadyLabel != cfg.Maestro.ReadyLabel || loaded.Maestro.Limit != cfg.Maestro.Limit {
+		t.Fatalf("loaded maestro scalar config = %+v, want %+v", loaded.Maestro, cfg.Maestro)
+	}
+	if len(loaded.Maestro.HardExcludeLabels) != 2 || loaded.Maestro.HardExcludeLabels[0] != "blocked" || loaded.Maestro.HardExcludeLabels[1] != "meta" {
+		t.Fatalf("loaded hard excludes = %#v", loaded.Maestro.HardExcludeLabels)
+	}
+}
+
 func TestValidateRejectsInvalidRuntimeSessionQueueLimit(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "config-test-invalid-queue-*")
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,6 +55,15 @@ storage_path: "/tmp/test.db"
 	if cfg.Memory.QMD.SearchMode != "search" {
 		t.Errorf("expected memory.qmd.search_mode=%q, got %q", "search", cfg.Memory.QMD.SearchMode)
 	}
+	if cfg.Maestro.ReadyLabel != "ready" {
+		t.Errorf("expected maestro.ready_label=%q, got %q", "ready", cfg.Maestro.ReadyLabel)
+	}
+	if cfg.Maestro.Limit != 50 {
+		t.Errorf("expected maestro.limit=%d, got %d", 50, cfg.Maestro.Limit)
+	}
+	if len(cfg.Maestro.HardExcludeLabels) != 7 {
+		t.Errorf("expected maestro hard excludes, got %#v", cfg.Maestro.HardExcludeLabels)
+	}
 }
 
 func TestLoadFromLegacyRuntimeModeCompatibility(t *testing.T) {

--- a/internal/maestro/gh.go
+++ b/internal/maestro/gh.go
@@ -1,0 +1,157 @@
+package maestro
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// GHClient reads issue state through the GitHub CLI.
+type GHClient struct {
+	Dir    string
+	Binary string
+}
+
+func NewGHClient(dir string) *GHClient {
+	return &GHClient{Dir: dir, Binary: "gh"}
+}
+
+func (c *GHClient) ListOpenIssues(ctx context.Context, repo string, limit int) ([]Issue, error) {
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+	args := []string{"issue", "list", "--state", "open", "--limit", strconv.Itoa(limit), "--json", "number,title,body,labels,state"}
+	if strings.TrimSpace(repo) != "" {
+		args = append(args, "--repo", repo)
+	}
+	out, err := c.run(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw []struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		State  string `json:"state"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse gh issue list: %w", err)
+	}
+
+	issues := make([]Issue, 0, len(raw))
+	for _, item := range raw {
+		labels := make([]string, 0, len(item.Labels))
+		for _, label := range item.Labels {
+			labels = append(labels, label.Name)
+		}
+		issues = append(issues, Issue{
+			Number: item.Number,
+			Title:  item.Title,
+			Body:   item.Body,
+			State:  item.State,
+			Labels: labels,
+		})
+	}
+	return issues, nil
+}
+
+func (c *GHClient) ResolveDependency(ctx context.Context, defaultRepo string, ref DependencyRef) (DependencyStatus, error) {
+	repo := strings.TrimSpace(ref.Repo)
+	if repo == "" {
+		repo = strings.TrimSpace(defaultRepo)
+	}
+	status := DependencyStatus{Ref: ref}
+
+	issueState, issueErr := c.issueState(ctx, repo, ref.Number)
+	if issueErr == nil {
+		status.State = strings.ToLower(issueState)
+		if status.Satisfied() {
+			return status, nil
+		}
+	}
+
+	prStatus, prErr := c.prStatus(ctx, repo, ref.Number)
+	if prErr == nil {
+		return prStatus, nil
+	}
+	if issueErr != nil {
+		return status, issueErr
+	}
+	return status, nil
+}
+
+func (c *GHClient) issueState(ctx context.Context, repo string, number int) (string, error) {
+	args := []string{"issue", "view", strconv.Itoa(number), "--json", "state", "--jq", ".state"}
+	if repo != "" {
+		args = append(args, "--repo", repo)
+	}
+	out, err := c.run(ctx, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (c *GHClient) prStatus(ctx context.Context, repo string, number int) (DependencyStatus, error) {
+	args := []string{"pr", "view", strconv.Itoa(number), "--json", "state,isDraft,mergeStateStatus"}
+	if repo != "" {
+		args = append(args, "--repo", repo)
+	}
+	out, err := c.run(ctx, args...)
+	if err != nil {
+		return DependencyStatus{}, err
+	}
+	var raw struct {
+		State            string `json:"state"`
+		IsDraft          bool   `json:"isDraft"`
+		MergeStateStatus string `json:"mergeStateStatus"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return DependencyStatus{}, fmt.Errorf("parse gh pr view: %w", err)
+	}
+	mergeState := strings.ToUpper(strings.TrimSpace(raw.MergeStateStatus))
+	return DependencyStatus{
+		Ref:           refFromNumber(repo, number),
+		State:         strings.ToLower(strings.TrimSpace(raw.State)),
+		IsPullRequest: true,
+		MergeReady:    !raw.IsDraft && (mergeState == "CLEAN" || mergeState == "HAS_HOOKS"),
+		MergeState:    mergeState,
+		Draft:         raw.IsDraft,
+	}, nil
+}
+
+func refFromNumber(repo string, number int) DependencyRef {
+	ref := DependencyRef{Number: number, Raw: fmt.Sprintf("#%d", number)}
+	if repo != "" {
+		ref.Repo = repo
+		ref.Raw = fmt.Sprintf("%s#%d", repo, number)
+	}
+	return ref
+}
+
+func (c *GHClient) run(ctx context.Context, args ...string) ([]byte, error) {
+	binary := c.Binary
+	if binary == "" {
+		binary = "gh"
+	}
+	cmd := exec.CommandContext(ctx, binary, args...)
+	if c.Dir != "" {
+		cmd.Dir = c.Dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			return nil, err
+		}
+		return nil, fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, msg)
+	}
+	return out, nil
+}

--- a/internal/maestro/intake.go
+++ b/internal/maestro/intake.go
@@ -1,0 +1,348 @@
+package maestro
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	DefaultReadyLabel = "ready"
+	DefaultLimit      = 50
+)
+
+var (
+	dependencyLineRE = regexp.MustCompile(`(?i)^(?:depends(?:\s+on)?|dependencies|dependency|blocked\s+by|requires)(?:\s*:\s*|\s+)(.+)$`)
+	issueRefRE       = regexp.MustCompile(`(?i)(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(\d+)`)
+)
+
+// Issue is the GitHub issue data needed by the intake policy.
+type Issue struct {
+	Number int
+	Title  string
+	Body   string
+	Labels []string
+	State  string
+}
+
+// DependencyRef identifies one dependency issue or PR reference.
+type DependencyRef struct {
+	Repo   string
+	Number int
+	Raw    string
+}
+
+func (r DependencyRef) String() string {
+	if r.Raw != "" {
+		return r.Raw
+	}
+	if r.Repo != "" {
+		return fmt.Sprintf("%s#%d", r.Repo, r.Number)
+	}
+	return fmt.Sprintf("#%d", r.Number)
+}
+
+// DependencyStatus is the resolved state of a dependency reference.
+type DependencyStatus struct {
+	Ref           DependencyRef
+	State         string
+	IsPullRequest bool
+	MergeReady    bool
+	MergeState    string
+	Draft         bool
+}
+
+// Satisfied reports whether the dependency gate allows the candidate issue.
+func (s DependencyStatus) Satisfied() bool {
+	state := strings.ToLower(strings.TrimSpace(s.State))
+	if state == "closed" || state == "merged" {
+		return true
+	}
+	return s.IsPullRequest && !s.Draft && s.MergeReady
+}
+
+func (s DependencyStatus) unsatisfiedReason(ref DependencyRef) string {
+	label := ref.String()
+	state := strings.ToLower(strings.TrimSpace(s.State))
+	if state == "" {
+		state = "unknown"
+	}
+	if s.IsPullRequest {
+		mergeState := strings.TrimSpace(s.MergeState)
+		if mergeState == "" {
+			mergeState = "unknown"
+		}
+		if s.Draft {
+			return fmt.Sprintf("dependency %s is a draft PR", label)
+		}
+		return fmt.Sprintf("dependency %s is not merge-ready (state=%s, merge_state=%s)", label, state, mergeState)
+	}
+	return fmt.Sprintf("dependency %s is %s", label, state)
+}
+
+// Source provides issue candidates and dependency state.
+type Source interface {
+	ListOpenIssues(ctx context.Context, repo string, limit int) ([]Issue, error)
+	ResolveDependency(ctx context.Context, repo string, ref DependencyRef) (DependencyStatus, error)
+}
+
+// Policy controls issue intake gates.
+type Policy struct {
+	Repo              string
+	ReadyLabel        string
+	HardExcludeLabels []string
+	Limit             int
+	Override          bool
+	OverrideReason    string
+}
+
+// CandidateDecision records the policy outcome for one issue.
+type CandidateDecision struct {
+	Issue           Issue
+	Eligible        bool
+	SkipReasons     []string
+	Dependencies    []DependencyRef
+	OverrideUsed    bool
+	OverrideReasons []string
+}
+
+// Decision is the complete dry-run/status result.
+type Decision struct {
+	Policy  Policy
+	Next    *CandidateDecision
+	Skipped []CandidateDecision
+}
+
+// DefaultHardExcludeLabels returns the labels that are never eligible unless a
+// maintainer explicitly uses the override flag.
+func DefaultHardExcludeLabels() []string {
+	return []string{"blocked", "epic", "meta", "question", "wontfix", "duplicate", "invalid"}
+}
+
+// DryRun lists open issues from source and evaluates the strict intake policy.
+func DryRun(ctx context.Context, source Source, policy Policy) (Decision, error) {
+	policy = NormalizePolicy(policy)
+	issues, err := source.ListOpenIssues(ctx, policy.Repo, policy.Limit)
+	if err != nil {
+		return Decision{}, err
+	}
+	return Evaluate(ctx, issues, source, policy), nil
+}
+
+// Evaluate applies the intake policy to already-loaded candidate issues.
+func Evaluate(ctx context.Context, issues []Issue, resolver Source, policy Policy) Decision {
+	policy = NormalizePolicy(policy)
+	decision := Decision{Policy: policy}
+
+	for _, issue := range issues {
+		candidate := evaluateIssue(ctx, issue, resolver, policy)
+		if policy.Override {
+			candidate.Eligible = true
+			candidate.OverrideUsed = true
+			candidate.OverrideReasons = append([]string(nil), candidate.SkipReasons...)
+			candidate.SkipReasons = nil
+			decision.Next = &candidate
+			return decision
+		}
+		if candidate.Eligible {
+			decision.Next = &candidate
+			return decision
+		}
+		decision.Skipped = append(decision.Skipped, candidate)
+	}
+
+	return decision
+}
+
+// NormalizePolicy fills strict safe defaults.
+func NormalizePolicy(policy Policy) Policy {
+	policy.ReadyLabel = strings.TrimSpace(policy.ReadyLabel)
+	if policy.ReadyLabel == "" {
+		policy.ReadyLabel = DefaultReadyLabel
+	}
+	if policy.Limit <= 0 {
+		policy.Limit = DefaultLimit
+	}
+	policy.HardExcludeLabels = normalizeLabels(policy.HardExcludeLabels)
+	if len(policy.HardExcludeLabels) == 0 {
+		policy.HardExcludeLabels = DefaultHardExcludeLabels()
+	}
+	return policy
+}
+
+func evaluateIssue(ctx context.Context, issue Issue, resolver Source, policy Policy) CandidateDecision {
+	labels := labelSet(issue.Labels)
+	candidate := CandidateDecision{Issue: issue}
+
+	if _, ok := labels[strings.ToLower(policy.ReadyLabel)]; !ok {
+		candidate.SkipReasons = append(candidate.SkipReasons, fmt.Sprintf("missing ready label %q", policy.ReadyLabel))
+	}
+
+	for _, label := range policy.HardExcludeLabels {
+		if _, ok := labels[strings.ToLower(label)]; ok {
+			candidate.SkipReasons = append(candidate.SkipReasons, fmt.Sprintf("hard-exclude label %q", label))
+		}
+	}
+
+	deps := ParseDependencyRefs(issue.Body)
+	candidate.Dependencies = deps
+	for _, dep := range deps {
+		if resolver == nil {
+			candidate.SkipReasons = append(candidate.SkipReasons, fmt.Sprintf("dependency %s status unavailable", dep.String()))
+			continue
+		}
+		status, err := resolver.ResolveDependency(ctx, policy.Repo, dep)
+		if err != nil {
+			candidate.SkipReasons = append(candidate.SkipReasons, fmt.Sprintf("dependency %s status unavailable: %v", dep.String(), err))
+			continue
+		}
+		if !status.Satisfied() {
+			candidate.SkipReasons = append(candidate.SkipReasons, status.unsatisfiedReason(dep))
+		}
+	}
+
+	candidate.Eligible = len(candidate.SkipReasons) == 0
+	return candidate
+}
+
+// ParseDependencyRefs extracts dedicated dependency-line issue references while
+// ignoring fenced code blocks, inline-code examples, and example sections.
+func ParseDependencyRefs(body string) []DependencyRef {
+	var refs []DependencyRef
+	seen := map[string]struct{}{}
+	inFence := false
+	inExample := false
+
+	for _, rawLine := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(rawLine)
+		if isFenceLine(trimmed) {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		if trimmed == "" {
+			inExample = false
+			continue
+		}
+		if isExampleHeading(trimmed) {
+			inExample = true
+			continue
+		}
+		if inExample || strings.HasPrefix(trimmed, ">") || strings.HasPrefix(trimmed, "<!--") {
+			continue
+		}
+
+		line := stripMarkdownListPrefix(trimmed)
+		line = stripInlineCode(line)
+		match := dependencyLineRE.FindStringSubmatch(strings.TrimSpace(line))
+		if match == nil {
+			continue
+		}
+		for _, ref := range refsFromText(match[1]) {
+			key := strings.ToLower(ref.String())
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+
+	return refs
+}
+
+func refsFromText(text string) []DependencyRef {
+	matches := issueRefRE.FindAllStringSubmatch(text, -1)
+	refs := make([]DependencyRef, 0, len(matches))
+	for _, match := range matches {
+		n, err := strconv.Atoi(match[2])
+		if err != nil || n <= 0 {
+			continue
+		}
+		raw := fmt.Sprintf("#%d", n)
+		if match[1] != "" {
+			raw = fmt.Sprintf("%s#%d", match[1], n)
+		}
+		refs = append(refs, DependencyRef{Repo: match[1], Number: n, Raw: raw})
+	}
+	return refs
+}
+
+func isFenceLine(line string) bool {
+	return strings.HasPrefix(line, "```") || strings.HasPrefix(line, "~~~")
+}
+
+func isExampleHeading(line string) bool {
+	line = strings.TrimLeft(line, "# ")
+	lower := strings.ToLower(strings.TrimSpace(line))
+	lower = strings.TrimSuffix(lower, ":")
+	return lower == "example" || lower == "examples" || strings.HasPrefix(lower, "for example") || strings.HasPrefix(lower, "e.g.")
+}
+
+func stripMarkdownListPrefix(line string) string {
+	line = strings.TrimSpace(line)
+	for _, prefix := range []string{"- ", "* ", "+ "} {
+		if strings.HasPrefix(line, prefix) {
+			line = strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			break
+		}
+	}
+	if strings.HasPrefix(line, "[ ] ") || strings.HasPrefix(strings.ToLower(line), "[x] ") {
+		line = strings.TrimSpace(line[4:])
+	}
+	if idx := strings.IndexAny(line, ".)"); idx > 0 {
+		if _, err := strconv.Atoi(line[:idx]); err == nil {
+			line = strings.TrimSpace(line[idx+1:])
+		}
+	}
+	return line
+}
+
+func stripInlineCode(line string) string {
+	var b strings.Builder
+	for i := 0; i < len(line); i++ {
+		if line[i] != '`' {
+			b.WriteByte(line[i])
+			continue
+		}
+		i++
+		for i < len(line) && line[i] != '`' {
+			i++
+		}
+	}
+	return b.String()
+}
+
+func labelSet(labels []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		label = strings.ToLower(strings.TrimSpace(label))
+		if label != "" {
+			set[label] = struct{}{}
+		}
+	}
+	return set
+}
+
+func normalizeLabels(labels []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(labels))
+	for _, label := range labels {
+		label = strings.ToLower(strings.TrimSpace(label))
+		if label == "" {
+			continue
+		}
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		out = append(out, label)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/maestro/intake.go
+++ b/internal/maestro/intake.go
@@ -139,17 +139,19 @@ func Evaluate(ctx context.Context, issues []Issue, resolver Source, policy Polic
 
 	for _, issue := range issues {
 		candidate := evaluateIssue(ctx, issue, resolver, policy)
-		if policy.Override {
+		if policy.Override && decision.Next == nil {
 			candidate.Eligible = true
 			candidate.OverrideUsed = true
 			candidate.OverrideReasons = append([]string(nil), candidate.SkipReasons...)
 			candidate.SkipReasons = nil
 			decision.Next = &candidate
-			return decision
+			continue
 		}
 		if candidate.Eligible {
-			decision.Next = &candidate
-			return decision
+			if decision.Next == nil {
+				decision.Next = &candidate
+			}
+			continue
 		}
 		decision.Skipped = append(decision.Skipped, candidate)
 	}
@@ -209,20 +211,27 @@ func evaluateIssue(ctx context.Context, issue Issue, resolver Source, policy Pol
 }
 
 // ParseDependencyRefs extracts dedicated dependency-line issue references while
-// ignoring fenced code blocks, inline-code examples, and example sections.
+// ignoring fenced code blocks, inline-code examples, HTML comments, and example sections.
 func ParseDependencyRefs(body string) []DependencyRef {
 	var refs []DependencyRef
 	seen := map[string]struct{}{}
 	inFence := false
 	inExample := false
+	inHTMLComment := false
 
 	for _, rawLine := range strings.Split(body, "\n") {
-		trimmed := strings.TrimSpace(rawLine)
-		if isFenceLine(trimmed) {
-			inFence = !inFence
+		trimmedRaw := strings.TrimSpace(rawLine)
+		if inFence {
+			if isFenceLine(trimmedRaw) {
+				inFence = false
+			}
 			continue
 		}
-		if inFence {
+
+		line := stripHTMLComments(rawLine, &inHTMLComment)
+		trimmed := strings.TrimSpace(line)
+		if isFenceLine(trimmed) {
+			inFence = true
 			continue
 		}
 		if trimmed == "" {
@@ -233,11 +242,11 @@ func ParseDependencyRefs(body string) []DependencyRef {
 			inExample = true
 			continue
 		}
-		if inExample || strings.HasPrefix(trimmed, ">") || strings.HasPrefix(trimmed, "<!--") {
+		if inExample || strings.HasPrefix(trimmed, ">") {
 			continue
 		}
 
-		line := stripMarkdownListPrefix(trimmed)
+		line = stripMarkdownListPrefix(trimmed)
 		line = stripInlineCode(line)
 		match := dependencyLineRE.FindStringSubmatch(strings.TrimSpace(line))
 		if match == nil {
@@ -254,6 +263,35 @@ func ParseDependencyRefs(body string) []DependencyRef {
 	}
 
 	return refs
+}
+
+func stripHTMLComments(line string, inComment *bool) string {
+	var b strings.Builder
+	for {
+		if *inComment {
+			end := strings.Index(line, "-->")
+			if end < 0 {
+				return b.String()
+			}
+			line = line[end+len("-->"):]
+			*inComment = false
+			continue
+		}
+
+		start := strings.Index(line, "<!--")
+		if start < 0 {
+			b.WriteString(line)
+			return b.String()
+		}
+		b.WriteString(line[:start])
+		line = line[start+len("<!--"):]
+		end := strings.Index(line, "-->")
+		if end < 0 {
+			*inComment = true
+			return b.String()
+		}
+		line = line[end+len("-->"):]
+	}
 }
 
 func refsFromText(text string) []DependencyRef {

--- a/internal/maestro/intake_test.go
+++ b/internal/maestro/intake_test.go
@@ -1,0 +1,204 @@
+package maestro
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type fakeSource struct {
+	issues  []Issue
+	deps    map[int]DependencyStatus
+	depErrs map[int]error
+	calls   []DependencyRef
+}
+
+func (f *fakeSource) ListOpenIssues(_ context.Context, _ string, _ int) ([]Issue, error) {
+	return f.issues, nil
+}
+
+func (f *fakeSource) ResolveDependency(_ context.Context, _ string, ref DependencyRef) (DependencyStatus, error) {
+	f.calls = append(f.calls, ref)
+	if err := f.depErrs[ref.Number]; err != nil {
+		return DependencyStatus{}, err
+	}
+	if status, ok := f.deps[ref.Number]; ok {
+		return status, nil
+	}
+	return DependencyStatus{Ref: ref, State: "open"}, nil
+}
+
+func TestEvaluateRequiresReadyLabelByDefault(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeSource{}
+	decision := Evaluate(context.Background(), []Issue{
+		{Number: 1, Title: "not ready", Labels: []string{"bug"}},
+		{Number: 2, Title: "ready", Labels: []string{"ready"}},
+	}, source, Policy{})
+
+	if decision.Next == nil || decision.Next.Issue.Number != 2 {
+		t.Fatalf("next issue = %#v, want #2", decision.Next)
+	}
+	if len(decision.Skipped) != 1 {
+		t.Fatalf("skipped count = %d, want 1", len(decision.Skipped))
+	}
+	assertReasonContains(t, decision.Skipped[0].SkipReasons, `missing ready label "ready"`)
+}
+
+func TestEvaluateDoesNotSelectDemoWaveWithoutReady(t *testing.T) {
+	t.Parallel()
+
+	decision := Evaluate(context.Background(), []Issue{{
+		Number: 13,
+		Title:  "demo wave task",
+		Labels: []string{"demo-wave"},
+	}}, &fakeSource{}, Policy{})
+
+	if decision.Next != nil {
+		t.Fatalf("next issue = %#v, want none", decision.Next)
+	}
+	assertReasonContains(t, decision.Skipped[0].SkipReasons, `missing ready label "ready"`)
+}
+
+func TestEvaluateHardExcludesBlockedLabel(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeSource{}
+	decision := Evaluate(context.Background(), []Issue{
+		{Number: 1, Title: "blocked", Labels: []string{"ready", "blocked"}},
+		{Number: 2, Title: "ready", Labels: []string{"ready"}},
+	}, source, Policy{})
+
+	if decision.Next == nil || decision.Next.Issue.Number != 2 {
+		t.Fatalf("next issue = %#v, want #2", decision.Next)
+	}
+	assertReasonContains(t, decision.Skipped[0].SkipReasons, `hard-exclude label "blocked"`)
+}
+
+func TestEvaluateSkipsMissingDependency(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeSource{deps: map[int]DependencyStatus{
+		9: {State: "open"},
+	}}
+	decision := Evaluate(context.Background(), []Issue{{
+		Number: 1,
+		Title:  "depends",
+		Labels: []string{"ready"},
+		Body:   "Depends on: #9",
+	}}, source, Policy{})
+
+	if decision.Next != nil {
+		t.Fatalf("next issue = %#v, want none", decision.Next)
+	}
+	if len(decision.Skipped) != 1 {
+		t.Fatalf("skipped count = %d, want 1", len(decision.Skipped))
+	}
+	assertReasonContains(t, decision.Skipped[0].SkipReasons, "dependency #9 is open")
+}
+
+func TestEvaluateAllowsClosedDependency(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeSource{deps: map[int]DependencyStatus{
+		9: {State: "closed"},
+	}}
+	decision := Evaluate(context.Background(), []Issue{{
+		Number: 1,
+		Title:  "depends",
+		Labels: []string{"ready"},
+		Body:   "Depends on: #9",
+	}}, source, Policy{})
+
+	if decision.Next == nil || decision.Next.Issue.Number != 1 {
+		t.Fatalf("next issue = %#v, want #1", decision.Next)
+	}
+	if len(source.calls) != 1 || source.calls[0].Number != 9 {
+		t.Fatalf("dependency calls = %#v, want #9", source.calls)
+	}
+}
+
+func TestParseDependencyRefsIgnoresExamplesAndCode(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Join([]string{
+		"This issue mentions `Depends on: #9` inline.",
+		"",
+		"```md",
+		"Depends on: #10",
+		"```",
+		"",
+		"Example:",
+		"Depends on: #11",
+		"",
+		"Previously depended on: #12",
+	}, "\n")
+
+	refs := ParseDependencyRefs(body)
+	if len(refs) != 0 {
+		t.Fatalf("refs = %#v, want none", refs)
+	}
+}
+
+func TestEvaluateOverrideSelectsFirstIssueAndShowsBypassedReasons(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeSource{deps: map[int]DependencyStatus{
+		9: {State: "open"},
+	}}
+	decision := Evaluate(context.Background(), []Issue{{
+		Number: 1,
+		Title:  "force me",
+		Labels: []string{"blocked"},
+		Body:   "Depends on: #9",
+	}}, source, Policy{Override: true, OverrideReason: "maintainer reviewed"})
+
+	if decision.Next == nil || decision.Next.Issue.Number != 1 {
+		t.Fatalf("next issue = %#v, want #1", decision.Next)
+	}
+	if !decision.Next.OverrideUsed {
+		t.Fatalf("expected override to be visible: %#v", decision.Next)
+	}
+	if len(decision.Skipped) != 0 {
+		t.Fatalf("skipped count = %d, want 0", len(decision.Skipped))
+	}
+	assertReasonContains(t, decision.Next.OverrideReasons, `missing ready label "ready"`)
+	assertReasonContains(t, decision.Next.OverrideReasons, `hard-exclude label "blocked"`)
+	assertReasonContains(t, decision.Next.OverrideReasons, "dependency #9 is open")
+}
+
+func TestParseDependencyRefsDedicatedLines(t *testing.T) {
+	t.Parallel()
+
+	refs := ParseDependencyRefs(strings.Join([]string{
+		"- Depends on: #3, BeFeast/ok-gobot#4",
+		"1. blocked by #5",
+	}, "\n"))
+	if len(refs) != 3 {
+		t.Fatalf("refs = %#v, want 3 refs", refs)
+	}
+	want := []string{"#3", "BeFeast/ok-gobot#4", "#5"}
+	for i := range want {
+		if refs[i].String() != want[i] {
+			t.Fatalf("ref[%d] = %q, want %q", i, refs[i].String(), want[i])
+		}
+	}
+}
+
+func assertReasonContains(t *testing.T, reasons []string, want string) {
+	t.Helper()
+	for _, reason := range reasons {
+		if strings.Contains(reason, want) {
+			return
+		}
+	}
+	t.Fatalf("reasons %v do not contain %q", reasons, want)
+}
+
+func ExampleParseDependencyRefs() {
+	refs := ParseDependencyRefs("Depends on: #353")
+	fmt.Println(refs[0].String())
+	// Output: #353
+}

--- a/internal/maestro/intake_test.go
+++ b/internal/maestro/intake_test.go
@@ -77,6 +77,28 @@ func TestEvaluateHardExcludesBlockedLabel(t *testing.T) {
 	assertReasonContains(t, decision.Skipped[0].SkipReasons, `hard-exclude label "blocked"`)
 }
 
+func TestEvaluateContinuesScanningSkippedCandidatesAfterNext(t *testing.T) {
+	t.Parallel()
+
+	source := &fakeSource{deps: map[int]DependencyStatus{
+		9: {State: "open"},
+	}}
+	decision := Evaluate(context.Background(), []Issue{
+		{Number: 1, Title: "ready", Labels: []string{"ready"}},
+		{Number: 2, Title: "blocked", Labels: []string{"ready", "blocked"}},
+		{Number: 3, Title: "depends", Labels: []string{"ready"}, Body: "Depends on: #9"},
+	}, source, Policy{})
+
+	if decision.Next == nil || decision.Next.Issue.Number != 1 {
+		t.Fatalf("next issue = %#v, want #1", decision.Next)
+	}
+	if len(decision.Skipped) != 2 {
+		t.Fatalf("skipped count = %d, want 2", len(decision.Skipped))
+	}
+	assertReasonContains(t, decision.Skipped[0].SkipReasons, `hard-exclude label "blocked"`)
+	assertReasonContains(t, decision.Skipped[1].SkipReasons, "dependency #9 is open")
+}
+
 func TestEvaluateSkipsMissingDependency(t *testing.T) {
 	t.Parallel()
 
@@ -139,6 +161,22 @@ func TestParseDependencyRefsIgnoresExamplesAndCode(t *testing.T) {
 	refs := ParseDependencyRefs(body)
 	if len(refs) != 0 {
 		t.Fatalf("refs = %#v, want none", refs)
+	}
+}
+
+func TestParseDependencyRefsIgnoresMultilineHTMLComments(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Join([]string{
+		"<!--",
+		"Depends on: #9",
+		"-->",
+		"Depends on: #10",
+	}, "\n")
+
+	refs := ParseDependencyRefs(body)
+	if len(refs) != 1 || refs[0].String() != "#10" {
+		t.Fatalf("refs = %#v, want only #10", refs)
 	}
 }
 


### PR DESCRIPTION
Implements #355

## Changes
- Add strict Maestro intake requiring the configured ready label by default, enforcing hard-exclude labels, and gating dedicated dependency lines until dependencies are closed or merge-ready.
- Add `ok-gobot maestro dry-run` and `ok-gobot maestro status` output with skipped-candidate reasons and visible maintainer override details.
- Address review feedback: require non-empty `maestro.ready_label`, document the current status/dry-run relationship, continue scanning skipped candidates after selecting `Next`, ignore multiline HTML comments in dependency parsing, and persist `maestro.*` fields in `Save()`.

## Testing
- `go test ./internal/maestro ./internal/config ./internal/cli` (passed)
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/` (passed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a strict Maestro issue intake policy (#355), gating worker selection on a configurable ready label, hard-exclude labels, and dependency closure checks parsed from issue bodies. It adds `ok-gobot maestro dry-run` and `ok-gobot maestro status` subcommands with full decision output (next eligible issue, per-candidate skip reasons, maintainer override transparency), backed by focused unit tests, config/schema/docs updates, and a corrected `Save()` round-trip for all new `maestro.*` fields.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic bugs identified in the changed code paths

All three intake gates (ready label, hard-exclude, dependency) are correctly composed and tested. The dependency fallback (issue → PR) handles every error branch correctly. ParseDependencyRefs correctly handles fenced blocks, multi-line HTML comments, example sections, and inline code. Config defaults, validation, Save(), and the CLI flag/config propagation are all consistent. Previously flagged issues (Save() omission, compound Validate guard) are addressed in this revision.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/maestro/intake.go | Core intake logic: evaluates issues against ready-label, hard-exclude, and dependency gates; implements NormalizePolicy, Evaluate, DryRun, and ParseDependencyRefs with careful handling of fenced code, HTML comments, and example sections |
| internal/maestro/gh.go | GHClient wraps the gh CLI for issue listing and dependency resolution; fallback from issue-view to pr-view is correctly sequenced; uses CombinedOutput (minor robustness concern in noisy environments) |
| internal/cli/maestro.go | Adds dry-run and status subcommands; status intentionally reuses DryRun until worker runtime state is tracked (comment present); flag binding and config-to-opts propagation are correct |
| internal/config/config.go | Adds MaestroConfig struct, Viper defaults in both Load/LoadFrom, simple Validate guards, and Save() round-trip fields; previous omission of Save fields is now fixed |
| internal/maestro/intake_test.go | Comprehensive tests covering ready-label requirement, hard-exclude blocking, dependency gating, override with bypassed-reason transparency, HTML comment stripping, and fenced-code/example-section ignoring |
| internal/config/config_test.go | Adds default-value assertions, blank-ready-label rejection, and Save/LoadFrom round-trip test for all maestro fields; existing test fixtures updated to include ReadyLabel to satisfy new validation |
| internal/cli/maestro_test.go | Focused unit tests for renderMaestroDecision covering no-eligible-issue output with skip reasons and override header/bypassed-reasons display |
| config.example.yaml | Adds maestro block with documented defaults matching code constants; consistent with config.schema.json and ARCHITECTURE.md |
| config.schema.json | Adds maestro object with additionalProperties:false, matching field types and defaults from Go code |
| docs/MISSION-CONTROL.md | Adds Maestro Intake Status section documenting dry-run, status, dependency gating, and override flag usage |
| docs/ARCHITECTURE.md | Adds maestro block to the config schema documentation; consistent with config.schema.json |
| internal/cli/root.go | Registers newMaestroCommand in the root command tree; single line change, correct placement |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: persist Maestro config fields (#355..."](https://github.com/befeast/ok-gobot/commit/5d694811679aa4f34dc80db0478c4051e6ae9b54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30452334)</sub>

<!-- /greptile_comment -->