### PR TITLE
feat: improve Telegram role job controls (#346)

### DIFF
--- a/internal/artifacts/display.go
+++ b/internal/artifacts/display.go
@@ -185,6 +185,98 @@ func (s Serializer) SerializeAll(rows []storage.JobArtifact) []Info {
 	return out
 }
 
+// FormatProofHints renders artifact references that are safe to show in chat
+// surfaces. It intentionally never includes local filesystem paths.
+func FormatProofHints(infos []Info, max int) []string {
+	if len(infos) == 0 {
+		return nil
+	}
+	if max <= 0 || max > len(infos) {
+		max = len(infos)
+	}
+
+	hints := make([]string, 0, max+1)
+	for i := 0; i < max; i++ {
+		hints = append(hints, FormatProofHint(infos[i]))
+	}
+	if remaining := len(infos) - max; remaining > 0 {
+		hints = append(hints, fmt.Sprintf("...and %d more artifact(s)", remaining))
+	}
+	return hints
+}
+
+// FormatProofHint renders one artifact reference without exposing unsafe local
+// paths. Safe remote URLs may be shown directly; local files are referenced by
+// durable artifact ID instead.
+func FormatProofHint(info Info) string {
+	label := artifactHintLabel(info)
+	if info.ID > 0 {
+		label = fmt.Sprintf("%s (#%d)", label, info.ID)
+	}
+
+	switch {
+	case strings.TrimSpace(info.URL) != "":
+		return fmt.Sprintf("%s: %s", label, info.URL)
+	case info.Display.Safe && info.Display.Kind == KindImage && info.Path != "":
+		return fmt.Sprintf("%s: safe local image artifact", label)
+	case info.Display.Safe && strings.TrimSpace(info.Display.Href) != "":
+		return fmt.Sprintf("%s: %s", label, info.Display.Href)
+	case info.Display.Safe && info.Display.Inline:
+		return fmt.Sprintf("%s: inline %s artifact", label, displayKindLabel(info.Display.Kind))
+	case info.Display.Safe:
+		return fmt.Sprintf("%s: stored %s artifact", label, displayKindLabel(info.Display.Kind))
+	default:
+		reason := strings.TrimSpace(info.Display.Reason)
+		if reason == "" {
+			reason = "not safe to display"
+		}
+		return fmt.Sprintf("%s: hidden (%s)", label, reason)
+	}
+}
+
+// FirstSafeLocalImage returns the first image artifact backed by a safe local
+// path. Callers may upload the path but should not include it in user-visible
+// text.
+func FirstSafeLocalImage(infos []Info) (Info, bool) {
+	for _, info := range infos {
+		if info.Display.Safe && info.Display.Kind == KindImage && strings.TrimSpace(info.Path) != "" {
+			return info, true
+		}
+	}
+	return Info{}, false
+}
+
+func artifactHintLabel(info Info) string {
+	for _, candidate := range []string{info.Label, info.Name, info.Type, info.ArtifactType} {
+		candidate = strings.TrimSpace(candidate)
+		if candidate != "" {
+			return truncateRunes(candidate, 80)
+		}
+	}
+	return "artifact"
+}
+
+func displayKindLabel(kind string) string {
+	if strings.TrimSpace(kind) == "" {
+		return KindArtifact
+	}
+	return strings.TrimSpace(kind)
+}
+
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
+}
+
 // SafeLocalPath returns a canonical local path only when rawURI points inside
 // one of the configured roots.
 func SafeLocalPath(rawURI string, roots []string) (string, bool) {

--- a/internal/artifacts/display_test.go
+++ b/internal/artifacts/display_test.go
@@ -3,6 +3,7 @@ package artifacts
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"ok-gobot/internal/storage"
@@ -99,4 +100,69 @@ func TestSerializerClassifiesURLAndTextReport(t *testing.T) {
 	if reportInfo.Display.Kind != KindTextReport || !reportInfo.Display.Safe || !reportInfo.Display.Inline || reportInfo.Content != "tests passed" {
 		t.Fatalf("unexpected text report artifact info: %+v", reportInfo)
 	}
+}
+
+func TestFormatProofHintsAvoidsLocalPaths(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "shot.png")
+	if err := os.WriteFile(path, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	info := NewSerializer([]string{root}, "/api/artifacts").Serialize(storage.JobArtifact{
+		ID:           42,
+		Name:         "Screenshot",
+		ArtifactType: "screenshot",
+		MimeType:     "image/png",
+		URI:          path,
+	})
+
+	hints := FormatProofHints([]Info{info}, 5)
+	if len(hints) != 1 {
+		t.Fatalf("expected one hint, got %#v", hints)
+	}
+	if got := hints[0]; got == "" || containsAny(got, path, root) {
+		t.Fatalf("hint leaked local path: %q", got)
+	}
+	if got := hints[0]; !containsAll(got, "Screenshot", "#42", "safe local image") {
+		t.Fatalf("hint missing artifact details: %q", got)
+	}
+}
+
+func TestFirstSafeLocalImageRequiresSafeLocalPath(t *testing.T) {
+	root := t.TempDir()
+	safePath := filepath.Join(root, "shot.png")
+	if err := os.WriteFile(safePath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	serializer := NewSerializer([]string{root}, "/api/artifacts")
+	safe := serializer.Serialize(storage.JobArtifact{ID: 1, Name: "safe", ArtifactType: "screenshot", MimeType: "image/png", URI: safePath})
+	unsafe := serializer.Serialize(storage.JobArtifact{ID: 2, Name: "outside", ArtifactType: "screenshot", MimeType: "image/png", URI: filepath.Join(t.TempDir(), "outside.png")})
+	remote := serializer.Serialize(storage.JobArtifact{ID: 3, Name: "remote", ArtifactType: "screenshot", MimeType: "image/png", URI: "https://example.com/shot.png"})
+
+	got, ok := FirstSafeLocalImage([]Info{unsafe, remote, safe})
+	if !ok {
+		t.Fatal("expected safe local image")
+	}
+	if got.ID != safe.ID || got.Path != safePath {
+		t.Fatalf("FirstSafeLocalImage = %+v, want safe artifact", got)
+	}
+}
+
+func containsAny(s string, needles ...string) bool {
+	for _, needle := range needles {
+		if needle != "" && strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAll(s string, needles ...string) bool {
+	for _, needle := range needles {
+		if needle != "" && !strings.Contains(s, needle) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -306,6 +306,7 @@ func (b *Bot) registerCommands() {
 		{Text: "verbose", Description: "Toggle verbose mode"},
 		{Text: "active_memory", Description: "Pre-reply memory recall (status/on/off)"},
 		{Text: "queue", Description: "Adjust queue settings"},
+		{Text: "steer", Description: "Add steering input to active work"},
 		{Text: "tts", Description: "Control text-to-speech"},
 		{Text: "estop", Description: "Emergency stop dangerous tools"},
 		{Text: "task", Description: "Spawn a sub-agent task"},
@@ -372,6 +373,7 @@ func (b *Bot) Start(ctx context.Context) error {
 /tools - List available tools
 /model - Manage AI model (list/set/clear)
 /agent - Manage agents (list/switch)
+/steer <text> - Add steering input to active work
 /auth - Authorization management (admin only)
 /pair <code> - Pair with bot using pairing code
 /estop on|off|status - Toggle dangerous tool families (admin only)

--- a/internal/bot/commands.go
+++ b/internal/bot/commands.go
@@ -12,6 +12,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/bootstrap"
+	"ok-gobot/internal/control"
 	"ok-gobot/internal/storage"
 	"ok-gobot/internal/tools"
 )
@@ -64,6 +65,10 @@ func (b *Bot) registerExtraHandlers() {
 
 	b.api.Handle("/queue", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
 		return b.handleQueueCommand(c)
+	}))
+
+	b.api.Handle("/steer", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
+		return b.handleSteerCommand(c)
 	}))
 
 	b.api.Handle("/tts", b.guardUnauthorizedDM(false, func(c telebot.Context) error {
@@ -180,6 +185,7 @@ func (b *Bot) handleCommandsCommand(c telebot.Context) error {
 		{"verbose", "Toggle verbose mode (on/off)"},
 		{"active_memory", "Pre-reply memory recall (status/on/off)"},
 		{"queue", "Adjust queue settings"},
+		{"steer", "Add steering input to active work"},
 		{"tts", "Control text-to-speech"},
 		{"estop", "Emergency stop for dangerous tools (admin)"},
 		{"task", "Spawn a sub-agent task"},
@@ -659,6 +665,31 @@ func (b *Bot) handleQueueCommand(c telebot.Context) error {
 	}
 
 	return c.Send(fmt.Sprintf("✅ Queue mode set to: `%s`", mode),
+		&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+}
+
+// handleSteerCommand adds steering input to the active run without changing the
+// chat's durable queue mode.
+func (b *Bot) handleSteerCommand(c telebot.Context) error {
+	chatID := c.Chat().ID
+	payload := strings.TrimSpace(c.Message().Payload)
+	if payload == "" {
+		return c.Send("Usage: `/steer <guidance>`\n\nAdds steering input to the active run without changing `/queue` mode.",
+			&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+	}
+	if b.queueManager == nil || !b.queueManager.IsRunning(chatID) {
+		return c.Send("No active run to steer. Send a normal message to start work.")
+	}
+
+	b.queueManager.Enqueue(chatID, payload)
+	if b.controlHub != nil {
+		b.controlHub.Emit(control.EvtSessionQueued, control.SessionInfo{
+			ChatID: chatID,
+			State:  "queued",
+		})
+	}
+	mode := b.getQueueMode(chatID)
+	return c.Send(fmt.Sprintf("🪢 Steering added to the active run.\nQueue depth: %d\nQueue mode remains `%s`.", b.queueManager.GetQueueDepth(chatID), mode),
 		&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 }
 

--- a/internal/bot/interrupt_integration_test.go
+++ b/internal/bot/interrupt_integration_test.go
@@ -100,16 +100,18 @@ func waitForInterruptBotIdle(t *testing.T, b *Bot, chatID int64, timeout time.Du
 }
 
 type fakeTelegramAPI struct {
-	server        *httptest.Server
-	mu            sync.Mutex
-	requests      []telegramRequest
-	nextMessageID int
-	updates       chan struct{}
+	server               *httptest.Server
+	mu                   sync.Mutex
+	requests             []telegramRequest
+	nextMessageID        int
+	markdownSendFailures int
+	updates              chan struct{}
 }
 
 type telegramRequest struct {
 	Method    string
 	Text      string
+	ParseMode string
 	Action    string
 	ChatID    int64
 	MessageID int
@@ -135,16 +137,21 @@ func (f *fakeTelegramAPI) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req := telegramRequest{
-		Method: path.Base(r.URL.Path),
-		Text:   payload["text"],
-		Action: payload["action"],
-		ChatID: parseInt64(payload["chat_id"]),
+		Method:    path.Base(r.URL.Path),
+		Text:      payload["text"],
+		ParseMode: payload["parse_mode"],
+		Action:    payload["action"],
+		ChatID:    parseInt64(payload["chat_id"]),
 	}
 	if payload["message_id"] != "" {
 		req.MessageID, _ = strconv.Atoi(payload["message_id"])
 	}
 
 	f.mu.Lock()
+	shouldFail := req.Method == "sendMessage" && req.ParseMode == telebot.ModeMarkdown && f.markdownSendFailures > 0
+	if shouldFail {
+		f.markdownSendFailures--
+	}
 	switch req.Method {
 	case "sendMessage":
 		f.nextMessageID++
@@ -161,6 +168,10 @@ func (f *fakeTelegramAPI) handle(w http.ResponseWriter, r *http.Request) {
 	select {
 	case f.updates <- struct{}{}:
 	default:
+	}
+	if shouldFail {
+		writeTelegramError(w, http.StatusBadRequest, "Bad Request: can't parse entities")
+		return
 	}
 
 	switch req.Method {
@@ -181,11 +192,33 @@ func (f *fakeTelegramAPI) handle(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (f *fakeTelegramAPI) failNextMarkdownSend() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.markdownSendFailures++
+}
+
+func (f *fakeTelegramAPI) snapshotRequests() []telegramRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]telegramRequest(nil), f.requests...)
+}
+
 func writeTelegramOK(w http.ResponseWriter, result any) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"ok":     true,
 		"result": result,
+	})
+}
+
+func writeTelegramError(w http.ResponseWriter, code int, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"ok":          false,
+		"error_code":  code,
+		"description": description,
 	})
 }
 

--- a/internal/bot/role_commands.go
+++ b/internal/bot/role_commands.go
@@ -220,13 +220,13 @@ func (b *Bot) handleRoleRunCommand(c telebot.Context) error {
 		return c.Send(fmt.Sprintf("Failed to start role job: %v", err))
 	}
 
-	worker := spec.Worker
-	if worker == "" {
-		worker = "(default)"
+	notifyWait := 10 * time.Minute
+	if spec.Timeout > 0 {
+		notifyWait = spec.Timeout + time.Minute
 	}
-	return c.Send(fmt.Sprintf("Job started: `%s`\nRole: *%s*\nWorker: %s\n\nUse `/job %s` to check status.",
-		job.JobID, m.Name, worker, job.JobID),
-		&telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
+	b.waitAndNotifyRoleJob(chat, job.JobID, notifyWait)
+
+	return c.Send(formatRoleJobAck(job.JobID, m.Name, spec.Worker), &telebot.SendOptions{ParseMode: telebot.ModeMarkdown})
 }
 
 // handleTGJobsCommand handles /jobs — list recent durable jobs.
@@ -315,20 +315,14 @@ func (b *Bot) handleTGJobCommand(c telebot.Context) error {
 		sb.WriteString("\n")
 	}
 
-	artifacts, err := b.store.ListJobArtifacts(job.JobID, 10)
+	artifacts, err := b.store.ListJobArtifacts(job.JobID, 20)
 	if err != nil {
 		log.Printf("[jobs] failed to list artifacts for %s: %v", job.JobID, err)
 	} else if len(artifacts) > 0 {
 		serializer := artifactview.NewSerializer(b.artifactRoots, "")
-		sb.WriteString("\nArtifacts:\n")
-		for _, info := range serializer.SerializeAll(artifacts) {
-			detail := ""
-			if info.URL != "" {
-				detail = " - " + info.URL
-			} else if !info.Display.Safe {
-				detail = " - unsafe local artifact hidden"
-			}
-			sb.WriteString(fmt.Sprintf("- `%s` (%s)%s\n", info.Label, info.Type, detail))
+		sb.WriteString("\nProof artifacts:\n")
+		for _, hint := range artifactview.FormatProofHints(serializer.SerializeAll(artifacts), 8) {
+			sb.WriteString(fmt.Sprintf("- %s\n", hint))
 		}
 	}
 

--- a/internal/bot/role_commands_test.go
+++ b/internal/bot/role_commands_test.go
@@ -1,8 +1,12 @@
 package bot
 
 import (
+	"strings"
 	"testing"
 	"time"
+
+	artifactview "ok-gobot/internal/artifacts"
+	"ok-gobot/internal/storage"
 )
 
 func TestJobStatusIcon(t *testing.T) {
@@ -101,5 +105,55 @@ func TestFindBotRole_NotFound(t *testing.T) {
 	_, err := b.findBotRole("nonexistent-role-xyz")
 	if err == nil {
 		t.Fatal("expected error for nonexistent role")
+	}
+}
+
+func TestFormatRoleJobAckIncludesWorkerAndJobHint(t *testing.T) {
+	out := formatRoleJobAck("job-123", "researcher", "premium")
+	for _, want := range []string{"Role job started", "job-123", "researcher", "Worker tier: `premium`", "Use `/job job-123`"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in %q", want, out)
+		}
+	}
+}
+
+func TestFormatRoleJobFinalSuccessIncludesSummaryAndArtifactHints(t *testing.T) {
+	out := formatRoleJobFinal(storage.Job{
+		JobID:    "job-123",
+		Status:   "succeeded",
+		RoleName: "researcher",
+		Worker:   "premium",
+		Summary:  "found the answer",
+	}, []artifactview.Info{{
+		ID:    7,
+		Label: "Screenshot",
+		Type:  "screenshot",
+		Path:  "/tmp/ok-gobot-safe/shot.png",
+		Display: artifactview.DisplayMetadata{
+			Kind: artifactview.KindImage,
+			Safe: true,
+		},
+	}})
+
+	for _, want := range []string{"Role job completed", "Summary:", "found the answer", "Proof artifacts:", "Screenshot (#7): safe local image artifact", "Use `/job job-123`"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in %q", want, out)
+		}
+	}
+	if strings.Contains(out, "/tmp/ok-gobot-safe") {
+		t.Fatalf("final notification leaked a local path: %q", out)
+	}
+}
+
+func TestFormatRoleJobFinalFailureIncludesReason(t *testing.T) {
+	out := formatRoleJobFinal(storage.Job{
+		JobID:  "job-err",
+		Status: "timed_out",
+		Error:  "context deadline exceeded",
+	}, nil)
+	for _, want := range []string{"Role job timed out", "Reason: context deadline exceeded", "Use `/job job-err`"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in %q", want, out)
+		}
 	}
 }

--- a/internal/bot/role_commands_test.go
+++ b/internal/bot/role_commands_test.go
@@ -1,9 +1,12 @@
 package bot
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/telebot.v4"
 
 	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/storage"
@@ -155,5 +158,55 @@ func TestFormatRoleJobFinalFailureIncludesReason(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("expected %q in %q", want, out)
 		}
+	}
+}
+
+func TestSendRoleJobFinalNotificationRetriesPlainTextWhenMarkdownFails(t *testing.T) {
+	tg := newFakeTelegramAPI(t)
+	tg.failNextMarkdownSend()
+
+	api, err := telebot.NewBot(telebot.Settings{
+		Token:   "TEST",
+		URL:     tg.server.URL,
+		Client:  tg.server.Client(),
+		Offline: true,
+	})
+	if err != nil {
+		t.Fatalf("telebot.NewBot() error = %v", err)
+	}
+	api.Me = &telebot.User{ID: 1, Username: "okgobot", IsBot: true}
+
+	store, err := storage.New(filepath.Join(t.TempDir(), "bot.db"))
+	if err != nil {
+		t.Fatalf("storage.New() error = %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	bot := &Bot{api: api, store: store}
+	bot.sendRoleJobFinalNotification(&telebot.Chat{ID: 99, Type: telebot.ChatPrivate}, storage.Job{
+		JobID:    "job-md",
+		Status:   "succeeded",
+		RoleName: "researcher",
+		Worker:   "premium",
+		Summary:  "AI produced *unbalanced _markdown [tokens",
+	})
+
+	var sends []telegramRequest
+	for _, req := range tg.snapshotRequests() {
+		if req.Method == "sendMessage" {
+			sends = append(sends, req)
+		}
+	}
+	if len(sends) != 2 {
+		t.Fatalf("sendMessage request count = %d, want 2: %+v", len(sends), sends)
+	}
+	if sends[0].ParseMode != telebot.ModeMarkdown {
+		t.Fatalf("first send parse mode = %q, want Markdown", sends[0].ParseMode)
+	}
+	if sends[1].ParseMode != "" {
+		t.Fatalf("fallback send parse mode = %q, want plain text", sends[1].ParseMode)
+	}
+	if !strings.Contains(sends[1].Text, "AI produced *unbalanced _markdown [tokens") {
+		t.Fatalf("fallback send lost summary text: %q", sends[1].Text)
 	}
 }

--- a/internal/bot/role_job_notifications.go
+++ b/internal/bot/role_job_notifications.go
@@ -44,15 +44,20 @@ func (b *Bot) waitAndNotifyRoleJob(chat *telebot.Chat, jobID string, maxWait tim
 		defer ticker.Stop()
 		deadline := time.NewTimer(maxWait)
 		defer deadline.Stop()
+		pollErrors := 0
 
 		for {
 			select {
 			case <-ticker.C:
 				job, err := b.store.GetJob(jobID)
 				if err != nil {
-					log.Printf("[role] failed to poll job %s for Telegram notification: %v", jobID, err)
-					return
+					pollErrors++
+					if pollErrors == 1 || pollErrors%10 == 0 {
+						log.Printf("[role] failed to poll job %s for Telegram notification (%d consecutive errors): %v", jobID, pollErrors, err)
+					}
+					continue
 				}
+				pollErrors = 0
 				if job != nil && isTerminalRoleJobStatus(job.Status) {
 					b.sendRoleJobFinalNotification(chat, *job)
 					return

--- a/internal/bot/role_job_notifications.go
+++ b/internal/bot/role_job_notifications.go
@@ -77,8 +77,11 @@ func (b *Bot) sendRoleJobFinalNotification(chat *telebot.Chat, job storage.Job) 
 	infos := b.roleJobArtifactInfos(job.JobID)
 	text := formatRoleJobFinal(job, infos)
 	if _, err := b.api.Send(chat, text, &telebot.SendOptions{ParseMode: telebot.ModeMarkdown}); err != nil {
-		log.Printf("[role] failed to send final notification for job %s: %v", job.JobID, err)
-		return
+		log.Printf("[role] markdown final notification failed for job %s, retrying as plain text: %v", job.JobID, err)
+		if _, err2 := b.api.Send(chat, text); err2 != nil {
+			log.Printf("[role] failed to send final notification for job %s: markdown=%v plain=%v", job.JobID, err, err2)
+			return
+		}
 	}
 
 	if info, ok := artifactview.FirstSafeLocalImage(infos); ok {

--- a/internal/bot/role_job_notifications.go
+++ b/internal/bot/role_job_notifications.go
@@ -1,0 +1,218 @@
+package bot
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/telebot.v4"
+
+	artifactview "ok-gobot/internal/artifacts"
+	"ok-gobot/internal/storage"
+)
+
+func displayRoleWorker(worker string) string {
+	worker = strings.TrimSpace(worker)
+	if worker == "" {
+		return "default"
+	}
+	return worker
+}
+
+func formatRoleJobAck(jobID, roleName, worker string) string {
+	return fmt.Sprintf("⚙️ Role job started\nJob: `%s`\nRole: *%s*\nWorker tier: `%s`\n\nUse `/job %s` for durable status and artifacts.",
+		jobID, roleName, displayRoleWorker(worker), jobID)
+}
+
+func (b *Bot) waitAndNotifyRoleJob(chat *telebot.Chat, jobID string, maxWait time.Duration) {
+	if b == nil || b.api == nil || b.store == nil || chat == nil || strings.TrimSpace(jobID) == "" {
+		return
+	}
+	if maxWait <= 0 {
+		maxWait = 10 * time.Minute
+	}
+
+	go func() {
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		deadline := time.NewTimer(maxWait)
+		defer deadline.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				job, err := b.store.GetJob(jobID)
+				if err != nil {
+					log.Printf("[role] failed to poll job %s for Telegram notification: %v", jobID, err)
+					return
+				}
+				if job != nil && isTerminalRoleJobStatus(job.Status) {
+					b.sendRoleJobFinalNotification(chat, *job)
+					return
+				}
+			case <-deadline.C:
+				log.Printf("[role] timed out waiting for job %s terminal notification", jobID)
+				return
+			}
+		}
+	}()
+}
+
+func (b *Bot) sendRoleJobFinalNotification(chat *telebot.Chat, job storage.Job) {
+	infos := b.roleJobArtifactInfos(job.JobID)
+	text := formatRoleJobFinal(job, infos)
+	if _, err := b.api.Send(chat, text, &telebot.SendOptions{ParseMode: telebot.ModeMarkdown}); err != nil {
+		log.Printf("[role] failed to send final notification for job %s: %v", job.JobID, err)
+		return
+	}
+
+	if info, ok := artifactview.FirstSafeLocalImage(infos); ok {
+		b.sendRoleJobProofArtifact(chat, job.JobID, info)
+	}
+}
+
+func (b *Bot) roleJobArtifactInfos(jobID string) []artifactview.Info {
+	rows, err := b.store.ListJobArtifacts(jobID, 20)
+	if err != nil {
+		log.Printf("[role] failed to list artifacts for job %s: %v", jobID, err)
+		return nil
+	}
+	return artifactview.NewSerializer(b.artifactRoots, "").SerializeAll(rows)
+}
+
+func formatRoleJobFinal(job storage.Job, infos []artifactview.Info) string {
+	var sb strings.Builder
+	sb.WriteString(roleJobFinalHeading(job.Status))
+	sb.WriteString(fmt.Sprintf("\nJob: `%s`", job.JobID))
+	if roleName := strings.TrimSpace(job.RoleName); roleName != "" {
+		sb.WriteString(fmt.Sprintf("\nRole: *%s*", roleName))
+	}
+	if worker := displayRoleWorker(job.Worker); worker != "" {
+		sb.WriteString(fmt.Sprintf("\nWorker tier: `%s`", worker))
+	}
+
+	if job.Status == "succeeded" {
+		summary := truncateTelegramField(job.Summary, 700)
+		if summary == "" {
+			summary = "Completed successfully."
+		}
+		sb.WriteString("\n\nSummary:\n")
+		sb.WriteString(summary)
+	} else {
+		sb.WriteString("\n\nReason: ")
+		sb.WriteString(truncateTelegramField(roleJobFailureReason(job), 700))
+		if summary := truncateTelegramField(job.Summary, 500); summary != "" {
+			sb.WriteString("\n\nSummary:\n")
+			sb.WriteString(summary)
+		}
+	}
+
+	if len(infos) > 0 {
+		sb.WriteString("\n\nProof artifacts:")
+		for _, hint := range artifactview.FormatProofHints(infos, 6) {
+			sb.WriteString("\n- ")
+			sb.WriteString(hint)
+		}
+		if _, ok := artifactview.FirstSafeLocalImage(infos); ok {
+			sb.WriteString("\nSafe image proof will be attached separately when Telegram accepts the file.")
+		}
+	}
+
+	sb.WriteString(fmt.Sprintf("\n\nUse `/job %s` for durable status and artifacts.", job.JobID))
+	return sb.String()
+}
+
+func isTerminalRoleJobStatus(status string) bool {
+	switch status {
+	case "succeeded", "failed", "cancelled", "timed_out", "budget_exceeded":
+		return true
+	default:
+		return false
+	}
+}
+
+func roleJobFinalHeading(status string) string {
+	switch status {
+	case "succeeded":
+		return "✅ *Role job completed*"
+	case "timed_out":
+		return "⏰ *Role job timed out*"
+	case "cancelled":
+		return "🛑 *Role job cancelled*"
+	case "budget_exceeded":
+		return "🛑 *Role job budget exceeded*"
+	default:
+		return "❌ *Role job failed*"
+	}
+}
+
+func roleJobFailureReason(job storage.Job) string {
+	if job.Status == "budget_exceeded" {
+		if reason := strings.TrimSpace(job.LimitReason); reason != "" {
+			return "budget exceeded: " + reason
+		}
+		return "budget exceeded"
+	}
+	if errMsg := strings.TrimSpace(job.Error); errMsg != "" {
+		return errMsg
+	}
+	switch job.Status {
+	case "timed_out":
+		return "job timed out"
+	case "cancelled":
+		return "job was cancelled"
+	case "failed":
+		return "job failed"
+	default:
+		return job.Status
+	}
+}
+
+func (b *Bot) sendRoleJobProofArtifact(chat *telebot.Chat, jobID string, info artifactview.Info) {
+	if strings.TrimSpace(info.Path) == "" {
+		return
+	}
+	stat, err := os.Stat(info.Path)
+	if err != nil || stat.IsDir() {
+		b.sendRoleJobAttachmentFallback(chat, jobID, info)
+		return
+	}
+
+	caption := fmt.Sprintf("Proof artifact #%d for job %s", info.ID, jobID)
+	if label := strings.TrimSpace(info.Label); label != "" {
+		caption = fmt.Sprintf("%s: %s", caption, truncateTelegramField(label, 120))
+	}
+	photo := &telebot.Photo{File: telebot.FromDisk(info.Path), Caption: caption}
+	if _, err := b.api.Send(chat, photo); err == nil {
+		return
+	}
+	doc := &telebot.Document{File: telebot.FromDisk(info.Path), Caption: caption}
+	if _, err := b.api.Send(chat, doc); err != nil {
+		log.Printf("[role] failed to attach proof artifact id=%d for job %s", info.ID, jobID)
+		b.sendRoleJobAttachmentFallback(chat, jobID, info)
+	}
+}
+
+func (b *Bot) sendRoleJobAttachmentFallback(chat *telebot.Chat, jobID string, info artifactview.Info) {
+	msg := fmt.Sprintf("Proof image artifact #%d could not be attached. Use `/job %s` for durable artifact details.", info.ID, jobID)
+	if _, err := b.api.Send(chat, msg, &telebot.SendOptions{ParseMode: telebot.ModeMarkdown}); err != nil {
+		log.Printf("[role] failed to send proof attachment fallback for job %s", jobID)
+	}
+}
+
+func truncateTelegramField(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if max <= 0 || s == "" {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
+}

--- a/internal/bot/role_job_notifications.go
+++ b/internal/bot/role_job_notifications.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -33,6 +34,10 @@ func (b *Bot) waitAndNotifyRoleJob(chat *telebot.Chat, jobID string, maxWait tim
 	if maxWait <= 0 {
 		maxWait = 10 * time.Minute
 	}
+	ctx := b.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	go func() {
 		ticker := time.NewTicker(500 * time.Millisecond)
@@ -54,6 +59,9 @@ func (b *Bot) waitAndNotifyRoleJob(chat *telebot.Chat, jobID string, maxWait tim
 				}
 			case <-deadline.C:
 				log.Printf("[role] timed out waiting for job %s terminal notification", jobID)
+				return
+			case <-ctx.Done():
+				log.Printf("[role] bot shutting down; cancelling notification wait for job %s", jobID)
 				return
 			}
 		}

--- a/internal/bot/steer_command_test.go
+++ b/internal/bot/steer_command_test.go
@@ -1,0 +1,73 @@
+package bot
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/telebot.v4"
+
+	"ok-gobot/internal/storage"
+)
+
+func TestHandleSteerCommandQueuesInputWithoutChangingQueueMode(t *testing.T) {
+	store, err := storage.New(filepath.Join(t.TempDir(), "bot.db"))
+	if err != nil {
+		t.Fatalf("storage.New() error = %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	const chatID int64 = 77
+	if err := store.SetSessionOption(chatID, "queue_mode", "collect"); err != nil {
+		t.Fatalf("SetSessionOption() error = %v", err)
+	}
+
+	bot := &Bot{store: store, queueManager: NewQueueManager()}
+	runToken := bot.queueManager.StartRun(chatID)
+	defer bot.queueManager.EndRun(chatID, runToken)
+
+	ctx := &fakeContext{msg: &telebot.Message{
+		Payload: "please focus on the failing test first",
+		Chat:    &telebot.Chat{ID: chatID, Type: telebot.ChatPrivate},
+		Sender:  &telebot.User{ID: 1},
+	}}
+
+	if err := bot.handleSteerCommand(ctx); err != nil {
+		t.Fatalf("handleSteerCommand() error = %v", err)
+	}
+	if depth := bot.queueManager.GetQueueDepth(chatID); depth != 1 {
+		t.Fatalf("queue depth = %d, want 1", depth)
+	}
+	mode, err := store.GetSessionOption(chatID, "queue_mode")
+	if err != nil {
+		t.Fatalf("GetSessionOption() error = %v", err)
+	}
+	if mode != "collect" {
+		t.Fatalf("queue mode changed to %q, want collect", mode)
+	}
+	if len(ctx.sent) != 1 || !strings.Contains(ctx.sent[0], "Queue mode remains `collect`") {
+		t.Fatalf("unexpected response: %#v", ctx.sent)
+	}
+}
+
+func TestHandleSteerCommandRequiresActiveRun(t *testing.T) {
+	store, err := storage.New(filepath.Join(t.TempDir(), "bot.db"))
+	if err != nil {
+		t.Fatalf("storage.New() error = %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	bot := &Bot{store: store, queueManager: NewQueueManager()}
+	ctx := &fakeContext{msg: &telebot.Message{
+		Payload: "new direction",
+		Chat:    &telebot.Chat{ID: 78, Type: telebot.ChatPrivate},
+		Sender:  &telebot.User{ID: 1},
+	}}
+
+	if err := bot.handleSteerCommand(ctx); err != nil {
+		t.Fatalf("handleSteerCommand() error = %v", err)
+	}
+	if len(ctx.sent) != 1 || !strings.Contains(ctx.sent[0], "No active run") {
+		t.Fatalf("unexpected response: %#v", ctx.sent)
+	}
+}


### PR DESCRIPTION
Implements #346

## Changes
- Sends role job start acknowledgements with job ID, role name, worker tier, and `/job` guidance.
- Adds terminal Telegram notifications for role jobs with success/failure reasons, proof artifact hints, and safe local image attachment fallback.
- Adds `/steer <text>` to queue steering input for active work without changing the chat's durable queue mode.

## Testing
- `bash .maestro/verify.sh` passed
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/` passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves Telegram role job controls by adding start acknowledgements with job metadata, terminal notifications with Markdown→plain-text fallback and proof artifact attachment, and a new `/steer` command for queuing steering input without changing durable queue mode. All three issues raised in the previous review round (missing shutdown context, permanent silence on transient store errors, and unescaped Markdown crashing the terminal notification) are fully addressed in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic bugs found; previous P1 findings are all resolved.

All three prior P1 issues are addressed: the goroutine now listens to ctx.Done(), transient store errors are counted and retried with continue, and Markdown send failures fall back to plain text. No new logic bugs were found across the nine changed files.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/bot/role_job_notifications.go | New file implementing polling goroutine for role job terminal notifications; all three prior review issues (shutdown context, transient error handling, Markdown fallback) are addressed. |
| internal/bot/commands.go | Adds `/steer` command handler that enqueues steering input to an active run without persisting queue mode changes. |
| internal/bot/role_commands.go | Delegates start acknowledgement to `formatRoleJobAck` and hooks `waitAndNotifyRoleJob`; upgrades artifact listing to use `FormatProofHints`. |
| internal/artifacts/display.go | Adds `FormatProofHints`, `FormatProofHint`, `FirstSafeLocalImage`, and supporting helpers; correctly avoids leaking local paths in user-visible text. |
| internal/bot/role_commands_test.go | New tests covering ack format, final notification formatting (success/failure), and the Markdown→plain-text retry path. |
| internal/bot/steer_command_test.go | Integration tests verify steering enqueues without mutating queue mode and that missing active run returns the correct message. |
| internal/artifacts/display_test.go | Adds tests confirming proof hints never leak local paths and `FirstSafeLocalImage` correctly skips unsafe or remote artifacts. |
| internal/bot/interrupt_integration_test.go | Extends the fake Telegram API to support controlled Markdown send failures and captures `ParseMode` per request, enabling the retry test. |
| internal/bot/bot.go | Registers `/steer` in the command menu and help text. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: retry role notifications as plain t..."](https://github.com/befeast/ok-gobot/commit/740d08c49f335af1ac8e4ab5e158b80d4e4ee625) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30480997)</sub>

<!-- /greptile_comment -->