### PR TITLE
feat: add supervisor recovery decisions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -378,6 +378,17 @@ Get the active AI provider and model.
 }
 ```
 
+### GET /api/mission/supervisor
+
+Get the latest supervisor stuck-state decision and last safe recovery action.
+
+**Requires authentication**
+
+The response includes `current_decision` with the state, target, blocker reason,
+safe actions, and any approval-only action that still requires an operator.
+`last_safe_action` records the latest idempotent safe action applied by the
+supervisor.
+
 ## Event and Artifact Retention
 
 Job records, events, and artifacts are stored in SQLite and retained indefinitely by default.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Daemon management (launchd on macOS, systemd on Linux)
 - Doctor diagnostic command checking config and dependencies
 - Typing indicators during AI processing
+- Supervisor recovery decision ledger with Mission Control exposure for stuck workers and PR states
 
 #### Packages
 - `internal/api/` — HTTP API server and middleware

--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -30,6 +30,7 @@ api:
 | `/api/mission/providers` | GET | Active AI provider and model |
 | `/api/mission/memory` | GET | Memory health: enabled state, backend, watcher, counts, freshness, and last error |
 | `/api/mission/evidence?session_key=...` | GET | Concise structured evidence timeline for a session, including Markdown rendering |
+| `/api/mission/supervisor` | GET | Current supervisor decision and the last idempotent safe action |
 
 Job detail responses from `/api/jobs/{id}` include proof artifacts with `type`,
 `label`, `path` or `url`, `created_at`, and `display` metadata. Mission Control
@@ -53,6 +54,7 @@ Run query parameters: `limit` (1-200), `status` (filter by run status). Stats qu
 - **Stats** -- aggregate token usage and message counts
 - **Controls** -- emergency-stop state and active provider/model
 - **Memory** -- whether the memory index is enabled, fresh, watched, and error-free
+- **Supervisor** -- current stuck-state decision, blocker reason, required approval action, and last safe recovery action
 
 ## Architecture
 
@@ -79,7 +81,7 @@ Mission Control is a read-only API layer over existing runtime data. It does not
 
 ## Safety Notes
 
-Mission Control artifact browsing is read-only. It does not modify roles, start jobs, or change configuration.
+Mission Control artifact browsing is read-only. Supervisor state is exposed as a decision ledger: safe recovery actions are idempotent and approval-only actions such as merging PRs, closing issues, deleting worktrees, or changing global configuration are never performed without explicit approval.
 
 ### Maestro Intake Status
 

--- a/internal/api/mission.go
+++ b/internal/api/mission.go
@@ -372,3 +372,28 @@ func (s *APIServer) handleMissionStats(w http.ResponseWriter, r *http.Request) {
 		"session_count":  totals.SessionCount,
 	})
 }
+
+// handleMissionSupervisor returns the latest supervisor decision and safe action.
+func (s *APIServer) handleMissionSupervisor(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.bot == nil {
+		writeJSONError(w, "Bot not available", http.StatusInternalServerError)
+		return
+	}
+
+	store := s.bot.GetStore()
+	if store == nil {
+		writeJSONError(w, "Store not available", http.StatusInternalServerError)
+		return
+	}
+
+	status, err := store.GetSupervisorStatus()
+	if err != nil {
+		writeJSONError(w, "Failed to read supervisor status: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, status)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -87,6 +87,7 @@ func (s *APIServer) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/mission/providers", s.handleMissionProviders)
 	mux.HandleFunc("/api/mission/memory", s.handleMissionMemory)
 	mux.HandleFunc("/api/mission/evidence", s.handleMissionEvidence)
+	mux.HandleFunc("/api/mission/supervisor", s.handleMissionSupervisor)
 
 	// Apply middleware
 	handler := loggingMiddleware(mux)

--- a/internal/control/mission.go
+++ b/internal/control/mission.go
@@ -41,6 +41,7 @@ func (s *Server) registerMissionRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/mission/providers", s.corsWrap(missionProviders(s)))
 	mux.HandleFunc("/api/mission/memory", s.corsWrap(missionMemory(mp)))
 	mux.HandleFunc("/api/mission/evidence", s.corsWrap(missionEvidence(mp)))
+	mux.HandleFunc("/api/mission/supervisor", s.corsWrap(missionSupervisor(mp)))
 	mux.HandleFunc("/api/mission/artifacts/", s.corsWrap(missionArtifactContent(mp, s.artifactRoots)))
 }
 
@@ -442,5 +443,25 @@ func missionEvidence(mp MissionProvider) http.HandlerFunc {
 			"events":      events,
 			"markdown":    evidence.RenderMarkdown(events, evidence.RenderOptions{Limit: limit}),
 		})
+	}
+}
+
+func missionSupervisor(mp MissionProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeJSONErr(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		store := mp.GetStore()
+		if store == nil {
+			writeJSONErr(w, "store unavailable", http.StatusInternalServerError)
+			return
+		}
+		status, err := store.GetSupervisorStatus()
+		if err != nil {
+			writeJSONErr(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, status)
 	}
 }

--- a/internal/control/mission_supervisor_test.go
+++ b/internal/control/mission_supervisor_test.go
@@ -1,0 +1,91 @@
+package control_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/control"
+	"ok-gobot/internal/memory"
+	"ok-gobot/internal/storage"
+	"ok-gobot/internal/supervisor"
+	"ok-gobot/internal/tools"
+)
+
+type missionSupervisorState struct {
+	*mockTUIState
+	store *storage.Store
+}
+
+func (m *missionSupervisorState) GetStore() *storage.Store { return m.store }
+
+func (m *missionSupervisorState) GetAgentRegistry() *agent.AgentRegistry { return nil }
+
+func (m *missionSupervisorState) GetScheduler() tools.CronScheduler { return nil }
+
+func (m *missionSupervisorState) GetMemoryStatus(context.Context) (memory.IndexStatus, error) {
+	return memory.IndexStatus{}, nil
+}
+
+func TestMissionSupervisorEndpointExposesDecisionAndLastAction(t *testing.T) {
+	store, err := storage.New(filepath.Join(t.TempDir(), "mission-supervisor.db"))
+	if err != nil {
+		t.Fatalf("storage.New: %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	status := supervisor.Status{
+		CurrentDecision: &supervisor.Decision{
+			State:      supervisor.StateWaitingMergeApproval,
+			TargetKind: "pr",
+			TargetID:   "356",
+			Reason:     "checks are green and merge approval is required",
+		},
+		LastSafeAction: &supervisor.ActionRecord{
+			DecisionState: supervisor.StateWaitingMergeApproval,
+			Action: supervisor.Action{
+				Type:       supervisor.ActionLabelIssueReady,
+				TargetKind: "issue",
+				TargetID:   "356",
+				Label:      "ready",
+				Reason:     "PR is green and waiting for merge approval",
+			},
+			AppliedAt: "2026-05-01T12:00:00Z",
+		},
+	}
+	if err := store.SetSupervisorStatus(status); err != nil {
+		t.Fatalf("SetSupervisorStatus: %v", err)
+	}
+
+	state := &missionSupervisorState{mockTUIState: &mockTUIState{}, store: store}
+	_, addr, cancel := startServerWithStore(t, state, store)
+	defer cancel()
+
+	resp, err := http.Get("http://" + addr + "/api/mission/supervisor")
+	if err != nil {
+		t.Fatalf("GET supervisor status: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status code = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var got supervisor.Status
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.CurrentDecision == nil || got.CurrentDecision.State != supervisor.StateWaitingMergeApproval {
+		t.Fatalf("current decision = %+v, want waiting merge approval", got.CurrentDecision)
+	}
+	if got.LastSafeAction == nil || got.LastSafeAction.Action.Type != supervisor.ActionLabelIssueReady {
+		t.Fatalf("last safe action = %+v, want label issue ready", got.LastSafeAction)
+	}
+	if got.LastSafeAction.Action.Label != "ready" {
+		t.Fatalf("last safe action label = %q, want ready", got.LastSafeAction.Action.Label)
+	}
+
+	var _ control.MissionProvider = state
+}

--- a/internal/storage/supervisor.go
+++ b/internal/storage/supervisor.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"ok-gobot/internal/supervisor"
+)
+
+const supervisorStatusStateKey = "supervisor_status"
+
+// GetSupervisorStatus returns the latest supervisor decision snapshot.
+// Missing state is treated as clear so Mission Control can render a stable shape.
+func (s *Store) GetSupervisorStatus() (supervisor.Status, error) {
+	var raw string
+	err := s.db.QueryRow(`SELECT value FROM app_state WHERE key = ?`, supervisorStatusStateKey).Scan(&raw)
+	if err == sql.ErrNoRows {
+		clear := supervisor.Decision{State: supervisor.StateClear, Reason: "supervisor has not run yet"}
+		return supervisor.Status{CurrentDecision: &clear}, nil
+	}
+	if err != nil {
+		return supervisor.Status{}, err
+	}
+	if strings.TrimSpace(raw) == "" {
+		clear := supervisor.Decision{State: supervisor.StateClear, Reason: "supervisor has not run yet"}
+		return supervisor.Status{CurrentDecision: &clear}, nil
+	}
+
+	var status supervisor.Status
+	if err := json.Unmarshal([]byte(raw), &status); err != nil {
+		return supervisor.Status{}, fmt.Errorf("decode supervisor status: %w", err)
+	}
+	return status, nil
+}
+
+// SetSupervisorStatus persists the latest supervisor decision and action ledger.
+func (s *Store) SetSupervisorStatus(status supervisor.Status) error {
+	data, err := json.Marshal(status)
+	if err != nil {
+		return fmt.Errorf("encode supervisor status: %w", err)
+	}
+	_, err = s.db.Exec(`
+		INSERT INTO app_state (key, value, updated_at)
+		VALUES (?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(key) DO UPDATE SET
+			value = excluded.value,
+			updated_at = CURRENT_TIMESTAMP
+	`, supervisorStatusStateKey, string(data))
+	return err
+}

--- a/internal/storage/supervisor_test.go
+++ b/internal/storage/supervisor_test.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"ok-gobot/internal/supervisor"
+)
+
+func TestSupervisorStatusPersistsAcrossReopen(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "supervisor.db")
+	store, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	status := supervisor.Status{
+		CurrentDecision: &supervisor.Decision{
+			State:      supervisor.StatePRChecksFailing,
+			TargetKind: "pr",
+			TargetID:   "356",
+			Reason:     "CI checks are failing",
+		},
+		LastSafeAction: &supervisor.ActionRecord{
+			DecisionState: supervisor.StatePRChecksFailing,
+			Action: supervisor.Action{
+				Type:       supervisor.ActionCommentBlocker,
+				TargetKind: "pr",
+				TargetID:   "356",
+				Reason:     "CI checks are failing",
+			},
+			AppliedAt: "2026-05-01T12:00:00Z",
+		},
+		TransitionKeys: map[string]string{"pr:356": "pr:356:pr_checks_failing"},
+		AppliedActions: map[string]string{"pr:356:pr_checks_failing:comment_blocker:pr:356:": "2026-05-01T12:00:00Z"},
+	}
+	if err := store.SetSupervisorStatus(status); err != nil {
+		t.Fatalf("SetSupervisorStatus() failed: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+
+	reopened, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New() reopen failed: %v", err)
+	}
+	defer reopened.Close() //nolint:errcheck
+
+	got, err := reopened.GetSupervisorStatus()
+	if err != nil {
+		t.Fatalf("GetSupervisorStatus() failed: %v", err)
+	}
+	if got.CurrentDecision == nil || got.CurrentDecision.State != supervisor.StatePRChecksFailing {
+		t.Fatalf("current decision = %+v, want PR checks failing", got.CurrentDecision)
+	}
+	if got.LastSafeAction == nil || got.LastSafeAction.Action.Type != supervisor.ActionCommentBlocker {
+		t.Fatalf("last safe action = %+v, want comment blocker", got.LastSafeAction)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1,0 +1,650 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const DefaultStaleWorkerAfter = 15 * time.Minute
+
+type StuckState string
+
+const (
+	StateClear                StuckState = "clear"
+	StateWorkerNoLogProgress  StuckState = "worker_no_log_progress"
+	StateDeadWorkerNoPR       StuckState = "dead_worker_no_pr"
+	StatePRChecksFailing      StuckState = "pr_checks_failing"
+	StatePRReviewFeedback     StuckState = "pr_review_feedback"
+	StatePRMergeBlocked       StuckState = "pr_merge_blocked"
+	StateRetryExhaustedOpenPR StuckState = "retry_exhausted_open_pr"
+	StateWaitingMergeApproval StuckState = "waiting_merge_approval"
+)
+
+type ActionType string
+
+const (
+	ActionRefreshPRMetadata  ActionType = "refresh_pr_metadata"
+	ActionCreateMissingPR    ActionType = "create_missing_pr"
+	ActionCommentBlocker     ActionType = "comment_blocker"
+	ActionRetryWorker        ActionType = "retry_worker"
+	ActionLabelIssueBlocked  ActionType = "label_issue_blocked"
+	ActionLabelIssueReady    ActionType = "label_issue_ready"
+	ActionUpdateMissionBlock ActionType = "update_mission_reason"
+)
+
+type ApprovalAction string
+
+const (
+	ApprovalNone         ApprovalAction = ""
+	ApprovalMergePR      ApprovalAction = "merge_pr"
+	ApprovalCloseIssue   ApprovalAction = "close_issue"
+	ApprovalDeleteTree   ApprovalAction = "delete_worktree"
+	ApprovalChangeConfig ApprovalAction = "change_global_config"
+)
+
+type CheckState string
+
+const (
+	CheckUnknown CheckState = "unknown"
+	CheckPending CheckState = "pending"
+	CheckFailing CheckState = "failing"
+	CheckGreen   CheckState = "green"
+)
+
+type ReviewState string
+
+const (
+	ReviewNone       ReviewState = "none"
+	ReviewActionable ReviewState = "actionable"
+	ReviewApproved   ReviewState = "approved"
+)
+
+type MergeState string
+
+const (
+	MergeUnknown MergeState = "unknown"
+	MergeClean   MergeState = "clean"
+	MergeBehind  MergeState = "behind"
+	MergeDirty   MergeState = "dirty"
+)
+
+type Worker struct {
+	ID             string    `json:"id"`
+	JobID          string    `json:"job_id,omitempty"`
+	Running        bool      `json:"running"`
+	Branch         string    `json:"branch,omitempty"`
+	PRNumber       int       `json:"pr_number,omitempty"`
+	BranchPushed   bool      `json:"branch_pushed,omitempty"`
+	StartedAt      time.Time `json:"started_at,omitempty"`
+	LastProgressAt time.Time `json:"last_progress_at,omitempty"`
+	Attempt        int       `json:"attempt,omitempty"`
+	MaxAttempts    int       `json:"max_attempts,omitempty"`
+}
+
+type PullRequest struct {
+	Number         int         `json:"number"`
+	Branch         string      `json:"branch,omitempty"`
+	URL            string      `json:"url,omitempty"`
+	Open           bool        `json:"open"`
+	Checks         CheckState  `json:"checks,omitempty"`
+	Review         ReviewState `json:"review,omitempty"`
+	Merge          MergeState  `json:"merge,omitempty"`
+	IssueNumber    int         `json:"issue_number,omitempty"`
+	RetryExhausted bool        `json:"retry_exhausted,omitempty"`
+	Attempt        int         `json:"attempt,omitempty"`
+	MaxAttempts    int         `json:"max_attempts,omitempty"`
+}
+
+type Snapshot struct {
+	Now          time.Time     `json:"now"`
+	Workers      []Worker      `json:"workers,omitempty"`
+	PullRequests []PullRequest `json:"pull_requests,omitempty"`
+}
+
+type Action struct {
+	Type       ActionType        `json:"type"`
+	TargetKind string            `json:"target_kind"`
+	TargetID   string            `json:"target_id"`
+	Reason     string            `json:"reason"`
+	Message    string            `json:"message,omitempty"`
+	Label      string            `json:"label,omitempty"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+}
+
+type Decision struct {
+	State          StuckState     `json:"state"`
+	TargetKind     string         `json:"target_kind,omitempty"`
+	TargetID       string         `json:"target_id,omitempty"`
+	Reason         string         `json:"reason"`
+	Blocker        string         `json:"blocker,omitempty"`
+	SafeActions    []Action       `json:"safe_actions,omitempty"`
+	ApprovalAction ApprovalAction `json:"approval_action,omitempty"`
+}
+
+func (d Decision) TargetKey() string {
+	if d.TargetKind == "" && d.TargetID == "" {
+		return string(d.State)
+	}
+	return d.TargetKind + ":" + d.TargetID
+}
+
+func (d Decision) TransitionKey() string {
+	return d.TargetKey() + ":" + string(d.State)
+}
+
+type ActionRecord struct {
+	DecisionState StuckState `json:"decision_state"`
+	Action        Action     `json:"action"`
+	AppliedAt     string     `json:"applied_at"`
+	Result        string     `json:"result,omitempty"`
+	Error         string     `json:"error,omitempty"`
+}
+
+type Status struct {
+	CurrentDecision *Decision         `json:"current_decision,omitempty"`
+	LastSafeAction  *ActionRecord     `json:"last_safe_action,omitempty"`
+	UpdatedAt       string            `json:"updated_at,omitempty"`
+	TransitionKeys  map[string]string `json:"transition_keys,omitempty"`
+	AppliedActions  map[string]string `json:"applied_actions,omitempty"`
+}
+
+type Source interface {
+	Snapshot(ctx context.Context) (Snapshot, error)
+}
+
+type StateStore interface {
+	GetSupervisorStatus() (Status, error)
+	SetSupervisorStatus(Status) error
+}
+
+type ActionResult struct {
+	Message string
+}
+
+type Executor interface {
+	ExecuteSafeAction(ctx context.Context, action Action) (ActionResult, error)
+}
+
+type Notifier interface {
+	Notify(ctx context.Context, decision Decision) error
+}
+
+type Option func(*Supervisor)
+
+type Supervisor struct {
+	source     Source
+	store      StateStore
+	executor   Executor
+	notifier   Notifier
+	staleAfter time.Duration
+	now        func() time.Time
+}
+
+func New(source Source, opts ...Option) *Supervisor {
+	s := &Supervisor{
+		source:     source,
+		store:      NewMemoryStateStore(),
+		executor:   NoopExecutor{},
+		notifier:   NoopNotifier{},
+		staleAfter: DefaultStaleWorkerAfter,
+		now:        time.Now,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.staleAfter <= 0 {
+		s.staleAfter = DefaultStaleWorkerAfter
+	}
+	if s.store == nil {
+		s.store = NewMemoryStateStore()
+	}
+	if s.executor == nil {
+		s.executor = NoopExecutor{}
+	}
+	if s.notifier == nil {
+		s.notifier = NoopNotifier{}
+	}
+	if s.now == nil {
+		s.now = time.Now
+	}
+	return s
+}
+
+func WithStateStore(store StateStore) Option {
+	return func(s *Supervisor) { s.store = store }
+}
+
+func WithExecutor(executor Executor) Option {
+	return func(s *Supervisor) { s.executor = executor }
+}
+
+func WithNotifier(notifier Notifier) Option {
+	return func(s *Supervisor) { s.notifier = notifier }
+}
+
+func WithStaleWorkerAfter(d time.Duration) Option {
+	return func(s *Supervisor) { s.staleAfter = d }
+}
+
+func WithClock(now func() time.Time) Option {
+	return func(s *Supervisor) { s.now = now }
+}
+
+func (s *Supervisor) RunOnce(ctx context.Context) ([]Decision, error) {
+	if s.source == nil {
+		return nil, fmt.Errorf("supervisor source is required")
+	}
+	snapshot, err := s.source.Snapshot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if snapshot.Now.IsZero() {
+		snapshot.Now = s.now()
+	}
+
+	decisions := Decide(snapshot, s.staleAfter)
+	status, err := s.store.GetSupervisorStatus()
+	if err != nil {
+		return decisions, err
+	}
+	status.ensureMaps()
+	status.UpdatedAt = snapshot.Now.UTC().Format(time.RFC3339)
+	if len(decisions) == 0 {
+		clear := Decision{State: StateClear, Reason: "no stuck states detected"}
+		status.CurrentDecision = &clear
+		status.TransitionKeys = map[string]string{}
+		status.AppliedActions = map[string]string{}
+		return decisions, s.store.SetSupervisorStatus(status)
+	}
+
+	current := decisions[0]
+	status.CurrentDecision = &current
+	active := make(map[string]struct{}, len(decisions))
+	var firstErr error
+	for _, decision := range decisions {
+		targetKey := decision.TargetKey()
+		transitionKey := decision.TransitionKey()
+		active[targetKey] = struct{}{}
+		if status.TransitionKeys[targetKey] != transitionKey {
+			if err := s.notifier.Notify(ctx, decision); err != nil && firstErr == nil {
+				firstErr = err
+			} else if err == nil {
+				status.TransitionKeys[targetKey] = transitionKey
+			}
+		}
+		for _, action := range decision.SafeActions {
+			key := actionKey(decision, action)
+			if _, ok := status.AppliedActions[key]; ok {
+				continue
+			}
+			record := ActionRecord{
+				DecisionState: decision.State,
+				Action:        action,
+				AppliedAt:     snapshot.Now.UTC().Format(time.RFC3339),
+			}
+			result, err := s.executor.ExecuteSafeAction(ctx, action)
+			if result.Message != "" {
+				record.Result = result.Message
+			}
+			if err != nil {
+				record.Error = err.Error()
+				status.LastSafeAction = &record
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			status.LastSafeAction = &record
+			status.AppliedActions[key] = record.AppliedAt
+		}
+	}
+	for targetKey := range status.TransitionKeys {
+		if _, ok := active[targetKey]; !ok {
+			delete(status.TransitionKeys, targetKey)
+			deleteAppliedActionsForTarget(status.AppliedActions, targetKey)
+		}
+	}
+	if err := s.store.SetSupervisorStatus(status); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return decisions, firstErr
+}
+
+func (s *Supervisor) Run(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	if _, err := s.RunOnce(ctx); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if _, err := s.RunOnce(ctx); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func Decide(snapshot Snapshot, staleAfter time.Duration) []Decision {
+	if staleAfter <= 0 {
+		staleAfter = DefaultStaleWorkerAfter
+	}
+	now := snapshot.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	decisions := make([]Decision, 0)
+	for _, worker := range snapshot.Workers {
+		if decision, ok := decideWorker(worker, now, staleAfter); ok {
+			decisions = append(decisions, decision)
+		}
+	}
+	for _, pr := range snapshot.PullRequests {
+		if decision, ok := decidePullRequest(pr); ok {
+			decisions = append(decisions, decision)
+		}
+	}
+	return decisions
+}
+
+func decideWorker(worker Worker, now time.Time, staleAfter time.Duration) (Decision, bool) {
+	workerID := workerTargetID(worker)
+	if worker.Running {
+		lastProgress := worker.LastProgressAt
+		if lastProgress.IsZero() {
+			lastProgress = worker.StartedAt
+		}
+		if !lastProgress.IsZero() && now.Sub(lastProgress) >= staleAfter {
+			reason := fmt.Sprintf("worker %s has not produced log progress for %s", workerID, now.Sub(lastProgress).Round(time.Second))
+			actions := []Action{}
+			if retryPermitted(worker.Attempt, worker.MaxAttempts) {
+				actions = append(actions, Action{
+					Type:       ActionRetryWorker,
+					TargetKind: "worker",
+					TargetID:   workerID,
+					Reason:     "stale worker is within retry budget",
+					Metadata: map[string]string{
+						"job_id":       worker.JobID,
+						"attempt":      strconv.Itoa(worker.Attempt),
+						"max_attempts": strconv.Itoa(worker.MaxAttempts),
+					},
+				})
+			} else {
+				actions = append(actions, Action{
+					Type:       ActionCommentBlocker,
+					TargetKind: "worker",
+					TargetID:   workerID,
+					Reason:     "stale worker retry budget is exhausted",
+					Message:    reason,
+				})
+			}
+			actions = append(actions, missionAction(workerID, reason))
+			return Decision{
+				State:       StateWorkerNoLogProgress,
+				TargetKind:  "worker",
+				TargetID:    workerID,
+				Reason:      reason,
+				Blocker:     "no recent worker log progress",
+				SafeActions: actions,
+			}, true
+		}
+		return Decision{}, false
+	}
+
+	if strings.TrimSpace(worker.Branch) != "" && worker.PRNumber == 0 && worker.BranchPushed {
+		reason := fmt.Sprintf("worker %s is no longer running; branch %q is pushed but has no PR", workerID, worker.Branch)
+		return Decision{
+			State:      StateDeadWorkerNoPR,
+			TargetKind: "worker",
+			TargetID:   workerID,
+			Reason:     reason,
+			Blocker:    "branch has no pull request",
+			SafeActions: []Action{
+				{
+					Type:       ActionCreateMissingPR,
+					TargetKind: "branch",
+					TargetID:   worker.Branch,
+					Reason:     "dead worker left a pushed branch without a PR",
+					Metadata: map[string]string{
+						"worker_id": workerID,
+						"job_id":    worker.JobID,
+					},
+				},
+				missionAction(workerID, reason),
+			},
+		}, true
+	}
+	return Decision{}, false
+}
+
+func decidePullRequest(pr PullRequest) (Decision, bool) {
+	if !pr.Open {
+		return Decision{}, false
+	}
+	if pr.RetryExhausted || retryExhausted(pr.Attempt, pr.MaxAttempts) {
+		reason := fmt.Sprintf("PR %s is still open after retry budget was exhausted", prTargetID(pr))
+		return blockedPRDecision(StateRetryExhaustedOpenPR, pr, reason, "retry budget exhausted", ApprovalCloseIssue), true
+	}
+	if pr.Checks == CheckFailing {
+		reason := fmt.Sprintf("PR %s has failing CI checks", prTargetID(pr))
+		return blockedPRDecision(StatePRChecksFailing, pr, reason, "CI checks are failing", ApprovalNone), true
+	}
+	if pr.Review == ReviewActionable {
+		reason := fmt.Sprintf("PR %s has actionable review feedback", prTargetID(pr))
+		return blockedPRDecision(StatePRReviewFeedback, pr, reason, "review feedback requires changes", ApprovalNone), true
+	}
+	if pr.Merge == MergeBehind || pr.Merge == MergeDirty {
+		blocker := "branch is behind base"
+		if pr.Merge == MergeDirty {
+			blocker = "merge state is dirty"
+		}
+		reason := fmt.Sprintf("PR %s is not merge-ready: %s", prTargetID(pr), blocker)
+		return blockedPRDecision(StatePRMergeBlocked, pr, reason, blocker, ApprovalNone), true
+	}
+	if pr.Checks == CheckGreen && (pr.Merge == "" || pr.Merge == MergeClean) && pr.Review != ReviewActionable {
+		reason := fmt.Sprintf("PR %s is green and waiting for explicit merge approval", prTargetID(pr))
+		return Decision{
+			State:          StateWaitingMergeApproval,
+			TargetKind:     "pr",
+			TargetID:       prTargetID(pr),
+			Reason:         reason,
+			Blocker:        "merge approval required",
+			ApprovalAction: ApprovalMergePR,
+			SafeActions: []Action{
+				refreshPRAction(pr, reason),
+				labelIssueAction(pr, ActionLabelIssueReady, "ready", "PR is green and waiting for merge approval"),
+				missionAction(prTargetID(pr), reason),
+			},
+		}, true
+	}
+	return Decision{}, false
+}
+
+func blockedPRDecision(state StuckState, pr PullRequest, reason, blocker string, approval ApprovalAction) Decision {
+	return Decision{
+		State:          state,
+		TargetKind:     "pr",
+		TargetID:       prTargetID(pr),
+		Reason:         reason,
+		Blocker:        blocker,
+		ApprovalAction: approval,
+		SafeActions: []Action{
+			refreshPRAction(pr, reason),
+			{
+				Type:       ActionCommentBlocker,
+				TargetKind: "pr",
+				TargetID:   prTargetID(pr),
+				Reason:     blocker,
+				Message:    reason,
+			},
+			labelIssueAction(pr, ActionLabelIssueBlocked, "blocked", blocker),
+			missionAction(prTargetID(pr), reason),
+		},
+	}
+}
+
+func retryPermitted(attempt, maxAttempts int) bool {
+	if maxAttempts <= 0 {
+		return true
+	}
+	if attempt <= 0 {
+		attempt = 1
+	}
+	return attempt < maxAttempts
+}
+
+func retryExhausted(attempt, maxAttempts int) bool {
+	return maxAttempts > 0 && attempt >= maxAttempts
+}
+
+func workerTargetID(worker Worker) string {
+	if strings.TrimSpace(worker.ID) != "" {
+		return strings.TrimSpace(worker.ID)
+	}
+	if strings.TrimSpace(worker.JobID) != "" {
+		return strings.TrimSpace(worker.JobID)
+	}
+	if strings.TrimSpace(worker.Branch) != "" {
+		return strings.TrimSpace(worker.Branch)
+	}
+	return "unknown"
+}
+
+func prTargetID(pr PullRequest) string {
+	if pr.Number > 0 {
+		return strconv.Itoa(pr.Number)
+	}
+	if strings.TrimSpace(pr.Branch) != "" {
+		return strings.TrimSpace(pr.Branch)
+	}
+	return "unknown"
+}
+
+func refreshPRAction(pr PullRequest, reason string) Action {
+	return Action{
+		Type:       ActionRefreshPRMetadata,
+		TargetKind: "pr",
+		TargetID:   prTargetID(pr),
+		Reason:     reason,
+	}
+}
+
+func labelIssueAction(pr PullRequest, actionType ActionType, label, reason string) Action {
+	targetID := prTargetID(pr)
+	if pr.IssueNumber > 0 {
+		targetID = strconv.Itoa(pr.IssueNumber)
+	}
+	return Action{
+		Type:       actionType,
+		TargetKind: "issue",
+		TargetID:   targetID,
+		Label:      label,
+		Reason:     reason,
+	}
+}
+
+func missionAction(targetID, reason string) Action {
+	return Action{
+		Type:       ActionUpdateMissionBlock,
+		TargetKind: "mission",
+		TargetID:   targetID,
+		Reason:     reason,
+	}
+}
+
+func actionKey(decision Decision, action Action) string {
+	parts := []string{
+		decision.TransitionKey(),
+		string(action.Type),
+		action.TargetKind,
+		action.TargetID,
+		action.Label,
+	}
+	return strings.Join(parts, ":")
+}
+
+func deleteAppliedActionsForTarget(actions map[string]string, targetKey string) {
+	for key := range actions {
+		if strings.HasPrefix(key, targetKey+":") {
+			delete(actions, key)
+		}
+	}
+}
+
+func (s *Status) ensureMaps() {
+	if s.TransitionKeys == nil {
+		s.TransitionKeys = make(map[string]string)
+	}
+	if s.AppliedActions == nil {
+		s.AppliedActions = make(map[string]string)
+	}
+}
+
+type MemoryStateStore struct {
+	mu     sync.Mutex
+	status Status
+}
+
+func NewMemoryStateStore() *MemoryStateStore {
+	return &MemoryStateStore{}
+}
+
+func (s *MemoryStateStore) GetSupervisorStatus() (Status, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneStatus(s.status), nil
+}
+
+func (s *MemoryStateStore) SetSupervisorStatus(status Status) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = cloneStatus(status)
+	return nil
+}
+
+type NoopExecutor struct{}
+
+func (NoopExecutor) ExecuteSafeAction(_ context.Context, action Action) (ActionResult, error) {
+	return ActionResult{Message: string(action.Type) + " recorded"}, nil
+}
+
+type NoopNotifier struct{}
+
+func (NoopNotifier) Notify(context.Context, Decision) error { return nil }
+
+func cloneStatus(status Status) Status {
+	out := status
+	if status.CurrentDecision != nil {
+		decision := *status.CurrentDecision
+		decision.SafeActions = append([]Action(nil), status.CurrentDecision.SafeActions...)
+		out.CurrentDecision = &decision
+	}
+	if status.LastSafeAction != nil {
+		record := *status.LastSafeAction
+		out.LastSafeAction = &record
+	}
+	if status.TransitionKeys != nil {
+		out.TransitionKeys = make(map[string]string, len(status.TransitionKeys))
+		for k, v := range status.TransitionKeys {
+			out.TransitionKeys[k] = v
+		}
+	}
+	if status.AppliedActions != nil {
+		out.AppliedActions = make(map[string]string, len(status.AppliedActions))
+		for k, v := range status.AppliedActions {
+			out.AppliedActions[k] = v
+		}
+	}
+	return out
+}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,0 +1,265 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDecideCoversStuckStates(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	staleAfter := 10 * time.Minute
+
+	tests := []struct {
+		name       string
+		snapshot   Snapshot
+		wantState  StuckState
+		wantAction ActionType
+		wantLabel  string
+		wantAsk    ApprovalAction
+	}{
+		{
+			name: "running worker with no log progress",
+			snapshot: Snapshot{Now: now, Workers: []Worker{{
+				ID:             "worker-stale",
+				JobID:          "job-stale",
+				Running:        true,
+				StartedAt:      now.Add(-30 * time.Minute),
+				LastProgressAt: now.Add(-20 * time.Minute),
+				Attempt:        1,
+				MaxAttempts:    2,
+			}}},
+			wantState:  StateWorkerNoLogProgress,
+			wantAction: ActionRetryWorker,
+		},
+		{
+			name: "dead worker with branch but no PR",
+			snapshot: Snapshot{Now: now, Workers: []Worker{{
+				ID:           "worker-dead",
+				Branch:       "feat/dead-worker",
+				BranchPushed: true,
+			}}},
+			wantState:  StateDeadWorkerNoPR,
+			wantAction: ActionCreateMissingPR,
+		},
+		{
+			name: "PR open with failing CI",
+			snapshot: Snapshot{Now: now, PullRequests: []PullRequest{{
+				Number:      101,
+				Open:        true,
+				Checks:      CheckFailing,
+				IssueNumber: 356,
+			}}},
+			wantState:  StatePRChecksFailing,
+			wantAction: ActionCommentBlocker,
+			wantLabel:  "blocked",
+		},
+		{
+			name: "PR open with review feedback",
+			snapshot: Snapshot{Now: now, PullRequests: []PullRequest{{
+				Number:      102,
+				Open:        true,
+				Checks:      CheckPending,
+				Review:      ReviewActionable,
+				IssueNumber: 356,
+			}}},
+			wantState:  StatePRReviewFeedback,
+			wantAction: ActionCommentBlocker,
+			wantLabel:  "blocked",
+		},
+		{
+			name: "PR branch behind",
+			snapshot: Snapshot{Now: now, PullRequests: []PullRequest{{
+				Number:      103,
+				Open:        true,
+				Checks:      CheckPending,
+				Merge:       MergeBehind,
+				IssueNumber: 356,
+			}}},
+			wantState:  StatePRMergeBlocked,
+			wantAction: ActionCommentBlocker,
+			wantLabel:  "blocked",
+		},
+		{
+			name: "retry exhausted with open PR",
+			snapshot: Snapshot{Now: now, PullRequests: []PullRequest{{
+				Number:         104,
+				Open:           true,
+				RetryExhausted: true,
+				IssueNumber:    356,
+			}}},
+			wantState:  StateRetryExhaustedOpenPR,
+			wantAction: ActionCommentBlocker,
+			wantLabel:  "blocked",
+			wantAsk:    ApprovalCloseIssue,
+		},
+		{
+			name: "checks green waiting for merge approval",
+			snapshot: Snapshot{Now: now, PullRequests: []PullRequest{{
+				Number:      105,
+				Open:        true,
+				Checks:      CheckGreen,
+				Review:      ReviewApproved,
+				Merge:       MergeClean,
+				IssueNumber: 356,
+			}}},
+			wantState:  StateWaitingMergeApproval,
+			wantAction: ActionLabelIssueReady,
+			wantLabel:  "ready",
+			wantAsk:    ApprovalMergePR,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decisions := Decide(tt.snapshot, staleAfter)
+			if len(decisions) != 1 {
+				t.Fatalf("decision count = %d, want 1 (%+v)", len(decisions), decisions)
+			}
+			decision := decisions[0]
+			if decision.State != tt.wantState {
+				t.Fatalf("state = %q, want %q", decision.State, tt.wantState)
+			}
+			if tt.wantAsk != "" && decision.ApprovalAction != tt.wantAsk {
+				t.Fatalf("approval action = %q, want %q", decision.ApprovalAction, tt.wantAsk)
+			}
+			if tt.wantAction != "" && !hasAction(decision.SafeActions, tt.wantAction) {
+				t.Fatalf("actions %+v do not include %q", decision.SafeActions, tt.wantAction)
+			}
+			if tt.wantLabel != "" && !hasLabel(decision.SafeActions, tt.wantLabel) {
+				t.Fatalf("actions %+v do not include label %q", decision.SafeActions, tt.wantLabel)
+			}
+			if !hasAction(decision.SafeActions, ActionUpdateMissionBlock) {
+				t.Fatalf("actions %+v do not update Mission Control reason block", decision.SafeActions)
+			}
+		})
+	}
+}
+
+func TestRunOnceNotifiesOncePerStateTransition(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	source := &fakeSource{snapshot: Snapshot{Now: now, Workers: []Worker{{
+		ID:             "worker-stale",
+		Running:        true,
+		LastProgressAt: now.Add(-20 * time.Minute),
+		Attempt:        1,
+		MaxAttempts:    2,
+	}}}}
+	executor := &recordingExecutor{}
+	notifier := &recordingNotifier{}
+	store := NewMemoryStateStore()
+	s := New(source,
+		WithStateStore(store),
+		WithExecutor(executor),
+		WithNotifier(notifier),
+		WithStaleWorkerAfter(10*time.Minute),
+		WithClock(func() time.Time { return now }),
+	)
+
+	if _, err := s.RunOnce(context.Background()); err != nil {
+		t.Fatalf("first RunOnce: %v", err)
+	}
+	if _, err := s.RunOnce(context.Background()); err != nil {
+		t.Fatalf("second RunOnce: %v", err)
+	}
+	if got := notifier.count(); got != 1 {
+		t.Fatalf("notifications after repeated same state = %d, want 1", got)
+	}
+	if got := executor.count(); got != 2 {
+		t.Fatalf("safe actions after repeated same state = %d, want 2", got)
+	}
+
+	source.snapshot = Snapshot{Now: now.Add(time.Minute), PullRequests: []PullRequest{{
+		Number:      42,
+		Open:        true,
+		Checks:      CheckFailing,
+		IssueNumber: 356,
+	}}}
+	if _, err := s.RunOnce(context.Background()); err != nil {
+		t.Fatalf("transition RunOnce: %v", err)
+	}
+	if _, err := s.RunOnce(context.Background()); err != nil {
+		t.Fatalf("repeated transitioned RunOnce: %v", err)
+	}
+	if got := notifier.count(); got != 2 {
+		t.Fatalf("notifications after one state transition = %d, want 2", got)
+	}
+	if got := executor.count(); got != 6 {
+		t.Fatalf("safe actions after one state transition = %d, want 6", got)
+	}
+}
+
+func TestMissionStatusTracksDecisionAndLastSafeAction(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	store := NewMemoryStateStore()
+	s := New(&fakeSource{snapshot: Snapshot{Now: now, PullRequests: []PullRequest{{
+		Number:      77,
+		Open:        true,
+		Checks:      CheckGreen,
+		Review:      ReviewApproved,
+		Merge:       MergeClean,
+		IssueNumber: 356,
+	}}}}, WithStateStore(store), WithExecutor(&recordingExecutor{}))
+
+	if _, err := s.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	status, err := store.GetSupervisorStatus()
+	if err != nil {
+		t.Fatalf("GetSupervisorStatus: %v", err)
+	}
+	if status.CurrentDecision == nil || status.CurrentDecision.State != StateWaitingMergeApproval {
+		t.Fatalf("current decision = %+v, want waiting merge approval", status.CurrentDecision)
+	}
+	if status.LastSafeAction == nil || status.LastSafeAction.Action.Type != ActionUpdateMissionBlock {
+		t.Fatalf("last safe action = %+v, want mission reason update", status.LastSafeAction)
+	}
+}
+
+func hasAction(actions []Action, want ActionType) bool {
+	for _, action := range actions {
+		if action.Type == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLabel(actions []Action, want string) bool {
+	for _, action := range actions {
+		if action.Label == want {
+			return true
+		}
+	}
+	return false
+}
+
+type fakeSource struct {
+	snapshot Snapshot
+}
+
+func (f *fakeSource) Snapshot(context.Context) (Snapshot, error) {
+	return f.snapshot, nil
+}
+
+type recordingExecutor struct {
+	actions []Action
+}
+
+func (r *recordingExecutor) ExecuteSafeAction(_ context.Context, action Action) (ActionResult, error) {
+	r.actions = append(r.actions, action)
+	return ActionResult{Message: string(action.Type)}, nil
+}
+
+func (r *recordingExecutor) count() int { return len(r.actions) }
+
+type recordingNotifier struct {
+	decisions []Decision
+}
+
+func (r *recordingNotifier) Notify(_ context.Context, decision Decision) error {
+	r.decisions = append(r.decisions, decision)
+	return nil
+}
+
+func (r *recordingNotifier) count() int { return len(r.decisions) }


### PR DESCRIPTION
## Summary
- Add a supervisor decision loop for stale worker and PR states, with approval-only actions represented but not auto-executed.
- Persist supervisor state for Mission Control and expose it through `/api/mission/supervisor`.
- Add coverage for stuck-state decisions, transition notifications, persisted status, and Mission Control exposure.

## Verification
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/`
- `make test`

Closes #356

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a supervisor decision loop that classifies stuck workers and PR states into named `StuckState` values, executes idempotent safe actions, deduplicates transition notifications, and persists the resulting `Status` to SQLite — exposing it through a new `/api/mission/supervisor` endpoint in both the API and control servers.

- **P1 — stale `AppliedActions` after notification failure**: when `Notify` returns an error the `targetKey` is never written to `TransitionKeys`. The cleanup loop at lines 305-309 iterates only over `TransitionKeys`, so `AppliedActions` entries for that target are never pruned. If the same target reappears in the same stuck state, previously-applied recovery actions (e.g., `ActionRetryWorker`) are silently suppressed.
- **P2 — incomplete deep clone in `cloneStatus`**: `SafeActions` slice is cloned but `Action.Metadata` maps inside each element remain shared references, breaking the isolation guarantee of `MemoryStateStore`.

<h3>Confidence Score: 3/5</h3>

Hold for the stale AppliedActions bug before merging — persistent notification failures can cause recovery actions to be silently skipped on recurring stuck workers.

One P1 defect (stale AppliedActions after notification failure suppresses future recovery-action execution) combined with a P2 incomplete deep clone in MemoryStateStore pulls the score to 3. The rest of the implementation — state classification, SQLite persistence, API exposure, and test coverage — is well-structured.

internal/supervisor/supervisor.go — cleanup loop (lines 305-309) and cloneStatus (lines 626-650)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Core supervisor logic; P1 bug where notification failures cause AppliedActions entries to leak and suppress future recovery-action re-execution; also incomplete deep clone of Action.Metadata in cloneStatus. |
| internal/storage/supervisor.go | SQLite-backed GetSupervisorStatus / SetSupervisorStatus using app_state upsert; correct error handling and empty-row treatment. |
| internal/api/mission.go | Adds handleMissionSupervisor endpoint; correctly delegates to store, returns 405 for non-GET, handles nil store and store errors. |
| internal/api/server.go | Registers /api/mission/supervisor route in the mux; clean addition with auth middleware applied uniformly. |
| internal/control/mission.go | Adds missionSupervisor handler to the control-server mission routes; logic mirrors the api/mission.go handler correctly. |
| internal/supervisor/supervisor_test.go | Good coverage: per-state decision table, notification deduplication, and status persistence; fakeSource, recordingExecutor, recordingNotifier helpers are clean. |
| internal/storage/supervisor_test.go | Round-trip persistence test across DB reopen; well-structured and covers the key fields. |
| internal/control/mission_supervisor_test.go | Integration test for /api/mission/supervisor endpoint; covers JSON shape and key fields correctly. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/supervisor/supervisor.go:305-309
**Stale `AppliedActions` entries leak when notification fails**

When `Notify` returns an error the corresponding `targetKey` is never written into `status.TransitionKeys`. The cleanup loop at line 305 iterates only over `TransitionKeys`, so applied actions for that target are never purged even after the target disappears from the snapshot. If the same target re-enters the snapshot in the same stuck state, the already-present `AppliedActions` keys suppress re-execution of recovery actions (e.g., `ActionRetryWorker`), causing the supervisor to silently skip the retry it should be performing.

A cleaner fix: drive `AppliedActions` cleanup from the `active` map directly, independently of `TransitionKeys`, so entries for any inactive target are removed regardless of whether notification ever succeeded.

### Issue 2 of 3
internal/supervisor/supervisor.go:629-631
**`Action.Metadata` maps not deep-cloned in `cloneStatus`**

`cloneStatus` explicitly clones the `SafeActions` slice, but the `Metadata map[string]string` inside each `Action` remains a shared reference between the original and the clone. Any caller that modifies `Metadata` on the returned status will corrupt the stored copy, breaking the isolation guarantee of `MemoryStateStore`. Each action's `Metadata` map should be copied in the same loop that copies the slice.

### Issue 3 of 3
internal/supervisor/supervisor.go:317-335
**`Run` exits on any transient `RunOnce` error**

Any transient failure (notification hiccup, brief DB unavailability) causes `Run` to return, terminating the entire supervisor loop. Consider logging the error and continuing rather than returning, so the supervisor stays alive through transient faults.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add supervisor recovery decisions ..."](https://github.com/befeast/ok-gobot/commit/a753174006376ab54e7ba00b27b39ac950c0ff98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30473887)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->