### PR TITLE
feat: add GitHub reliability benchmark provider (#365)

### DIFF
--- a/docs/RELIABILITY-BENCHMARK.md
+++ b/docs/RELIABILITY-BENCHMARK.md
@@ -37,6 +37,42 @@ Use `--format json` or `--format markdown` to print either artifact to stdout.
 Use `--fail-on-failure` when wiring the benchmark into a gate that should exit
 non-zero if any scenario is blocked.
 
+## GitHub-Backed Provider
+
+The `github` provider scores recorded Maestro sessions against read-only GitHub
+PR state. It requires an existing ok-gobot SQLite storage file with evidence
+ledger entries and authenticated `gh` access.
+
+Score recent sessions with evidence:
+
+```bash
+ok-gobot benchmark reliability \
+  --provider github \
+  --repo BeFeast/ok-gobot \
+  --lookback 20
+```
+
+Score explicit sessions:
+
+```bash
+ok-gobot benchmark reliability \
+  --provider github \
+  --repo BeFeast/ok-gobot \
+  --session agent:default:telegram:dm:123 \
+  --session agent:default:telegram:dm:456
+```
+
+The provider uses local evidence to correlate the session, issue, branch, PR,
+retry count, and evidence ledger. It uses GitHub only for read operations such
+as PR state, checks, and reviews. It never writes issues, PRs, labels, comments,
+checks, branches, or worktrees.
+
+GitHub-backed JSON and Markdown reports include a `data_source` plus evidence
+links for the issue, PR, checks, reviews, and session evidence ledger when those
+links are available. Missing GitHub authentication or missing explicit session
+state fails before scoring; run `gh auth login` or choose a session from
+`ok-gobot sessions list` with evidence visible via `ok-gobot sessions evidence`.
+
 ## Manifest
 
 The default fake manifest lives at
@@ -58,5 +94,5 @@ skipped scenarios include one failure category: `agent_failure`,
 `environment_failure`, `ci_failure`, `review_failure`, or `policy_gated_skip`.
 
 The runner is provider-neutral. The bundled `fake` provider replays manifest
-events for local testing. A future GitHub-backed provider can implement the same
-`reliability.Evaluator` interface and use the existing report generation.
+events for local testing. The `github` provider implements the same
+`reliability.Evaluator` interface and reuses the existing report generation.

--- a/internal/cli/benchmark.go
+++ b/internal/cli/benchmark.go
@@ -3,32 +3,84 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/reliability"
+	"ok-gobot/internal/storage"
 )
 
 const defaultReliabilityManifest = "benchmarks/reliability/fake-scenarios.yaml"
+const defaultGitHubReliabilityLookback = 10
+const maxGitHubReliabilityLookback = 100
+const defaultGitHubReliabilityEvidenceLimit = 200
+const defaultGitHubReliabilityPRSearchLimit = 100
 
-func newBenchmarkCommand() *cobra.Command {
+type reliabilityBenchmarkDeps struct {
+	openStore       func(path string) (reliabilitySessionStore, error)
+	newGitHubClient func(dir string) reliability.GitHubClient
+}
+
+type reliabilitySessionStore interface {
+	Close() error
+	ListSessionsV2(limit int) ([]storage.SessionV2, error)
+	GetSessionV2(sessionKey string) (*storage.SessionV2, error)
+	ListEvidenceEvents(sessionKey string, limit int) ([]evidence.Event, error)
+}
+
+type reliabilityBenchmarkOptions struct {
+	manifestPath  string
+	format        string
+	jsonOut       string
+	markdownOut   string
+	failOnFailure bool
+	provider      string
+	repo          string
+	storagePath   string
+	sessionKeys   []string
+	lookback      int
+	evidenceLimit int
+	prSearchLimit int
+}
+
+func newBenchmarkCommand(cfg *config.Config) *cobra.Command {
+	deps := reliabilityBenchmarkDeps{
+		openStore: func(path string) (reliabilitySessionStore, error) {
+			return storage.OpenReadOnly(path)
+		},
+		newGitHubClient: func(dir string) reliability.GitHubClient {
+			return reliability.NewGHCLIClient(dir)
+		},
+	}
+	return newBenchmarkCommandWithDeps(cfg, deps)
+}
+
+func newBenchmarkCommandWithDeps(cfg *config.Config, deps reliabilityBenchmarkDeps) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "benchmark",
 		Short: "Run local benchmark harnesses",
 	}
-	cmd.AddCommand(newReliabilityBenchmarkCommand())
+	cmd.AddCommand(newReliabilityBenchmarkCommand(cfg, deps))
 	return cmd
 }
 
