### PR TITLE
feat: add worker preflight gate (#354)

### DIFF
--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -24,7 +24,7 @@ api:
 |----------|--------|-------------|
 | `/api/mission/roles` | GET | Registered agent profiles with metadata (name, display name, model, tools) |
 | `/api/mission/schedules` | GET | Scheduled jobs with cron expression, next run time, timeout |
-| `/api/mission/runs` | GET | Recent job runs with status, summary, errors, attempt count |
+| `/api/mission/runs` | GET | Recent job runs with status, summary, errors, attempt count, and preflight refusal reasons |
 | `/api/mission/stats` | GET | Daily and total statistics (tokens, messages, sessions) |
 | `/api/mission/estop` | GET | Current emergency-stop state |
 | `/api/mission/providers` | GET | Active AI provider and model |
@@ -41,7 +41,7 @@ Run query parameters: `limit` (1-200), `status` (filter by run status). Stats qu
 
 - **Profiles** -- which agent profiles are loaded and what tools/models they use
 - **Schedules** -- when each role is next due to run
-- **Runs** -- whether recent job runs succeeded or failed, with summaries
+- **Runs** -- whether recent job runs succeeded, failed, or were refused by preflight, with summaries and errors
 - **Proof artifacts** -- screenshots, URLs, and text reports linked from job and worker rows
 - **Stats** -- aggregate token usage and message counts
 - **Controls** -- emergency-stop state and active provider/model

--- a/internal/batch/runner.go
+++ b/internal/batch/runner.go
@@ -26,6 +26,8 @@ type Config struct {
 	// WorktreeParent is the parent directory for worktree paths.
 	// If empty, os.TempDir() is used.
 	WorktreeParent string
+	// WorkerModel is forwarded to worker backends and reported in preflight.
+	WorkerModel string
 	// Progress is called after each subtask completes (may be nil).
 	Progress func(SubtaskResult)
 	// Out receives log/status lines (may be nil; falls back to os.Stderr).
@@ -224,7 +226,15 @@ func runSubtask(ctx context.Context, cfg Config, idx int, subtask Subtask, adapt
 	// Run the worker adapter.
 	req := worker.Request{
 		Task:    subtask.Description,
+		Model:   cfg.WorkerModel,
 		WorkDir: workDir,
+	}
+	if report, ok := worker.RunAdapterPreflight(ctx, adapter, req); ok {
+		fmt.Fprintf(out, "[batch] subtask %d preflight: %s\n", idx, report.Summary())
+		if !report.OK {
+			res.Error = fmt.Errorf("worker preflight failed: %s", report.Summary())
+			return res
+		}
 	}
 
 	result, err := adapter.Run(ctx, req)

--- a/internal/cli/batch.go
+++ b/internal/cli/batch.go
@@ -88,6 +88,7 @@ Examples:
 				RepoRoot:       repoRoot,
 				BaseBranch:     baseBranch,
 				WorktreeParent: worktreeParent,
+				WorkerModel:    workerModel,
 				Out:            out,
 				Progress: func(res batch.SubtaskResult) {
 					if res.Error != nil {

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -19,13 +19,14 @@ import (
 type JobStatus string
 
 const (
-	JobStatusPending        JobStatus = "pending"
-	JobStatusRunning        JobStatus = "running"
-	JobStatusSucceeded      JobStatus = "succeeded"
-	JobStatusFailed         JobStatus = "failed"
-	JobStatusCancelled      JobStatus = "cancelled"
-	JobStatusTimedOut       JobStatus = "timed_out"
-	JobStatusBudgetExceeded JobStatus = "budget_exceeded"
+	JobStatusPending         JobStatus = "pending"
+	JobStatusRunning         JobStatus = "running"
+	JobStatusSucceeded       JobStatus = "succeeded"
+	JobStatusFailed          JobStatus = "failed"
+	JobStatusPreflightFailed JobStatus = "preflight_failed"
+	JobStatusCancelled       JobStatus = "cancelled"
+	JobStatusTimedOut        JobStatus = "timed_out"
+	JobStatusBudgetExceeded  JobStatus = "budget_exceeded"
 )
 
 // JobEventType is the persisted event stream for a job.
@@ -37,6 +38,7 @@ const (
 	JobEventProgress        JobEventType = "progress"
 	JobEventSucceeded       JobEventType = "succeeded"
 	JobEventFailed          JobEventType = "failed"
+	JobEventPreflightFailed JobEventType = "preflight_failed"
 	JobEventCancelRequested JobEventType = "cancel_requested"
 	JobEventCancelled       JobEventType = "cancelled"
 	JobEventTimedOut        JobEventType = "timed_out"
@@ -83,6 +85,31 @@ type JobRunResult struct {
 // JobRunner executes one durable job.
 type JobRunner func(context.Context, *storage.Job, *JobService) (JobRunResult, error)
 
+// PreflightFailure indicates that a worker was refused before any code attempt.
+type PreflightFailure struct {
+	Message string
+	Details []string
+}
+
+func (e *PreflightFailure) Error() string {
+	if e == nil || strings.TrimSpace(e.Message) == "" {
+		return "preflight failed"
+	}
+	return e.Message
+}
+
+func (e *PreflightFailure) eventPayload() map[string]any {
+	if e == nil || len(e.Details) == 0 {
+		return nil
+	}
+	return map[string]any{"details": e.Details}
+}
+
+// NewPreflightFailure creates a classified preflight error for job runners.
+func NewPreflightFailure(message string, details []string) error {
+	return &PreflightFailure{Message: strings.TrimSpace(message), Details: details}
+}
+
 // JobService persists and tracks first-class background jobs.
 type JobService struct {
 	store *storage.Store
@@ -128,8 +155,16 @@ func (s *JobService) RetryDetached(parentCtx context.Context, jobID string, runn
 	case string(JobStatusPending), string(JobStatusRunning):
 		return nil, fmt.Errorf("job %q is not retryable while status=%s", jobID, existing.Status)
 	}
-	if existing.MaxAttempts > 0 && existing.Attempt >= existing.MaxAttempts {
+	preflightRetry := existing.Status == string(JobStatusPreflightFailed)
+	if !preflightRetry && existing.MaxAttempts > 0 && existing.Attempt >= existing.MaxAttempts {
 		return nil, fmt.Errorf("job %q reached max attempts (%d)", jobID, existing.MaxAttempts)
+	}
+	nextAttempt := existing.Attempt + 1
+	if preflightRetry {
+		nextAttempt = existing.Attempt
+		if nextAttempt <= 0 {
+			nextAttempt = 1
+		}
 	}
 
 	retryJob, err := s.StartDetached(parentCtx, JobSpec{
@@ -139,7 +174,7 @@ func (s *JobService) RetryDetached(parentCtx context.Context, jobID string, runn
 		DeliverySessionKey: existing.DeliverySessionKey,
 		RetryOfJobID:       existing.JobID,
 		Description:        existing.Description,
-		Attempt:            existing.Attempt + 1,
+		Attempt:            nextAttempt,
 		MaxAttempts:        existing.MaxAttempts,
 		Timeout:            time.Duration(existing.TimeoutSeconds) * time.Second,
 		MaxToolCalls:       existing.MaxToolCalls,
@@ -363,8 +398,17 @@ func (s *JobService) run(parentCtx context.Context, job *storage.Job, spec JobSp
 	}
 
 	var budgetErr *delegation.BudgetExceededError
+	var preflightErr *PreflightFailure
 
 	switch {
+	case errors.As(runErr, &preflightErr):
+		if err := s.store.MarkJobPreflightFailed(job.JobID, preflightErr.Error()); err != nil {
+			log.Printf("[jobs] failed to mark %s preflight_failed: %v", job.JobID, err)
+			return
+		}
+		if err := s.AppendEvent(job.JobID, JobEventPreflightFailed, preflightErr.Error(), preflightErr.eventPayload()); err != nil {
+			log.Printf("[jobs] failed to persist preflight event for %s: %v", job.JobID, err)
+		}
 	case errors.As(runErr, &budgetErr):
 		summary := budgetErr.Report.Summary
 		if summary == "" {

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -484,6 +484,39 @@ func TestJobServiceRetryDetachedUsesRunnerArtifactRoots(t *testing.T) {
 	t.Fatalf("missing retry screenshot artifact rooted at %q: %+v", root, artifacts)
 }
 
+func TestJobServiceRetryDetachedPreflightDoesNotIncrementAttempt(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	if err := store.CreateJob(storage.Job{
+		JobID:       "job-preflight-retry",
+		Kind:        "background_task",
+		Worker:      "retry_runner",
+		Description: "env not ready",
+		Status:      string(JobStatusPreflightFailed),
+		Attempt:     1,
+		MaxAttempts: 1,
+		Error:       "preflight failed: gh auth missing",
+	}); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	svc := NewJobService(store)
+	retry, err := svc.RetryDetached(context.Background(), "job-preflight-retry", func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{Summary: "env fixed"}, nil
+	})
+	if err != nil {
+		t.Fatalf("RetryDetached failed: %v", err)
+	}
+
+	retried := waitForJobStatus(t, store, retry.JobID, string(JobStatusSucceeded))
+	if retried.Attempt != 1 {
+		t.Fatalf("preflight retry attempt = %d, want 1", retried.Attempt)
+	}
+}
+
 func TestJobServiceBudgetExceededMarksBudgetExceeded(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -1739,6 +1739,11 @@ func (s *Store) MarkJobFailed(jobID, errMsg string) error {
 	return s.markJobTerminal(jobID, "failed", "", errMsg)
 }
 
+// MarkJobPreflightFailed marks the job as refused before a worker code attempt.
+func (s *Store) MarkJobPreflightFailed(jobID, errMsg string) error {
+	return s.markJobTerminal(jobID, "preflight_failed", "", errMsg)
+}
+
 // MarkJobCancelled marks the job cancelled and stores the cancellation reason.
 func (s *Store) MarkJobCancelled(jobID, errMsg string) error {
 	return s.markJobTerminal(jobID, "cancelled", "", errMsg)

--- a/internal/worker/bridge.go
+++ b/internal/worker/bridge.go
@@ -13,6 +13,22 @@ import (
 // mapped onto the job's summary and persisted as a text artifact.
 func AdapterJobRunner(adapter Adapter, req Request) runtime.JobRunner {
 	return func(ctx context.Context, job *storage.Job, svc *runtime.JobService) (runtime.JobRunResult, error) {
+		if report, ok := RunAdapterPreflight(ctx, adapter, req); ok {
+			_ = svc.AddArtifact(job.JobID, runtime.JobArtifactSpec{
+				Name:     "preflight.json",
+				Type:     "preflight_evidence",
+				MimeType: "application/json",
+				Content:  report.EvidenceJSON(),
+			})
+			if !report.OK {
+				return runtime.JobRunResult{}, runtime.NewPreflightFailure(report.Summary(), report.FailureReasons())
+			}
+			_ = svc.AppendEvent(job.JobID, runtime.JobEventProgress, "preflight passed", map[string]any{
+				"backend": report.Backend,
+				"model":   report.Model,
+			})
+		}
+
 		_ = svc.AppendEvent(job.JobID, runtime.JobEventProgress, fmt.Sprintf("running %s task", job.Worker), nil)
 
 		result, err := adapter.Run(ctx, req)

--- a/internal/worker/bridge_test.go
+++ b/internal/worker/bridge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,6 +22,26 @@ func (s *stubAdapter) Run(_ context.Context, _ Request) (*Result, error) {
 }
 
 func (s *stubAdapter) Stream(_ context.Context, _ Request) <-chan Event {
+	ch := make(chan Event)
+	close(ch)
+	return ch
+}
+
+type preflightStubAdapter struct {
+	opts PreflightOptions
+	runs atomic.Int32
+}
+
+func (s *preflightStubAdapter) PreflightOptions(_ Request) PreflightOptions {
+	return s.opts
+}
+
+func (s *preflightStubAdapter) Run(_ context.Context, _ Request) (*Result, error) {
+	s.runs.Add(1)
+	return &Result{Content: "should not run"}, nil
+}
+
+func (s *preflightStubAdapter) Stream(_ context.Context, _ Request) <-chan Event {
 	ch := make(chan Event)
 	close(ch)
 	return ch
@@ -124,6 +145,71 @@ func TestAdapterJobRunnerFailure(t *testing.T) {
 	}
 }
 
+func TestAdapterJobRunnerPreflightFailureRefusesWorker(t *testing.T) {
+	t.Parallel()
+
+	store := newBridgeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const routeKey = "agent:test:telegram:group:202"
+	if err := store.SaveSessionRoute(storage.SessionRoute{
+		SessionKey: routeKey,
+		Channel:    "telegram",
+		ChatID:     202,
+	}); err != nil {
+		t.Fatalf("SaveSessionRoute failed: %v", err)
+	}
+
+	repo := newPreflightRepo(t)
+	opts := passingPreflightOptions(repo)
+	opts.CommandRunner = func(_ context.Context, _ string, name string, args ...string) CommandResult {
+		if name == "gh" {
+			return CommandResult{Stderr: "not authenticated", Err: errors.New("exit status 1")}
+		}
+		return passingCommandResult(repo, name, args...)
+	}
+	adapter := &preflightStubAdapter{opts: opts}
+	runner := AdapterJobRunner(adapter, Request{Task: "build project", Model: "test-model", WorkDir: repo})
+
+	svc := runtime.NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), runtime.JobSpec{
+		Kind:               "worker_task",
+		Worker:             "stub",
+		SessionKey:         "agent:test:main",
+		DeliverySessionKey: routeKey,
+		Description:        "test preflight bridge",
+		Timeout:            2 * time.Second,
+		MaxAttempts:        2,
+	}, runner)
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	finished := waitForBridgeJobStatus(t, store, job.JobID, string(runtime.JobStatusPreflightFailed))
+	if adapter.runs.Load() != 0 {
+		t.Fatalf("adapter ran %d time(s), want 0", adapter.runs.Load())
+	}
+	if finished.Error == "" {
+		t.Fatal("expected preflight error to be stored")
+	}
+
+	artifacts, err := store.ListJobArtifacts(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	if len(artifacts) != 1 || artifacts[0].Name != "preflight.json" || artifacts[0].ArtifactType != "preflight_evidence" {
+		t.Fatalf("unexpected preflight artifacts: %+v", artifacts)
+	}
+
+	events, err := store.ListJobEvents(job.JobID, 20)
+	if err != nil {
+		t.Fatalf("ListJobEvents failed: %v", err)
+	}
+	if !hasJobEvent(events, string(runtime.JobEventPreflightFailed)) {
+		t.Fatalf("expected preflight_failed event, got %+v", events)
+	}
+}
+
 func waitForBridgeJobStatus(t *testing.T, store *storage.Store, jobID, want string) *storage.Job {
 	t.Helper()
 
@@ -140,4 +226,13 @@ func waitForBridgeJobStatus(t *testing.T, store *storage.Store, jobID, want stri
 	}
 	t.Fatalf("timed out waiting for job %s to reach status %s", jobID, want)
 	return nil
+}
+
+func hasJobEvent(events []storage.JobEvent, eventType string) bool {
+	for _, event := range events {
+		if event.EventType == eventType {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -32,6 +32,11 @@ func NewClaudeAdapter(cfg ClaudeConfig) *ClaudeAdapter {
 	return &ClaudeAdapter{config: cfg}
 }
 
+// PreflightOptions declares the readiness checks required before Claude starts.
+func (a *ClaudeAdapter) PreflightOptions(req Request) PreflightOptions {
+	return WorkerPreflightOptions("claude", a.config.BinaryPath, req.Model, a.workDir(req), []string{"api.anthropic.com"})
+}
+
 // claudeResult is the JSON envelope returned by `claude -p --output-format json`.
 type claudeResult struct {
 	Result    string `json:"result"`

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -34,7 +34,7 @@ func NewClaudeAdapter(cfg ClaudeConfig) *ClaudeAdapter {
 
 // PreflightOptions declares the readiness checks required before Claude starts.
 func (a *ClaudeAdapter) PreflightOptions(req Request) PreflightOptions {
-	return WorkerPreflightOptions("claude", a.config.BinaryPath, req.Model, a.workDir(req), []string{"api.anthropic.com"})
+	return WorkerPreflightOptions("claude", a.config.BinaryPath, req.Model, a.workDir(req), []string{"api.anthropic.com"}, "./cmd/ok-gobot/")
 }
 
 // claudeResult is the JSON envelope returned by `claude -p --output-format json`.

--- a/internal/worker/codex.go
+++ b/internal/worker/codex.go
@@ -31,7 +31,7 @@ func NewCodexAdapter(cfg CodexConfig) *CodexAdapter {
 
 // PreflightOptions declares the readiness checks required before Codex starts.
 func (a *CodexAdapter) PreflightOptions(req Request) PreflightOptions {
-	return WorkerPreflightOptions("codex", a.config.BinaryPath, req.Model, a.workDir(req), []string{"api.openai.com"})
+	return WorkerPreflightOptions("codex", a.config.BinaryPath, req.Model, a.workDir(req), []string{"api.openai.com"}, "./cmd/ok-gobot/")
 }
 
 func (a *CodexAdapter) buildArgs(req Request) []string {

--- a/internal/worker/codex.go
+++ b/internal/worker/codex.go
@@ -29,6 +29,11 @@ func NewCodexAdapter(cfg CodexConfig) *CodexAdapter {
 	return &CodexAdapter{config: cfg}
 }
 
+// PreflightOptions declares the readiness checks required before Codex starts.
+func (a *CodexAdapter) PreflightOptions(req Request) PreflightOptions {
+	return WorkerPreflightOptions("codex", a.config.BinaryPath, req.Model, a.workDir(req), []string{"api.openai.com"})
+}
+
 func (a *CodexAdapter) buildArgs(req Request) []string {
 	args := []string{"--quiet", "--full-auto"}
 

--- a/internal/worker/droid.go
+++ b/internal/worker/droid.go
@@ -33,6 +33,15 @@ func NewDroidAdapter(cfg DroidConfig) *DroidAdapter {
 	return &DroidAdapter{config: cfg}
 }
 
+// PreflightOptions declares the readiness checks required before Droid starts.
+func (a *DroidAdapter) PreflightOptions(req Request) PreflightOptions {
+	workDir := strings.TrimSpace(req.WorkDir)
+	if workDir == "" {
+		workDir = strings.TrimSpace(a.config.WorkDir)
+	}
+	return WorkerPreflightOptions("droid", a.config.BinaryPath, req.Model, workDir, []string{"api.factory.ai"})
+}
+
 type droidStreamEvent struct {
 	Type    string `json:"type"`
 	Content string `json:"content,omitempty"`

--- a/internal/worker/droid.go
+++ b/internal/worker/droid.go
@@ -39,7 +39,7 @@ func (a *DroidAdapter) PreflightOptions(req Request) PreflightOptions {
 	if workDir == "" {
 		workDir = strings.TrimSpace(a.config.WorkDir)
 	}
-	return WorkerPreflightOptions("droid", a.config.BinaryPath, req.Model, workDir, []string{"api.factory.ai"})
+	return WorkerPreflightOptions("droid", a.config.BinaryPath, req.Model, workDir, []string{"api.factory.ai"}, "./cmd/ok-gobot/")
 }
 
 type droidStreamEvent struct {

--- a/internal/worker/preflight.go
+++ b/internal/worker/preflight.go
@@ -1,0 +1,553 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PreflightStatus is the outcome for one preflight check.
+type PreflightStatus string
+
+const (
+	PreflightPassed  PreflightStatus = "passed"
+	PreflightFailed  PreflightStatus = "failed"
+	PreflightSkipped PreflightStatus = "skipped"
+)
+
+// PreflightCheck is one redacted readiness check result.
+type PreflightCheck struct {
+	Name        string          `json:"name"`
+	Status      PreflightStatus `json:"status"`
+	Detail      string          `json:"detail,omitempty"`
+	Remediation string          `json:"remediation,omitempty"`
+}
+
+// PreflightReport is the session evidence emitted before a worker starts.
+type PreflightReport struct {
+	OK           bool             `json:"ok"`
+	Backend      string           `json:"backend,omitempty"`
+	Model        string           `json:"model,omitempty"`
+	SourceDir    string           `json:"source_dir,omitempty"`
+	WorkDir      string           `json:"work_dir,omitempty"`
+	TestCommands []string         `json:"test_commands,omitempty"`
+	Checks       []PreflightCheck `json:"checks"`
+	StartedAt    time.Time        `json:"started_at"`
+	CompletedAt  time.Time        `json:"completed_at"`
+}
+
+// FailureReasons returns concise, redacted failure details for status events.
+func (r PreflightReport) FailureReasons() []string {
+	reasons := make([]string, 0)
+	for _, check := range r.Checks {
+		if check.Status != PreflightFailed {
+			continue
+		}
+		reason := check.Name
+		if check.Detail != "" {
+			reason += ": " + check.Detail
+		}
+		reasons = append(reasons, RedactSecrets(reason))
+	}
+	return reasons
+}
+
+// Summary returns a short redacted summary suitable for job errors.
+func (r PreflightReport) Summary() string {
+	if r.OK {
+		return "preflight passed"
+	}
+	reasons := r.FailureReasons()
+	if len(reasons) == 0 {
+		return "preflight failed"
+	}
+	if len(reasons) > 3 {
+		reasons = append(reasons[:3], fmt.Sprintf("%d more failure(s)", len(reasons)-3))
+	}
+	return "preflight failed: " + strings.Join(reasons, "; ")
+}
+
+// EvidenceJSON returns the redacted report as formatted JSON.
+func (r PreflightReport) EvidenceJSON() string {
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Sprintf(`{"ok":false,"error":%q}`, RedactSecrets(err.Error()))
+	}
+	return string(b)
+}
+
+// CommandResult captures stdout/stderr without exposing command details directly.
+type CommandResult struct {
+	Stdout string
+	Stderr string
+	Err    error
+}
+
+// CommandRunner runs a command for a preflight probe.
+type CommandRunner func(ctx context.Context, dir, name string, args ...string) CommandResult
+
+// PreflightOptions configures worker readiness checks.
+type PreflightOptions struct {
+	Backend              string
+	Model                string
+	BinaryPath           string
+	SourceDir            string
+	WorkDir              string
+	RequiredTools        []string
+	RequireGitHubAuth    bool
+	RequiredGitHubScopes []string
+	RequiredNetworkHosts []string
+	NetworkDisabled      bool
+	NetworkAllowlist     []string
+	RequireBrowser       bool
+	CommandRunner        CommandRunner
+	LookPath             func(string) (string, error)
+	Now                  func() time.Time
+}
+
+// PreflightPlanner is implemented by adapters that know their backend checks.
+type PreflightPlanner interface {
+	PreflightOptions(req Request) PreflightOptions
+}
+
+// WorkerPreflightOptions returns the mandatory baseline checks for a worker CLI.
+func WorkerPreflightOptions(backend, binaryPath, model, workDir string, networkHosts []string) PreflightOptions {
+	return PreflightOptions{
+		Backend:              backend,
+		Model:                model,
+		BinaryPath:           binaryPath,
+		WorkDir:              workDir,
+		RequiredTools:        []string{"git", "sh"},
+		RequireGitHubAuth:    true,
+		RequiredGitHubScopes: []string{"repo"},
+		RequiredNetworkHosts: append([]string{"github.com", "api.github.com"}, networkHosts...),
+	}
+}
+
+// RunAdapterPreflight runs preflight for adapters that declare requirements.
+func RunAdapterPreflight(ctx context.Context, adapter Adapter, req Request) (PreflightReport, bool) {
+	planner, ok := adapter.(PreflightPlanner)
+	if !ok {
+		return PreflightReport{}, false
+	}
+	return RunPreflight(ctx, planner.PreflightOptions(req)), true
+}
+
+// RunPreflight checks worker readiness without invoking the worker backend.
+func RunPreflight(ctx context.Context, opts PreflightOptions) PreflightReport {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	runner := opts.CommandRunner
+	if runner == nil {
+		runner = defaultCommandRunner
+	}
+	lookPath := opts.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+
+	started := now()
+	workDir := strings.TrimSpace(opts.WorkDir)
+	if workDir == "" {
+		if wd, err := os.Getwd(); err == nil {
+			workDir = wd
+		}
+	}
+	sourceDir := strings.TrimSpace(opts.SourceDir)
+	if sourceDir == "" {
+		sourceDir = workDir
+	}
+	model := strings.TrimSpace(opts.Model)
+	if model == "" {
+		model = "backend default"
+	}
+
+	report := PreflightReport{
+		Backend:   strings.TrimSpace(opts.Backend),
+		Model:     RedactSecrets(model),
+		SourceDir: RedactSecrets(sourceDir),
+		WorkDir:   RedactSecrets(workDir),
+		StartedAt: started,
+	}
+
+	add := func(name string, status PreflightStatus, detail, remediation string) {
+		report.Checks = append(report.Checks, PreflightCheck{
+			Name:        name,
+			Status:      status,
+			Detail:      RedactSecrets(detail),
+			Remediation: RedactSecrets(remediation),
+		})
+	}
+
+	tools := requiredTools(opts, sourceDir)
+	missingTools := map[string]bool{}
+	for _, tool := range tools {
+		if _, err := lookPath(tool); err != nil {
+			missingTools[tool] = true
+			add("tool: "+tool, PreflightFailed, "not found in PATH", fmt.Sprintf("Install %s or configure its binary path before starting the worker.", tool))
+			continue
+		}
+		add("tool: "+tool, PreflightPassed, "available", "")
+	}
+
+	if opts.RequireBrowser {
+		if browser := firstAvailable(lookPath, []string{"google-chrome", "chromium", "chromium-browser", "chrome"}); browser == "" {
+			add("browser tooling", PreflightFailed, "no Chrome/Chromium binary found", "Install Chrome/Chromium or configure browser.chrome_path before running browser tasks.")
+		} else {
+			add("browser tooling", PreflightPassed, browser+" available", "")
+		}
+	}
+
+	checkGitHubAuth(ctx, opts, runner, workDir, missingTools, add)
+	checkWritablePath("source path writable", sourceDir, add)
+	checkWritablePath("worktree path writable", workDir, add)
+	checkGitTrust(ctx, runner, workDir, missingTools, add)
+	checkNetwork(opts, add)
+
+	testCommands := DiscoverTestCommands(sourceDir)
+	report.TestCommands = testCommands
+	if len(testCommands) == 0 {
+		add("repo test command discovery", PreflightSkipped, "no repo-specific test command detected", "")
+	} else {
+		add("repo test command discovery", PreflightPassed, strings.Join(testCommands, "; "), "")
+	}
+
+	report.CompletedAt = now()
+	report.OK = true
+	for _, check := range report.Checks {
+		if check.Status == PreflightFailed {
+			report.OK = false
+			break
+		}
+	}
+	return report
+}
+
+// DiscoverTestCommands returns deterministic repo-specific verification commands.
+func DiscoverTestCommands(repoDir string) []string {
+	var commands []string
+	if fileExists(filepath.Join(repoDir, "go.mod")) {
+		commands = append(commands, "go test ./...", "go vet ./...")
+		if dirExists(filepath.Join(repoDir, "cmd", "ok-gobot")) {
+			commands = append(commands, "go build ./cmd/ok-gobot/")
+		}
+	}
+	if fileExists(filepath.Join(repoDir, "package.json")) {
+		commands = append(commands, "npm test")
+	}
+	if fileExists(filepath.Join(repoDir, "bun.lock")) || fileExists(filepath.Join(repoDir, "bun.lockb")) {
+		commands = append(commands, "bun test")
+	}
+	return commands
+}
+
+var secretRedactors = []struct {
+	re   *regexp.Regexp
+	repl string
+}{
+	{regexp.MustCompile(`(?i)Bearer\s+[^\s'\"]+`), "Bearer [REDACTED]"},
+	{regexp.MustCompile(`(?i)oauth:[A-Za-z0-9._\-]+`), "oauth:[REDACTED]"},
+	{regexp.MustCompile(`(?i)github_pat_[A-Za-z0-9_]+`), "[REDACTED]"},
+	{regexp.MustCompile(`(?i)gh[pousr]_[A-Za-z0-9_]{20,}`), "[REDACTED]"},
+	{regexp.MustCompile(`(?i)sk-[A-Za-z0-9_\-]{20,}`), "[REDACTED]"},
+	{regexp.MustCompile(`(?i)xox[baprs]-[A-Za-z0-9\-]{20,}`), "[REDACTED]"},
+	{regexp.MustCompile(`(?i)((?:api[_-]?key|token|authorization|password|secret)\s*[:=]\s*)[^\s,;]+`), "${1}[REDACTED]"},
+}
+
+// RedactSecrets masks token-shaped values before writing preflight evidence.
+func RedactSecrets(s string) string {
+	out := s
+	for _, redactor := range secretRedactors {
+		out = redactor.re.ReplaceAllString(out, redactor.repl)
+	}
+	return out
+}
+
+func defaultCommandRunner(ctx context.Context, dir, name string, args ...string) CommandResult {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if strings.TrimSpace(dir) != "" {
+		cmd.Dir = dir
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return CommandResult{Stdout: stdout.String(), Stderr: stderr.String(), Err: err}
+}
+
+func requiredTools(opts PreflightOptions, repoDir string) []string {
+	seen := map[string]bool{}
+	var tools []string
+	add := func(tool string) {
+		tool = strings.TrimSpace(tool)
+		if tool == "" || seen[tool] {
+			return
+		}
+		seen[tool] = true
+		tools = append(tools, tool)
+	}
+	add(opts.BinaryPath)
+	for _, tool := range opts.RequiredTools {
+		add(tool)
+	}
+	if opts.RequireGitHubAuth {
+		add("gh")
+	}
+	if fileExists(filepath.Join(repoDir, "go.mod")) {
+		add("go")
+	}
+	if fileExists(filepath.Join(repoDir, "package.json")) {
+		add("node")
+	}
+	if fileExists(filepath.Join(repoDir, "bun.lock")) || fileExists(filepath.Join(repoDir, "bun.lockb")) {
+		add("bun")
+	}
+	sort.Strings(tools)
+	return tools
+}
+
+func checkGitHubAuth(ctx context.Context, opts PreflightOptions, runner CommandRunner, workDir string, missingTools map[string]bool, add func(string, PreflightStatus, string, string)) {
+	if !opts.RequireGitHubAuth {
+		add("github auth", PreflightSkipped, "not required", "")
+		return
+	}
+	if missingTools["gh"] {
+		add("github auth", PreflightFailed, "gh CLI is not available", "Install gh and run gh auth login with PR/check/review permissions.")
+		return
+	}
+
+	res := runner(ctx, workDir, "gh", "auth", "status", "-h", "github.com")
+	combined := strings.TrimSpace(res.Stdout + "\n" + res.Stderr)
+	if res.Err != nil {
+		detail := strings.TrimSpace(combined)
+		if detail == "" {
+			detail = res.Err.Error()
+		}
+		add("github auth", PreflightFailed, detail, "Run gh auth login and ensure the token can create PRs, checks, and reviews.")
+		return
+	}
+
+	scopes, foundScopes := parseGitHubScopes(combined)
+	missingScopes := missingGitHubScopes(scopes, opts.RequiredGitHubScopes)
+	if foundScopes && len(missingScopes) > 0 {
+		add("github auth", PreflightFailed, "missing required scope(s): "+strings.Join(missingScopes, ", "), "Refresh gh auth with the required GitHub scopes.")
+		return
+	}
+	if foundScopes {
+		add("github auth", PreflightPassed, "authenticated with required scopes", "")
+		return
+	}
+	add("github auth", PreflightPassed, "authenticated; scope header unavailable", "")
+}
+
+func checkWritablePath(name, path string, add func(string, PreflightStatus, string, string)) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		add(name, PreflightFailed, "path is empty", "Configure a valid source/worktree path before starting the worker.")
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		add(name, PreflightFailed, err.Error(), "Create the path or fix permissions before starting the worker.")
+		return
+	}
+	if !info.IsDir() {
+		add(name, PreflightFailed, "path is not a directory", "Configure a directory path before starting the worker.")
+		return
+	}
+	if info.Mode().Perm()&0o222 == 0 {
+		add(name, PreflightFailed, "directory has no write permission bits", "Make the directory writable before starting the worker.")
+		return
+	}
+	tmp, err := os.CreateTemp(path, ".ok-gobot-preflight-*")
+	if err != nil {
+		add(name, PreflightFailed, err.Error(), "Make the directory writable before starting the worker.")
+		return
+	}
+	tmpName := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		add(name, PreflightFailed, err.Error(), "Fix filesystem permissions before starting the worker.")
+		return
+	}
+	_ = os.Remove(tmpName)
+	add(name, PreflightPassed, "writable", "")
+}
+
+func checkGitTrust(ctx context.Context, runner CommandRunner, workDir string, missingTools map[string]bool, add func(string, PreflightStatus, string, string)) {
+	if missingTools["git"] {
+		add("git trust", PreflightFailed, "git is not available", "Install git before starting the worker.")
+		return
+	}
+	root := runner(ctx, workDir, "git", "-C", workDir, "rev-parse", "--show-toplevel")
+	if root.Err != nil {
+		addGitFailure("git trust", root, add)
+		return
+	}
+	status := runner(ctx, workDir, "git", "-C", workDir, "status", "--short")
+	if status.Err != nil {
+		addGitFailure("git trust", status, add)
+		return
+	}
+	add("git trust", PreflightPassed, "git status succeeded", "")
+}
+
+func addGitFailure(name string, result CommandResult, add func(string, PreflightStatus, string, string)) {
+	detail := strings.TrimSpace(result.Stdout + "\n" + result.Stderr)
+	if detail == "" && result.Err != nil {
+		detail = result.Err.Error()
+	}
+	remediation := "Fix the repository or git configuration before starting the worker."
+	if strings.Contains(strings.ToLower(detail), "safe.directory") || strings.Contains(strings.ToLower(detail), "dubious ownership") {
+		remediation = "Add the repository to git safe.directory after verifying ownership."
+	}
+	add(name, PreflightFailed, detail, remediation)
+}
+
+func checkNetwork(opts PreflightOptions, add func(string, PreflightStatus, string, string)) {
+	if opts.NetworkDisabled {
+		add("network allowlist", PreflightFailed, "network operations are disabled", "Enable network access for GitHub and model backend operations.")
+		return
+	}
+	requiredHosts := uniqueStrings(opts.RequiredNetworkHosts)
+	allowlist := uniqueStrings(opts.NetworkAllowlist)
+	if len(requiredHosts) == 0 {
+		add("network allowlist", PreflightSkipped, "no required hosts configured", "")
+		return
+	}
+	if len(allowlist) == 0 {
+		add("network allowlist", PreflightPassed, "all public hosts allowed", "")
+		return
+	}
+	var blocked []string
+	for _, host := range requiredHosts {
+		if !hostMatchesAllowlist(host, allowlist) {
+			blocked = append(blocked, host)
+		}
+	}
+	if len(blocked) > 0 {
+		add("network allowlist", PreflightFailed, "missing host(s): "+strings.Join(blocked, ", "), "Add the required GitHub/backend hosts to network_allowlist.")
+		return
+	}
+	add("network allowlist", PreflightPassed, "required hosts allowed", "")
+}
+
+func parseGitHubScopes(output string) ([]string, bool) {
+	var scopes []string
+	for _, line := range strings.Split(output, "\n") {
+		lower := strings.ToLower(line)
+		if !strings.Contains(lower, "token scopes") && !strings.Contains(lower, "x-oauth-scopes") {
+			continue
+		}
+		idx := strings.Index(line, ":")
+		if idx < 0 {
+			continue
+		}
+		raw := strings.NewReplacer("'", " ", "\"", " ", ",", " ").Replace(line[idx+1:])
+		for _, field := range strings.Fields(raw) {
+			field = strings.TrimSpace(field)
+			if field != "" {
+				scopes = append(scopes, field)
+			}
+		}
+		return uniqueStrings(scopes), true
+	}
+	return nil, false
+}
+
+func missingGitHubScopes(scopes, required []string) []string {
+	if len(required) == 0 {
+		required = []string{"repo"}
+	}
+	var missing []string
+	for _, req := range required {
+		req = strings.TrimSpace(req)
+		if req == "" {
+			continue
+		}
+		if !hasGitHubScope(scopes, req) {
+			missing = append(missing, req)
+		}
+	}
+	return missing
+}
+
+func hasGitHubScope(scopes []string, required string) bool {
+	for _, scope := range scopes {
+		if scope == required {
+			return true
+		}
+		if required == "repo" && scope == "public_repo" {
+			return true
+		}
+	}
+	return false
+}
+
+func firstAvailable(lookPath func(string) (string, error), names []string) string {
+	for _, name := range names {
+		if _, err := lookPath(name); err == nil {
+			return name
+		}
+	}
+	return ""
+}
+
+func uniqueStrings(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		s = strings.TrimSpace(strings.ToLower(s))
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func hostMatchesAllowlist(host string, allowlist []string) bool {
+	host = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	for _, pattern := range allowlist {
+		pattern = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(pattern), "."))
+		if pattern == "" {
+			continue
+		}
+		if strings.HasPrefix(pattern, "*.") {
+			suffix := strings.TrimPrefix(pattern, "*.")
+			if strings.HasSuffix(host, "."+suffix) {
+				return true
+			}
+			continue
+		}
+		if host == pattern {
+			return true
+		}
+	}
+	return false
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/worker/preflight.go
+++ b/internal/worker/preflight.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -105,6 +106,7 @@ type PreflightOptions struct {
 	RequireGitHubAuth    bool
 	RequiredGitHubScopes []string
 	RequiredNetworkHosts []string
+	GoBuildTargets       []string
 	NetworkDisabled      bool
 	NetworkAllowlist     []string
 	RequireBrowser       bool
@@ -119,7 +121,7 @@ type PreflightPlanner interface {
 }
 
 // WorkerPreflightOptions returns the mandatory baseline checks for a worker CLI.
-func WorkerPreflightOptions(backend, binaryPath, model, workDir string, networkHosts []string) PreflightOptions {
+func WorkerPreflightOptions(backend, binaryPath, model, workDir string, networkHosts []string, goBuildTargets ...string) PreflightOptions {
 	return PreflightOptions{
 		Backend:              backend,
 		Model:                model,
@@ -129,6 +131,7 @@ func WorkerPreflightOptions(backend, binaryPath, model, workDir string, networkH
 		RequireGitHubAuth:    true,
 		RequiredGitHubScopes: []string{"repo"},
 		RequiredNetworkHosts: append([]string{"github.com", "api.github.com"}, networkHosts...),
+		GoBuildTargets:       append([]string(nil), goBuildTargets...),
 	}
 }
 
@@ -217,7 +220,10 @@ func RunPreflight(ctx context.Context, opts PreflightOptions) PreflightReport {
 	checkGitTrust(ctx, runner, workDir, missingTools, add)
 	checkNetwork(opts, add)
 
-	testCommands := DiscoverTestCommands(sourceDir)
+	testCommands := DiscoverTestCommands(sourceDir, opts.GoBuildTargets...)
+	for i, command := range testCommands {
+		testCommands[i] = RedactSecrets(command)
+	}
 	report.TestCommands = testCommands
 	if len(testCommands) == 0 {
 		add("repo test command discovery", PreflightSkipped, "no repo-specific test command detected", "")
@@ -237,12 +243,15 @@ func RunPreflight(ctx context.Context, opts PreflightOptions) PreflightReport {
 }
 
 // DiscoverTestCommands returns deterministic repo-specific verification commands.
-func DiscoverTestCommands(repoDir string) []string {
+func DiscoverTestCommands(repoDir string, goBuildTargets ...string) []string {
 	var commands []string
 	if fileExists(filepath.Join(repoDir, "go.mod")) {
 		commands = append(commands, "go test ./...", "go vet ./...")
-		if dirExists(filepath.Join(repoDir, "cmd", "ok-gobot")) {
-			commands = append(commands, "go build ./cmd/ok-gobot/")
+		for _, target := range goBuildTargets {
+			target = strings.TrimSpace(target)
+			if target != "" {
+				commands = append(commands, "go build "+target)
+			}
 		}
 	}
 	if fileExists(filepath.Join(repoDir, "package.json")) {
@@ -379,12 +388,33 @@ func checkWritablePath(name, path string, add func(string, PreflightStatus, stri
 	}
 	tmpName := tmp.Name()
 	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName)
-		add(name, PreflightFailed, err.Error(), "Fix filesystem permissions before starting the worker.")
+		detail := filesystemErrorDetail(err)
+		if cleanupDetail := cleanupPreflightTemp(tmpName); cleanupDetail != "" {
+			detail += "; " + cleanupDetail
+		}
+		add(name, PreflightFailed, detail, "Fix filesystem permissions before starting the worker.")
 		return
 	}
-	_ = os.Remove(tmpName)
-	add(name, PreflightPassed, "writable", "")
+	detail := "writable"
+	if cleanupDetail := cleanupPreflightTemp(tmpName); cleanupDetail != "" {
+		detail += "; " + cleanupDetail
+	}
+	add(name, PreflightPassed, detail, "")
+}
+
+func cleanupPreflightTemp(path string) string {
+	if err := os.Remove(path); err != nil {
+		return "cleanup failed for preflight temp file: " + filesystemErrorDetail(err)
+	}
+	return ""
+}
+
+func filesystemErrorDetail(err error) string {
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) && pathErr.Err != nil {
+		return pathErr.Op + ": " + pathErr.Err.Error()
+	}
+	return err.Error()
 }
 
 func checkGitTrust(ctx context.Context, runner CommandRunner, workDir string, missingTools map[string]bool, add func(string, PreflightStatus, string, string)) {
@@ -545,9 +575,4 @@ func hostMatchesAllowlist(host string, allowlist []string) bool {
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
-}
-
-func dirExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.IsDir()
 }

--- a/internal/worker/preflight_test.go
+++ b/internal/worker/preflight_test.go
@@ -21,8 +21,25 @@ func TestRunPreflightPass(t *testing.T) {
 	if !containsString(report.TestCommands, "go test ./...") {
 		t.Fatalf("test commands = %v, want go test ./...", report.TestCommands)
 	}
+	if !containsString(report.TestCommands, "go build ./cmd/ok-gobot/") {
+		t.Fatalf("test commands = %v, want go build ./cmd/ok-gobot/", report.TestCommands)
+	}
 	if !hasCheck(report, "github auth", PreflightPassed) {
 		t.Fatalf("expected github auth to pass: %+v", report.Checks)
+	}
+}
+
+func TestDiscoverTestCommandsRequiresConfiguredBuildTargets(t *testing.T) {
+	repo := newPreflightRepo(t)
+
+	commands := DiscoverTestCommands(repo)
+	if containsString(commands, "go build ./cmd/ok-gobot/") {
+		t.Fatalf("unexpected ok-gobot build command without configured target: %v", commands)
+	}
+
+	commands = DiscoverTestCommands(repo, "./cmd/ok-gobot/")
+	if !containsString(commands, "go build ./cmd/ok-gobot/") {
+		t.Fatalf("test commands = %v, want configured go build target", commands)
 	}
 }
 
@@ -99,6 +116,17 @@ func TestRedactSecrets(t *testing.T) {
 	}
 }
 
+func TestCleanupPreflightTempReportsRemoveFailure(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing")
+	detail := cleanupPreflightTemp(missingPath)
+	if detail == "" {
+		t.Fatalf("expected cleanup failure detail")
+	}
+	if strings.Contains(detail, filepath.Dir(missingPath)) {
+		t.Fatalf("cleanup detail exposed local path: %q", detail)
+	}
+}
+
 func newPreflightRepo(t *testing.T) string {
 	t.Helper()
 	repo := t.TempDir()
@@ -112,7 +140,7 @@ func newPreflightRepo(t *testing.T) string {
 }
 
 func passingPreflightOptions(repo string) PreflightOptions {
-	opts := WorkerPreflightOptions("claude", "claude", "claude-sonnet-test", repo, []string{"api.anthropic.com"})
+	opts := WorkerPreflightOptions("claude", "claude", "claude-sonnet-test", repo, []string{"api.anthropic.com"}, "./cmd/ok-gobot/")
 	opts.SourceDir = repo
 	opts.NetworkAllowlist = []string{"github.com", "api.github.com", "api.anthropic.com"}
 	opts.LookPath = func(name string) (string, error) {

--- a/internal/worker/preflight_test.go
+++ b/internal/worker/preflight_test.go
@@ -1,0 +1,157 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunPreflightPass(t *testing.T) {
+	repo := newPreflightRepo(t)
+	opts := passingPreflightOptions(repo)
+
+	report := RunPreflight(context.Background(), opts)
+	if !report.OK {
+		t.Fatalf("preflight failed: %s", report.Summary())
+	}
+	if !containsString(report.TestCommands, "go test ./...") {
+		t.Fatalf("test commands = %v, want go test ./...", report.TestCommands)
+	}
+	if !hasCheck(report, "github auth", PreflightPassed) {
+		t.Fatalf("expected github auth to pass: %+v", report.Checks)
+	}
+}
+
+func TestRunPreflightMissingTool(t *testing.T) {
+	repo := newPreflightRepo(t)
+	opts := passingPreflightOptions(repo)
+	opts.LookPath = func(name string) (string, error) {
+		if name == "go" {
+			return "", errors.New("missing go")
+		}
+		return "/usr/bin/" + filepath.Base(name), nil
+	}
+
+	report := RunPreflight(context.Background(), opts)
+	if report.OK {
+		t.Fatalf("preflight unexpectedly passed")
+	}
+	if !hasCheck(report, "tool: go", PreflightFailed) {
+		t.Fatalf("expected missing go failure: %+v", report.Checks)
+	}
+}
+
+func TestRunPreflightMissingAuth(t *testing.T) {
+	repo := newPreflightRepo(t)
+	secret := "ghp_abcdefghijklmnopqrstuvwxyz123456"
+	opts := passingPreflightOptions(repo)
+	opts.CommandRunner = func(_ context.Context, _ string, name string, args ...string) CommandResult {
+		if name == "gh" {
+			return CommandResult{Stderr: "not logged in token=" + secret, Err: errors.New("exit status 1")}
+		}
+		return passingCommandResult(repo, name, args...)
+	}
+
+	report := RunPreflight(context.Background(), opts)
+	if report.OK {
+		t.Fatalf("preflight unexpectedly passed")
+	}
+	if !hasCheck(report, "github auth", PreflightFailed) {
+		t.Fatalf("expected github auth failure: %+v", report.Checks)
+	}
+	if strings.Contains(report.Summary(), secret) || strings.Contains(report.EvidenceJSON(), secret) {
+		t.Fatalf("preflight output leaked secret: %s", report.EvidenceJSON())
+	}
+}
+
+func TestRunPreflightNonWritableWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod write-bit test is POSIX-specific")
+	}
+	repo := newPreflightRepo(t)
+	if err := os.Chmod(repo, 0o555); err != nil {
+		t.Fatalf("chmod repo read-only: %v", err)
+	}
+	defer os.Chmod(repo, 0o755) //nolint:errcheck
+
+	report := RunPreflight(context.Background(), passingPreflightOptions(repo))
+	if report.OK {
+		t.Fatalf("preflight unexpectedly passed")
+	}
+	if !hasCheck(report, "worktree path writable", PreflightFailed) {
+		t.Fatalf("expected worktree writable failure: %+v", report.Checks)
+	}
+}
+
+func TestRedactSecrets(t *testing.T) {
+	secret := "github_pat_abcdefghijklmnopqrstuvwxyz1234567890"
+	input := "Authorization: Bearer sk-abcdefghijklmnopqrstuvwxyz123456 token=" + secret
+	redacted := RedactSecrets(input)
+	if strings.Contains(redacted, secret) || strings.Contains(redacted, "sk-abcdefghijklmnopqrstuvwxyz123456") {
+		t.Fatalf("redaction leaked secret: %q", redacted)
+	}
+	if !strings.Contains(redacted, "[REDACTED]") {
+		t.Fatalf("redaction should include marker, got %q", redacted)
+	}
+}
+
+func newPreflightRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module example.com/preflight\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "cmd", "ok-gobot"), 0o755); err != nil {
+		t.Fatalf("mkdir cmd/ok-gobot: %v", err)
+	}
+	return repo
+}
+
+func passingPreflightOptions(repo string) PreflightOptions {
+	opts := WorkerPreflightOptions("claude", "claude", "claude-sonnet-test", repo, []string{"api.anthropic.com"})
+	opts.SourceDir = repo
+	opts.NetworkAllowlist = []string{"github.com", "api.github.com", "api.anthropic.com"}
+	opts.LookPath = func(name string) (string, error) {
+		return "/usr/bin/" + filepath.Base(name), nil
+	}
+	opts.CommandRunner = func(_ context.Context, _ string, name string, args ...string) CommandResult {
+		return passingCommandResult(repo, name, args...)
+	}
+	return opts
+}
+
+func passingCommandResult(repo, name string, args ...string) CommandResult {
+	switch name {
+	case "gh":
+		return CommandResult{Stdout: "Logged in to github.com\nToken scopes: 'repo', 'read:org'\n"}
+	case "git":
+		if len(args) > 0 && args[len(args)-1] == "--show-toplevel" {
+			return CommandResult{Stdout: repo + "\n"}
+		}
+		return CommandResult{}
+	default:
+		return CommandResult{}
+	}
+}
+
+func hasCheck(report PreflightReport, name string, status PreflightStatus) bool {
+	for _, check := range report.Checks {
+		if check.Name == name && check.Status == status {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Implements #354

## Changes
- Adds a mandatory preflight gate for Claude, Codex, and Droid workers before adapter execution.
- Checks GitHub auth/scopes, backend/toolchain availability, writable source/worktree paths, git trust, network allowlist coverage, and repo test command discovery.
- Persists redacted preflight evidence as a job artifact, records `preflight_failed` status/events, and keeps preflight retries from consuming another attempt.
- Surfaces preflight refusal reasons through Mission Control job status/error data.

## Testing
- `.maestro/verify.sh`
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a mandatory preflight gate for Claude, Codex, and Droid workers that checks GitHub auth/scopes, tool availability, filesystem writability, git trust, network allowlist coverage, and test command discovery before any adapter execution. The implementation is well-structured: evidence is always persisted as a job artifact, `preflight_failed` is a dedicated job status that bypasses the attempt counter on retry, and secret redaction is applied consistently throughout the report.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no new logic defects found beyond the previously flagged double-prefix in the batch error message.

All P0/P1 findings were raised in prior review rounds and are either addressed or already tracked. The retry logic, error classification, artifact persistence, and secret redaction are all implemented correctly. Test coverage is solid with injectable dependencies.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/worker/preflight.go | New preflight gate implementation: readiness checks for tools, GitHub auth, writable paths, git trust, network allowlist, and test command discovery. Core logic is sound; previous review comments addressed the hardcoded build target and temp-file cleanup. |
| internal/worker/bridge.go | Wires preflight into the runtime JobRunner: persists evidence artifact unconditionally, returns PreflightFailure on gate rejection, appends progress event on pass. Logic is correct. |
| internal/runtime/jobs.go | Adds JobStatusPreflightFailed and PreflightFailure error type; RetryDetached correctly keeps attempt count unchanged for preflight retries so they don't consume an attempt slot. |
| internal/batch/runner.go | Preflight gate added to runSubtask before adapter execution; existing worktree is retained in res.WorkDir so CleanWorktrees will still remove it on preflight failure. Double "failed" prefix in error message was flagged in a previous review. |
| internal/worker/preflight_test.go | Good coverage: pass, missing tool, auth failure with secret-redaction assertion, non-writable worktree, and temp-file cleanup reporting. Tests use injectable CommandRunner and LookPath to avoid real system calls. |
| internal/worker/claude.go | Implements PreflightPlanner; delegates to WorkerPreflightOptions with Anthropic network host and configurable build target. |
| internal/worker/codex.go | Implements PreflightPlanner; delegates to WorkerPreflightOptions with OpenAI network host and configurable build target. |
| internal/worker/droid.go | Implements PreflightPlanner; delegates to WorkerPreflightOptions with factory.ai network host and configurable build target. |
| internal/storage/sqlite.go | Adds MarkJobPreflightFailed migration and DB method; schema change is additive and backward-compatible. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/batch/runner.go`, line 45-47 ([link](https://github.com/befeast/ok-gobot/blob/f8e98ad69b1a90ae2beeb8459fc40477c0f2ae30/internal/batch/runner.go#L45-L47)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Double-nested "failed" prefix in batch error message**

   `report.Summary()` already returns a string beginning with `"preflight failed: ..."`. Wrapping it again as `"worker preflight failed: %s"` produces messages like `"worker preflight failed: preflight failed: github auth: not authenticated"`. Consider using `report.Summary()` directly, or changing the wrapper to something like `"preflight gate: %s"` to avoid the redundancy.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/batch/runner.go
   Line: 45-47

   Comment:
   **Double-nested "failed" prefix in batch error message**

   `report.Summary()` already returns a string beginning with `"preflight failed: ..."`. Wrapping it again as `"worker preflight failed: %s"` produces messages like `"worker preflight failed: preflight failed: github auth: not authenticated"`. Consider using `report.Summary()` directly, or changing the wrapper to something like `"preflight gate: %s"` to avoid the redundancy.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: address worker preflight review fee..."](https://github.com/befeast/ok-gobot/commit/41ff0d0c8015a7c2790f9157c69cafd07288086b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30453344)</sub>

<!-- /greptile_comment -->