### PR TITLE
Add backend health preflight and fallback policy

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -278,7 +278,10 @@ ai:
     - "claude-haiku-3-5-20241022"
 ```
 
-Note: fallback models share the same provider and API key as the primary.
+Backend health is preflighted before runs start. Unavailable or rate-limited
+models can fall through the configured order; auth, quota, and missing-tool
+failures stop immediately so they do not burn retry attempts. Fallback models
+share the same provider and API key as the primary.
 
 ---
 

--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -27,7 +27,7 @@ api:
 | `/api/mission/runs` | GET | Recent job runs with status, summary, errors, attempt count, and preflight refusal reasons |
 | `/api/mission/stats` | GET | Daily and total statistics (tokens, messages, sessions) |
 | `/api/mission/estop` | GET | Current emergency-stop state |
-| `/api/mission/providers` | GET | Active AI provider and model |
+| `/api/mission/providers` | GET | Active AI provider, backend identity, model tier/effort, health, and fallback decision |
 | `/api/mission/memory` | GET | Memory health: enabled state, backend, watcher, counts, freshness, and last error |
 | `/api/mission/evidence?session_key=...` | GET | Concise structured evidence timeline for a session, including Markdown rendering |
 | `/api/mission/supervisor` | GET | Current supervisor recovery decision and last safe action |
@@ -52,7 +52,7 @@ Run query parameters: `limit` (1-200), `status` (filter by run status). Stats qu
 - **Proof artifacts** -- screenshots, URLs, and text reports linked from job and worker rows
 - **Evidence timelines** -- redacted structured session ledger for preflight, commands, checks, reviews, retries, and final outcomes
 - **Stats** -- aggregate token usage and message counts
-- **Controls** -- emergency-stop state and active provider/model
+- **Controls** -- emergency-stop state plus active provider/model/backend health
 - **Memory** -- whether the memory index is enabled, fresh, watched, and error-free
 - **Supervisor** -- the current stuck-state decision, reason, planned approval action, and most recent safe recovery action
 

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -70,6 +70,9 @@ type RunComponents struct {
 	Agent         *ToolCallingAgent
 	Profile       *AgentProfile
 	BackendHealth ai.BackendHealth
+	Model         string
+	ModelTier     string
+	Effort        string
 }
 
 // Resolve creates the tool-calling agent and its dependencies for a chat session.
@@ -115,7 +118,7 @@ func (r *RunResolver) resolve(ctx context.Context, chatID int64, overrides *RunO
 	}
 	ta.SetHookRunner(NewHookRunner(r.HooksDir))
 
-	return &RunComponents{Agent: ta, Profile: profile, BackendHealth: backendHealth}, nil
+	return &RunComponents{Agent: ta, Profile: profile, BackendHealth: backendHealth, Model: model, ModelTier: modelTier, Effort: thinkLevel}, nil
 }
 
 func (r *RunResolver) preflightBackend(ctx context.Context, model, tier, effort string) (ai.BackendHealth, error) {

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -1,7 +1,10 @@
 package agent
 
 import (
+	"context"
+	"fmt"
 	"log"
+	"strings"
 
 	"ok-gobot/internal/ai"
 	"ok-gobot/internal/config"
@@ -20,13 +23,15 @@ type SessionStore interface {
 
 // AIResolverConfig holds AI provider configuration for creating clients.
 type AIResolverConfig struct {
-	Provider        string
-	Model           string
-	APIKey          string
-	BaseURL         string
-	DefaultThinking string
-	DefaultClient   ai.Client
-	ModelAliases    map[string]string
+	Provider         string
+	Model            string
+	APIKey           string
+	BaseURL          string
+	DefaultThinking  string
+	DefaultClient    ai.Client
+	ModelAliases     map[string]string
+	ModelTier        string
+	BackendPreflight func(context.Context, string, string, string) (ai.BackendHealth, error)
 	// MemoryMode controls how memory is injected into the system prompt.
 	// Recognized values: "eager" (default), "retrieval_first", "startup_recent".
 	MemoryMode string
@@ -62,20 +67,30 @@ type RunOverrides struct {
 
 // RunComponents holds everything needed to execute a single agent run.
 type RunComponents struct {
-	Agent   *ToolCallingAgent
-	Profile *AgentProfile
+	Agent         *ToolCallingAgent
+	Profile       *AgentProfile
+	BackendHealth ai.BackendHealth
 }
 
 // Resolve creates the tool-calling agent and its dependencies for a chat session.
 // isSubagent prevents injecting browser_task (avoids recursive subagent spawning).
 func (r *RunResolver) Resolve(chatID int64, overrides *RunOverrides, job *delegation.Job, isSubagent ...bool) (*RunComponents, error) {
-	return r.resolve(chatID, overrides, job, nil, isSubagent...)
+	return r.resolve(context.Background(), chatID, overrides, job, nil, isSubagent...)
 }
 
-func (r *RunResolver) resolve(chatID int64, overrides *RunOverrides, job *delegation.Job, recallCtx *memory.RecallContext, isSubagent ...bool) (*RunComponents, error) {
+func (r *RunResolver) resolve(ctx context.Context, chatID int64, overrides *RunOverrides, job *delegation.Job, recallCtx *memory.RecallContext, isSubagent ...bool) (*RunComponents, error) {
 	profile := r.resolveProfile(chatID)
 	model := r.resolveModel(chatID, profile, overrides)
 	thinkLevel := r.resolveThinkLevel(chatID, overrides)
+	modelTier := r.resolveModelTier(profile, job, overrides)
+	backendHealth, err := r.preflightBackend(ctx, model, modelTier, thinkLevel)
+	if err != nil {
+		return nil, err
+	}
+	if backendHealth.Identity.Model != "" && backendHealth.Identity.Model != model {
+		log.Printf("[resolver] backend fallback selected model=%s instead of requested=%s reason=%s", backendHealth.Identity.Model, model, backendHealth.Fallback.Reason)
+		model = backendHealth.Identity.Model
+	}
 	aiClient := r.buildAIClient(model, thinkLevel)
 	sub := len(isSubagent) > 0 && isSubagent[0]
 	memoryPolicy := r.buildMemoryRecallPolicy(chatID, profile, job, recallCtx)
@@ -100,7 +115,43 @@ func (r *RunResolver) resolve(chatID int64, overrides *RunOverrides, job *delega
 	}
 	ta.SetHookRunner(NewHookRunner(r.HooksDir))
 
-	return &RunComponents{Agent: ta, Profile: profile}, nil
+	return &RunComponents{Agent: ta, Profile: profile, BackendHealth: backendHealth}, nil
+}
+
+func (r *RunResolver) preflightBackend(ctx context.Context, model, tier, effort string) (ai.BackendHealth, error) {
+	if r == nil || r.AIConfig.BackendPreflight == nil {
+		return ai.BackendHealth{}, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	health, err := r.AIConfig.BackendPreflight(ctx, model, tier, effort)
+	identity := health.Identity.String()
+	if identity == "" {
+		identity = fmt.Sprintf("provider=%s model=%s tier=%s effort=%s", r.AIConfig.Provider, model, tier, effort)
+	}
+	decision := health.Fallback
+	log.Printf("[resolver] backend preflight: %s health=%s fallback_action=%s fallback_to=%s reason=%s", identity, health.Status, decision.Action, decision.ToModel, decision.Reason)
+	if err != nil {
+		return health, fmt.Errorf("backend preflight blocked session start: %w", err)
+	}
+	return health, nil
+}
+
+func (r *RunResolver) resolveModelTier(profile *AgentProfile, job *delegation.Job, overrides *RunOverrides) string {
+	if job != nil && strings.TrimSpace(job.Model) != "" {
+		return "job"
+	}
+	if overrides != nil && strings.TrimSpace(overrides.Model) != "" {
+		return "override"
+	}
+	if profile != nil && strings.TrimSpace(profile.Model) != "" {
+		return "agent"
+	}
+	if strings.TrimSpace(r.AIConfig.ModelTier) != "" {
+		return strings.TrimSpace(r.AIConfig.ModelTier)
+	}
+	return "default"
 }
 
 func (r *RunResolver) buildMemoryRecallPolicy(chatID int64, profile *AgentProfile, job *delegation.Job, recallCtx *memory.RecallContext) *memory.RecallPolicy {

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -182,7 +182,7 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 		}
 		recallCtx = &memoryScope
 	}
-	components, err := h.resolver.resolve(req.ChatID, overrides, job, recallCtx, req.IsSubagent)
+	components, err := h.resolver.resolve(req.Context, req.ChatID, overrides, job, recallCtx, req.IsSubagent)
 	if err != nil {
 		events <- RunEvent{Type: RunEventError, Err: err}
 		close(events)
@@ -301,7 +301,11 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 			history = extended
 		}
 
-		log.Printf("[hub] starting run for session %s (agent: %s)", req.SessionKey, profileName)
+		if components.BackendHealth.Identity.Model != "" {
+			log.Printf("[hub] starting run for session %s (agent: %s backend: %s fallback=%s)", req.SessionKey, profileName, components.BackendHealth.Identity.String(), components.BackendHealth.Fallback.Action)
+		} else {
+			log.Printf("[hub] starting run for session %s (agent: %s)", req.SessionKey, profileName)
+		}
 		result, err := components.Agent.ProcessRequestWithContent(ctx, content, req.UserContent, req.Session, history)
 
 		// Notify the task observer (evolution metrics collection).

--- a/internal/agent/runtime.go
+++ b/internal/agent/runtime.go
@@ -72,6 +72,19 @@ type RunEvent struct {
 	ProfileName string         // agent profile that handled the run
 }
 
+// RunStartInfo is emitted once a run has resolved backend preflight and been
+// registered as active.
+type RunStartInfo struct {
+	SessionKey    SessionKey
+	ChatID        int64
+	ProfileName   string
+	Model         string
+	ModelTier     string
+	Effort        string
+	Backend       string
+	BackendHealth ai.BackendHealth
+}
+
 // RunRequest carries everything the hub needs to execute an agent run.
 // The hub owns agent creation via its RunResolver — callers no longer
 // supply a pre-built ToolCallingAgent.
@@ -86,6 +99,7 @@ type RunRequest struct {
 	OnToolEvent  func(ToolEvent) // optional callback for tool status updates
 	OnDelta      func(string)    // optional callback for streamed text tokens
 	OnDeltaReset func()          // optional callback when tool calls follow text
+	OnRunStarted func(RunStartInfo)
 	Overrides    *RunOverrides   // optional explicit model/thinking overrides
 	Job          *delegation.Job // optional delegated-run contract
 	IsSubagent   bool            // true = don't inject browser_task into the run
@@ -272,6 +286,10 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 	h.active[req.SessionKey] = slot
 	h.mu.Unlock()
 
+	if req.OnRunStarted != nil {
+		req.OnRunStarted(h.runStartInfo(req, components, profileName))
+	}
+
 	go func() {
 		startTime := time.Now()
 		defer func() {
@@ -339,6 +357,37 @@ func (h *RuntimeHub) Submit(req RunRequest) <-chan RunEvent {
 	}()
 
 	return events
+}
+
+func (h *RuntimeHub) runStartInfo(req RunRequest, components *RunComponents, profileName string) RunStartInfo {
+	health := components.BackendHealth
+	model := components.Model
+	if health.Identity.Model != "" {
+		model = health.Identity.Model
+	}
+	modelTier := components.ModelTier
+	if health.Identity.Tier != "" {
+		modelTier = health.Identity.Tier
+	}
+	effort := components.Effort
+	if health.Identity.Effort != "" {
+		effort = health.Identity.Effort
+	}
+	backend := health.Identity.Backend
+	if backend == "" && h != nil && h.resolver != nil {
+		backend = h.resolver.AIConfig.Provider
+	}
+
+	return RunStartInfo{
+		SessionKey:    req.SessionKey,
+		ChatID:        req.ChatID,
+		ProfileName:   profileName,
+		Model:         model,
+		ModelTier:     modelTier,
+		Effort:        effort,
+		Backend:       backend,
+		BackendHealth: health,
+	}
 }
 
 // Cancel stops the active run for the given session key (no-op if none).

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -101,6 +102,42 @@ func TestRuntimeHub_SubmitAndReceiveResult(t *testing.T) {
 	}
 	if got.ProfileName != "default" {
 		t.Fatalf("expected profile 'default', got '%s'", got.ProfileName)
+	}
+}
+
+func TestRuntimeHub_PreflightFailureBlocksBeforeRunStarts(t *testing.T) {
+	resolver := newTestResolver("should not run")
+	resolver.AIConfig.BackendPreflight = func(context.Context, string, string, string) (ai.BackendHealth, error) {
+		return ai.BackendHealth{
+			Identity: ai.BackendIdentity{Provider: "anthropic", Backend: "anthropic", Model: "test-model"},
+			Status:   ai.BackendHealthAuthFailed,
+			Fallback: ai.FallbackDecision{Action: ai.FallbackActionStop, Reason: "auth requires operator action"},
+		}, errors.New("authentication failed")
+	}
+	hub := NewRuntimeHub(resolver)
+
+	events := hub.Submit(RunRequest{
+		SessionKey: "dm:preflight",
+		ChatID:     123,
+		Content:    "hi",
+		Context:    context.Background(),
+	})
+
+	var got *RunEvent
+	for ev := range events {
+		got = &ev
+	}
+	if got == nil || got.Type != RunEventError {
+		t.Fatalf("expected preflight error event, got %+v", got)
+	}
+	if !strings.Contains(got.Err.Error(), "backend preflight blocked session start") {
+		t.Fatalf("unexpected error: %v", got.Err)
+	}
+	hub.mu.Lock()
+	active := len(hub.active)
+	hub.mu.Unlock()
+	if active != 0 {
+		t.Fatalf("active runs=%d, want 0", active)
 	}
 }
 

--- a/internal/agent/runtime_test.go
+++ b/internal/agent/runtime_test.go
@@ -115,12 +115,16 @@ func TestRuntimeHub_PreflightFailureBlocksBeforeRunStarts(t *testing.T) {
 		}, errors.New("authentication failed")
 	}
 	hub := NewRuntimeHub(resolver)
+	started := false
 
 	events := hub.Submit(RunRequest{
 		SessionKey: "dm:preflight",
 		ChatID:     123,
 		Content:    "hi",
 		Context:    context.Background(),
+		OnRunStarted: func(RunStartInfo) {
+			started = true
+		},
 	})
 
 	var got *RunEvent
@@ -133,11 +137,85 @@ func TestRuntimeHub_PreflightFailureBlocksBeforeRunStarts(t *testing.T) {
 	if !strings.Contains(got.Err.Error(), "backend preflight blocked session start") {
 		t.Fatalf("unexpected error: %v", got.Err)
 	}
+	if started {
+		t.Fatal("OnRunStarted must not fire when backend preflight blocks the run")
+	}
 	hub.mu.Lock()
 	active := len(hub.active)
 	hub.mu.Unlock()
 	if active != 0 {
 		t.Fatalf("active runs=%d, want 0", active)
+	}
+}
+
+func TestRuntimeHub_OnRunStartedUsesResolvedBackendMetadata(t *testing.T) {
+	resolver := newTestResolver("resolved")
+	resolver.AIConfig.DefaultThinking = "high"
+	resolver.AIConfig.BackendPreflight = func(ctx context.Context, model, tier, effort string) (ai.BackendHealth, error) {
+		if model != "test-model" {
+			t.Fatalf("preflight model=%q, want test-model", model)
+		}
+		if tier != "agent" {
+			t.Fatalf("preflight tier=%q, want agent", tier)
+		}
+		if effort != "high" {
+			t.Fatalf("preflight effort=%q, want high", effort)
+		}
+		return ai.BackendHealth{
+			Identity: ai.BackendIdentity{
+				Provider: "anthropic",
+				Backend:  "opencode",
+				Model:    "fallback-model",
+				Tier:     tier,
+				Effort:   effort,
+			},
+			Status: ai.BackendHealthHealthy,
+			Fallback: ai.FallbackDecision{
+				Action:    ai.FallbackActionFallback,
+				FromModel: model,
+				ToModel:   "fallback-model",
+				Reason:    "rate_limit is fallbackable",
+			},
+		}, nil
+	}
+	hub := NewRuntimeHub(resolver)
+
+	var started []RunStartInfo
+	events := hub.Submit(RunRequest{
+		SessionKey: "dm:resolved",
+		ChatID:     321,
+		Content:    "hi",
+		Context:    context.Background(),
+		OnRunStarted: func(info RunStartInfo) {
+			started = append(started, info)
+		},
+	})
+
+	var got *RunEvent
+	for ev := range events {
+		got = &ev
+	}
+	if got == nil || got.Type != RunEventDone {
+		t.Fatalf("expected successful run, got %+v", got)
+	}
+	if len(started) != 1 {
+		t.Fatalf("OnRunStarted calls=%d, want 1", len(started))
+	}
+	info := started[0]
+	if info.Model != "fallback-model" {
+		t.Fatalf("started model=%q, want fallback-model", info.Model)
+	}
+	if info.ModelTier != "agent" {
+		t.Fatalf("started tier=%q, want agent", info.ModelTier)
+	}
+	if info.Effort != "high" {
+		t.Fatalf("started effort=%q, want high", info.Effort)
+	}
+	if info.Backend != "opencode" {
+		t.Fatalf("started backend=%q, want opencode", info.Backend)
+	}
+	if info.BackendHealth.Status != ai.BackendHealthHealthy {
+		t.Fatalf("started health=%q, want healthy", info.BackendHealth.Status)
 	}
 }
 

--- a/internal/ai/backend_health.go
+++ b/internal/ai/backend_health.go
@@ -1,0 +1,470 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+// BackendFailureKind is the normalized reason a backend/model is not usable.
+type BackendFailureKind string
+
+const (
+	BackendFailureNone        BackendFailureKind = ""
+	BackendFailureUnavailable BackendFailureKind = "unavailable"
+	BackendFailureAuth        BackendFailureKind = "auth"
+	BackendFailureQuota       BackendFailureKind = "quota"
+	BackendFailureRateLimit   BackendFailureKind = "rate_limit"
+	BackendFailureToolMissing BackendFailureKind = "tool_missing"
+	BackendFailureModel       BackendFailureKind = "model_missing"
+	BackendFailureUnknown     BackendFailureKind = "unknown"
+)
+
+// BackendHealthStatus is the health state shown in status and Mission Control.
+type BackendHealthStatus string
+
+const (
+	BackendHealthHealthy          BackendHealthStatus = "healthy"
+	BackendHealthUnavailable      BackendHealthStatus = "unavailable"
+	BackendHealthAuthFailed       BackendHealthStatus = "auth_failed"
+	BackendHealthQuotaFailed      BackendHealthStatus = "quota_failed"
+	BackendHealthRateLimited      BackendHealthStatus = "rate_limited"
+	BackendHealthToolMissing      BackendHealthStatus = "tool_missing"
+	BackendHealthModelMissing     BackendHealthStatus = "model_missing"
+	BackendHealthApprovalRequired BackendHealthStatus = "approval_required"
+	BackendHealthSkipped          BackendHealthStatus = "skipped"
+)
+
+// BackendIdentity describes the concrete backend/model selected for a run.
+type BackendIdentity struct {
+	Provider      string   `json:"provider"`
+	Backend       string   `json:"backend,omitempty"`
+	Model         string   `json:"model"`
+	Tier          string   `json:"tier,omitempty"`
+	Effort        string   `json:"effort,omitempty"`
+	BaseURL       string   `json:"base_url,omitempty"`
+	FallbackOrder []string `json:"fallback_order,omitempty"`
+}
+
+// String returns a compact identity suitable for logs.
+func (id BackendIdentity) String() string {
+	parts := []string{}
+	if id.Provider != "" {
+		parts = append(parts, "provider="+id.Provider)
+	}
+	if id.Backend != "" {
+		parts = append(parts, "backend="+id.Backend)
+	}
+	if id.Model != "" {
+		parts = append(parts, "model="+id.Model)
+	}
+	if id.Tier != "" {
+		parts = append(parts, "tier="+id.Tier)
+	}
+	if id.Effort != "" {
+		parts = append(parts, "effort="+id.Effort)
+	}
+	return strings.Join(parts, " ")
+}
+
+// FallbackAction is the policy action selected for a backend failure.
+type FallbackAction string
+
+const (
+	FallbackActionPrimary  FallbackAction = "primary"
+	FallbackActionFallback FallbackAction = "fallback"
+	FallbackActionStop     FallbackAction = "stop"
+	FallbackActionApproval FallbackAction = "approval_required"
+)
+
+// FallbackDecision records why a backend was used, skipped, or blocked.
+type FallbackDecision struct {
+	Action      FallbackAction     `json:"action"`
+	Enabled     bool               `json:"enabled"`
+	FailureKind BackendFailureKind `json:"failure_kind,omitempty"`
+	FromModel   string             `json:"from_model,omitempty"`
+	ToModel     string             `json:"to_model,omitempty"`
+	Order       []string           `json:"order,omitempty"`
+	Reason      string             `json:"reason,omitempty"`
+}
+
+// BackendHealth is the health snapshot exposed to runtime/status surfaces.
+type BackendHealth struct {
+	Identity    BackendIdentity     `json:"identity"`
+	Status      BackendHealthStatus `json:"status"`
+	FailureKind BackendFailureKind  `json:"failure_kind,omitempty"`
+	Detail      string              `json:"detail,omitempty"`
+	LatencyMS   int64               `json:"latency_ms,omitempty"`
+	CheckedAt   string              `json:"checked_at,omitempty"`
+	Fallback    FallbackDecision    `json:"fallback"`
+}
+
+// OK reports whether this health snapshot allows a run to start.
+func (h BackendHealth) OK() bool {
+	return h.Status == BackendHealthHealthy
+}
+
+// BackendPreflightConfig configures backend/model checks.
+type BackendPreflightConfig struct {
+	Provider        ProviderConfig
+	Droid           DroidConfig
+	FallbackModels  []string
+	FallbackEnabled bool
+	CacheTTL        time.Duration
+	Now             func() time.Time
+	Probe           func(context.Context, ProviderConfig, DroidConfig) ProbeResult
+}
+
+// BackendPreflight probes and caches backend/model health before runs start.
+type BackendPreflight struct {
+	cfg BackendPreflightConfig
+
+	mu    sync.Mutex
+	cache map[string]cachedBackendHealth
+}
+
+type cachedBackendHealth struct {
+	health    BackendHealth
+	expiresAt time.Time
+}
+
+// NewBackendPreflight creates a reusable backend health checker.
+func NewBackendPreflight(cfg BackendPreflightConfig) *BackendPreflight {
+	if cfg.CacheTTL <= 0 {
+		cfg.CacheTTL = 30 * time.Second
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Probe == nil {
+		cfg.Probe = ProbeProvider
+	}
+	return &BackendPreflight{cfg: cfg, cache: make(map[string]cachedBackendHealth)}
+}
+
+// Check verifies model health and returns the selected identity. If fallback is
+// used, the returned identity points at the fallback model that should be used.
+func (p *BackendPreflight) Check(ctx context.Context, model, tier, effort string) (BackendHealth, error) {
+	if p == nil {
+		return BackendHealth{}, fmt.Errorf("backend preflight is not configured")
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		model = strings.TrimSpace(p.cfg.Provider.Model)
+	}
+	tier = strings.TrimSpace(tier)
+	effort = strings.TrimSpace(effort)
+
+	cacheKey := strings.Join([]string{model, tier, effort}, "\x00")
+	if health, ok := p.cached(cacheKey); ok {
+		if health.OK() {
+			return health, nil
+		}
+		return health, backendPreflightError(health)
+	}
+
+	order := fallbackOrder(model, p.cfg.FallbackModels)
+	primaryProbe := p.probe(ctx, model)
+	primaryIdentity := p.identity(primaryProbe, model, tier, effort, order)
+	if primaryProbe.Status == ProbeOK {
+		health := backendHealthFromProbe(primaryProbe, primaryIdentity, FallbackDecision{
+			Action:  FallbackActionPrimary,
+			Enabled: p.cfg.FallbackEnabled && len(order) > 1,
+			Order:   order,
+			Reason:  "primary backend healthy",
+		})
+		p.store(cacheKey, health)
+		return health, nil
+	}
+
+	kind := primaryProbe.FailureKind
+	if kind == "" {
+		kind = failureKindForProbeStatus(primaryProbe.Status)
+	}
+	decision := DecideFallback(kind, p.cfg.FallbackEnabled && len(order) > 1, model, order)
+	if decision.Action == FallbackActionFallback {
+		var last BackendHealth
+		for _, fallbackModel := range order[1:] {
+			probe := p.probe(ctx, fallbackModel)
+			identity := p.identity(probe, fallbackModel, tier, effort, order)
+			decision.ToModel = fallbackModel
+			if probe.Status == ProbeOK {
+				health := backendHealthFromProbe(probe, identity, decision)
+				p.store(cacheKey, health)
+				return health, nil
+			}
+			last = backendHealthFromProbe(probe, identity, decision)
+			last.Detail = strings.TrimSpace(last.Detail)
+			if !fallbackableFailure(last.FailureKind) {
+				break
+			}
+		}
+		if last.Status != "" {
+			last.Fallback.Action = FallbackActionStop
+			if last.Fallback.Reason == "" {
+				last.Fallback.Reason = "fallback order exhausted"
+			}
+			p.store(cacheKey, last)
+			return last, backendPreflightError(last)
+		}
+	}
+
+	health := backendHealthFromProbe(primaryProbe, primaryIdentity, decision)
+	if decision.Action == FallbackActionApproval {
+		health.Status = BackendHealthApprovalRequired
+	}
+	p.store(cacheKey, health)
+	return health, backendPreflightError(health)
+}
+
+func (p *BackendPreflight) probe(ctx context.Context, model string) ProbeResult {
+	cfg := p.cfg.Provider
+	cfg.Model = model
+	return p.cfg.Probe(ctx, cfg, p.cfg.Droid)
+}
+
+func (p *BackendPreflight) identity(probe ProbeResult, model, tier, effort string, order []string) BackendIdentity {
+	provider := strings.TrimSpace(p.cfg.Provider.Name)
+	if probe.Provider != "" {
+		provider = probe.Provider
+	}
+	backend := strings.TrimSpace(probe.Backend)
+	if backend == "" {
+		backend = provider
+	}
+	baseURL := strings.TrimSpace(p.cfg.Provider.BaseURL)
+	if probe.BaseURL != "" {
+		baseURL = probe.BaseURL
+	}
+	return BackendIdentity{
+		Provider:      provider,
+		Backend:       backend,
+		Model:         model,
+		Tier:          tier,
+		Effort:        effort,
+		BaseURL:       baseURL,
+		FallbackOrder: append([]string(nil), order...),
+	}
+}
+
+func (p *BackendPreflight) cached(key string) (BackendHealth, bool) {
+	now := p.cfg.Now()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cached, ok := p.cache[key]
+	if !ok || now.After(cached.expiresAt) {
+		return BackendHealth{}, false
+	}
+	return cached.health, true
+}
+
+func (p *BackendPreflight) store(key string, health BackendHealth) {
+	p.mu.Lock()
+	p.cache[key] = cachedBackendHealth{health: health, expiresAt: p.cfg.Now().Add(p.cfg.CacheTTL)}
+	p.mu.Unlock()
+}
+
+func backendHealthFromProbe(probe ProbeResult, identity BackendIdentity, decision FallbackDecision) BackendHealth {
+	kind := probe.FailureKind
+	if kind == "" {
+		kind = failureKindForProbeStatus(probe.Status)
+	}
+	return BackendHealth{
+		Identity:    identity,
+		Status:      backendStatusForProbe(probe.Status),
+		FailureKind: kind,
+		Detail:      strings.TrimSpace(probe.Detail),
+		LatencyMS:   probe.Latency.Milliseconds(),
+		CheckedAt:   time.Now().UTC().Format(time.RFC3339),
+		Fallback:    decision,
+	}
+}
+
+func backendPreflightError(health BackendHealth) error {
+	if health.OK() {
+		return nil
+	}
+	reason := health.Fallback.Reason
+	if reason == "" {
+		reason = health.Detail
+	}
+	if reason == "" {
+		reason = string(health.Status)
+	}
+	return fmt.Errorf("%s backend preflight failed for model %q: %s", health.Identity.Provider, health.Identity.Model, reason)
+}
+
+// DecideFallback encodes the runtime fallback policy.
+func DecideFallback(kind BackendFailureKind, enabled bool, fromModel string, order []string) FallbackDecision {
+	decision := FallbackDecision{
+		Enabled:     enabled,
+		FailureKind: kind,
+		FromModel:   fromModel,
+		Order:       append([]string(nil), order...),
+	}
+	if kind == BackendFailureNone {
+		decision.Action = FallbackActionPrimary
+		decision.Reason = "primary backend healthy"
+		return decision
+	}
+	if !enabled || len(order) <= 1 {
+		decision.Action = FallbackActionStop
+		decision.Reason = "fallback disabled"
+		return decision
+	}
+	switch kind {
+	case BackendFailureUnavailable, BackendFailureRateLimit:
+		decision.Action = FallbackActionFallback
+		decision.Reason = fmt.Sprintf("%s is fallbackable", kind)
+		return decision
+	case BackendFailureAuth, BackendFailureQuota, BackendFailureToolMissing:
+		decision.Action = FallbackActionStop
+		decision.Reason = fmt.Sprintf("%s requires operator action", kind)
+		return decision
+	case BackendFailureModel, BackendFailureUnknown:
+		decision.Action = FallbackActionApproval
+		decision.Reason = fmt.Sprintf("%s requires approval before changing model", kind)
+		return decision
+	default:
+		decision.Action = FallbackActionApproval
+		decision.Reason = "unclassified backend failure requires approval"
+		return decision
+	}
+}
+
+// ClassifyBackendError normalizes provider and CLI errors for fallback policy.
+func ClassifyBackendError(err error) BackendFailureKind {
+	if err == nil {
+		return BackendFailureNone
+	}
+	msg := strings.ToLower(err.Error())
+	var statusCode int
+	if _, scanErr := fmt.Sscanf(err.Error(), "API error (status %d):", &statusCode); scanErr == nil {
+		return failureKindForHTTP(statusCode, msg)
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return BackendFailureUnavailable
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return BackendFailureUnavailable
+	}
+	switch {
+	case strings.Contains(msg, "unauthorized"), strings.Contains(msg, "forbidden"), strings.Contains(msg, "invalid api key"), strings.Contains(msg, "authentication failed"), strings.Contains(msg, "invalid x-api-key"):
+		return BackendFailureAuth
+	case strings.Contains(msg, "insufficient_quota"), strings.Contains(msg, "quota exceeded"), strings.Contains(msg, "billing hard limit"), strings.Contains(msg, "credit balance"):
+		return BackendFailureQuota
+	case strings.Contains(msg, "rate limit"), strings.Contains(msg, "too many requests"), strings.Contains(msg, "429"):
+		return BackendFailureRateLimit
+	case strings.Contains(msg, "tool not found"), strings.Contains(msg, "missing tool"), strings.Contains(msg, "tools unsupported"), strings.Contains(msg, "tool use not supported"), strings.Contains(msg, "unknown tool"):
+		return BackendFailureToolMissing
+	case strings.Contains(msg, "context_length_exceeded"), strings.Contains(msg, "context length"):
+		return BackendFailureUnavailable
+	case strings.Contains(msg, "model not found"), strings.Contains(msg, "unknown model"), strings.Contains(msg, "does not exist"):
+		return BackendFailureModel
+	case strings.Contains(msg, "connection reset"), strings.Contains(msg, "tls handshake"), strings.Contains(msg, "no such host"), strings.Contains(msg, "binary not found"), strings.Contains(msg, "executable file not found"):
+		return BackendFailureUnavailable
+	default:
+		return BackendFailureUnknown
+	}
+}
+
+func fallbackOrder(primary string, fallbacks []string) []string {
+	seen := map[string]struct{}{}
+	order := []string{}
+	for _, model := range append([]string{primary}, fallbacks...) {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		if _, ok := seen[model]; ok {
+			continue
+		}
+		seen[model] = struct{}{}
+		order = append(order, model)
+	}
+	return order
+}
+
+func fallbackableFailure(kind BackendFailureKind) bool {
+	return kind == BackendFailureUnavailable || kind == BackendFailureRateLimit
+}
+
+func backendStatusForProbe(status ProbeStatus) BackendHealthStatus {
+	switch status {
+	case ProbeOK:
+		return BackendHealthHealthy
+	case ProbeAuthFailed:
+		return BackendHealthAuthFailed
+	case ProbeQuotaFailed:
+		return BackendHealthQuotaFailed
+	case ProbeRateLimited:
+		return BackendHealthRateLimited
+	case ProbeToolMissing:
+		return BackendHealthToolMissing
+	case ProbeModelNotFound:
+		return BackendHealthModelMissing
+	case ProbeSkipped:
+		return BackendHealthSkipped
+	default:
+		return BackendHealthUnavailable
+	}
+}
+
+func failureKindForProbeStatus(status ProbeStatus) BackendFailureKind {
+	switch status {
+	case ProbeOK:
+		return BackendFailureNone
+	case ProbeAuthFailed:
+		return BackendFailureAuth
+	case ProbeQuotaFailed:
+		return BackendFailureQuota
+	case ProbeRateLimited:
+		return BackendFailureRateLimit
+	case ProbeToolMissing:
+		return BackendFailureToolMissing
+	case ProbeModelNotFound:
+		return BackendFailureModel
+	case ProbeEndpointUnreachable:
+		return BackendFailureUnavailable
+	default:
+		return BackendFailureUnknown
+	}
+}
+
+func failureKindForHTTP(statusCode int, body string) BackendFailureKind {
+	switch statusCode {
+	case 401, 403:
+		return BackendFailureAuth
+	case 402:
+		return BackendFailureQuota
+	case 429:
+		if strings.Contains(body, "insufficient_quota") || strings.Contains(body, "quota") {
+			return BackendFailureQuota
+		}
+		return BackendFailureRateLimit
+	case 404:
+		return BackendFailureModel
+	case 500, 502, 503, 504:
+		return BackendFailureUnavailable
+	}
+	if strings.Contains(body, "tool") && (strings.Contains(body, "not found") || strings.Contains(body, "unsupported") || strings.Contains(body, "missing")) {
+		return BackendFailureToolMissing
+	}
+	if strings.Contains(body, "context_length_exceeded") || strings.Contains(body, "context length") {
+		return BackendFailureUnavailable
+	}
+	if strings.Contains(body, "insufficient_quota") || strings.Contains(body, "quota exceeded") {
+		return BackendFailureQuota
+	}
+	if strings.Contains(body, "rate limit") || strings.Contains(body, "too many requests") {
+		return BackendFailureRateLimit
+	}
+	return BackendFailureUnknown
+}

--- a/internal/ai/backend_health_test.go
+++ b/internal/ai/backend_health_test.go
@@ -1,0 +1,136 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestBackendPreflightHealthy(t *testing.T) {
+	checker := NewBackendPreflight(BackendPreflightConfig{
+		Provider: ProviderConfig{Name: "anthropic", Model: "claude-sonnet"},
+		Probe: func(context.Context, ProviderConfig, DroidConfig) ProbeResult {
+			return ProbeResult{Provider: "anthropic", Backend: "anthropic", Model: "claude-sonnet", Status: ProbeOK}
+		},
+	})
+
+	health, err := checker.Check(context.Background(), "claude-sonnet", "premium", "high")
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if health.Status != BackendHealthHealthy {
+		t.Fatalf("status=%s, want healthy", health.Status)
+	}
+	if health.Identity.Model != "claude-sonnet" || health.Identity.Tier != "premium" || health.Identity.Effort != "high" {
+		t.Fatalf("identity not recorded: %+v", health.Identity)
+	}
+	if health.Fallback.Action != FallbackActionPrimary {
+		t.Fatalf("fallback action=%s, want primary", health.Fallback.Action)
+	}
+}
+
+func TestBackendPreflightUnavailableFallsBack(t *testing.T) {
+	probes := map[string]ProbeStatus{
+		"primary":  ProbeEndpointUnreachable,
+		"fallback": ProbeOK,
+	}
+	checker := NewBackendPreflight(BackendPreflightConfig{
+		Provider:        ProviderConfig{Name: "openai", Model: "primary"},
+		FallbackModels:  []string{"fallback"},
+		FallbackEnabled: true,
+		Probe: func(_ context.Context, cfg ProviderConfig, _ DroidConfig) ProbeResult {
+			status := probes[cfg.Model]
+			return ProbeResult{Provider: "openai", Backend: "openai", Model: cfg.Model, Status: status, FailureKind: failureKindForProbeStatus(status), Detail: "probe result"}
+		},
+	})
+
+	health, err := checker.Check(context.Background(), "primary", "standard", "medium")
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if health.Identity.Model != "fallback" {
+		t.Fatalf("model=%q, want fallback", health.Identity.Model)
+	}
+	if health.Fallback.Action != FallbackActionFallback || health.Fallback.FromModel != "primary" || health.Fallback.ToModel != "fallback" {
+		t.Fatalf("unexpected fallback decision: %+v", health.Fallback)
+	}
+}
+
+func TestBackendPreflightAuthFailureStops(t *testing.T) {
+	checker := NewBackendPreflight(BackendPreflightConfig{
+		Provider:        ProviderConfig{Name: "openai", Model: "primary"},
+		FallbackModels:  []string{"fallback"},
+		FallbackEnabled: true,
+		Probe: func(_ context.Context, cfg ProviderConfig, _ DroidConfig) ProbeResult {
+			return ProbeResult{Provider: "openai", Backend: "openai", Model: cfg.Model, Status: ProbeAuthFailed, FailureKind: BackendFailureAuth, Detail: "bad key"}
+		},
+	})
+
+	health, err := checker.Check(context.Background(), "primary", "standard", "off")
+	if err == nil {
+		t.Fatal("expected auth preflight error")
+	}
+	if health.Status != BackendHealthAuthFailed || health.Fallback.Action != FallbackActionStop {
+		t.Fatalf("unexpected health=%+v", health)
+	}
+}
+
+func TestBackendPreflightQuotaFailureStops(t *testing.T) {
+	checker := NewBackendPreflight(BackendPreflightConfig{
+		Provider:        ProviderConfig{Name: "openai", Model: "primary"},
+		FallbackModels:  []string{"fallback"},
+		FallbackEnabled: true,
+		Probe: func(_ context.Context, cfg ProviderConfig, _ DroidConfig) ProbeResult {
+			return ProbeResult{Provider: "openai", Backend: "openai", Model: cfg.Model, Status: ProbeQuotaFailed, FailureKind: BackendFailureQuota, Detail: "quota exceeded"}
+		},
+	})
+
+	health, err := checker.Check(context.Background(), "primary", "standard", "off")
+	if err == nil {
+		t.Fatal("expected quota preflight error")
+	}
+	if health.FailureKind != BackendFailureQuota || health.Fallback.Action != FallbackActionStop {
+		t.Fatalf("unexpected health=%+v", health)
+	}
+}
+
+func TestBackendPreflightFallbackDisabled(t *testing.T) {
+	checker := NewBackendPreflight(BackendPreflightConfig{
+		Provider:        ProviderConfig{Name: "openai", Model: "primary"},
+		FallbackModels:  []string{"fallback"},
+		FallbackEnabled: false,
+		Probe: func(_ context.Context, cfg ProviderConfig, _ DroidConfig) ProbeResult {
+			return ProbeResult{Provider: "openai", Backend: "openai", Model: cfg.Model, Status: ProbeEndpointUnreachable, FailureKind: BackendFailureUnavailable, Detail: "down"}
+		},
+	})
+
+	health, err := checker.Check(context.Background(), "primary", "standard", "off")
+	if err == nil {
+		t.Fatal("expected fallback-disabled preflight error")
+	}
+	if health.Fallback.Action != FallbackActionStop || !strings.Contains(health.Fallback.Reason, "disabled") {
+		t.Fatalf("unexpected decision=%+v", health.Fallback)
+	}
+}
+
+func TestClassifyBackendErrorDistinguishesFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want BackendFailureKind
+	}{
+		{"auth", errors.New("API error (status 401): unauthorized"), BackendFailureAuth},
+		{"quota", errors.New("API error (status 402): insufficient_quota"), BackendFailureQuota},
+		{"rate limit", errors.New("API error (status 429): rate limit exceeded"), BackendFailureRateLimit},
+		{"tool missing", errors.New("tool not found: browser"), BackendFailureToolMissing},
+		{"unavailable", errors.New("request failed: no such host"), BackendFailureUnavailable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyBackendError(tt.err); got != tt.want {
+				t.Fatalf("ClassifyBackendError()=%s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ai/droid_client.go
+++ b/internal/ai/droid_client.go
@@ -47,12 +47,25 @@ func newDroidClientWithAdapter(config ProviderConfig, droidCfg DroidConfig, adap
 		droidCfg.BinaryPath = "droid"
 	}
 	if adapter == nil {
-		adapter = worker.NewDroidAdapter(droidCfg)
+		adapter = newCLITransportAdapter(droidCfg)
 	}
 	return &DroidClient{
 		config:   config,
 		droidCfg: droidCfg,
 		adapter:  adapter,
+	}
+}
+
+func newCLITransportAdapter(cfg DroidConfig) worker.Adapter {
+	switch worker.DetectBackend(cfg.BinaryPath) {
+	case "claude":
+		return worker.NewClaudeAdapter(worker.ClaudeConfig{BinaryPath: cfg.BinaryPath, WorkDir: cfg.WorkDir})
+	case "codex":
+		return worker.NewCodexAdapter(worker.CodexConfig{BinaryPath: cfg.BinaryPath, WorkDir: cfg.WorkDir})
+	case "opencode":
+		return worker.NewOpenCodeAdapter(worker.OpenCodeConfig{BinaryPath: cfg.BinaryPath, WorkDir: cfg.WorkDir})
+	default:
+		return worker.NewDroidAdapter(cfg)
 	}
 }
 

--- a/internal/ai/droid_client_test.go
+++ b/internal/ai/droid_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 
@@ -46,6 +47,26 @@ func TestNewDroidClient_CustomBinary(t *testing.T) {
 	client := NewDroidClient(ProviderConfig{Name: "droid"}, DroidConfig{BinaryPath: "/usr/local/bin/droid"})
 	if client.droidCfg.BinaryPath != "/usr/local/bin/droid" {
 		t.Errorf("expected custom binary_path, got %q", client.droidCfg.BinaryPath)
+	}
+}
+
+func TestNewDroidClient_SelectsCLITransportAdapter(t *testing.T) {
+	tests := []struct {
+		binary string
+		want   string
+	}{
+		{"claude", "*worker.ClaudeAdapter"},
+		{"codex", "*worker.CodexAdapter"},
+		{"opencode", "*worker.OpenCodeAdapter"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.binary, func(t *testing.T) {
+			client := NewDroidClient(ProviderConfig{Name: "droid"}, DroidConfig{BinaryPath: tt.binary})
+			got := reflect.TypeOf(client.adapter).String()
+			if got != tt.want {
+				t.Fatalf("adapter=%s, want %s", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/ai/failover.go
+++ b/internal/ai/failover.go
@@ -23,9 +23,10 @@ type failoverEntry struct {
 // FailoverClient wraps multiple clients and tries them in order on retryable errors.
 // It implements the Client interface.
 type FailoverClient struct {
-	entries   []failoverEntry
-	cooldowns map[string]time.Time
-	mu        sync.RWMutex
+	entries      []failoverEntry
+	cooldowns    map[string]time.Time
+	lastDecision FallbackDecision
+	mu           sync.RWMutex
 }
 
 // SupportsVision reports true when every configured fallback client supports
@@ -94,6 +95,14 @@ func isRetryableError(statusCode int, body string) bool {
 // isRetryableFromErr extracts the status code from an error message and decides
 // whether the error is retryable. Also treats network-level failures as retryable.
 func isRetryableFromErr(err error) bool {
+	decision := DecideFallback(ClassifyBackendError(err), true, "", []string{"primary", "fallback"})
+	if decision.Action == FallbackActionFallback {
+		return true
+	}
+	if decision.Action == FallbackActionStop || decision.Action == FallbackActionApproval {
+		return false
+	}
+
 	msg := err.Error()
 	var statusCode int
 	if _, scanErr := fmt.Sscanf(msg, "API error (status %d):", &statusCode); scanErr == nil {
@@ -117,6 +126,16 @@ func isRetryableFromErr(err error) bool {
 	return false
 }
 
+// LastFallbackDecision returns the most recent failover decision for status/logging.
+func (fc *FailoverClient) LastFallbackDecision() FallbackDecision {
+	if fc == nil {
+		return FallbackDecision{}
+	}
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.lastDecision
+}
+
 // isCooledDown reports whether a model is currently in cooldown.
 func (fc *FailoverClient) isCooledDown(model string) bool {
 	fc.mu.RLock()
@@ -135,6 +154,12 @@ func (fc *FailoverClient) setCooldown(model string) {
 	defer fc.mu.Unlock()
 
 	fc.cooldowns[model] = time.Now().Add(cooldownDuration)
+}
+
+func (fc *FailoverClient) setDecision(decision FallbackDecision) {
+	fc.mu.Lock()
+	fc.lastDecision = decision
+	fc.mu.Unlock()
 }
 
 // Complete implements Client. It tries each model in order, skipping ones in
@@ -160,13 +185,17 @@ func (fc *FailoverClient) Complete(ctx context.Context, messages []Message) (str
 		}
 
 		lastErr = err
-		if isRetryableFromErr(err) {
-			log.Printf("[failover] Complete: model %s failed with retryable error (%v), trying next", entry.model, err)
+		kind := ClassifyBackendError(err)
+		decision := DecideFallback(kind, hasNextAvailableModel(fc, entry.model), entry.model, fc.models())
+		fc.setDecision(decision)
+		if decision.Action == FallbackActionFallback {
+			log.Printf("[failover] Complete: model %s failed (%s), fallback decision=%s next=%s err=%v", entry.model, kind, decision.Action, nextAvailableModel(fc, entry.model), err)
 			fc.setCooldown(entry.model)
 			continue
 		}
 
 		// Non-retryable error — surface immediately.
+		log.Printf("[failover] Complete: model %s failed (%s), fallback decision=%s reason=%s", entry.model, kind, decision.Action, decision.Reason)
 		return "", err
 	}
 
@@ -199,13 +228,17 @@ func (fc *FailoverClient) CompleteWithTools(ctx context.Context, messages []Chat
 		}
 
 		lastErr = err
-		if isRetryableFromErr(err) {
-			log.Printf("[failover] CompleteWithTools: model %s failed with retryable error (%v), trying next", entry.model, err)
+		kind := ClassifyBackendError(err)
+		decision := DecideFallback(kind, hasNextAvailableModel(fc, entry.model), entry.model, fc.models())
+		fc.setDecision(decision)
+		if decision.Action == FallbackActionFallback {
+			log.Printf("[failover] CompleteWithTools: model %s failed (%s), fallback decision=%s next=%s err=%v", entry.model, kind, decision.Action, nextAvailableModel(fc, entry.model), err)
 			fc.setCooldown(entry.model)
 			continue
 		}
 
 		// Non-retryable error — surface immediately.
+		log.Printf("[failover] CompleteWithTools: model %s failed (%s), fallback decision=%s reason=%s", entry.model, kind, decision.Action, decision.Reason)
 		return nil, err
 	}
 
@@ -213,4 +246,30 @@ func (fc *FailoverClient) CompleteWithTools(ctx context.Context, messages []Chat
 		return nil, fmt.Errorf("all models failed or are in cooldown: %w", lastErr)
 	}
 	return nil, fmt.Errorf("all models are in cooldown")
+}
+
+func (fc *FailoverClient) models() []string {
+	models := make([]string, 0, len(fc.entries))
+	for _, entry := range fc.entries {
+		models = append(models, entry.model)
+	}
+	return models
+}
+
+func hasNextAvailableModel(fc *FailoverClient, current string) bool {
+	return nextAvailableModel(fc, current) != ""
+}
+
+func nextAvailableModel(fc *FailoverClient, current string) string {
+	seenCurrent := false
+	for _, entry := range fc.entries {
+		if !seenCurrent {
+			seenCurrent = entry.model == current
+			continue
+		}
+		if !fc.isCooledDown(entry.model) {
+			return entry.model
+		}
+	}
+	return ""
 }

--- a/internal/ai/failover.go
+++ b/internal/ai/failover.go
@@ -2,11 +2,8 @@ package ai
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"log"
-	"net"
 	"strings"
 	"sync"
 	"time"
@@ -92,38 +89,10 @@ func isRetryableError(statusCode int, body string) bool {
 	return false
 }
 
-// isRetryableFromErr extracts the status code from an error message and decides
-// whether the error is retryable. Also treats network-level failures as retryable.
+// isRetryableFromErr applies the shared backend failure classification policy.
 func isRetryableFromErr(err error) bool {
 	decision := DecideFallback(ClassifyBackendError(err), true, "", []string{"primary", "fallback"})
-	if decision.Action == FallbackActionFallback {
-		return true
-	}
-	if decision.Action == FallbackActionStop || decision.Action == FallbackActionApproval {
-		return false
-	}
-
-	msg := err.Error()
-	var statusCode int
-	if _, scanErr := fmt.Sscanf(msg, "API error (status %d):", &statusCode); scanErr == nil {
-		return isRetryableError(statusCode, msg)
-	}
-
-	// Network-level errors: timeouts, connection resets, EOF, TLS failures.
-	var netErr net.Error
-	if errors.As(err, &netErr) {
-		return true
-	}
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-		return true
-	}
-	if strings.Contains(msg, "connection reset") ||
-		strings.Contains(msg, "TLS handshake") ||
-		strings.Contains(msg, "no such host") {
-		return true
-	}
-
-	return false
+	return decision.Action == FallbackActionFallback
 }
 
 // LastFallbackDecision returns the most recent failover decision for status/logging.

--- a/internal/ai/failover.go
+++ b/internal/ai/failover.go
@@ -89,10 +89,21 @@ func isRetryableError(statusCode int, body string) bool {
 	return false
 }
 
-// isRetryableFromErr applies the shared backend failure classification policy.
+// isRetryableFromErr classifies an error and decides whether a fallback model
+// should be tried.
 func isRetryableFromErr(err error) bool {
+	if err == nil {
+		return false
+	}
 	decision := DecideFallback(ClassifyBackendError(err), true, "", []string{"primary", "fallback"})
-	return decision.Action == FallbackActionFallback
+	switch decision.Action {
+	case FallbackActionFallback:
+		return true
+	case FallbackActionStop, FallbackActionApproval:
+		return false
+	default:
+		return false
+	}
 }
 
 // LastFallbackDecision returns the most recent failover decision for status/logging.

--- a/internal/ai/probe.go
+++ b/internal/ai/probe.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"ok-gobot/internal/worker"
 )
 
 // ProbeStatus classifies the outcome of a provider health check.
@@ -23,6 +25,12 @@ const (
 	ProbeEndpointUnreachable
 	// ProbeModelNotFound means auth succeeded but the configured model is unknown.
 	ProbeModelNotFound
+	// ProbeQuotaFailed means the provider reported quota/billing exhaustion.
+	ProbeQuotaFailed
+	// ProbeRateLimited means the provider is currently rate limiting requests.
+	ProbeRateLimited
+	// ProbeToolMissing means the selected backend cannot provide required tools.
+	ProbeToolMissing
 	// ProbeSkipped means the provider cannot be probed (e.g. droid subprocess).
 	ProbeSkipped
 )
@@ -30,8 +38,11 @@ const (
 // ProbeResult holds the outcome of a provider health check.
 type ProbeResult struct {
 	Provider        string
+	Backend         string
 	Model           string
+	BaseURL         string
 	Status          ProbeStatus
+	FailureKind     BackendFailureKind
 	Latency         time.Duration
 	AvailableModels []string // populated on ModelNotFound when discoverable
 	Detail          string   // human-readable detail / error context
@@ -42,7 +53,7 @@ type ProbeResult struct {
 // The context should carry a reasonable timeout (e.g. 10 s).
 // For the "droid" provider, pass DroidConfig to resolve the binary path.
 func ProbeProvider(ctx context.Context, cfg ProviderConfig, droidCfg DroidConfig) ProbeResult {
-	base := ProbeResult{Provider: cfg.Name, Model: cfg.Model}
+	base := ProbeResult{Provider: cfg.Name, Backend: cfg.Name, Model: cfg.Model, BaseURL: cfg.BaseURL}
 
 	switch cfg.Name {
 	case "droid":
@@ -69,15 +80,18 @@ func probeOpenAICompat(ctx context.Context, res ProbeResult, cfg ProviderConfig)
 			baseURL = "https://openrouter.ai/api/v1"
 		default:
 			res.Status = ProbeSkipped
+			res.FailureKind = BackendFailureUnavailable
 			res.Detail = "no base_url configured for custom provider"
 			return res
 		}
 	}
+	res.BaseURL = baseURL
 
 	modelsURL := strings.TrimRight(baseURL, "/") + "/models"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
 	if err != nil {
 		res.Status = ProbeEndpointUnreachable
+		res.FailureKind = BackendFailureUnavailable
 		res.Detail = fmt.Sprintf("invalid URL: %v", err)
 		return res
 	}
@@ -92,6 +106,7 @@ func probeOpenAICompat(ctx context.Context, res ProbeResult, cfg ProviderConfig)
 	latency := time.Since(start)
 	if err != nil {
 		res.Status = ProbeEndpointUnreachable
+		res.FailureKind = BackendFailureUnavailable
 		res.Detail = fmt.Sprintf("endpoint unreachable: %v", err)
 		return res
 	}
@@ -102,12 +117,13 @@ func probeOpenAICompat(ctx context.Context, res ProbeResult, cfg ProviderConfig)
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		res.Status = ProbeAuthFailed
+		res.FailureKind = BackendFailureAuth
 		res.Detail = "authentication failed (check API key)"
 		return res
 	}
-
-	if resp.StatusCode != http.StatusOK {
-		res.Status = ProbeEndpointUnreachable
+	if status := probeStatusForHTTP(resp.StatusCode, string(body)); status != ProbeOK {
+		res.Status = status
+		res.FailureKind = failureKindForProbeStatus(status)
 		res.Detail = fmt.Sprintf("unexpected status %d: %s", resp.StatusCode, truncate(string(body), 200))
 		return res
 	}
@@ -116,6 +132,7 @@ func probeOpenAICompat(ctx context.Context, res ProbeResult, cfg ProviderConfig)
 	models := parseOpenAIModelList(body)
 	if len(models) == 0 {
 		res.Status = ProbeEndpointUnreachable
+		res.FailureKind = BackendFailureUnavailable
 		res.Detail = "endpoint returned 200 but model list could not be parsed"
 		return res
 	}
@@ -129,6 +146,7 @@ func probeOpenAICompat(ctx context.Context, res ProbeResult, cfg ProviderConfig)
 		}
 		if !found {
 			res.Status = ProbeModelNotFound
+			res.FailureKind = BackendFailureModel
 			res.AvailableModels = models
 			res.Detail = fmt.Sprintf("model %q not found", cfg.Model)
 			return res
@@ -136,6 +154,7 @@ func probeOpenAICompat(ctx context.Context, res ProbeResult, cfg ProviderConfig)
 	}
 
 	res.Status = ProbeOK
+	res.FailureKind = BackendFailureNone
 	res.Detail = fmt.Sprintf("ok (model %s, latency %dms)", cfg.Model, latency.Milliseconds())
 	return res
 }
@@ -165,12 +184,14 @@ func probeAnthropic(ctx context.Context, res ProbeResult, cfg ProviderConfig) Pr
 	if cfg.BaseURL == "" {
 		cfg.BaseURL = "https://api.anthropic.com"
 	}
+	res.BaseURL = cfg.BaseURL
 
 	// Resolve API key (supports OAuth).
 	tmpClient := NewAnthropicClient(cfg)
 	apiKey, err := tmpClient.resolveAPIKey(ctx)
 	if err != nil {
 		res.Status = ProbeAuthFailed
+		res.FailureKind = BackendFailureAuth
 		res.Detail = fmt.Sprintf("authentication failed: %v", err)
 		return res
 	}
@@ -181,6 +202,7 @@ func probeAnthropic(ctx context.Context, res ProbeResult, cfg ProviderConfig) Pr
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
 	if err != nil {
 		res.Status = ProbeEndpointUnreachable
+		res.FailureKind = BackendFailureUnavailable
 		res.Detail = fmt.Sprintf("invalid URL: %v", err)
 		return res
 	}
@@ -200,6 +222,7 @@ func probeAnthropic(ctx context.Context, res ProbeResult, cfg ProviderConfig) Pr
 	latency := time.Since(start)
 	if err != nil {
 		res.Status = ProbeEndpointUnreachable
+		res.FailureKind = BackendFailureUnavailable
 		res.Detail = fmt.Sprintf("endpoint unreachable: %v", err)
 		return res
 	}
@@ -210,12 +233,13 @@ func probeAnthropic(ctx context.Context, res ProbeResult, cfg ProviderConfig) Pr
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		res.Status = ProbeAuthFailed
+		res.FailureKind = BackendFailureAuth
 		res.Detail = "authentication failed (check API key)"
 		return res
 	}
-
-	if resp.StatusCode != http.StatusOK {
-		res.Status = ProbeEndpointUnreachable
+	if status := probeStatusForHTTP(resp.StatusCode, string(body)); status != ProbeOK {
+		res.Status = status
+		res.FailureKind = failureKindForProbeStatus(status)
 		res.Detail = fmt.Sprintf("unexpected status %d: %s", resp.StatusCode, truncate(string(body), 200))
 		return res
 	}
@@ -239,6 +263,7 @@ func probeAnthropic(ctx context.Context, res ProbeResult, cfg ProviderConfig) Pr
 		}
 		if !found {
 			res.Status = ProbeModelNotFound
+			res.FailureKind = BackendFailureModel
 			res.AvailableModels = modelsToCheck
 			res.Detail = fmt.Sprintf("model %q not found", cfg.Model)
 			return res
@@ -246,6 +271,7 @@ func probeAnthropic(ctx context.Context, res ProbeResult, cfg ProviderConfig) Pr
 	}
 
 	res.Status = ProbeOK
+	res.FailureKind = BackendFailureNone
 	res.Detail = fmt.Sprintf("ok (model %s, latency %dms)", cfg.Model, latency.Milliseconds())
 	return res
 }
@@ -256,6 +282,7 @@ func probeChatGPT(ctx context.Context, res ProbeResult, cfg ProviderConfig) Prob
 	if cfg.BaseURL == "" {
 		cfg.BaseURL = "https://chatgpt.com/backend-api"
 	}
+	res.BaseURL = cfg.BaseURL
 
 	// ChatGPT uses session tokens — just verify the endpoint is reachable
 	// and the token produces a non-401 response.
@@ -263,6 +290,7 @@ func probeChatGPT(ctx context.Context, res ProbeResult, cfg ProviderConfig) Prob
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pingURL, nil)
 	if err != nil {
 		res.Status = ProbeEndpointUnreachable
+		res.FailureKind = BackendFailureUnavailable
 		res.Detail = fmt.Sprintf("invalid URL: %v", err)
 		return res
 	}
@@ -274,6 +302,7 @@ func probeChatGPT(ctx context.Context, res ProbeResult, cfg ProviderConfig) Prob
 	latency := time.Since(start)
 	if err != nil {
 		res.Status = ProbeEndpointUnreachable
+		res.FailureKind = BackendFailureUnavailable
 		res.Detail = fmt.Sprintf("endpoint unreachable: %v", err)
 		return res
 	}
@@ -282,14 +311,16 @@ func probeChatGPT(ctx context.Context, res ProbeResult, cfg ProviderConfig) Prob
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		res.Status = ProbeAuthFailed
+		res.FailureKind = BackendFailureAuth
 		res.Detail = "authentication failed (check API key)"
 		return res
 	}
 
 	body, _ := io.ReadAll(resp.Body)
 
-	if resp.StatusCode != http.StatusOK {
-		res.Status = ProbeEndpointUnreachable
+	if status := probeStatusForHTTP(resp.StatusCode, string(body)); status != ProbeOK {
+		res.Status = status
+		res.FailureKind = failureKindForProbeStatus(status)
 		res.Detail = fmt.Sprintf("unexpected status %d: %s", resp.StatusCode, truncate(string(body), 200))
 		return res
 	}
@@ -306,6 +337,7 @@ func probeChatGPT(ctx context.Context, res ProbeResult, cfg ProviderConfig) Prob
 		}
 		if !found {
 			res.Status = ProbeModelNotFound
+			res.FailureKind = BackendFailureModel
 			res.AvailableModels = knownModels
 			res.Detail = fmt.Sprintf("model %q not in known catalog", cfg.Model)
 			return res
@@ -313,6 +345,7 @@ func probeChatGPT(ctx context.Context, res ProbeResult, cfg ProviderConfig) Prob
 	}
 
 	res.Status = ProbeOK
+	res.FailureKind = BackendFailureNone
 	res.Detail = fmt.Sprintf("ok (model %s, latency %dms)", cfg.Model, latency.Milliseconds())
 	return res
 }
@@ -324,15 +357,18 @@ func probeDroid(res ProbeResult, cfg ProviderConfig, droidCfg DroidConfig) Probe
 	if binary == "" {
 		binary = "droid"
 	}
+	backend := worker.DetectBackend(binary)
+	res.Backend = backend
 
 	if _, err := exec.LookPath(binary); err != nil {
 		res.Status = ProbeEndpointUnreachable
-		res.Detail = fmt.Sprintf("droid binary not found: %s", binary)
+		res.FailureKind = BackendFailureUnavailable
+		res.Detail = fmt.Sprintf("%s binary not found: %s", backend, binary)
 		return res
 	}
 
-	// Check model against known catalog.
-	knownModels := AvailableModels()["droid"]
+	// Check model against a known catalog only for backends with stable catalogs.
+	knownModels := knownCLIBackendModels(backend)
 	if cfg.Model != "" && len(knownModels) > 0 {
 		found := false
 		for _, m := range knownModels {
@@ -343,18 +379,52 @@ func probeDroid(res ProbeResult, cfg ProviderConfig, droidCfg DroidConfig) Probe
 		}
 		if !found {
 			res.Status = ProbeModelNotFound
+			res.FailureKind = BackendFailureModel
 			res.AvailableModels = knownModels
-			res.Detail = fmt.Sprintf("model %q not in known catalog", cfg.Model)
+			res.Detail = fmt.Sprintf("model %q not in known %s catalog", cfg.Model, backend)
 			return res
 		}
 	}
 
 	res.Status = ProbeOK
-	res.Detail = fmt.Sprintf("ok (binary %s, model %s)", binary, cfg.Model)
+	res.FailureKind = BackendFailureNone
+	res.Detail = fmt.Sprintf("ok (backend %s, binary %s, model %s)", backend, binary, cfg.Model)
 	return res
 }
 
 // ---------- helpers ----------
+
+func knownCLIBackendModels(backend string) []string {
+	switch backend {
+	case "droid":
+		return AvailableModels()["droid"]
+	case "claude":
+		return AvailableModels()["anthropic"]
+	default:
+		return nil
+	}
+}
+
+func probeStatusForHTTP(statusCode int, body string) ProbeStatus {
+	if statusCode == http.StatusOK {
+		return ProbeOK
+	}
+	kind := failureKindForHTTP(statusCode, strings.ToLower(body))
+	switch kind {
+	case BackendFailureAuth:
+		return ProbeAuthFailed
+	case BackendFailureQuota:
+		return ProbeQuotaFailed
+	case BackendFailureRateLimit:
+		return ProbeRateLimited
+	case BackendFailureToolMissing:
+		return ProbeToolMissing
+	case BackendFailureModel:
+		return ProbeModelNotFound
+	default:
+		return ProbeEndpointUnreachable
+	}
+}
 
 func truncate(s string, max int) string {
 	s = strings.TrimSpace(s)

--- a/internal/ai/probe_test.go
+++ b/internal/ai/probe_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -24,6 +26,44 @@ func TestProbeOpenAICompat_AuthFailed(t *testing.T) {
 
 	if res.Status != ProbeAuthFailed {
 		t.Fatalf("expected ProbeAuthFailed, got %d (detail: %s)", res.Status, res.Detail)
+	}
+}
+
+func TestProbeOpenAICompat_QuotaFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPaymentRequired)
+		w.Write([]byte(`{"error":{"message":"insufficient_quota"}}`))
+	}))
+	defer srv.Close()
+
+	res := ProbeProvider(context.Background(), ProviderConfig{
+		Name:    "openai",
+		APIKey:  "key",
+		BaseURL: srv.URL,
+		Model:   "gpt-4o",
+	}, DroidConfig{})
+
+	if res.Status != ProbeQuotaFailed || res.FailureKind != BackendFailureQuota {
+		t.Fatalf("expected quota failure, got status=%d kind=%s detail=%s", res.Status, res.FailureKind, res.Detail)
+	}
+}
+
+func TestProbeOpenAICompat_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
+	}))
+	defer srv.Close()
+
+	res := ProbeProvider(context.Background(), ProviderConfig{
+		Name:    "openai",
+		APIKey:  "key",
+		BaseURL: srv.URL,
+		Model:   "gpt-4o",
+	}, DroidConfig{})
+
+	if res.Status != ProbeRateLimited || res.FailureKind != BackendFailureRateLimit {
+		t.Fatalf("expected rate limit, got status=%d kind=%s detail=%s", res.Status, res.FailureKind, res.Detail)
 	}
 }
 
@@ -190,14 +230,29 @@ func TestProbeDroid_BinaryNotFound(t *testing.T) {
 }
 
 func TestProbeDroid_ModelNotFound(t *testing.T) {
-	// Use a binary that exists on PATH (e.g. "true" or "echo")
+	binary := writeProbeBinary(t, "droid")
 	res := ProbeProvider(context.Background(), ProviderConfig{
 		Name:  "droid",
 		Model: "nonexistent-model",
-	}, DroidConfig{BinaryPath: "true"})
+	}, DroidConfig{BinaryPath: binary})
 
 	if res.Status != ProbeModelNotFound {
 		t.Fatalf("expected ProbeModelNotFound, got %d (detail: %s)", res.Status, res.Detail)
+	}
+}
+
+func TestProbeDroid_DetectsOpenCodeBackendWithoutDroidCatalog(t *testing.T) {
+	binary := writeProbeBinary(t, "opencode")
+	res := ProbeProvider(context.Background(), ProviderConfig{
+		Name:  "droid",
+		Model: "anthropic/claude-sonnet-4-5",
+	}, DroidConfig{BinaryPath: binary})
+
+	if res.Status != ProbeOK {
+		t.Fatalf("expected ProbeOK, got %d (detail: %s)", res.Status, res.Detail)
+	}
+	if res.Backend != "opencode" {
+		t.Fatalf("backend=%q, want opencode", res.Backend)
 	}
 }
 
@@ -322,4 +377,13 @@ func TestTruncate(t *testing.T) {
 	if got := truncate("Привет мир", 6); got != "Привет…" {
 		t.Fatalf("expected 'Привет…', got %q", got)
 	}
+}
+
+func writeProbeBinary(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write probe binary: %v", err)
+	}
+	return path
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -220,6 +220,10 @@ func (a *App) Start(ctx context.Context) error {
 		}
 	}
 
+	activeAIModel := a.config.AI.Model
+	var backendHealth ai.BackendHealth
+	var backendPreflight *ai.BackendPreflight
+
 	// Initialize AI client if configured
 	if aiAPIKey != "" || a.config.AI.Provider == "droid" {
 		log.Printf("🤖 Initializing AI client (%s)...", a.config.AI.Provider)
@@ -234,9 +238,29 @@ func (a *App) Start(ctx context.Context) error {
 			AutoLevel:  a.config.AI.Droid.AutoLevel,
 			WorkDir:    a.config.AI.Droid.WorkDir,
 		}
-		if len(a.config.AI.FallbackModels) > 0 {
-			log.Printf("🔄 Failover enabled: %d fallback model(s) configured", len(a.config.AI.FallbackModels))
-			aiClient, err := ai.NewClientWithFailover(primaryCfg, a.config.AI.FallbackModels)
+
+		backendPreflight = ai.NewBackendPreflight(ai.BackendPreflightConfig{
+			Provider:        primaryCfg,
+			Droid:           droidCfg,
+			FallbackModels:  a.config.AI.FallbackModels,
+			FallbackEnabled: len(a.config.AI.FallbackModels) > 0,
+		})
+		preflightCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		backendHealth, err = backendPreflight.Check(preflightCtx, primaryCfg.Model, "default", a.config.AI.DefaultThinking)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("backend preflight failed: %w", err)
+		}
+		log.Printf("✅ Backend preflight passed (%s health=%s fallback=%s)", backendHealth.Identity.String(), backendHealth.Status, backendHealth.Fallback.Action)
+		if backendHealth.Identity.Model != "" {
+			activeAIModel = backendHealth.Identity.Model
+			primaryCfg.Model = activeAIModel
+		}
+
+		fallbackModels := remainingFallbackModels(activeAIModel, a.config.AI.Model, a.config.AI.FallbackModels)
+		if len(fallbackModels) > 0 {
+			log.Printf("🔄 Failover enabled: %d fallback model(s) configured", len(fallbackModels))
+			aiClient, err := ai.NewClientWithFailover(primaryCfg, fallbackModels)
 			if err != nil {
 				return fmt.Errorf("failed to initialize AI client with failover: %w", err)
 			}
@@ -248,7 +272,7 @@ func (a *App) Start(ctx context.Context) error {
 			}
 			a.ai = aiClient
 		}
-		log.Printf("✅ AI client ready (model: %s)", a.config.AI.Model)
+		log.Printf("✅ AI client ready (model: %s)", activeAIModel)
 	}
 
 	// Initialize durable job service for background work
@@ -389,14 +413,19 @@ func (a *App) Start(ctx context.Context) error {
 	// Initialize bot
 	aiCfg := bot.AIConfig{
 		Provider:        a.config.AI.Provider,
-		Model:           a.config.AI.Model,
+		Model:           activeAIModel,
+		ModelTier:       "default",
 		APIKey:          aiAPIKey,
 		BaseURL:         a.config.AI.BaseURL,
 		FallbackModels:  a.config.AI.FallbackModels,
 		ModelAliases:    a.config.ModelAliases,
 		DefaultThinking: a.config.AI.DefaultThinking,
+		BackendHealth:   backendHealth,
 		Routing:         a.config.AI.Routing,
 		MemoryMode:      config.NormalizeMemoryMode(a.config.Memory.Mode),
+	}
+	if backendPreflight != nil {
+		aiCfg.BackendPreflight = backendPreflight.Check
 	}
 	memoryExtras, err := a.normalizedExtraPaths()
 	if err != nil {
@@ -635,6 +664,39 @@ func parseDurationOrDefault(value string, fallback time.Duration) time.Duration 
 		return fallback
 	}
 	return duration
+}
+
+func remainingFallbackModels(activeModel, configuredPrimary string, configuredFallbacks []string) []string {
+	activeModel = strings.TrimSpace(activeModel)
+	configuredPrimary = strings.TrimSpace(configuredPrimary)
+	order := make([]string, 0, 1+len(configuredFallbacks))
+	if configuredPrimary != "" {
+		order = append(order, configuredPrimary)
+	}
+	for _, model := range configuredFallbacks {
+		model = strings.TrimSpace(model)
+		if model != "" {
+			order = append(order, model)
+		}
+	}
+
+	remaining := []string{}
+	seenActive := activeModel == ""
+	seen := map[string]struct{}{}
+	for _, model := range order {
+		if _, ok := seen[model]; ok {
+			continue
+		}
+		seen[model] = struct{}{}
+		if !seenActive {
+			seenActive = model == activeModel
+			continue
+		}
+		if model != activeModel {
+			remaining = append(remaining, model)
+		}
+	}
+	return remaining
 }
 
 func (a *App) startMemoryIndexer(ctx context.Context, rootPath string, store *memory.MemoryStore, embedder memory.EmbeddingBatchClient, reporter *memory.StatusReporter) {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -77,11 +77,14 @@ type MemoryStatusProvider interface {
 type AIConfig struct {
 	Provider              string
 	Model                 string
+	ModelTier             string
 	APIKey                string
 	BaseURL               string
 	FallbackModels        []string
 	ModelAliases          map[string]string
-	DefaultThinking       string                    // Default thinking level when no session override is set
+	DefaultThinking       string           // Default thinking level when no session override is set
+	BackendHealth         ai.BackendHealth // Last backend preflight result for status surfaces
+	BackendPreflight      func(context.Context, string, string, string) (ai.BackendHealth, error)
 	Routing               config.ModelRoutingConfig // Per-task-type model routing
 	MemoryMode            string                    // Memory prompt mode: "eager", "retrieval_first", "startup_recent"
 	MemoryExtraPathLabels []string                  // configured external memory source labels allowed for recall
@@ -222,14 +225,16 @@ func New(token string, store *storage.Store, aiClient ai.Client, aiCfg AIConfig,
 		Registry:           agentRegistry,
 		DefaultPersonality: personality,
 		AIConfig: agent.AIResolverConfig{
-			Provider:        aiCfg.Provider,
-			Model:           aiCfg.Model,
-			APIKey:          aiCfg.APIKey,
-			BaseURL:         aiCfg.BaseURL,
-			DefaultThinking: aiCfg.DefaultThinking,
-			DefaultClient:   aiClient,
-			ModelAliases:    aiCfg.ModelAliases,
-			MemoryMode:      aiCfg.MemoryMode,
+			Provider:         aiCfg.Provider,
+			Model:            aiCfg.Model,
+			APIKey:           aiCfg.APIKey,
+			BaseURL:          aiCfg.BaseURL,
+			DefaultThinking:  aiCfg.DefaultThinking,
+			DefaultClient:    aiClient,
+			ModelAliases:     aiCfg.ModelAliases,
+			ModelTier:        aiCfg.ModelTier,
+			BackendPreflight: aiCfg.BackendPreflight,
+			MemoryMode:       aiCfg.MemoryMode,
 		},
 		ToolRegistry:  toolRegistry,
 		Scheduler:     scheduler,
@@ -869,11 +874,20 @@ func (b *Bot) GetStatus() map[string]interface{} {
 		"status": "running",
 	}
 
-	if b.aiConfig.APIKey != "" {
-		status["ai"] = map[string]string{
-			"provider": b.aiConfig.Provider,
-			"model":    b.aiConfig.Model,
+	if b.aiConfig.APIKey != "" || b.aiConfig.Provider == "droid" {
+		aiStatus := map[string]interface{}{
+			"provider":   b.aiConfig.Provider,
+			"model":      b.aiConfig.Model,
+			"model_tier": valueOrStatus(b.aiConfig.ModelTier, "default"),
+			"effort":     valueOrStatus(b.aiConfig.DefaultThinking, "off"),
 		}
+		if b.aiConfig.BackendHealth.Identity.Backend != "" {
+			aiStatus["backend"] = b.aiConfig.BackendHealth.Identity.Backend
+		}
+		if b.aiConfig.BackendHealth.Status != "" {
+			aiStatus["health"] = b.aiConfig.BackendHealth
+		}
+		status["ai"] = aiStatus
 	}
 
 	// Get session count from store

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -204,9 +204,16 @@ func (b *Bot) processViaHubWithContent(
 
 	// Emit session.accepted and run.started to control hub.
 	if b.controlHub != nil {
+		backend := b.aiConfig.BackendHealth.Identity.Backend
+		backendHealth := string(b.aiConfig.BackendHealth.Status)
 		b.controlHub.Emit(control.EvtSessionAccepted, control.SessionInfo{
-			ChatID: chatID,
-			State:  "running",
+			ChatID:        chatID,
+			Model:         b.getEffectiveModel(chatID),
+			ModelTier:     valueOrStatus(b.aiConfig.ModelTier, "default"),
+			Effort:        valueOrStatus(b.aiConfig.DefaultThinking, "off"),
+			Backend:       backend,
+			BackendHealth: backendHealth,
+			State:         "running",
 		})
 		b.controlHub.Emit(control.EvtRunStarted, control.RunEventPayload{ChatID: chatID})
 	}

--- a/internal/bot/hub_handler.go
+++ b/internal/bot/hub_handler.go
@@ -202,22 +202,6 @@ func (b *Bot) processViaHubWithContent(
 		}
 	}
 
-	// Emit session.accepted and run.started to control hub.
-	if b.controlHub != nil {
-		backend := b.aiConfig.BackendHealth.Identity.Backend
-		backendHealth := string(b.aiConfig.BackendHealth.Status)
-		b.controlHub.Emit(control.EvtSessionAccepted, control.SessionInfo{
-			ChatID:        chatID,
-			Model:         b.getEffectiveModel(chatID),
-			ModelTier:     valueOrStatus(b.aiConfig.ModelTier, "default"),
-			Effort:        valueOrStatus(b.aiConfig.DefaultThinking, "off"),
-			Backend:       backend,
-			BackendHealth: backendHealth,
-			State:         "running",
-		})
-		b.controlHub.Emit(control.EvtRunStarted, control.RunEventPayload{ChatID: chatID})
-	}
-
 	// Start typing indicator while the hub is running.
 	stopTyping := NewTypingIndicator(b.api, delivery.Chat)
 	defer stopTyping()
@@ -247,16 +231,31 @@ func (b *Bot) processViaHubWithContent(
 	// Submit to the hub — the hub owns agent resolution, tool execution,
 	// and run lifecycle. We only provide the inbound envelope.
 	req := agent.RunRequest{
-		SessionKey:         sessionKey,
-		ChatID:             chatID,
-		Content:            content,
-		UserContent:        userContent,
-		Session:            session,
-		History:            history,
-		Context:            ctx,
-		OnToolEvent:        onToolEvent,
-		OnDelta:            onDelta,
-		OnDeltaReset:       onDeltaReset,
+		SessionKey:   sessionKey,
+		ChatID:       chatID,
+		Content:      content,
+		UserContent:  userContent,
+		Session:      session,
+		History:      history,
+		Context:      ctx,
+		OnToolEvent:  onToolEvent,
+		OnDelta:      onDelta,
+		OnDeltaReset: onDeltaReset,
+		OnRunStarted: func(info agent.RunStartInfo) {
+			if b.controlHub == nil {
+				return
+			}
+			b.controlHub.Emit(control.EvtSessionAccepted, control.SessionInfo{
+				ChatID:        info.ChatID,
+				Model:         info.Model,
+				ModelTier:     valueOrStatus(info.ModelTier, "default"),
+				Effort:        valueOrStatus(info.Effort, "off"),
+				Backend:       info.Backend,
+				BackendHealth: string(info.BackendHealth.Status),
+				State:         "running",
+			})
+			b.controlHub.Emit(control.EvtRunStarted, control.RunEventPayload{ChatID: info.ChatID})
+		},
 		PreUserSystemNotes: preNotes,
 		MemoryScope:        b.memoryRecallContext(chatID, userID, string(delivery.Chat.Type), sessionKey),
 	}

--- a/internal/bot/status.go
+++ b/internal/bot/status.go
@@ -92,6 +92,14 @@ func (b *Bot) buildStatusStringForScope(chatID, userID int64, chatType string) s
 	if b.aiConfig.APIKey != "" {
 		maskedKey := strings.ReplaceAll(maskAPIKey(b.aiConfig.APIKey), "_", "\\_")
 		sb.WriteString(fmt.Sprintf("🧠 Model: `%s` · 🔑 %s (%s)\n", b.aiConfig.Model, maskedKey, b.aiConfig.Provider))
+		if line := b.backendStatusLine(); line != "" {
+			sb.WriteString(line + "\n")
+		}
+	} else if b.aiConfig.Provider == "droid" {
+		sb.WriteString(fmt.Sprintf("🧠 Model: `%s` · CLI backend (%s)\n", b.aiConfig.Model, b.aiConfig.Provider))
+		if line := b.backendStatusLine(); line != "" {
+			sb.WriteString(line + "\n")
+		}
 	} else {
 		sb.WriteString("⚠️ AI not configured\n")
 	}
@@ -166,6 +174,21 @@ func (b *Bot) buildStatusStringForScope(chatID, userID int64, chatType string) s
 	sb.WriteString(fmt.Sprintf("\n🟢 Running for %s", formatDuration(uptime)))
 
 	return sb.String()
+}
+
+func (b *Bot) backendStatusLine() string {
+	tier := valueOrStatus(b.aiConfig.ModelTier, "default")
+	effort := valueOrStatus(b.aiConfig.DefaultThinking, "off")
+	health := b.aiConfig.BackendHealth
+	backend := valueOrStatus(health.Identity.Backend, b.aiConfig.Provider)
+	if health.Status == "" {
+		return fmt.Sprintf("🧭 Backend: `%s` · tier=%s · effort=%s", backend, tier, effort)
+	}
+	decision := string(health.Fallback.Action)
+	if decision == "" {
+		decision = "primary"
+	}
+	return fmt.Sprintf("🧭 Backend: `%s` · health=%s · tier=%s · effort=%s · fallback=%s", backend, health.Status, tier, effort, decision)
 }
 
 func sessionKeyForStatus(chatID int64, chatType string) agent.SessionKey {

--- a/internal/bot/status_test.go
+++ b/internal/bot/status_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"ok-gobot/internal/ai"
 	"ok-gobot/internal/memory"
 )
 
@@ -126,5 +127,26 @@ func TestBuildQMDStatusStringUsesRuntimeQMDStatus(t *testing.T) {
 	}
 	if strings.Contains(out, "QMD: used") {
 		t.Fatalf("expected runtime QMD status to replace startup status: %q", out)
+	}
+}
+
+func TestBackendStatusLineIncludesModelTierEffortAndHealth(t *testing.T) {
+	b := &Bot{aiConfig: AIConfig{
+		Provider:        "anthropic",
+		Model:           "claude-sonnet",
+		ModelTier:       "premium",
+		DefaultThinking: "high",
+		BackendHealth: ai.BackendHealth{
+			Identity: ai.BackendIdentity{Backend: "claude", Model: "claude-sonnet"},
+			Status:   ai.BackendHealthHealthy,
+			Fallback: ai.FallbackDecision{Action: ai.FallbackActionPrimary},
+		},
+	}}
+
+	out := b.backendStatusLine()
+	for _, want := range []string{"claude", "health=healthy", "tier=premium", "effort=high", "fallback=primary"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output: %q", want, out)
+		}
 	}
 }

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -67,15 +67,15 @@ func newSessionsListCommand(cfg *config.Config) *cobra.Command {
 			}
 
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "SESSION KEY\tAGENT\tMSGS\tTOKENS\tFORKED FROM\tUPDATED")
+			fmt.Fprintln(w, "SESSION KEY\tAGENT\tMODEL\tEFFORT\tMSGS\tTOKENS\tFORKED FROM\tUPDATED")
 			for _, s := range sessions {
 				key := truncate(s.SessionKey, 50)
 				forkedFrom := ""
 				if s.ForkedFrom != "" {
 					forkedFrom = truncate(s.ForkedFrom, 40)
 				}
-				fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\t%s\n",
-					key, s.AgentID, s.MessageCount, s.TotalTokens, forkedFrom, formatTime(s.UpdatedAt))
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\n",
+					key, s.AgentID, sessionField(s.ModelOverride), sessionField(s.ThinkLevel), s.MessageCount, s.TotalTokens, forkedFrom, formatTime(s.UpdatedAt))
 			}
 			return w.Flush()
 		},
@@ -83,6 +83,14 @@ func newSessionsListCommand(cfg *config.Config) *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 50, "maximum number of sessions to show")
 	cmd.Flags().BoolVar(&onlyForks, "forks", false, "show only forked sessions")
 	return cmd
+}
+
+func sessionField(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
 }
 
 // --- sessions fork ---

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -27,6 +27,36 @@ func TestSessionsIndexRequiresMemoryEnabled(t *testing.T) {
 	}
 }
 
+func TestSessionsListIncludesModelAndEffort(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+
+	if err := store.UpsertSessionV2(&storage.SessionV2{
+		SessionKey:    "agent:default:telegram:dm:42",
+		AgentID:       "default",
+		ModelOverride: "claude-sonnet",
+		ThinkLevel:    "high",
+	}); err != nil {
+		t.Fatalf("UpsertSessionV2: %v", err)
+	}
+
+	cmd := newSessionsCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"list"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	output := out.String()
+	for _, want := range []string{"MODEL", "EFFORT", "claude-sonnet", "high"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
 func TestSessionsShowReturnsSpanAroundAnchor(t *testing.T) {
 	t.Parallel()
 	store, cfg := newTestStore(t)

--- a/internal/control/mission.go
+++ b/internal/control/mission.go
@@ -393,6 +393,12 @@ func missionProviders(srv *Server) http.HandlerFunc {
 			case map[string]interface{}:
 				result["provider"] = ai["provider"]
 				result["model"] = ai["model"]
+				result["backend"] = ai["backend"]
+				result["model_tier"] = ai["model_tier"]
+				result["effort"] = ai["effort"]
+				if health, ok := ai["health"]; ok {
+					result["health"] = health
+				}
 			case map[string]string:
 				result["provider"] = ai["provider"]
 				result["model"] = ai["model"]

--- a/internal/control/mission_test.go
+++ b/internal/control/mission_test.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"ok-gobot/internal/agent"
+	"ok-gobot/internal/ai"
 	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/memory"
 	"ok-gobot/internal/storage"
@@ -28,6 +30,14 @@ func (m missionEvidenceProvider) GetScheduler() tools.CronScheduler { return nil
 func (m missionEvidenceProvider) GetMemoryStatus(context.Context) (memory.IndexStatus, error) {
 	return memory.IndexStatus{}, nil
 }
+
+type missionStateStub struct {
+	status map[string]interface{}
+}
+
+func (s missionStateStub) GetStatus() map[string]interface{} { return s.status }
+
+func (s missionStateStub) RespondToApproval(string, bool) error { return nil }
 
 func TestMissionEvidenceRendersSessionTimeline(t *testing.T) {
 	t.Parallel()
@@ -105,5 +115,48 @@ func TestMissionEvidenceListFailureUsesGenericError(t *testing.T) {
 	}
 	if strings.Contains(body, "database") || strings.Contains(body, "evidence_events") {
 		t.Fatalf("raw storage detail leaked in body: %s", body)
+	}
+}
+
+func TestMissionProvidersIncludesBackendHealth(t *testing.T) {
+	srv := &Server{state: missionStateStub{status: map[string]interface{}{
+		"ai": map[string]interface{}{
+			"provider":   "droid",
+			"backend":    "opencode",
+			"model":      "anthropic/claude-sonnet",
+			"model_tier": "premium",
+			"effort":     "high",
+			"health": ai.BackendHealth{
+				Identity: ai.BackendIdentity{Provider: "droid", Backend: "opencode", Model: "anthropic/claude-sonnet"},
+				Status:   ai.BackendHealthHealthy,
+				Fallback: ai.FallbackDecision{Action: ai.FallbackActionPrimary},
+			},
+		},
+	}}}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mission/providers", nil)
+	rec := httptest.NewRecorder()
+	missionProviders(srv)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	for key, want := range map[string]string{
+		"provider":   "droid",
+		"backend":    "opencode",
+		"model":      "anthropic/claude-sonnet",
+		"model_tier": "premium",
+		"effort":     "high",
+	} {
+		if got[key] != want {
+			t.Fatalf("%s=%v, want %s", key, got[key], want)
+		}
+	}
+	if got["health"] == nil {
+		t.Fatal("expected health payload")
 	}
 }

--- a/internal/control/protocol.go
+++ b/internal/control/protocol.go
@@ -15,10 +15,14 @@ const (
 )
 
 type SessionInfo struct {
-	ChatID   int64  `json:"chat_id"`
-	Username string `json:"username,omitempty"`
-	Model    string `json:"model,omitempty"`
-	State    string `json:"state"`
+	ChatID        int64  `json:"chat_id"`
+	Username      string `json:"username,omitempty"`
+	Model         string `json:"model,omitempty"`
+	ModelTier     string `json:"model_tier,omitempty"`
+	Effort        string `json:"effort,omitempty"`
+	Backend       string `json:"backend,omitempty"`
+	BackendHealth string `json:"backend_health,omitempty"`
+	State         string `json:"state"`
 }
 
 type RunDeltaPayload struct {

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -66,6 +66,7 @@ type JobSpec struct {
 	Timeout            time.Duration
 	MaxToolCalls       int
 	ArtifactRoots      []string
+	Preflight          func(context.Context) error
 }
 
 // JobArtifactSpec describes one durable artifact emitted by a job.
@@ -133,6 +134,14 @@ func NewJobService(store *storage.Store) *JobService {
 func (s *JobService) StartDetached(parentCtx context.Context, spec JobSpec, runner JobRunner) (*storage.Job, error) {
 	if runner == nil {
 		return nil, fmt.Errorf("job runner is required")
+	}
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	if spec.Preflight != nil {
+		if err := spec.Preflight(parentCtx); err != nil {
+			return nil, fmt.Errorf("job preflight failed: %w", err)
+		}
 	}
 
 	job, err := s.createJob(spec)

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -145,6 +145,37 @@ func TestJobServiceStartDetachedIgnoresInitialEvidenceFailure(t *testing.T) {
 	}
 }
 
+func TestJobServicePreflightFailureDoesNotCreateAttempt(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	svc := NewJobService(store)
+
+	_, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:        "background_task",
+		Worker:      "test_runner",
+		Description: "blocked before start",
+		MaxAttempts: 2,
+		Preflight: func(context.Context) error {
+			return errors.New("backend unavailable")
+		},
+	}, func(context.Context, *storage.Job, *JobService) (JobRunResult, error) {
+		return JobRunResult{Summary: "should not run"}, nil
+	})
+	if err == nil {
+		t.Fatal("expected preflight error")
+	}
+	jobs, listErr := store.ListJobs(10)
+	if listErr != nil {
+		t.Fatalf("ListJobs: %v", listErr)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("jobs created=%d, want 0", len(jobs))
+	}
+}
+
 func TestJobServiceRoleSuccessExtractsReportAndURLArtifacts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -1,0 +1,27 @@
+package worker
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// DetectBackend normalizes a CLI binary path into the backend identity used in
+// health/status output.
+func DetectBackend(binaryPath string) string {
+	name := strings.ToLower(strings.TrimSpace(filepath.Base(binaryPath)))
+	name = strings.TrimSuffix(name, filepath.Ext(name))
+	switch name {
+	case "", "droid":
+		return "droid"
+	case "claude", "claude-code":
+		return "claude"
+	case "codex", "openai-codex":
+		return "codex"
+	case "opencode", "open-code":
+		return "opencode"
+	case "gemini":
+		return "gemini"
+	default:
+		return name
+	}
+}

--- a/internal/worker/opencode.go
+++ b/internal/worker/opencode.go
@@ -89,6 +89,7 @@ func (a *OpenCodeAdapter) Stream(ctx context.Context, req Request) <-chan Event 
 			select {
 			case <-ctx.Done():
 				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
 				ch <- Event{Error: ctx.Err(), Done: true}
 				return
 			default:

--- a/internal/worker/opencode.go
+++ b/internal/worker/opencode.go
@@ -98,6 +98,11 @@ func (a *OpenCodeAdapter) Stream(ctx context.Context, req Request) <-chan Event 
 				ch <- Event{Content: line}
 			}
 		}
+		if ctx.Err() != nil {
+			_ = cmd.Wait()
+			ch <- Event{Error: ctx.Err(), Done: true}
+			return
+		}
 		if err := scanner.Err(); err != nil {
 			ch <- Event{Error: fmt.Errorf("stream read error: %w", err), Done: true}
 		}

--- a/internal/worker/opencode.go
+++ b/internal/worker/opencode.go
@@ -1,0 +1,112 @@
+package worker
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// OpenCodeConfig holds OpenCode CLI-specific configuration.
+type OpenCodeConfig struct {
+	BinaryPath string `mapstructure:"binary_path"` // Path to opencode binary (default: "opencode")
+	WorkDir    string `mapstructure:"work_dir"`    // Working directory for opencode execution
+}
+
+// OpenCodeAdapter executes worker tasks through `opencode run`.
+type OpenCodeAdapter struct {
+	config OpenCodeConfig
+}
+
+var _ Adapter = (*OpenCodeAdapter)(nil)
+
+// NewOpenCodeAdapter creates an OpenCode-backed worker adapter.
+func NewOpenCodeAdapter(cfg OpenCodeConfig) *OpenCodeAdapter {
+	if cfg.BinaryPath == "" {
+		cfg.BinaryPath = "opencode"
+	}
+	return &OpenCodeAdapter{config: cfg}
+}
+
+func (a *OpenCodeAdapter) buildArgs(req Request) []string {
+	args := []string{"run"}
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
+	}
+	args = append(args, req.Task)
+	return args
+}
+
+func (a *OpenCodeAdapter) workDir(req Request) string {
+	workDir := strings.TrimSpace(req.WorkDir)
+	if workDir == "" {
+		workDir = strings.TrimSpace(a.config.WorkDir)
+	}
+	return workDir
+}
+
+// Run executes an opencode task and returns its final output.
+func (a *OpenCodeAdapter) Run(ctx context.Context, req Request) (*Result, error) {
+	cmd := exec.CommandContext(ctx, a.config.BinaryPath, a.buildArgs(req)...)
+	if dir := a.workDir(req); dir != "" {
+		cmd.Dir = dir
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("opencode exec failed (exit %d): %s", exitErr.ExitCode(), string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("opencode exec failed: %w", err)
+	}
+	return &Result{Content: strings.TrimSpace(string(output))}, nil
+}
+
+// Stream executes an opencode task and streams stdout line by line.
+func (a *OpenCodeAdapter) Stream(ctx context.Context, req Request) <-chan Event {
+	ch := make(chan Event, 100)
+	go func() {
+		defer close(ch)
+
+		cmd := exec.CommandContext(ctx, a.config.BinaryPath, a.buildArgs(req)...)
+		if dir := a.workDir(req); dir != "" {
+			cmd.Dir = dir
+		}
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			ch <- Event{Error: fmt.Errorf("failed to create stdout pipe: %w", err)}
+			return
+		}
+		if err := cmd.Start(); err != nil {
+			ch <- Event{Error: fmt.Errorf("failed to start opencode: %w", err)}
+			return
+		}
+
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				_ = cmd.Process.Kill()
+				ch <- Event{Error: ctx.Err(), Done: true}
+				return
+			default:
+			}
+			if line := scanner.Text(); line != "" {
+				ch <- Event{Content: line}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			ch <- Event{Error: fmt.Errorf("stream read error: %w", err), Done: true}
+		}
+		if err := cmd.Wait(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				ch <- Event{Error: fmt.Errorf("opencode exited with code %d: %s", exitErr.ExitCode(), string(exitErr.Stderr)), Done: true}
+			}
+		} else {
+			ch <- Event{Done: true}
+		}
+	}()
+	return ch
+}

--- a/internal/worker/opencode_test.go
+++ b/internal/worker/opencode_test.go
@@ -1,0 +1,79 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestNewOpenCodeAdapterDefaults(t *testing.T) {
+	adapter := NewOpenCodeAdapter(OpenCodeConfig{})
+	if adapter.config.BinaryPath != "opencode" {
+		t.Fatalf("binary_path = %q, want %q", adapter.config.BinaryPath, "opencode")
+	}
+}
+
+func TestOpenCodeAdapterBuildArgs(t *testing.T) {
+	adapter := NewOpenCodeAdapter(OpenCodeConfig{})
+	got := adapter.buildArgs(Request{Task: "do work", Model: "gpt-5.3-codex"})
+	want := []string{"run", "--model", "gpt-5.3-codex", "do work"}
+	if len(got) != len(want) {
+		t.Fatalf("arg count = %d, want %d; got %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("arg[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestOpenCodeAdapterStreamCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script mock not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockBinary := filepath.Join(tmpDir, "opencode")
+	mockScript := `#!/bin/sh
+echo "first"
+while true; do
+  echo "tick"
+  sleep 1
+done
+`
+	if err := os.WriteFile(mockBinary, []byte(mockScript), 0o755); err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+
+	adapter := NewOpenCodeAdapter(OpenCodeConfig{BinaryPath: mockBinary})
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := adapter.Stream(ctx, Request{Task: "test"})
+
+	first := <-ch
+	if first.Content != "first" {
+		t.Fatalf("first event = %+v, want content first", first)
+	}
+	cancel()
+
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				t.Fatal("stream closed without cancellation event")
+			}
+			if evt.Done {
+				if !errors.Is(evt.Error, context.Canceled) {
+					t.Fatalf("done error = %v, want context canceled", evt.Error)
+				}
+				return
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for stream cancellation")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add explicit backend/model preflight health with normalized failure kinds and fallback decisions before startup, sessions, and jobs consume attempts.
- Surface backend identity, model tier/effort, health, and fallback state in bot status, Mission Control providers, session events, and sessions list.
- Add CLI backend detection/OpenCode adapter support plus docs and tests for provider failure classification and fallback behavior.

## Verification
- git fetch origin
- git rebase origin/main
- go fmt ./...
- go vet ./...
- go test ./...
- go build ./cmd/ok-gobot/

Closes #359

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a comprehensive backend health preflight system: normalized failure classification, fallback policy decisions, a caching `BackendPreflight` checker, and a new `OpenCodeAdapter` for the opencode CLI. Health metadata is plumbed through session events, bot status, Mission Control providers, and the CLI sessions list.

- **P1 — `internal/worker/opencode.go` `Stream`**: when `scanner.Err()` is non-nil, a `Done: true` event is emitted but execution falls through to `cmd.Wait()` which emits a second `Done: true`. `CompleteStreamWithTools` forwards every event downstream, so consumers see two end-of-stream signals.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the double Done-event bug in OpenCodeAdapter.Stream.

One P1 logic bug in the new OpenCodeAdapter streaming path (double Done event on scanner error) affects all consumers of the opencode backend. The rest of the PR is well-structured, well-tested, and the preflight/fallback logic is sound.

internal/worker/opencode.go — Stream function scanner-error fallthrough

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/opencode.go | New OpenCode CLI adapter — Stream function has a double Done-event bug when scanner.Err() is non-nil (missing return before falling through to cmd.Wait()). |
| internal/ai/backend_health.go | New file defining BackendHealth types, BackendPreflight checker, DecideFallback policy, and ClassifyBackendError; solid logic with one minor issue: backendHealthFromProbe uses time.Now() directly instead of cfg.Now. |
| internal/app/app.go | Adds startup preflight check with 15s timeout, wires BackendPreflight into AIConfig, and adjusts failover model list after preflight selects an active model; looks correct. |
| internal/agent/resolver.go | Adds per-session backend preflight, model tier resolution, and fallback model substitution; ctx propagation and nil guards look correct. |
| internal/ai/failover.go | Replaces ad-hoc retryable-error logic with DecideFallback/ClassifyBackendError, adds LastFallbackDecision accessor; dead-code concern from previous review has been addressed. |
| internal/ai/probe.go | Adds quota/rate-limit/tool-missing probe statuses, populates FailureKind/Backend/BaseURL in all probe paths, and delegates to probeStatusForHTTP; comprehensive and consistent. |
| internal/runtime/jobs.go | Adds optional Preflight hook to JobSpec evaluated before job creation; blocks job creation without consuming an attempt. Clean and well-tested. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/worker/opencode.go:106-108
**Double `Done: true` emission on scanner error**

When `scanner.Err()` returns a non-nil error, an event with `Done: true` is emitted but there is no `return` statement — execution falls through to `cmd.Wait()`, which emits a second `Done: true` event (via either the `ExitError` branch or the `else` branch). Consumers such as `DroidClient.CompleteStreamWithTools` forward every event downstream; the caller's streaming pipeline will see two "done" signals for a single stream, which can cause double-processing of the end-of-stream state.

Add a `return` after the scanner-error emit, and call `cmd.Wait()` before returning to avoid leaving the process un-reaped:

```suggestion
		if err := scanner.Err(); err != nil {
			_ = cmd.Wait()
			ch <- Event{Error: fmt.Errorf("stream read error: %w", err), Done: true}
			return
		}