-func newReliabilityBenchmarkCommand() *cobra.Command {
-	var (
-		manifestPath  string
-		format        string
-		jsonOut       string
-		markdownOut   string
-		failOnFailure bool
-	)
+func newReliabilityBenchmarkCommand(cfg *config.Config, deps reliabilityBenchmarkDeps) *cobra.Command {
+	opts := reliabilityBenchmarkOptions{
+		manifestPath:  defaultReliabilityManifest,
+		format:        "compact",
+		provider:      reliability.ProviderFake,
+		lookback:      defaultGitHubReliabilityLookback,
+		evidenceLimit: defaultGitHubReliabilityEvidenceLimit,
+		prSearchLimit: defaultGitHubReliabilityPRSearchLimit,
+	}
+	if cfg != nil {
+		opts.storagePath = cfg.StoragePath
+		opts.repo = cfg.Maestro.Repo
+	}
 
 	cmd := &cobra.Command{
 		Use:   "reliability",
@@ -36,58 +88,244 @@ func newReliabilityBenchmarkCommand() *cobra.Command {
 		Long: `Run a manifest-driven reliability benchmark for the autonomous PR lifecycle.
 
 The default manifest uses deterministic fake scenarios, so it can run locally
-without GitHub credentials, Telegram credentials, or live LLM calls.`,
+without GitHub credentials, Telegram credentials, or live LLM calls.
+
+Use --provider github with --lookback or --session to score recorded Maestro
+sessions against read-only GitHub PR lifecycle state.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			manifest, err := reliability.LoadManifestFile(manifestPath)
+			report, err := runReliabilityBenchmark(cmd, opts, deps)
 			if err != nil {
 				return err
 			}
-
-			report, err := reliability.NewRunner(nil).Run(cmd.Context(), manifest)
-			if err != nil {
+			if err := renderReliabilityReport(cmd, report, opts); err != nil {
 				return err
 			}
-
-			jsonBytes, err := report.JSON()
-			if err != nil {
-				return fmt.Errorf("render JSON report: %w", err)
-			}
-			if jsonOut != "" {
-				if err := os.WriteFile(jsonOut, jsonBytes, 0o644); err != nil {
-					return fmt.Errorf("write JSON report: %w", err)
-				}
-			}
-			if markdownOut != "" {
-				if err := os.WriteFile(markdownOut, []byte(report.Markdown()), 0o644); err != nil {
-					return fmt.Errorf("write Markdown report: %w", err)
-				}
-			}
-
-			out := cmd.OutOrStdout()
-			switch strings.ToLower(strings.TrimSpace(format)) {
-			case "", "compact":
-				fmt.Fprint(out, report.Compact())
-			case "markdown", "md":
-				fmt.Fprint(out, report.Markdown())
-			case "json":
-				fmt.Fprintln(out, string(jsonBytes))
-			default:
-				return fmt.Errorf("unsupported format %q (supported: compact, markdown, json)", format)
-			}
-
-			if failOnFailure && report.Summary.Failed > 0 {
+			if opts.failOnFailure && report.Summary.Failed > 0 {
 				return fmt.Errorf("reliability benchmark reported %d failure(s)", report.Summary.Failed)
 			}
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&manifestPath, "manifest", defaultReliabilityManifest, "path to reliability benchmark manifest")
-	cmd.Flags().StringVar(&format, "format", "compact", "output format: compact, markdown, json")
-	cmd.Flags().StringVar(&jsonOut, "json-out", "", "write machine-readable JSON report to this path")
-	cmd.Flags().StringVar(&markdownOut, "markdown-out", "", "write human-readable Markdown report to this path")
-	cmd.Flags().BoolVar(&failOnFailure, "fail-on-failure", false, "exit non-zero when any scenario is blocked")
+	cmd.Flags().StringVar(&opts.manifestPath, "manifest", opts.manifestPath, "path to reliability benchmark manifest for the fake provider")
+	cmd.Flags().StringVar(&opts.provider, "provider", opts.provider, "benchmark provider: fake or github")
+	cmd.Flags().StringVar(&opts.format, "format", opts.format, "output format: compact, markdown, json")
+	cmd.Flags().StringVar(&opts.jsonOut, "json-out", "", "write machine-readable JSON report to this path")
+	cmd.Flags().StringVar(&opts.markdownOut, "markdown-out", "", "write human-readable Markdown report to this path")
+	cmd.Flags().BoolVar(&opts.failOnFailure, "fail-on-failure", false, "exit non-zero when any scenario is blocked")
+	cmd.Flags().StringVar(&opts.repo, "repo", opts.repo, "GitHub repo owner/name for the github provider (default: maestro.repo)")
+	cmd.Flags().StringVar(&opts.storagePath, "storage", opts.storagePath, "path to existing ok-gobot SQLite storage for the github provider")
+	cmd.Flags().StringSliceVar(&opts.sessionKeys, "session", nil, "explicit session key to score with the github provider; repeat or comma-separate")
+	cmd.Flags().IntVar(&opts.lookback, "lookback", opts.lookback, "recent sessions to inspect when --session is not set (github provider)")
+	cmd.Flags().IntVar(&opts.evidenceLimit, "evidence-limit", opts.evidenceLimit, "maximum evidence events to read per session (github provider)")
+	cmd.Flags().IntVar(&opts.prSearchLimit, "pr-search-limit", opts.prSearchLimit, "maximum recent PRs to scan when matching by linked issue (github provider)")
 
 	return cmd
+}
+
+func runReliabilityBenchmark(cmd *cobra.Command, opts reliabilityBenchmarkOptions, deps reliabilityBenchmarkDeps) (reliability.Report, error) {
+	switch strings.ToLower(strings.TrimSpace(opts.provider)) {
+	case "", reliability.ProviderFake:
+		manifest, err := reliability.LoadManifestFile(opts.manifestPath)
+		if err != nil {
+			return reliability.Report{}, err
+		}
+		return reliability.NewRunner(nil).Run(cmd.Context(), manifest)
+	case reliability.ProviderGitHub:
+		return runGitHubReliabilityBenchmark(cmd, opts, deps)
+	default:
+		return reliability.Report{}, fmt.Errorf("unsupported provider %q (supported: fake, github)", opts.provider)
+	}
+}
+
+func runGitHubReliabilityBenchmark(cmd *cobra.Command, opts reliabilityBenchmarkOptions, deps reliabilityBenchmarkDeps) (reliability.Report, error) {
+	if deps.openStore == nil {
+		return reliability.Report{}, fmt.Errorf("github provider requires session storage access")
+	}
+	if deps.newGitHubClient == nil {
+		return reliability.Report{}, fmt.Errorf("github provider requires a GitHub client")
+	}
+	store, err := deps.openStore(opts.storagePath)
+	if err != nil {
+		return reliability.Report{}, fmt.Errorf("open read-only session storage: %w", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	manifest, err := buildGitHubReliabilityManifest(store, opts)
+	if err != nil {
+		return reliability.Report{}, err
+	}
+
+	client := deps.newGitHubClient("")
+	if client == nil {
+		return reliability.Report{}, fmt.Errorf("github provider requires a GitHub client")
+	}
+	if err := client.CheckAuth(cmd.Context()); err != nil {
+		return reliability.Report{}, err
+	}
+
+	runner := reliability.NewRunner(map[string]reliability.Evaluator{
+		reliability.ProviderGitHub: reliability.GitHubEvaluator{
+			Client:        client,
+			Evidence:      store,
+			EvidenceLimit: opts.evidenceLimit,
+			PRSearchLimit: opts.prSearchLimit,
+		},
+	})
+	return runner.Run(cmd.Context(), manifest)
+}
+
+func buildGitHubReliabilityManifest(store reliabilitySessionStore, opts reliabilityBenchmarkOptions) (reliability.Manifest, error) {
+	if store == nil {
+		return reliability.Manifest{}, fmt.Errorf("session storage is required")
+	}
+	if opts.lookback < 0 {
+		return reliability.Manifest{}, fmt.Errorf("lookback cannot be negative")
+	}
+	if opts.lookback > maxGitHubReliabilityLookback {
+		return reliability.Manifest{}, fmt.Errorf("lookback %d exceeds maximum %d", opts.lookback, maxGitHubReliabilityLookback)
+	}
+	if opts.evidenceLimit <= 0 {
+		opts.evidenceLimit = defaultGitHubReliabilityEvidenceLimit
+	}
+	if opts.prSearchLimit <= 0 {
+		opts.prSearchLimit = defaultGitHubReliabilityPRSearchLimit
+	}
+
+	keys := normalizeSessionKeys(opts.sessionKeys)
+	var sessions []storage.SessionV2
+	if len(keys) > 0 {
+		for _, key := range keys {
+			sess, err := store.GetSessionV2(key)
+			if err != nil {
+				return reliability.Manifest{}, fmt.Errorf("read session %q: %w", key, err)
+			}
+			if sess == nil {
+				return reliability.Manifest{}, fmt.Errorf("session %q not found in storage; pass an existing session key from `ok-gobot sessions list`", key)
+			}
+			if err := requireSessionEvidence(store, key); err != nil {
+				return reliability.Manifest{}, err
+			}
+			sessions = append(sessions, *sess)
+		}
+	} else {
+		lookback := opts.lookback
+		if lookback <= 0 {
+			lookback = defaultGitHubReliabilityLookback
+		}
+		listed, err := store.ListSessionsV2(lookback)
+		if err != nil {
+			return reliability.Manifest{}, fmt.Errorf("list recent sessions: %w", err)
+		}
+		if len(listed) == 0 {
+			return reliability.Manifest{}, fmt.Errorf("no session state found in storage; pass --session with an existing Maestro session key")
+		}
+		for _, sess := range listed {
+			if hasSessionEvidence(store, sess.SessionKey) {
+				sessions = append(sessions, sess)
+			}
+		}
+		if len(sessions) == 0 {
+			return reliability.Manifest{}, fmt.Errorf("no sessions with evidence ledger entries found in the last %d sessions; pass --session with a recorded Maestro session", lookback)
+		}
+	}
+
+	scenarios := make([]reliability.Scenario, 0, len(sessions))
+	for i, sess := range sessions {
+		scenarios = append(scenarios, reliability.Scenario{
+			ID:       githubSessionScenarioID(sess.SessionKey, i),
+			Title:    fmt.Sprintf("GitHub evidence for %s", sess.SessionKey),
+			Provider: reliability.ProviderGitHub,
+			Repo:     strings.TrimSpace(opts.repo),
+			Metadata: map[string]string{
+				"session_key":     sess.SessionKey,
+				"created_at":      sess.CreatedAt,
+				"updated_at":      sess.UpdatedAt,
+				"evidence_limit":  strconv.Itoa(opts.evidenceLimit),
+				"pr_search_limit": strconv.Itoa(opts.prSearchLimit),
+			},
+		})
+	}
+	return reliability.Manifest{Name: "github-maestro-sessions", Version: 1, Scenarios: scenarios}, nil
+}
+
+func renderReliabilityReport(cmd *cobra.Command, report reliability.Report, opts reliabilityBenchmarkOptions) error {
+	jsonBytes, err := report.JSON()
+	if err != nil {
+		return fmt.Errorf("render JSON report: %w", err)
+	}
+	if opts.jsonOut != "" {
+		if err := os.WriteFile(opts.jsonOut, jsonBytes, 0o644); err != nil {
+			return fmt.Errorf("write JSON report: %w", err)
+		}
+	}
+	if opts.markdownOut != "" {
+		if err := os.WriteFile(opts.markdownOut, []byte(report.Markdown()), 0o644); err != nil {
+			return fmt.Errorf("write Markdown report: %w", err)
+		}
+	}
+
+	out := cmd.OutOrStdout()
+	switch strings.ToLower(strings.TrimSpace(opts.format)) {
+	case "", "compact":
+		fmt.Fprint(out, report.Compact())
+	case "markdown", "md":
+		fmt.Fprint(out, report.Markdown())
+	case "json":
+		fmt.Fprintln(out, string(jsonBytes))
+	default:
+		return fmt.Errorf("unsupported format %q (supported: compact, markdown, json)", opts.format)
+	}
+	return nil
+}
+
+func requireSessionEvidence(store reliabilitySessionStore, sessionKey string) error {
+	if hasSessionEvidence(store, sessionKey) {
+		return nil
+	}
+	return fmt.Errorf("session %q has no evidence ledger entries; run `ok-gobot sessions evidence %s` to inspect available evidence or choose another session", sessionKey, sessionKey)
+}
+
+func hasSessionEvidence(store reliabilitySessionStore, sessionKey string) bool {
+	events, err := store.ListEvidenceEvents(sessionKey, 1)
+	return err == nil && len(events) > 0
+}
+
+func normalizeSessionKeys(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	keys := make([]string, 0, len(values))
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			key := strings.TrimSpace(part)
+			if key == "" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+func githubSessionScenarioID(sessionKey string, index int) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(sessionKey)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+		if b.Len() >= 80 {
+			break
+		}
+	}
+	id := strings.Trim(b.String(), "-")
+	if id == "" {
+		id = fmt.Sprintf("session-%d", index+1)
+	}
+	return "github-" + id
 }

--- a/internal/cli/benchmark_test.go
+++ b/internal/cli/benchmark_test.go
@@ -2,10 +2,17 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/evidence"
+	"ok-gobot/internal/reliability"
+	"ok-gobot/internal/storage"
 )
 
 func TestBenchmarkReliabilityCommandPrintsAndWritesReports(t *testing.T) {
@@ -62,7 +69,7 @@ scenarios:
 		t.Fatalf("write manifest: %v", err)
 	}
 
-	cmd := newBenchmarkCommand()
+	cmd := newBenchmarkCommand(nil)
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -97,4 +104,168 @@ scenarios:
 	if !strings.Contains(string(markdownBytes), "# Reliability Benchmark Report") {
 		t.Fatalf("Markdown report missing heading:\n%s", markdownBytes)
 	}
+}
+
+func TestBenchmarkReliabilityGitHubProviderUsesSessionEvidence(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeBenchmarkStore{
+		sessions: map[string]storage.SessionV2{
+			"session-cli": {SessionKey: "session-cli", CreatedAt: "2026-05-01 12:00:00", UpdatedAt: "2026-05-01 12:10:00"},
+		},
+		evidence: map[string][]evidence.Event{
+			"session-cli": {
+				{SessionKey: "session-cli", Type: evidence.EventWorkspace, Status: "passed", Payload: map[string]any{"branch": "feat/session-cli"}},
+				{SessionKey: "session-cli", Type: evidence.EventPullRequest, Status: "passed", Payload: map[string]any{"pr_number": 55, "issue_number": 365}},
+			},
+		},
+	}
+	client := &fakeBenchmarkGitHubClient{prs: map[int]reliability.GitHubPullRequest{
+		55: {
+			Number:                 55,
+			URL:                    "https://github.com/BeFeast/ok-gobot/pull/55",
+			State:                  "MERGED",
+			Checks:                 []reliability.GitHubCheck{{Name: "test", Status: "COMPLETED", Conclusion: "SUCCESS"}},
+			ClosingIssueReferences: []reliability.GitHubIssueReference{{Number: 365, URL: "https://github.com/BeFeast/ok-gobot/issues/365"}},
+		},
+	}}
+	cmd := newBenchmarkCommandWithDeps(&config.Config{StoragePath: "unused.db", Maestro: config.MaestroConfig{Repo: "BeFeast/ok-gobot"}}, reliabilityBenchmarkDeps{
+		openStore:       func(string) (reliabilitySessionStore, error) { return store, nil },
+		newGitHubClient: func(string) reliability.GitHubClient { return client },
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"reliability", "--provider", "github", "--session", "session-cli", "--format", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	for _, want := range []string{`"provider": "github"`, `"outcome": "merge_ready"`, `"data_source": "github:BeFeast/ok-gobot session:session-cli"`, `"evidence_links"`} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+	if !client.authChecked {
+		t.Fatal("expected GitHub auth check")
+	}
+}
+
+func TestBenchmarkReliabilityGitHubProviderRequiresSessionStateBeforeAuth(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeBenchmarkGitHubClient{}
+	cmd := newBenchmarkCommandWithDeps(&config.Config{StoragePath: "unused.db"}, reliabilityBenchmarkDeps{
+		openStore: func(string) (reliabilitySessionStore, error) {
+			return &fakeBenchmarkStore{sessions: map[string]storage.SessionV2{}, evidence: map[string][]evidence.Event{}}, nil
+		},
+		newGitHubClient: func(string) reliability.GitHubClient { return client },
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"reliability", "--provider", "github", "--session", "missing"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), `session "missing" not found`) {
+		t.Fatalf("expected missing session error, got %v", err)
+	}
+	if client.authChecked {
+		t.Fatal("auth check should not run after missing local session state")
+	}
+}
+
+func TestBenchmarkReliabilityGitHubProviderRequiresAuth(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeBenchmarkStore{
+		sessions: map[string]storage.SessionV2{"session-auth": {SessionKey: "session-auth"}},
+		evidence: map[string][]evidence.Event{"session-auth": {{SessionKey: "session-auth", Type: evidence.EventPreflight, Status: "passed"}}},
+	}
+	client := &fakeBenchmarkGitHubClient{authErr: fmt.Errorf("GitHub authentication is required for provider %q; run `gh auth login`", reliability.ProviderGitHub)}
+	cmd := newBenchmarkCommandWithDeps(&config.Config{StoragePath: "unused.db"}, reliabilityBenchmarkDeps{
+		openStore:       func(string) (reliabilitySessionStore, error) { return store, nil },
+		newGitHubClient: func(string) reliability.GitHubClient { return client },
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"reliability", "--provider", "github", "--session", "session-auth"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "GitHub authentication is required") {
+		t.Fatalf("expected auth error, got %v", err)
+	}
+	if !client.authChecked {
+		t.Fatal("expected auth check")
+	}
+}
+
+type fakeBenchmarkStore struct {
+	sessions map[string]storage.SessionV2
+	evidence map[string][]evidence.Event
+}
+
+func (f *fakeBenchmarkStore) Close() error { return nil }
+
+func (f *fakeBenchmarkStore) ListSessionsV2(limit int) ([]storage.SessionV2, error) {
+	sessions := make([]storage.SessionV2, 0, len(f.sessions))
+	for _, session := range f.sessions {
+		sessions = append(sessions, session)
+		if limit > 0 && len(sessions) >= limit {
+			break
+		}
+	}
+	return sessions, nil
+}
+
+func (f *fakeBenchmarkStore) GetSessionV2(sessionKey string) (*storage.SessionV2, error) {
+	session, ok := f.sessions[sessionKey]
+	if !ok {
+		return nil, nil
+	}
+	return &session, nil
+}
+
+func (f *fakeBenchmarkStore) ListEvidenceEvents(sessionKey string, limit int) ([]evidence.Event, error) {
+	events := append([]evidence.Event(nil), f.evidence[sessionKey]...)
+	if limit > 0 && len(events) > limit {
+		events = events[:limit]
+	}
+	return events, nil
+}
+
+type fakeBenchmarkGitHubClient struct {
+	authErr     error
+	authChecked bool
+	prs         map[int]reliability.GitHubPullRequest
+}
+
+func (f *fakeBenchmarkGitHubClient) CheckAuth(context.Context) error {
+	f.authChecked = true
+	return f.authErr
+}
+
+func (f *fakeBenchmarkGitHubClient) PullRequest(_ context.Context, _ string, number int) (reliability.GitHubPullRequest, error) {
+	pr, ok := f.prs[number]
+	if !ok {
+		return reliability.GitHubPullRequest{}, nil
+	}
+	return pr, nil
+}
+
+func (f *fakeBenchmarkGitHubClient) FindPullRequest(_ context.Context, _ string, branch string, issueNumber, _ int) (*reliability.GitHubPullRequest, error) {
+	for _, pr := range f.prs {
+		if branch != "" && pr.HeadRefName == branch {
+			matched := pr
+			return &matched, nil
+		}
+		for _, issue := range pr.ClosingIssueReferences {
+			if issue.Number == issueNumber {
+				matched := pr
+				return &matched, nil
+			}
+		}
+	}
+	return nil, nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -55,7 +55,7 @@ Supports Telegram bot integration with personality and memory.`,
 	root.AddCommand(newExportCommand(cfg))
 	root.AddCommand(newEvolutionCommand(cfg))
 	root.AddCommand(newRolesCommand(cfg))
-	root.AddCommand(newBenchmarkCommand())
+	root.AddCommand(newBenchmarkCommand(cfg))
 
 	return root
 }

--- a/internal/reliability/github.go
+++ b/internal/reliability/github.go
@@ -1,0 +1,959 @@
+package reliability
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"ok-gobot/internal/evidence"
+)
+
+const (
+	defaultGitHubEvidenceLimit = 200
+	defaultGitHubPRSearchLimit = 100
+	githubPRJSONFields         = "number,title,url,state,isDraft,mergeStateStatus,headRefName,baseRefName,reviewDecision,statusCheckRollup,reviews,closingIssuesReferences"
+)
+
+// GitHubClient is the read-only GitHub surface used by the reliability provider.
+type GitHubClient interface {
+	CheckAuth(ctx context.Context) error
+	PullRequest(ctx context.Context, repo string, number int) (GitHubPullRequest, error)
+	FindPullRequest(ctx context.Context, repo, branch string, issueNumber, limit int) (*GitHubPullRequest, error)
+}
+
+// EvidenceSource reads the local Maestro evidence ledger for one session.
+type EvidenceSource interface {
+	ListEvidenceEvents(sessionKey string, limit int) ([]evidence.Event, error)
+}
+
+// GitHubPullRequest is a normalized, read-only PR lifecycle snapshot.
+type GitHubPullRequest struct {
+	Number                 int
+	Title                  string
+	URL                    string
+	State                  string
+	IsDraft                bool
+	MergeStateStatus       string
+	HeadRefName            string
+	BaseRefName            string
+	ReviewDecision         string
+	Checks                 []GitHubCheck
+	Reviews                []GitHubReview
+	ClosingIssueReferences []GitHubIssueReference
+}
+
+// GitHubCheck is one normalized status check or check run.
+type GitHubCheck struct {
+	Name       string
+	Status     string
+	Conclusion string
+	DetailsURL string
+}
+
+// GitHubReview is one normalized PR review.
+type GitHubReview struct {
+	Author string
+	State  string
+	URL    string
+}
+
+// GitHubIssueReference is an issue linked to a PR.
+type GitHubIssueReference struct {
+	Number int
+	URL    string
+}
+
+// GHCLIClient reads GitHub state through the gh CLI. It only uses view/list/auth
+// commands and never invokes mutating GitHub operations.
+type GHCLIClient struct {
+	Dir    string
+	Binary string
+}
+
+// NewGHCLIClient returns a read-only GitHub CLI client rooted at dir.
+func NewGHCLIClient(dir string) *GHCLIClient {
+	return &GHCLIClient{Dir: dir, Binary: "gh"}
+}
+
+// CheckAuth verifies that gh can read GitHub state before a benchmark starts.
+func (c *GHCLIClient) CheckAuth(ctx context.Context) error {
+	if _, err := c.run(ctx, "auth", "status", "--hostname", "github.com"); err != nil {
+		return fmt.Errorf("GitHub authentication is required for provider %q; run `gh auth login` or set GH_TOKEN/GITHUB_TOKEN: %w", ProviderGitHub, err)
+	}
+	return nil
+}
+
+// PullRequest reads one PR by number.
+func (c *GHCLIClient) PullRequest(ctx context.Context, repo string, number int) (GitHubPullRequest, error) {
+	if number <= 0 {
+		return GitHubPullRequest{}, fmt.Errorf("pull request number is required")
+	}
+	args := []string{"pr", "view", strconv.Itoa(number), "--json", githubPRJSONFields}
+	if strings.TrimSpace(repo) != "" {
+		args = append(args, "--repo", strings.TrimSpace(repo))
+	}
+	out, err := c.run(ctx, args...)
+	if err != nil {
+		return GitHubPullRequest{}, err
+	}
+	var raw ghRawPullRequest
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return GitHubPullRequest{}, fmt.Errorf("parse gh pr view: %w", err)
+	}
+	return normalizeRawPullRequest(raw), nil
+}
+
+// FindPullRequest looks for a PR by branch first, then by linked issue among
+// recent PRs. It returns nil when no matching PR exists.
+func (c *GHCLIClient) FindPullRequest(ctx context.Context, repo, branch string, issueNumber, limit int) (*GitHubPullRequest, error) {
+	if limit <= 0 {
+		limit = defaultGitHubPRSearchLimit
+	}
+	branch = strings.TrimSpace(branch)
+	var branchErr error
+	if branch != "" {
+		prs, err := c.listPullRequests(ctx, repo, limit, "--head", branch)
+		if err != nil {
+			branchErr = err
+		} else if len(prs) > 0 {
+			return &prs[0], nil
+		}
+	}
+
+	if issueNumber > 0 {
+		prs, err := c.listPullRequests(ctx, repo, limit)
+		if err != nil {
+			if branchErr != nil {
+				return nil, branchErr
+			}
+			return nil, err
+		}
+		for _, pr := range prs {
+			for _, issue := range pr.ClosingIssueReferences {
+				if issue.Number == issueNumber {
+					matched := pr
+					return &matched, nil
+				}
+			}
+		}
+	}
+
+	if branchErr != nil && issueNumber <= 0 {
+		return nil, branchErr
+	}
+	return nil, nil
+}
+
+func (c *GHCLIClient) listPullRequests(ctx context.Context, repo string, limit int, extraArgs ...string) ([]GitHubPullRequest, error) {
+	if limit <= 0 {
+		limit = defaultGitHubPRSearchLimit
+	}
+	args := []string{"pr", "list", "--state", "all", "--limit", strconv.Itoa(limit), "--json", githubPRJSONFields}
+	args = append(args, extraArgs...)
+	if strings.TrimSpace(repo) != "" {
+		args = append(args, "--repo", strings.TrimSpace(repo))
+	}
+	out, err := c.run(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	var raw []ghRawPullRequest
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse gh pr list: %w", err)
+	}
+	prs := make([]GitHubPullRequest, 0, len(raw))
+	for _, item := range raw {
+		prs = append(prs, normalizeRawPullRequest(item))
+	}
+	return prs, nil
+}
+
+func (c *GHCLIClient) run(ctx context.Context, args ...string) ([]byte, error) {
+	binary := c.Binary
+	if binary == "" {
+		binary = "gh"
+	}
+	cmd := exec.CommandContext(ctx, binary, args...)
+	if c.Dir != "" {
+		cmd.Dir = c.Dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			return nil, err
+		}
+		return nil, fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, msg)
+	}
+	return out, nil
+}
+
+type ghRawPullRequest struct {
+	Number                 int                   `json:"number"`
+	Title                  string                `json:"title"`
+	URL                    string                `json:"url"`
+	State                  string                `json:"state"`
+	IsDraft                bool                  `json:"isDraft"`
+	MergeStateStatus       string                `json:"mergeStateStatus"`
+	HeadRefName            string                `json:"headRefName"`
+	BaseRefName            string                `json:"baseRefName"`
+	ReviewDecision         string                `json:"reviewDecision"`
+	StatusCheckRollup      []map[string]any      `json:"statusCheckRollup"`
+	Reviews                []ghRawReview         `json:"reviews"`
+	ClosingIssueReferences []ghRawIssueReference `json:"closingIssuesReferences"`
+}
+
+type ghRawReview struct {
+	Author *struct {
+		Login string `json:"login"`
+	} `json:"author"`
+	State string `json:"state"`
+	URL   string `json:"url"`
+}
+
+type ghRawIssueReference struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+}
+
+func normalizeRawPullRequest(raw ghRawPullRequest) GitHubPullRequest {
+	pr := GitHubPullRequest{
+		Number:           raw.Number,
+		Title:            strings.TrimSpace(raw.Title),
+		URL:              strings.TrimSpace(raw.URL),
+		State:            strings.ToUpper(strings.TrimSpace(raw.State)),
+		IsDraft:          raw.IsDraft,
+		MergeStateStatus: strings.ToUpper(strings.TrimSpace(raw.MergeStateStatus)),
+		HeadRefName:      strings.TrimSpace(raw.HeadRefName),
+		BaseRefName:      strings.TrimSpace(raw.BaseRefName),
+		ReviewDecision:   strings.ToUpper(strings.TrimSpace(raw.ReviewDecision)),
+	}
+	for _, item := range raw.StatusCheckRollup {
+		check := GitHubCheck{
+			Name:       firstMapString(item, "name", "context"),
+			Status:     strings.ToUpper(firstMapString(item, "status", "state")),
+			Conclusion: strings.ToUpper(firstMapString(item, "conclusion")),
+			DetailsURL: firstMapString(item, "detailsUrl", "targetUrl", "url"),
+		}
+		if check.Name != "" || check.Status != "" || check.Conclusion != "" {
+			pr.Checks = append(pr.Checks, check)
+		}
+	}
+	for _, rawReview := range raw.Reviews {
+		review := GitHubReview{State: strings.ToUpper(strings.TrimSpace(rawReview.State)), URL: strings.TrimSpace(rawReview.URL)}
+		if rawReview.Author != nil {
+			review.Author = strings.TrimSpace(rawReview.Author.Login)
+		}
+		if review.State != "" || review.Author != "" || review.URL != "" {
+			pr.Reviews = append(pr.Reviews, review)
+		}
+	}
+	for _, issue := range raw.ClosingIssueReferences {
+		if issue.Number <= 0 {
+			continue
+		}
+		pr.ClosingIssueReferences = append(pr.ClosingIssueReferences, GitHubIssueReference{Number: issue.Number, URL: strings.TrimSpace(issue.URL)})
+	}
+	return pr
+}
+
+func firstMapString(item map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := item[key]
+		if !ok || value == nil {
+			continue
+		}
+		text := strings.TrimSpace(fmt.Sprint(value))
+		if text != "" && text != "<nil>" {
+			return text
+		}
+	}
+	return ""
+}
+
+// GitHubEvaluator scores one session by combining local evidence with read-only
+// GitHub PR state.
+type GitHubEvaluator struct {
+	Client        GitHubClient
+	Evidence      EvidenceSource
+	EvidenceLimit int
+	PRSearchLimit int
+}
+
+// Evaluate implements Evaluator.
+func (e GitHubEvaluator) Evaluate(ctx context.Context, scenario Scenario) (ScenarioResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ScenarioResult{}, err
+	}
+	if e.Client == nil {
+		return ScenarioResult{}, fmt.Errorf("github evaluator requires a GitHub client")
+	}
+	if e.Evidence == nil {
+		return ScenarioResult{}, fmt.Errorf("github evaluator requires a session evidence source")
+	}
+
+	sessionKey := strings.TrimSpace(scenario.Metadata["session_key"])
+	if sessionKey == "" {
+		return ScenarioResult{}, fmt.Errorf("scenario %q: metadata.session_key is required for provider %q", scenario.ID, ProviderGitHub)
+	}
+
+	limit := e.EvidenceLimit
+	if limit <= 0 {
+		limit = defaultGitHubEvidenceLimit
+	}
+	events, err := e.Evidence.ListEvidenceEvents(sessionKey, limit)
+	if err != nil {
+		return ScenarioResult{}, fmt.Errorf("read evidence for session %q: %w", sessionKey, err)
+	}
+	if len(events) == 0 {
+		return ScenarioResult{}, fmt.Errorf("session %q has no evidence ledger entries; choose a session with Maestro evidence or run `ok-gobot sessions evidence %s` to inspect it", sessionKey, sessionKey)
+	}
+
+	snapshot := extractGitHubSessionEvidence(scenario, sessionKey, events)
+	var pr *GitHubPullRequest
+	if !snapshot.PolicyGated {
+		if snapshot.PRNumber > 0 {
+			loaded, err := e.Client.PullRequest(ctx, snapshot.Repo, snapshot.PRNumber)
+			if err != nil {
+				return ScenarioResult{}, fmt.Errorf("read PR %s: %w", refWithRepo(snapshot.Repo, snapshot.PRNumber), err)
+			}
+			pr = &loaded
+		} else {
+			searchLimit := e.PRSearchLimit
+			if searchLimit <= 0 {
+				searchLimit = defaultGitHubPRSearchLimit
+			}
+			found, err := e.Client.FindPullRequest(ctx, snapshot.Repo, snapshot.Branch, snapshot.IssueNumber, searchLimit)
+			if err != nil {
+				return ScenarioResult{}, fmt.Errorf("search PR for session %q: %w", sessionKey, err)
+			}
+			pr = found
+		}
+	}
+	if pr != nil {
+		applyPRSnapshot(&snapshot, *pr)
+	}
+
+	result := classifyGitHubSession(snapshot, pr)
+	result.Repo = snapshot.Repo
+	result.IssueRef = issueRef(snapshot)
+	result.PRRef = prRef(snapshot)
+	result.DataSource = githubDataSource(snapshot)
+	result.EvidenceLinks = githubEvidenceLinks(snapshot, pr)
+	return result, nil
+}
+
+type githubSessionSnapshot struct {
+	SessionKey    string
+	Repo          string
+	IssueNumber   int
+	IssueURL      string
+	PRNumber      int
+	PRURL         string
+	Branch        string
+	JobID         string
+	RetryAttempts int
+	PolicyGated   bool
+	PolicyReason  string
+	FinalOutcome  string
+	FinalBlocker  string
+	FinalReason   string
+}
+
+func extractGitHubSessionEvidence(scenario Scenario, sessionKey string, events []evidence.Event) githubSessionSnapshot {
+	snapshot := githubSessionSnapshot{SessionKey: sessionKey, Repo: strings.TrimSpace(scenario.Repo)}
+	if repo, number, link, ok := parseRepoNumberRef(scenario.IssueRef, "issues"); ok {
+		setRepoIfEmpty(&snapshot, repo)
+		snapshot.IssueNumber = number
+		snapshot.IssueURL = link
+	}
+	if repo, number, link, ok := parseRepoNumberRef(scenario.PRRef, "pull"); ok {
+		setRepoIfEmpty(&snapshot, repo)
+		snapshot.PRNumber = number
+		snapshot.PRURL = link
+	}
+	applyStringMetadata(scenario.Metadata, "repo", &snapshot.Repo)
+	applyStringMetadata(scenario.Metadata, "branch", &snapshot.Branch)
+	if n := numberFromString(scenario.Metadata["issue_number"]); n > 0 {
+		snapshot.IssueNumber = n
+	}
+	if n := numberFromString(scenario.Metadata["pr_number"]); n > 0 {
+		snapshot.PRNumber = n
+	}
+	if n := numberFromString(scenario.Metadata["retry_attempts"]); n >= 0 {
+		snapshot.RetryAttempts = n
+	}
+	applyStringMetadata(scenario.Metadata, "job_id", &snapshot.JobID)
+
+	retryEvents := 0
+	maxAttempt := 0
+	for _, event := range events {
+		if snapshot.JobID == "" {
+			snapshot.JobID = strings.TrimSpace(event.JobID)
+		}
+		payload := event.Payload
+		setRepoIfEmpty(&snapshot, firstPayloadString(payload, "repo", "repository", "github_repo"))
+		if repo, number, link, ok := parseRepoNumberRef(firstPayloadString(payload, "issue_ref"), "issues"); ok {
+			setRepoIfEmpty(&snapshot, repo)
+			if snapshot.IssueNumber == 0 {
+				snapshot.IssueNumber = number
+			}
+			if snapshot.IssueURL == "" {
+				snapshot.IssueURL = link
+			}
+		}
+		if repo, number, link, ok := parseRepoNumberRef(firstPayloadString(payload, "issue_url"), "issues"); ok {
+			setRepoIfEmpty(&snapshot, repo)
+			if snapshot.IssueNumber == 0 {
+				snapshot.IssueNumber = number
+			}
+			if snapshot.IssueURL == "" {
+				snapshot.IssueURL = link
+			}
+		}
+		if n := firstPayloadInt(payload, "issue_number", "issue"); n > 0 && snapshot.IssueNumber == 0 {
+			snapshot.IssueNumber = n
+		}
+		if branch := firstPayloadString(payload, "branch", "head_ref", "head_ref_name", "headRefName", "source_branch"); branch != "" && snapshot.Branch == "" {
+			snapshot.Branch = strings.TrimPrefix(branch, "refs/heads/")
+		}
+
+		if event.Type == evidence.EventPullRequest {
+			if repo, number, link, ok := parseRepoNumberRef(firstPayloadString(payload, "pr_ref"), "pull"); ok {
+				setRepoIfEmpty(&snapshot, repo)
+				if snapshot.PRNumber == 0 {
+					snapshot.PRNumber = number
+				}
+				if snapshot.PRURL == "" {
+					snapshot.PRURL = link
+				}
+			}
+			if repo, number, link, ok := parseRepoNumberRef(firstPayloadString(payload, "url", "pr_url", "pull_request_url", "html_url"), "pull"); ok {
+				setRepoIfEmpty(&snapshot, repo)
+				if snapshot.PRNumber == 0 {
+					snapshot.PRNumber = number
+				}
+				if snapshot.PRURL == "" {
+					snapshot.PRURL = link
+				}
+			}
+			if n := firstPayloadInt(payload, "pr_number", "pull_request_number", "number"); n > 0 && snapshot.PRNumber == 0 {
+				snapshot.PRNumber = n
+			}
+		}
+
+		if event.Type == evidence.EventRetryDecision {
+			retryEvents++
+		}
+		if attempt := firstPayloadInt(payload, "attempt"); attempt > maxAttempt {
+			maxAttempt = attempt
+		}
+		if attempts := firstPayloadInt(payload, "retry_attempts", "retry_count"); attempts > snapshot.RetryAttempts {
+			snapshot.RetryAttempts = attempts
+		}
+
+		if eventPolicyGated(event) {
+			snapshot.PolicyGated = true
+			if snapshot.PolicyReason == "" {
+				snapshot.PolicyReason = firstNonEmpty(firstPayloadString(payload, "reason", "limit_reason", "policy_reason"), event.Summary)
+			}
+		}
+		if event.Type == evidence.EventFinalDecision {
+			snapshot.FinalOutcome = firstPayloadString(payload, "outcome", "status")
+			snapshot.FinalBlocker = firstPayloadString(payload, "blocker", "failure_category", "category", "limit_reason")
+			snapshot.FinalReason = firstNonEmpty(firstPayloadString(payload, "reason"), event.Summary)
+		}
+	}
+	if retryEvents > snapshot.RetryAttempts {
+		snapshot.RetryAttempts = retryEvents
+	}
+	if maxAttempt > 1 && maxAttempt-1 > snapshot.RetryAttempts {
+		snapshot.RetryAttempts = maxAttempt - 1
+	}
+	return snapshot
+}
+
+func classifyGitHubSession(snapshot githubSessionSnapshot, pr *GitHubPullRequest) ScenarioResult {
+	if snapshot.PolicyGated {
+		reason := strings.TrimSpace(snapshot.PolicyReason)
+		if reason == "" {
+			reason = "session was skipped by a policy gate"
+		}
+		return ScenarioResult{
+			Outcome:         OutcomeSkipped,
+			FailureCategory: CategoryPolicyGatedSkip,
+			Reason:          reason,
+			RetryAttempts:   snapshot.RetryAttempts,
+			Lifecycle:       githubLifecycle(snapshot, nil, checksSkipped, reviewsSkipped, OutcomeSkipped, CategoryPolicyGatedSkip),
+		}
+	}
+
+	if pr == nil || pr.Number <= 0 {
+		reason := "no pull request found for session evidence"
+		if snapshot.Branch != "" {
+			reason = fmt.Sprintf("branch %s was observed but no pull request was found", snapshot.Branch)
+		}
+		return ScenarioResult{
+			Outcome:         OutcomeBlocked,
+			FailureCategory: CategoryAgentFailure,
+			Reason:          reason,
+			RetryAttempts:   snapshot.RetryAttempts,
+			Lifecycle:       githubLifecycle(snapshot, nil, checksSkipped, reviewsSkipped, OutcomeBlocked, CategoryAgentFailure),
+		}
+	}
+
+	checks := classifyGitHubChecks(*pr)
+	reviews := classifyGitHubReviews(*pr)
+	state := strings.ToUpper(strings.TrimSpace(pr.State))
+	if state == "MERGED" {
+		return ScenarioResult{
+			Outcome:         OutcomeMergeReady,
+			FailureCategory: CategoryNone,
+			Reason:          fmt.Sprintf("pull request #%d was merged", pr.Number),
+			RetryAttempts:   snapshot.RetryAttempts,
+			Lifecycle:       githubLifecycle(snapshot, pr, checks, reviews, OutcomeMergeReady, CategoryNone),
+		}
+	}
+	if state == "CLOSED" {
+		return ScenarioResult{
+			Outcome:         OutcomeBlocked,
+			FailureCategory: CategoryAgentFailure,
+			Reason:          fmt.Sprintf("pull request #%d was closed without merge", pr.Number),
+			RetryAttempts:   snapshot.RetryAttempts,
+			Lifecycle:       githubLifecycle(snapshot, pr, checks, reviews, OutcomeBlocked, CategoryAgentFailure),
+		}
+	}
+	if pr.IsDraft {
+		return ScenarioResult{
+			Outcome:         OutcomeBlocked,
+			FailureCategory: CategoryAgentFailure,
+			Reason:          fmt.Sprintf("pull request #%d is still draft", pr.Number),
+			RetryAttempts:   snapshot.RetryAttempts,
+			Lifecycle:       githubLifecycle(snapshot, pr, checks, reviews, OutcomeBlocked, CategoryAgentFailure),
+		}
+	}
+	if checks == checksFailed {
+		return ScenarioResult{
+			Outcome:         OutcomeBlocked,
+			FailureCategory: CategoryCIFailure,
+			Reason:          fmt.Sprintf("pull request #%d has failing checks", pr.Number),
+			RetryAttempts:   snapshot.RetryAttempts,
+			Lifecycle:       githubLifecycle(snapshot, pr, checks, reviews, OutcomeBlocked, CategoryCIFailure),
+		}
+	}
+	if reviews == reviewsActionable {
+		return ScenarioResult{
+			Outcome:         OutcomeBlocked,
+			FailureCategory: CategoryReviewFailure,
+			Reason:          fmt.Sprintf("pull request #%d has blocking review feedback", pr.Number),
+			RetryAttempts:   snapshot.RetryAttempts,
+			Lifecycle:       githubLifecycle(snapshot, pr, checks, reviews, OutcomeBlocked, CategoryReviewFailure),
+		}
+	}
+	if checks == checksPending || checks == checksUnknown {
+		return ScenarioResult{
+			Outcome:         OutcomeBlocked,
+			FailureCategory: CategoryEnvironmentFailure,
+			Reason:          fmt.Sprintf("pull request #%d checks are not complete", pr.Number),
+			RetryAttempts:   snapshot.RetryAttempts,
+			Lifecycle:       githubLifecycle(snapshot, pr, checks, reviews, OutcomeBlocked, CategoryEnvironmentFailure),
+		}
+	}
+	return ScenarioResult{
+		Outcome:         OutcomeMergeReady,
+		FailureCategory: CategoryNone,
+		Reason:          fmt.Sprintf("pull request #%d is open with passing checks and no blocking review feedback", pr.Number),
+		RetryAttempts:   snapshot.RetryAttempts,
+		Lifecycle:       githubLifecycle(snapshot, pr, checks, reviews, OutcomeMergeReady, CategoryNone),
+	}
+}
+
+type checkClassification string
+
+const (
+	checksPassed  checkClassification = "passed"
+	checksFailed  checkClassification = "failed"
+	checksPending checkClassification = "pending"
+	checksUnknown checkClassification = "unknown"
+	checksSkipped checkClassification = "skipped"
+)
+
+type reviewClassification string
+
+const (
+	reviewsPassed     reviewClassification = "passed"
+	reviewsActionable reviewClassification = "actionable"
+	reviewsSkipped    reviewClassification = "skipped"
+)
+
+func classifyGitHubChecks(pr GitHubPullRequest) checkClassification {
+	if len(pr.Checks) == 0 {
+		switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
+		case "CLEAN", "HAS_HOOKS", "UNSTABLE":
+			return checksPassed
+		case "BLOCKED", "DIRTY", "UNKNOWN", "BEHIND":
+			return checksUnknown
+		default:
+			return checksUnknown
+		}
+	}
+	for _, check := range pr.Checks {
+		conclusion := strings.ToUpper(strings.TrimSpace(check.Conclusion))
+		status := strings.ToUpper(strings.TrimSpace(check.Status))
+		switch conclusion {
+		case "FAILURE", "FAILED", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED":
+			return checksFailed
+		}
+		switch status {
+		case "FAILURE", "FAILED", "ERROR":
+			return checksFailed
+		case "QUEUED", "PENDING", "IN_PROGRESS", "REQUESTED", "WAITING", "EXPECTED":
+			return checksPending
+		}
+		if conclusion == "" && status == "" {
+			return checksUnknown
+		}
+	}
+	return checksPassed
+}
+
+func classifyGitHubReviews(pr GitHubPullRequest) reviewClassification {
+	switch strings.ToUpper(strings.TrimSpace(pr.ReviewDecision)) {
+	case "CHANGES_REQUESTED":
+		return reviewsActionable
+	case "APPROVED":
+		return reviewsPassed
+	}
+	for _, review := range pr.Reviews {
+		if strings.ToUpper(strings.TrimSpace(review.State)) == "CHANGES_REQUESTED" {
+			return reviewsActionable
+		}
+	}
+	return reviewsPassed
+}
+
+func githubLifecycle(snapshot githubSessionSnapshot, pr *GitHubPullRequest, checks checkClassification, reviews reviewClassification, outcome Outcome, category FailureCategory) []LifecycleEvent {
+	events := []LifecycleEvent{{State: StateIssueSelected, Status: EventStatusPassed}}
+	if snapshot.IssueNumber == 0 {
+		events[0].Status = EventStatusInfo
+		events[0].Detail = "issue number not recorded"
+	}
+	preflight := LifecycleEvent{State: StatePreflightPassed, Status: EventStatusPassed}
+	if outcome == OutcomeSkipped {
+		preflight.Status = EventStatusSkipped
+		preflight.Detail = "policy gate declined execution"
+	}
+	events = append(events, preflight)
+
+	branch := strings.TrimSpace(snapshot.Branch)
+	if pr != nil && branch == "" {
+		branch = strings.TrimSpace(pr.HeadRefName)
+	}
+	branchEvent := LifecycleEvent{State: StateBranchCreated, Status: EventStatusPassed}
+	if branch == "" {
+		branchEvent.Status = EventStatusSkipped
+		branchEvent.Detail = "branch not recorded"
+	} else {
+		branchEvent.Detail = branch
+	}
+	events = append(events, branchEvent)
+
+	prEvent := LifecycleEvent{State: StatePROpened, Status: EventStatusPassed}
+	if pr == nil || pr.Number <= 0 {
+		if outcome == OutcomeSkipped {
+			prEvent.Status = EventStatusSkipped
+			prEvent.Detail = "policy-gated before PR creation"
+		} else {
+			prEvent.Status = EventStatusFailed
+			prEvent.Detail = "no PR found"
+		}
+	} else {
+		prEvent.Detail = refWithRepo(snapshot.Repo, pr.Number)
+	}
+	events = append(events, prEvent)
+
+	ciEvent := LifecycleEvent{State: StateCIChecked, Status: EventStatusPassed, Detail: string(checks)}
+	switch checks {
+	case checksFailed, checksPending, checksUnknown:
+		ciEvent.Status = EventStatusFailed
+	case checksSkipped:
+		ciEvent.Status = EventStatusSkipped
+	}
+	if pr == nil || pr.Number <= 0 {
+		ciEvent.Status = EventStatusSkipped
+		ciEvent.Detail = "no PR checks"
+	}
+	events = append(events, ciEvent)
+
+	reviewEvent := LifecycleEvent{State: StateReviewChecked, Status: EventStatusPassed, Detail: string(reviews)}
+	if reviews == reviewsActionable {
+		reviewEvent.Status = EventStatusFailed
+	}
+	if reviews == reviewsSkipped || pr == nil || pr.Number <= 0 || category == CategoryCIFailure {
+		reviewEvent.Status = EventStatusSkipped
+		if category == CategoryCIFailure {
+			reviewEvent.Detail = "not evaluated after CI failure"
+		} else if pr == nil || pr.Number <= 0 {
+			reviewEvent.Detail = "no PR reviews"
+		}
+	}
+	events = append(events, reviewEvent)
+
+	retryEvent := LifecycleEvent{State: StateRetryAttempted, Status: EventStatusSkipped, Detail: "no retries recorded"}
+	if snapshot.RetryAttempts > 0 {
+		retryEvent.Status = EventStatusPassed
+		retryEvent.Detail = fmt.Sprintf("%d retries recorded", snapshot.RetryAttempts)
+	}
+	events = append(events, retryEvent)
+
+	if outcome == OutcomeMergeReady {
+		events = append(events, LifecycleEvent{State: StateMergeReadyEmitted, Status: EventStatusPassed})
+	} else {
+		status := EventStatusFailed
+		if outcome == OutcomeSkipped {
+			status = EventStatusSkipped
+		}
+		events = append(events, LifecycleEvent{State: StateBlockerEmitted, Status: status, Detail: string(category)})
+	}
+	return events
+}
+
+func applyPRSnapshot(snapshot *githubSessionSnapshot, pr GitHubPullRequest) {
+	if snapshot.PRNumber == 0 {
+		snapshot.PRNumber = pr.Number
+	}
+	if snapshot.PRURL == "" {
+		snapshot.PRURL = strings.TrimSpace(pr.URL)
+	}
+	if snapshot.Branch == "" {
+		snapshot.Branch = strings.TrimSpace(pr.HeadRefName)
+	}
+	if repo, _, _, ok := parseRepoNumberRef(pr.URL, "pull"); ok {
+		setRepoIfEmpty(snapshot, repo)
+	}
+	if snapshot.IssueNumber == 0 && len(pr.ClosingIssueReferences) > 0 {
+		snapshot.IssueNumber = pr.ClosingIssueReferences[0].Number
+		snapshot.IssueURL = pr.ClosingIssueReferences[0].URL
+	}
+}
+
+func githubDataSource(snapshot githubSessionSnapshot) string {
+	parts := []string{ProviderGitHub}
+	if snapshot.Repo != "" {
+		parts[0] = ProviderGitHub + ":" + snapshot.Repo
+	}
+	if snapshot.SessionKey != "" {
+		parts = append(parts, "session:"+snapshot.SessionKey)
+	}
+	if snapshot.JobID != "" {
+		parts = append(parts, "job:"+snapshot.JobID)
+	}
+	return strings.Join(parts, " ")
+}
+
+func githubEvidenceLinks(snapshot githubSessionSnapshot, pr *GitHubPullRequest) []EvidenceLink {
+	repo := snapshot.Repo
+	if repo == "" && pr != nil {
+		repo, _, _, _ = parseRepoNumberRef(pr.URL, "pull")
+	}
+	var links []EvidenceLink
+	if issueURL := issueURL(snapshot, repo); issueURL != "" {
+		links = append(links, EvidenceLink{Type: "issue", Label: "issue", URL: issueURL})
+	}
+	if prURL := pullRequestURL(snapshot, repo); prURL != "" {
+		links = append(links, EvidenceLink{Type: "pr", Label: "PR", URL: prURL})
+		links = append(links, EvidenceLink{Type: "checks", Label: "checks", URL: strings.TrimRight(prURL, "/") + "/checks"})
+		links = append(links, EvidenceLink{Type: "reviews", Label: "reviews", URL: strings.TrimRight(prURL, "/") + "/files"})
+	}
+	if snapshot.SessionKey != "" {
+		ledger := url.URL{Scheme: "ok-gobot", Host: "sessions", Path: "/evidence"}
+		q := ledger.Query()
+		q.Set("key", snapshot.SessionKey)
+		ledger.RawQuery = q.Encode()
+		links = append(links, EvidenceLink{Type: "session_evidence", Label: "session evidence", URL: ledger.String()})
+	}
+	return links
+}
+
+func issueRef(snapshot githubSessionSnapshot) string {
+	if snapshot.IssueNumber <= 0 {
+		return ""
+	}
+	return refWithRepo(snapshot.Repo, snapshot.IssueNumber)
+}
+
+func prRef(snapshot githubSessionSnapshot) string {
+	if snapshot.PRNumber <= 0 {
+		return ""
+	}
+	return refWithRepo(snapshot.Repo, snapshot.PRNumber)
+}
+
+func issueURL(snapshot githubSessionSnapshot, repo string) string {
+	if snapshot.IssueURL != "" {
+		return snapshot.IssueURL
+	}
+	if repo != "" && snapshot.IssueNumber > 0 {
+		return fmt.Sprintf("https://github.com/%s/issues/%d", repo, snapshot.IssueNumber)
+	}
+	return ""
+}
+
+func pullRequestURL(snapshot githubSessionSnapshot, repo string) string {
+	if snapshot.PRURL != "" {
+		return snapshot.PRURL
+	}
+	if repo != "" && snapshot.PRNumber > 0 {
+		return fmt.Sprintf("https://github.com/%s/pull/%d", repo, snapshot.PRNumber)
+	}
+	return ""
+}
+
+func refWithRepo(repo string, number int) string {
+	if number <= 0 {
+		return ""
+	}
+	if strings.TrimSpace(repo) == "" {
+		return fmt.Sprintf("#%d", number)
+	}
+	return fmt.Sprintf("%s#%d", strings.TrimSpace(repo), number)
+}
+
+func parseRepoNumberRef(raw, githubPath string) (string, int, string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", 0, "", false
+	}
+	if parsed, err := url.Parse(raw); err == nil && strings.EqualFold(parsed.Host, "github.com") {
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) >= 4 && parts[0] != "" && parts[1] != "" && parts[2] == githubPath {
+			number := numberFromString(parts[3])
+			if number > 0 {
+				return parts[0] + "/" + parts[1], number, parsed.String(), true
+			}
+		}
+	}
+	if strings.HasPrefix(raw, "#") {
+		if number := numberFromString(strings.TrimPrefix(raw, "#")); number > 0 {
+			return "", number, "", true
+		}
+	}
+	if idx := strings.LastIndex(raw, "#"); idx >= 0 && idx < len(raw)-1 {
+		number := numberFromString(raw[idx+1:])
+		repo := strings.TrimSpace(raw[:idx])
+		if number > 0 && strings.Count(repo, "/") == 1 {
+			return repo, number, "", true
+		}
+	}
+	return "", 0, "", false
+}
+
+func numberFromString(raw string) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	raw = strings.TrimPrefix(raw, "#")
+	for i, r := range raw {
+		if r < '0' || r > '9' {
+			if i == 0 {
+				return 0
+			}
+			raw = raw[:i]
+			break
+		}
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+func applyStringMetadata(metadata map[string]string, key string, target *string) {
+	if target == nil || strings.TrimSpace(*target) != "" {
+		return
+	}
+	*target = strings.TrimSpace(metadata[key])
+}
+
+func setRepoIfEmpty(snapshot *githubSessionSnapshot, repo string) {
+	if strings.TrimSpace(snapshot.Repo) == "" {
+		snapshot.Repo = strings.TrimSpace(repo)
+	}
+}
+
+func firstPayloadString(payload map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := payload[key]
+		if !ok || value == nil {
+			continue
+		}
+		text := strings.TrimSpace(fmt.Sprint(value))
+		if text != "" && text != "<nil>" {
+			return text
+		}
+	}
+	return ""
+}
+
+func firstPayloadInt(payload map[string]any, keys ...string) int {
+	for _, key := range keys {
+		value, ok := payload[key]
+		if !ok || value == nil {
+			continue
+		}
+		switch v := value.(type) {
+		case int:
+			return v
+		case int64:
+			return int(v)
+		case float64:
+			return int(v)
+		case json.Number:
+			if n, err := v.Int64(); err == nil {
+				return int(n)
+			}
+		case string:
+			if n := numberFromString(v); n > 0 {
+				return n
+			}
+		default:
+			if n := numberFromString(fmt.Sprint(v)); n > 0 {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+func eventPolicyGated(event evidence.Event) bool {
+	status := strings.ToLower(strings.TrimSpace(event.Status))
+	summary := strings.ToLower(strings.TrimSpace(event.Summary))
+	if event.Type == evidence.EventPreflight && status == "skipped" {
+		return true
+	}
+	if strings.Contains(summary, "policy") && (strings.Contains(summary, "skip") || strings.Contains(summary, "gate")) {
+		return true
+	}
+	for _, key := range []string{"outcome", "blocker", "failure_category", "category", "limit_reason", "reason", "policy_reason"} {
+		value := strings.ToLower(firstPayloadString(event.Payload, key))
+		if strings.Contains(value, "policy") && (strings.Contains(value, "skip") || strings.Contains(value, "gate") || strings.Contains(value, "denied")) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/reliability/github_test.go
+++ b/internal/reliability/github_test.go
@@ -1,0 +1,204 @@
+package reliability
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/evidence"
+)
+
+func TestGitHubEvaluatorClassifiesRealLifecycleEvidence(t *testing.T) {
+	t.Parallel()
+
+	evidenceSource := fakeGitHubEvidenceSource{
+		"session-merged": {
+			workspaceEvidence("session-merged", "feat/merged"),
+			pullRequestEvidence("session-merged", 101, 365),
+		},
+		"session-ci": {
+			workspaceEvidence("session-ci", "feat/ci"),
+			pullRequestEvidence("session-ci", 102, 366),
+		},
+		"session-review": {
+			workspaceEvidence("session-review", "feat/review"),
+			pullRequestEvidence("session-review", 103, 367),
+		},
+		"session-no-pr": {
+			workspaceEvidence("session-no-pr", "feat/no-pr"),
+			{
+				SessionKey: "session-no-pr",
+				Type:       evidence.EventPreflight,
+				Status:     "passed",
+				Payload:    map[string]any{"issue_number": 368},
+			},
+		},
+		"session-policy": {
+			{
+				SessionKey: "session-policy",
+				Type:       evidence.EventPreflight,
+				Status:     "skipped",
+				Summary:    "policy gate skipped this issue",
+				Payload:    map[string]any{"issue_number": 369, "reason": "policy-gated skip"},
+			},
+		},
+	}
+	client := &fakeReliabilityGitHubClient{prs: map[int]GitHubPullRequest{
+		101: {
+			Number:                 101,
+			URL:                    "https://github.com/BeFeast/ok-gobot/pull/101",
+			State:                  "MERGED",
+			Checks:                 []GitHubCheck{{Name: "test", Status: "COMPLETED", Conclusion: "SUCCESS"}},
+			Reviews:                []GitHubReview{{Author: "reviewer", State: "APPROVED"}},
+			ClosingIssueReferences: []GitHubIssueReference{{Number: 365, URL: "https://github.com/BeFeast/ok-gobot/issues/365"}},
+		},
+		102: {
+			Number:                 102,
+			URL:                    "https://github.com/BeFeast/ok-gobot/pull/102",
+			State:                  "OPEN",
+			Checks:                 []GitHubCheck{{Name: "go test", Status: "COMPLETED", Conclusion: "FAILURE"}},
+			ClosingIssueReferences: []GitHubIssueReference{{Number: 366, URL: "https://github.com/BeFeast/ok-gobot/issues/366"}},
+		},
+		103: {
+			Number:                 103,
+			URL:                    "https://github.com/BeFeast/ok-gobot/pull/103",
+			State:                  "OPEN",
+			ReviewDecision:         "CHANGES_REQUESTED",
+			Checks:                 []GitHubCheck{{Name: "go test", Status: "COMPLETED", Conclusion: "SUCCESS"}},
+			Reviews:                []GitHubReview{{Author: "reviewer", State: "CHANGES_REQUESTED"}},
+			ClosingIssueReferences: []GitHubIssueReference{{Number: 367, URL: "https://github.com/BeFeast/ok-gobot/issues/367"}},
+		},
+	}}
+
+	manifest := Manifest{Name: "github-fixtures", Version: 1}
+	for _, sessionKey := range []string{"session-merged", "session-ci", "session-review", "session-no-pr", "session-policy"} {
+		manifest.Scenarios = append(manifest.Scenarios, Scenario{
+			ID:       sessionKey,
+			Provider: ProviderGitHub,
+			Repo:     "BeFeast/ok-gobot",
+			Metadata: map[string]string{"session_key": sessionKey},
+		})
+	}
+
+	report, err := NewRunner(map[string]Evaluator{ProviderGitHub: GitHubEvaluator{Client: client, Evidence: evidenceSource}}).Run(context.Background(), manifest)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	assertGitHubResult(t, report, "session-merged", OutcomeMergeReady, CategoryNone)
+	assertGitHubResult(t, report, "session-ci", OutcomeBlocked, CategoryCIFailure)
+	assertGitHubResult(t, report, "session-review", OutcomeBlocked, CategoryReviewFailure)
+	assertGitHubResult(t, report, "session-no-pr", OutcomeBlocked, CategoryAgentFailure)
+	assertGitHubResult(t, report, "session-policy", OutcomeSkipped, CategoryPolicyGatedSkip)
+
+	merged := findResult(t, report, "session-merged")
+	if !strings.Contains(merged.DataSource, "github:BeFeast/ok-gobot") || !strings.Contains(merged.DataSource, "session:session-merged") {
+		t.Fatalf("unexpected data source: %q", merged.DataSource)
+	}
+	for _, linkType := range []string{"issue", "pr", "checks", "reviews", "session_evidence"} {
+		if !hasEvidenceLink(merged, linkType) {
+			t.Fatalf("merged result missing evidence link %q: %+v", linkType, merged.EvidenceLinks)
+		}
+	}
+	markdown := report.Markdown()
+	if !strings.Contains(markdown, "[PR](https://github.com/BeFeast/ok-gobot/pull/101)") || !strings.Contains(markdown, "github:BeFeast/ok-gobot session:session-merged") {
+		t.Fatalf("markdown missing GitHub evidence/source:\n%s", markdown)
+	}
+}
+
+func TestGitHubEvaluatorRequiresSessionEvidence(t *testing.T) {
+	t.Parallel()
+
+	_, err := GitHubEvaluator{
+		Client:   &fakeReliabilityGitHubClient{},
+		Evidence: fakeGitHubEvidenceSource{},
+	}.Evaluate(context.Background(), Scenario{
+		ID:       "missing",
+		Provider: ProviderGitHub,
+		Metadata: map[string]string{"session_key": "missing-session"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "no evidence ledger entries") {
+		t.Fatalf("expected actionable missing evidence error, got %v", err)
+	}
+}
+
+type fakeGitHubEvidenceSource map[string][]evidence.Event
+
+func (f fakeGitHubEvidenceSource) ListEvidenceEvents(sessionKey string, limit int) ([]evidence.Event, error) {
+	events := append([]evidence.Event(nil), f[sessionKey]...)
+	if limit > 0 && len(events) > limit {
+		events = events[:limit]
+	}
+	return events, nil
+}
+
+type fakeReliabilityGitHubClient struct {
+	prs map[int]GitHubPullRequest
+}
+
+func (f *fakeReliabilityGitHubClient) CheckAuth(context.Context) error { return nil }
+
+func (f *fakeReliabilityGitHubClient) PullRequest(_ context.Context, _ string, number int) (GitHubPullRequest, error) {
+	pr, ok := f.prs[number]
+	if !ok {
+		return GitHubPullRequest{}, nil
+	}
+	return pr, nil
+}
+
+func (f *fakeReliabilityGitHubClient) FindPullRequest(_ context.Context, _ string, branch string, issueNumber, _ int) (*GitHubPullRequest, error) {
+	for _, pr := range f.prs {
+		if branch != "" && pr.HeadRefName == branch {
+			matched := pr
+			return &matched, nil
+		}
+		for _, issue := range pr.ClosingIssueReferences {
+			if issue.Number == issueNumber {
+				matched := pr
+				return &matched, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func workspaceEvidence(sessionKey, branch string) evidence.Event {
+	return evidence.Event{
+		SessionKey: sessionKey,
+		Type:       evidence.EventWorkspace,
+		Status:     "passed",
+		Payload:    map[string]any{"branch": branch},
+	}
+}
+
+func pullRequestEvidence(sessionKey string, prNumber, issueNumber int) evidence.Event {
+	return evidence.Event{
+		SessionKey: sessionKey,
+		Type:       evidence.EventPullRequest,
+		Status:     "passed",
+		Payload: map[string]any{
+			"pr_number":    prNumber,
+			"issue_number": issueNumber,
+		},
+	}
+}
+
+func assertGitHubResult(t *testing.T, report Report, id string, outcome Outcome, category FailureCategory) {
+	t.Helper()
+	result := findResult(t, report, id)
+	if result.Outcome != outcome || result.FailureCategory != category {
+		t.Fatalf("%s = outcome %s category %s, want %s/%s: %+v", id, result.Outcome, result.FailureCategory, outcome, category, result)
+	}
+	if result.DataSource == "" {
+		t.Fatalf("%s missing data source", id)
+	}
+}
+
+func hasEvidenceLink(result ScenarioResult, linkType string) bool {
+	for _, link := range result.EvidenceLinks {
+		if link.Type == linkType && link.URL != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/reliability/report.go
+++ b/internal/reliability/report.go
@@ -37,7 +37,11 @@ func (r Report) Compact() string {
 		if result.FailureCategory != "" && result.FailureCategory != CategoryNone {
 			category = fmt.Sprintf(" [%s]", result.FailureCategory)
 		}
-		fmt.Fprintf(&sb, "%s %s%s: %s\n", label, result.ID, category, result.Reason)
+		reason := result.Reason
+		if strings.TrimSpace(result.DataSource) != "" {
+			reason = fmt.Sprintf("%s (source: %s)", reason, result.DataSource)
+		}
+		fmt.Fprintf(&sb, "%s %s%s: %s\n", label, result.ID, category, reason)
 	}
 	return sb.String()
 }
@@ -60,20 +64,38 @@ func (r Report) Markdown() string {
 		fmt.Fprintf(&sb, "- Categories: %s\n", categories)
 	}
 
-	sb.WriteString("\n| Result | Scenario | Category | Reason | Lifecycle |\n")
-	sb.WriteString("|---|---|---|---|---|\n")
+	includeEvidence := reportHasEvidenceMetadata(r.Results)
+	if includeEvidence {
+		sb.WriteString("\n| Result | Scenario | Category | Reason | Data Source | Evidence | Lifecycle |\n")
+		sb.WriteString("|---|---|---|---|---|---|---|\n")
+	} else {
+		sb.WriteString("\n| Result | Scenario | Category | Reason | Lifecycle |\n")
+		sb.WriteString("|---|---|---|---|---|\n")
+	}
 	for _, result := range r.Results {
 		category := string(result.FailureCategory)
 		if category == "" {
 			category = string(CategoryNone)
 		}
-		fmt.Fprintf(&sb, "| %s | `%s` | `%s` | %s | %s |\n",
-			escapeCell(outcomeLabel(result.Outcome)),
-			escapeCell(result.ID),
-			escapeCell(category),
-			escapeCell(result.Reason),
-			escapeCell(formatLifecycle(result.Lifecycle)),
-		)
+		if includeEvidence {
+			fmt.Fprintf(&sb, "| %s | `%s` | `%s` | %s | %s | %s | %s |\n",
+				escapeCell(outcomeLabel(result.Outcome)),
+				escapeCell(result.ID),
+				escapeCell(category),
+				escapeCell(result.Reason),
+				escapeCell(result.DataSource),
+				formatEvidenceLinks(result.EvidenceLinks),
+				escapeCell(formatLifecycle(result.Lifecycle)),
+			)
+		} else {
+			fmt.Fprintf(&sb, "| %s | `%s` | `%s` | %s | %s |\n",
+				escapeCell(outcomeLabel(result.Outcome)),
+				escapeCell(result.ID),
+				escapeCell(category),
+				escapeCell(result.Reason),
+				escapeCell(formatLifecycle(result.Lifecycle)),
+			)
+		}
 	}
 	return sb.String()
 }
@@ -114,6 +136,34 @@ func formatLifecycle(events []LifecycleEvent) string {
 		parts = append(parts, fmt.Sprintf("%s:%s", event.State, status))
 	}
 	return strings.Join(parts, " -> ")
+}
+
+func reportHasEvidenceMetadata(results []ScenarioResult) bool {
+	for _, result := range results {
+		if strings.TrimSpace(result.DataSource) != "" || len(result.EvidenceLinks) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func formatEvidenceLinks(links []EvidenceLink) string {
+	if len(links) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(links))
+	for _, link := range links {
+		label := strings.TrimSpace(link.Label)
+		if label == "" {
+			label = strings.TrimSpace(link.Type)
+		}
+		url := strings.TrimSpace(link.URL)
+		if label == "" || url == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("[%s](%s)", escapeCell(label), escapeCell(url)))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func escapeCell(value string) string {

--- a/internal/reliability/types.go
+++ b/internal/reliability/types.go
@@ -3,9 +3,12 @@ package reliability
 import "time"
 
 // ProviderFake is the local, deterministic scenario evaluator used by tests and
-// by the default benchmark manifest. Real GitHub-backed evaluators can be added
-// behind the same Evaluator interface without changing the runner.
+// by the default benchmark manifest.
 const ProviderFake = "fake"
+
+// ProviderGitHub reads local Maestro evidence and GitHub PR state without
+// mutating either source.
+const ProviderGitHub = "github"
 
 // LifecycleState names the autonomous PR lifecycle gates tracked by the harness.
 type LifecycleState string
@@ -114,11 +117,20 @@ type ScenarioResult struct {
 	Repo            string           `json:"repo,omitempty"`
 	IssueRef        string           `json:"issue_ref,omitempty"`
 	PRRef           string           `json:"pr_ref,omitempty"`
+	DataSource      string           `json:"data_source,omitempty"`
+	EvidenceLinks   []EvidenceLink   `json:"evidence_links,omitempty"`
 	Outcome         Outcome          `json:"outcome"`
 	FailureCategory FailureCategory  `json:"failure_category"`
 	Reason          string           `json:"reason"`
 	RetryAttempts   int              `json:"retry_attempts"`
 	Lifecycle       []LifecycleEvent `json:"lifecycle"`
+}
+
+// EvidenceLink points to read-only evidence used to classify a scenario.
+type EvidenceLink struct {
+	Type  string `json:"type"`
+	Label string `json:"label"`
+	URL   string `json:"url"`
 }
 
 // Summary aggregates terminal outcomes across the manifest.

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,6 +57,35 @@ func New(dbPath string) (*Store, error) {
 	}
 
 	return store, nil
+}
+
+// OpenReadOnly opens an existing SQLite database without creating directories,
+// creating the database, or running migrations.
+func OpenReadOnly(dbPath string) (*Store, error) {
+	dbPath = strings.TrimSpace(dbPath)
+	if dbPath == "" {
+		return nil, fmt.Errorf("storage path is required")
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil, fmt.Errorf("session storage %s is not readable: %w", dbPath, err)
+	}
+	db, err := sql.Open("sqlite3", sqliteReadOnlyDSN(dbPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open read-only database: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close() //nolint:errcheck
+		return nil, fmt.Errorf("failed to ping read-only database: %w", err)
+	}
+	return &Store{db: db}, nil
+}
+
+func sqliteReadOnlyDSN(dbPath string) string {
+	u := url.URL{Scheme: "file", Path: dbPath}
+	q := u.Query()
+	q.Set("mode", "ro")
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 // Close closes the database connection

--- a/internal/storage/sqlite_schema_test.go
+++ b/internal/storage/sqlite_schema_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -19,6 +20,20 @@ func TestCanonicalSchemaTablesCreated(t *testing.T) {
 		if !tableExists(t, store.DB(), table) {
 			t.Fatalf("expected table %q to exist", table)
 		}
+	}
+}
+
+func TestOpenReadOnlyRequiresExistingDatabase(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "missing.db")
+	store, err := OpenReadOnly(dbPath)
+	if err == nil {
+		store.Close() //nolint:errcheck
+		t.Fatal("expected missing database error")
+	}
+	if _, statErr := os.Stat(dbPath); !os.IsNotExist(statErr) {
+		t.Fatalf("OpenReadOnly created missing database: stat err = %v", statErr)
 	}
 }
 


### PR DESCRIPTION
Implements #365

## Changes
- Adds a read-only GitHub-backed reliability provider that correlates local Maestro evidence with PR state, checks, reviews, retries, and final outcomes.
- Wires `ok-gobot benchmark reliability --provider github` with bounded `--lookback` or explicit `--session` selection while keeping fake scenarios as the default offline provider.
- Adds evidence/data-source reporting, read-only storage opening, docs, and focused tests for merged PRs, failing CI, review feedback, missing PRs, and policy-gated skips.

## Testing
- `bash .maestro/verify.sh`
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a read-only GitHub-backed reliability benchmark provider that correlates local Maestro evidence (sessions, branches, PRs, retries) with live GitHub PR state, wires it behind `--provider github`, and keeps the fake provider as the default.

- **P1 — `classifyGitHubChecks` early-exits on the first pending check** (`internal/reliability/github.go`): if any pending check precedes a failed check in the slice, the function returns `checksPending` and the session is mis-classified as `CategoryEnvironmentFailure` instead of `CategoryCIFailure`. The loop must accumulate the worst classification across all checks before returning.
- **P1 — `sqliteReadOnlyDSN` produces a malformed URI for relative paths** (`internal/storage/sqlite.go`): `url.URL{Scheme:"file", Path: relPath}` serializes to `file://relpath?mode=ro`, where the relative path lands in the *host* component instead of the path. `"file:" + url.PathEscape(dbPath)` avoids the ambiguity.

<h3>Confidence Score: 3/5</h3>

Two P1 logic bugs should be fixed before merging: check classification order and SQLite DSN construction for relative paths.

Two independent P1 findings in the core evaluation logic and storage layer pull the score below the P1 ceiling of 4. The check classification bug silently mis-categorises CI failures; the DSN bug can cause storage open failures for relative paths.

internal/reliability/github.go (classifyGitHubChecks, classifyGitHubReviews, eventPolicyGated) and internal/storage/sqlite.go (sqliteReadOnlyDSN)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/reliability/github.go | New 960-line GitHub reliability evaluator; has two logic bugs: early return in classifyGitHubChecks that masks failures behind pending checks (P1), and individual review scan that ignores superseded CHANGES_REQUESTED reviews (P2). Policy-gate detection is also over-broad for preflight skips (P2). |
| internal/storage/sqlite.go | Adds OpenReadOnly; sqliteReadOnlyDSN builds a file URI using url.URL which produces a malformed URI (host instead of path) for relative dbPath values (P1). |
| internal/cli/benchmark.go | Wires github provider into the CLI with clean dependency injection, lookback/session selection, and manifest building; no issues found. |
| internal/reliability/report.go | Adds conditional evidence columns to Markdown output and data-source annotation to Compact format; clean and backward-compatible. |
| internal/reliability/github_test.go | Covers merged PR, failing CI, review feedback, missing PR, and policy-gated scenarios; tests do not expose the check classification ordering bug because fake PRs use a single check per scenario. |
| internal/cli/benchmark_test.go | Adds integration-level CLI tests with a fake store and GitHub client; well-structured and covers auth ordering and missing session guards. |
| internal/storage/sqlite_schema_test.go | Adds test verifying OpenReadOnly rejects missing databases and does not create the file; appropriate coverage. |
| internal/reliability/types.go | Adds ProviderGitHub constant, DataSource/EvidenceLinks fields to ScenarioResult, and EvidenceLink struct; straightforward and safe. |
| internal/cli/root.go | Single-line change passing cfg to newBenchmarkCommand; correct. |
| docs/RELIABILITY-BENCHMARK.md | Documents the github provider with CLI examples, read-only semantics, and auth guidance; accurate and clear. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `internal/reliability/github.go`, line 1258-1276 ([link](https://github.com/befeast/ok-gobot/blob/b9ed15250f099fa056bfc4a4d144a3347137fdba/internal/reliability/github.go#L1258-L1276)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Early return on first pending check masks later failures**

   `classifyGitHubChecks` returns `checksPending` as soon as it encounters the first pending check, without scanning the remaining checks for failures. If GitHub returns checks in any order where a pending check precedes a failed one, the function returns `checksPending` and the session is classified as `CategoryEnvironmentFailure` instead of `CategoryCIFailure`. The severity hierarchy (failed > pending > passed) should be accumulated across all checks before returning.

   ```go
   func classifyGitHubChecks(pr GitHubPullRequest) checkClassification {
   	if len(pr.Checks) == 0 {
   		switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
   		case "CLEAN", "HAS_HOOKS", "UNSTABLE":
   			return checksPassed
   		default:
   			return checksUnknown
   		}
   	}
   	result := checksPassed
   	for _, check := range pr.Checks {
   		conclusion := strings.ToUpper(strings.TrimSpace(check.Conclusion))
   		status := strings.ToUpper(strings.TrimSpace(check.Status))
   		switch conclusion {
   		case "FAILURE", "FAILED", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED":
   			return checksFailed
   		}
   		switch status {
   		case "FAILURE", "FAILED", "ERROR":
   			return checksFailed
   		case "QUEUED", "PENDING", "IN_PROGRESS", "REQUESTED", "WAITING", "EXPECTED":
   			result = checksPending
   		default:
   			if conclusion == "" && status == "" && result == checksPassed {
   				result = checksUnknown
   			}
   		}
   	}
   	return result
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/reliability/github.go
   Line: 1258-1276

   Comment:
   **Early return on first pending check masks later failures**

   `classifyGitHubChecks` returns `checksPending` as soon as it encounters the first pending check, without scanning the remaining checks for failures. If GitHub returns checks in any order where a pending check precedes a failed one, the function returns `checksPending` and the session is classified as `CategoryEnvironmentFailure` instead of `CategoryCIFailure`. The severity hierarchy (failed > pending > passed) should be accumulated across all checks before returning.

   ```go
   func classifyGitHubChecks(pr GitHubPullRequest) checkClassification {
   	if len(pr.Checks) == 0 {
   		switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
   		case "CLEAN", "HAS_HOOKS", "UNSTABLE":
   			return checksPassed
   		default:
   			return checksUnknown
   		}
   	}
   	result := checksPassed
   	for _, check := range pr.Checks {
   		conclusion := strings.ToUpper(strings.TrimSpace(check.Conclusion))
   		status := strings.ToUpper(strings.TrimSpace(check.Status))
   		switch conclusion {
   		case "FAILURE", "FAILED", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED":
   			return checksFailed
   		}
   		switch status {
   		case "FAILURE", "FAILED", "ERROR":
   			return checksFailed
   		case "QUEUED", "PENDING", "IN_PROGRESS", "REQUESTED", "WAITING", "EXPECTED":
   			result = checksPending
   		default:
   			if conclusion == "" && status == "" && result == checksPassed {
   				result = checksUnknown
   			}
   		}
   	}
   	return result
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/storage/sqlite.go`, line 2004-2010 ([link](https://github.com/befeast/ok-gobot/blob/b9ed15250f099fa056bfc4a4d144a3347137fdba/internal/storage/sqlite.go#L2004-L2010)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Relative `dbPath` produces a malformed file URI**

   `url.URL{Scheme: "file", Path: dbPath}` with a non-absolute path (e.g. `"app.db"`) serializes to `file://app.db?mode=ro`, where `app.db` is parsed as the *host* component rather than the path. SQLite will fail to open the database. An explicit `file:` prefix with URL-only query encoding avoids the ambiguity.

   ```go
   func sqliteReadOnlyDSN(dbPath string) string {
   	q := url.Values{}
   	q.Set("mode", "ro")
   	return "file:" + url.PathEscape(dbPath) + "?" + q.Encode()
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/storage/sqlite.go
   Line: 2004-2010

   Comment:
   **Relative `dbPath` produces a malformed file URI**

   `url.URL{Scheme: "file", Path: dbPath}` with a non-absolute path (e.g. `"app.db"`) serializes to `file://app.db?mode=ro`, where `app.db` is parsed as the *host* component rather than the path. SQLite will fail to open the database. An explicit `file:` prefix with URL-only query encoding avoids the ambiguity.

   ```go
   func sqliteReadOnlyDSN(dbPath string) string {
   	q := url.Values{}
   	q.Set("mode", "ro")
   	return "file:" + url.PathEscape(dbPath) + "?" + q.Encode()
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `internal/reliability/github.go`, line 1588-1603 ([link](https://github.com/befeast/ok-gobot/blob/b9ed15250f099fa056bfc4a4d144a3347137fdba/internal/reliability/github.go#L1588-L1603)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`EventPreflight` skipped → policy-gated is too broad**

   Any `EventPreflight` event with `status == "skipped"` is treated as a policy gate, regardless of the actual reason. Preflight events can be skipped for reasons unrelated to policy (e.g., a normal agent timeout or a missing dependency). This causes those sessions to be silently classified as `CategoryPolicyGatedSkip` rather than `CategoryAgentFailure` or `CategoryEnvironmentFailure`, hiding real failures. Consider also checking for a non-empty `PolicyReason` or a more specific status marker before setting `PolicyGated = true` on preflight skips alone.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/reliability/github.go
   Line: 1588-1603

   Comment:
   **`EventPreflight` skipped → policy-gated is too broad**

   Any `EventPreflight` event with `status == "skipped"` is treated as a policy gate, regardless of the actual reason. Preflight events can be skipped for reasons unrelated to policy (e.g., a normal agent timeout or a missing dependency). This causes those sessions to be silently classified as `CategoryPolicyGatedSkip` rather than `CategoryAgentFailure` or `CategoryEnvironmentFailure`, hiding real failures. Consider also checking for a non-empty `PolicyReason` or a more specific status marker before setting `PolicyGated = true` on preflight skips alone.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


4. `internal/reliability/github.go`, line 1285-1290 ([link](https://github.com/befeast/ok-gobot/blob/b9ed15250f099fa056bfc4a4d144a3347137fdba/internal/reliability/github.go#L1285-L1290)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Individual review scan ignores superseded `CHANGES_REQUESTED` reviews**

   When `pr.ReviewDecision` is empty or `"REVIEW_REQUIRED"`, the fallback loop returns `reviewsActionable` on the first `CHANGES_REQUESTED` review regardless of whether that same reviewer subsequently approved. GitHub's own `reviewDecision` field accounts for this, but the fallback scan does not. A reviewer who requested changes and then approved will still trigger `CategoryReviewFailure` here. Since `ReviewDecision` is the authoritative signal, consider returning `reviewsPassed` immediately when it is non-empty and neither `"CHANGES_REQUESTED"` nor `"APPROVED"`, and only scanning individual reviews when it is empty.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/reliability/github.go
   Line: 1285-1290

   Comment:
   **Individual review scan ignores superseded `CHANGES_REQUESTED` reviews**

   When `pr.ReviewDecision` is empty or `"REVIEW_REQUIRED"`, the fallback loop returns `reviewsActionable` on the first `CHANGES_REQUESTED` review regardless of whether that same reviewer subsequently approved. GitHub's own `reviewDecision` field accounts for this, but the fallback scan does not. A reviewer who requested changes and then approved will still trigger `CategoryReviewFailure` here. Since `ReviewDecision` is the authoritative signal, consider returning `reviewsPassed` immediately when it is non-empty and neither `"CHANGES_REQUESTED"` nor `"APPROVED"`, and only scanning individual reviews when it is empty.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
internal/reliability/github.go:1258-1276
**Early return on first pending check masks later failures**

`classifyGitHubChecks` returns `checksPending` as soon as it encounters the first pending check, without scanning the remaining checks for failures. If GitHub returns checks in any order where a pending check precedes a failed one, the function returns `checksPending` and the session is classified as `CategoryEnvironmentFailure` instead of `CategoryCIFailure`. The severity hierarchy (failed > pending > passed) should be accumulated across all checks before returning.

```go
func classifyGitHubChecks(pr GitHubPullRequest) checkClassification {
	if len(pr.Checks) == 0 {
		switch strings.ToUpper(strings.TrimSpace(pr.MergeStateStatus)) {
		case "CLEAN", "HAS_HOOKS", "UNSTABLE":
			return checksPassed
		default:
			return checksUnknown
		}
	}
	result := checksPassed
	for _, check := range pr.Checks {
		conclusion := strings.ToUpper(strings.TrimSpace(check.Conclusion))
		status := strings.ToUpper(strings.TrimSpace(check.Status))
		switch conclusion {
		case "FAILURE", "FAILED", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED":
			return checksFailed
		}
		switch status {
		case "FAILURE", "FAILED", "ERROR":
			return checksFailed
		case "QUEUED", "PENDING", "IN_PROGRESS", "REQUESTED", "WAITING", "EXPECTED":
			result = checksPending
		default:
			if conclusion == "" && status == "" && result == checksPassed {
				result = checksUnknown
			}
		}
	}
	return result
}
```

### Issue 2 of 4
internal/storage/sqlite.go:2004-2010
**Relative `dbPath` produces a malformed file URI**

`url.URL{Scheme: "file", Path: dbPath}` with a non-absolute path (e.g. `"app.db"`) serializes to `file://app.db?mode=ro`, where `app.db` is parsed as the *host* component rather than the path. SQLite will fail to open the database. An explicit `file:` prefix with URL-only query encoding avoids the ambiguity.

```go
func sqliteReadOnlyDSN(dbPath string) string {
	q := url.Values{}
	q.Set("mode", "ro")
	return "file:" + url.PathEscape(dbPath) + "?" + q.Encode()
}
```

### Issue 3 of 4
internal/reliability/github.go:1588-1603
**`EventPreflight` skipped → policy-gated is too broad**

Any `EventPreflight` event with `status == "skipped"` is treated as a policy gate, regardless of the actual reason. Preflight events can be skipped for reasons unrelated to policy (e.g., a normal agent timeout or a missing dependency). This causes those sessions to be silently classified as `CategoryPolicyGatedSkip` rather than `CategoryAgentFailure` or `CategoryEnvironmentFailure`, hiding real failures. Consider also checking for a non-empty `PolicyReason` or a more specific status marker before setting `PolicyGated = true` on preflight skips alone.

### Issue 4 of 4
internal/reliability/github.go:1285-1290
**Individual review scan ignores superseded `CHANGES_REQUESTED` reviews**

When `pr.ReviewDecision` is empty or `"REVIEW_REQUIRED"`, the fallback loop returns `reviewsActionable` on the first `CHANGES_REQUESTED` review regardless of whether that same reviewer subsequently approved. GitHub's own `reviewDecision` field accounts for this, but the fallback scan does not. A reviewer who requested changes and then approved will still trigger `CategoryReviewFailure` here. Since `ReviewDecision` is the authoritative signal, consider returning `reviewsPassed` immediately when it is non-empty and neither `"CHANGES_REQUESTED"` nor `"APPROVED"`, and only scanning individual reviews when it is empty.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add GitHub reliability benchmark p..."](https://github.com/befeast/ok-gobot/commit/b9ed15250f099fa056bfc4a4d144a3347137fdba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30493336)</sub>

<!-- /greptile_comment -->