```

### Issue 2 of 3
internal/worker/opencode.go:109-115
**Missing `Done` event for non-`ExitError` `cmd.Wait()` failures**

If `cmd.Wait()` returns a non-nil error that is not `*exec.ExitError` (e.g., `exec.ErrWaitDelay` introduced in Go 1.20, or an OS-level wait failure), no `Done: true` event is sent. The goroutine returns and the channel is closed, but this is inconsistent with every other error exit path in this function, all of which emit `Done: true`.

```suggestion
		if err := cmd.Wait(); err != nil {
			if exitErr, ok := err.(*exec.ExitError); ok {
				ch <- Event{Error: fmt.Errorf("opencode exited with code %d: %s", exitErr.ExitCode(), string(exitErr.Stderr)), Done: true}
			} else {
				ch <- Event{Error: fmt.Errorf("opencode wait failed: %w", err), Done: true}
			}
		} else {
			ch <- Event{Done: true}
		}
```

### Issue 3 of 3
internal/ai/backend_health.go:684
**`CheckedAt` bypasses the injectable `Now` clock**

`backendHealthFromProbe` calls `time.Now()` directly to populate `CheckedAt`, but `BackendPreflightConfig` already accepts a `Now func() time.Time` specifically to make timestamps controllable in tests. Using the injected clock keeps behaviour consistent and avoids non-determinism in any future assertion on `CheckedAt`.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address backend health review block..."](https://github.com/befeast/ok-gobot/commit/05cae2a0df3a9bfffdf37ec5d67092ce75358fe7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30487174)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->