### PR TITLE
feat: add maestro hygiene report (#366)

### DIFF
--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -31,6 +31,7 @@ api:
 | `/api/mission/memory` | GET | Memory health: enabled state, backend, watcher, counts, freshness, and last error |
 | `/api/mission/evidence?session_key=...` | GET | Concise structured evidence timeline for a session, including Markdown rendering |
 | `/api/mission/supervisor` | GET | Current supervisor recovery decision and last safe action |
+| `/api/mission/hygiene` | GET | Read-only Maestro stale-state hygiene summary with safe and approval-required recommendations |
 
 Job detail responses from `/api/jobs/{id}` include proof artifacts with `type`,
 `label`, `path` or `url`, `created_at`, and `display` metadata. Mission Control
@@ -55,6 +56,7 @@ Run query parameters: `limit` (1-200), `status` (filter by run status). Stats qu
 - **Controls** -- emergency-stop state plus active provider/model/backend health
 - **Memory** -- whether the memory index is enabled, fresh, watched, and error-free
 - **Supervisor** -- the current stuck-state decision, reason, planned approval action, and most recent safe recovery action
+- **Hygiene** -- stale PRs, dead workers, stale approvals, checkout drift, orphaned worktrees, and policy-exhausted queues
 
 ## Architecture
 
@@ -90,6 +92,8 @@ Use `ok-gobot maestro dry-run` before starting a worker from GitHub issues. The 
 Use `ok-gobot maestro status` when no worker is running. It explains whether a worker is idle because there is no eligible issue, or which issue would be selected next. Dependency lines such as `Depends on: #353` block intake until the dependency is closed or a referenced PR is merge-ready. Inline-code snippets, fenced examples, and example sections are ignored.
 
 Maintainers can use `--override --override-reason "..."` to force the first open issue through the dry-run/status selection. The output and logs show that the maintainer override was used and list the gates it bypassed.
+
+Use `ok-gobot maestro hygiene` for a read-only stale-state report before dispatching more workers. It inspects GitHub PR/issue state, local checkout drift, durable jobs/sessions, pending approvals when available, and tracked worktrees. The report separates safe next actions from actions that require explicit operator approval and does not clean up, relabel, merge, close, or delete anything.
 
 Local file previews are restricted to artifact roots. Defaults are
 `~/.ok-gobot/screenshots` and `~/.ok-gobot/artifacts`; add more with:

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,9 +10,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"ok-gobot/internal/bot"
 	"ok-gobot/internal/config"
+	"ok-gobot/internal/hygiene"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 	"ok-gobot/internal/supervisor"
@@ -68,6 +71,14 @@ func (m *mockDataProvider) CancelJob(jobID string) error {
 
 func (m *mockDataProvider) WorkerSnapshots() []runtime.WorkerSnapshot {
 	return m.workers
+}
+
+type mockHygieneProvider struct {
+	report hygiene.Report
+}
+
+func (m mockHygieneProvider) GetHygieneReport(context.Context) (hygiene.Report, error) {
+	return m.report, nil
 }
 
 func newTestServer(dp DataProvider) *APIServer {
@@ -600,6 +611,40 @@ func TestHandleMissionSupervisor(t *testing.T) {
 	}
 }
 
+func TestHandleMissionHygiene(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	srv := newTestServer(&mockDataProvider{})
+	srv.SetHygieneProvider(mockHygieneProvider{report: hygiene.Report{
+		GeneratedAt: now,
+		Summary: hygiene.Summary{
+			Status:          "attention_needed",
+			TotalFindings:   1,
+			SafeActionCount: 1,
+			GeneratedAt:     now,
+		},
+		SafeActions: []hygiene.Finding{{
+			ID:          hygiene.FindingDeadWorker,
+			Severity:    hygiene.SeverityCritical,
+			Title:       "dead worker",
+			ActionGroup: hygiene.ActionSafe,
+		}},
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mission/hygiene", nil)
+	w := httptest.NewRecorder()
+	srv.handleMissionHygiene(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"attention_needed", "dead_worker", "safe_actions"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+}
+
 func TestHandleMissionSupervisor_WrongMethod(t *testing.T) {
 	srv := newTestServer(&mockDataProvider{})
 	req := httptest.NewRequest(http.MethodPost, "/api/mission/supervisor", nil)
@@ -649,6 +694,17 @@ func TestHandleMissionEvidence_WrongMethod(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/mission/evidence", nil)
 	w := httptest.NewRecorder()
 	srv.handleMissionEvidence(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("Expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleMissionHygiene_WrongMethod(t *testing.T) {
+	srv := newTestServer(&mockDataProvider{})
+	req := httptest.NewRequest(http.MethodPost, "/api/mission/hygiene", nil)
+	w := httptest.NewRecorder()
+	srv.handleMissionHygiene(w, req)
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("Expected 405, got %d", w.Code)

--- a/internal/api/mission.go
+++ b/internal/api/mission.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"ok-gobot/internal/evidence"
+	"ok-gobot/internal/hygiene"
 	"ok-gobot/internal/storage"
 )
 
@@ -340,6 +341,24 @@ func (s *APIServer) handleMissionSupervisor(w http.ResponseWriter, r *http.Reque
 	}
 
 	writeJSON(w, s.bot.GetSupervisorStatus())
+}
+
+// handleMissionHygiene returns the latest read-only stale-state hygiene report.
+func (s *APIServer) handleMissionHygiene(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.hygiene == nil {
+		writeJSON(w, hygiene.Report{})
+		return
+	}
+	report, err := s.hygiene.GetHygieneReport(r.Context())
+	if err != nil {
+		writeJSONError(w, "Failed to build hygiene report: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, report)
 }
 
 // handleMissionStats returns daily aggregate statistics.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,6 +11,7 @@ import (
 	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/bot"
 	"ok-gobot/internal/config"
+	"ok-gobot/internal/hygiene"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -27,14 +28,20 @@ type DataProvider interface {
 	WorkerSnapshots() []runtime.WorkerSnapshot
 }
 
+// HygieneProvider supplies read-only Maestro stale-state reports for Mission Control.
+type HygieneProvider interface {
+	GetHygieneReport(ctx context.Context) (hygiene.Report, error)
+}
+
 // APIServer handles HTTP API requests
 type APIServer struct {
-	config config.APIConfig
-	bot    *bot.Bot
-	data   DataProvider
-	server *http.Server
-	uptime time.Time
-	roots  []string
+	config  config.APIConfig
+	bot     *bot.Bot
+	data    DataProvider
+	hygiene HygieneProvider
+	server  *http.Server
+	uptime  time.Time
+	roots   []string
 }
 
 // NewAPIServer creates a new API server instance
@@ -49,6 +56,11 @@ func NewAPIServer(cfg config.APIConfig, b *bot.Bot) *APIServer {
 // SetDataProvider attaches a DataProvider for the extended control endpoints.
 func (s *APIServer) SetDataProvider(dp DataProvider) {
 	s.data = dp
+}
+
+// SetHygieneProvider attaches the read-only stale-state report provider.
+func (s *APIServer) SetHygieneProvider(provider HygieneProvider) {
+	s.hygiene = provider
 }
 
 // SetArtifactRoots configures local roots that artifact file previews may read from.
@@ -88,6 +100,7 @@ func (s *APIServer) Start(ctx context.Context) error {
 	mux.HandleFunc("/api/mission/memory", s.handleMissionMemory)
 	mux.HandleFunc("/api/mission/evidence", s.handleMissionEvidence)
 	mux.HandleFunc("/api/mission/supervisor", s.handleMissionSupervisor)
+	mux.HandleFunc("/api/mission/hygiene", s.handleMissionHygiene)
 
 	// Apply middleware
 	handler := loggingMiddleware(mux)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -90,11 +90,31 @@ func (a *stateAdapter) GetHygieneReport(ctx context.Context) (hygiene.Report, er
 			CreatedAt:  pending.CreatedAt,
 		})
 	}
+	workers := hygieneWorkers(a.b.SubagentHub(), time.Now())
 	return hygiene.BuildReport(ctx, hygiene.CollectOptions{
 		Config:    a.cfg,
 		Store:     a.b.GetStore(),
 		Approvals: approvals,
+		Workers:   workers,
 	}, hygiene.Options{})
+}
+
+func hygieneWorkers(hub *runtime.Hub, seenAt time.Time) []hygiene.Worker {
+	if hub == nil {
+		return nil
+	}
+	snapshots := hub.ListWorkers()
+	workers := make([]hygiene.Worker, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		workers = append(workers, hygiene.Worker{
+			SessionKey: snapshot.SessionKey,
+			Running:    snapshot.Running,
+			Alive:      true,
+			LastSeenAt: seenAt,
+			QueueDepth: snapshot.QueueDepth,
+		})
+	}
+	return workers
 }
 
 func (a *stateAdapter) RespondToApproval(id string, approved bool) error {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -18,6 +18,7 @@ import (
 	"ok-gobot/internal/cron"
 	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/evolution"
+	"ok-gobot/internal/hygiene"
 	"ok-gobot/internal/logger"
 	"ok-gobot/internal/memory"
 	"ok-gobot/internal/memorymcp"
@@ -51,7 +52,8 @@ type App struct {
 
 // stateAdapter bridges bot/storage to the control.StateProvider interface.
 type stateAdapter struct {
-	b *bot.Bot
+	b   *bot.Bot
+	cfg *config.Config
 }
 
 func (a *stateAdapter) GetStatus() map[string]interface{} {
@@ -76,6 +78,23 @@ func (a *stateAdapter) GetAgentRegistry() *agent.AgentRegistry {
 
 func (a *stateAdapter) GetScheduler() tools.CronScheduler {
 	return a.b.GetScheduler()
+}
+
+func (a *stateAdapter) GetHygieneReport(ctx context.Context) (hygiene.Report, error) {
+	var approvals []hygiene.Approval
+	for _, pending := range a.b.PendingApprovals() {
+		approvals = append(approvals, hygiene.Approval{
+			ID:         pending.ID,
+			SessionKey: fmt.Sprintf("telegram:%d", pending.ChatID),
+			Command:    pending.Command,
+			CreatedAt:  pending.CreatedAt,
+		})
+	}
+	return hygiene.BuildReport(ctx, hygiene.CollectOptions{
+		Config:    a.cfg,
+		Store:     a.b.GetStore(),
+		Approvals: approvals,
+	}, hygiene.Options{})
 }
 
 func (a *stateAdapter) RespondToApproval(id string, approved bool) error {
@@ -486,6 +505,7 @@ func (a *App) Start(ctx context.Context) error {
 		log.Printf("🌐 Initializing API server on port %d...", a.config.API.Port)
 		a.apiServer = api.NewAPIServer(a.config.API, a.bot)
 		a.apiServer.SetDataProvider(&dataProvider{store: a.store, bot: a.bot})
+		a.apiServer.SetHygieneProvider(&stateAdapter{b: a.bot, cfg: a.config})
 		a.apiServer.SetArtifactRoots(a.config.Artifacts.Roots)
 
 		// Start API server in goroutine
@@ -504,7 +524,7 @@ func (a *App) Start(ctx context.Context) error {
 			Token:                     a.config.Control.Token,
 			AllowLoopbackWithoutToken: a.config.Control.AllowLoopbackWithoutToken,
 		}
-		adapter := &stateAdapter{b: a.bot}
+		adapter := &stateAdapter{b: a.bot, cfg: a.config}
 		a.controlServer = control.New(ctrlCfg, adapter)
 		a.controlServer.SetStore(a.store)
 		a.controlServer.SetArtifactRoots(a.config.Artifacts.Roots)

--- a/internal/bot/approval.go
+++ b/internal/bot/approval.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -25,6 +26,15 @@ type PendingApproval struct {
 	ChatID    int64
 	Command   string
 	ResultCh  chan bool
+	CreatedAt time.Time
+}
+
+// PendingApprovalSnapshot is a read-only view of an approval that has not yet
+// been resolved. It is safe to expose to local Mission Control diagnostics.
+type PendingApprovalSnapshot struct {
+	ID        string
+	ChatID    int64
+	Command   string
 	CreatedAt time.Time
 }
 
@@ -84,6 +94,35 @@ func (am *ApprovalManager) SetControlHub(h *control.Hub) {
 	am.mu.Lock()
 	am.controlHub = h
 	am.mu.Unlock()
+}
+
+// Pending returns a stable read-only snapshot of unresolved approvals.
+func (am *ApprovalManager) Pending() []PendingApprovalSnapshot {
+	if am == nil {
+		return nil
+	}
+	am.mu.Lock()
+	defer am.mu.Unlock()
+
+	out := make([]PendingApprovalSnapshot, 0, len(am.pendingApprovals))
+	for id, pending := range am.pendingApprovals {
+		if pending == nil {
+			continue
+		}
+		out = append(out, PendingApprovalSnapshot{
+			ID:        id,
+			ChatID:    pending.ChatID,
+			Command:   pending.Command,
+			CreatedAt: pending.CreatedAt,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+	return out
 }
 
 // IsDangerous checks if a command matches dangerous patterns

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -866,6 +866,14 @@ func (b *Bot) GetSupervisorStatus() supervisor.Status {
 	return b.supervisorStatus.Clone()
 }
 
+// PendingApprovals returns a read-only snapshot of unresolved approval prompts.
+func (b *Bot) PendingApprovals() []PendingApprovalSnapshot {
+	if b == nil || b.approvalManager == nil {
+		return nil
+	}
+	return b.approvalManager.Pending()
+}
+
 // GetStatus returns bot status information for API
 func (b *Bot) GetStatus() map[string]interface{} {
 	status := map[string]interface{}{

--- a/internal/cli/maestro.go
+++ b/internal/cli/maestro.go
@@ -28,6 +28,7 @@ func newMaestroCommand(cfg *config.Config) *cobra.Command {
 	}
 	cmd.AddCommand(newMaestroDryRunCommand(cfg))
 	cmd.AddCommand(newMaestroStatusCommand(cfg))
+	cmd.AddCommand(newMaestroHygieneCommand(cfg))
 	return cmd
 }
 

--- a/internal/cli/maestro_hygiene.go
+++ b/internal/cli/maestro_hygiene.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/hygiene"
+	"ok-gobot/internal/storage"
+)
+
+type maestroHygieneOptions struct {
+	repo              string
+	readyLabel        string
+	hardExcludeLabels []string
+	limit             int
+	repoRoot          string
+	sourceBranch      string
+	upstreamBranch    string
+	worktreeStatePath string
+	stalePRDays       int
+	deadWorkerMinutes int
+	staleApprovalMins int
+	orphanedWTDays    int
+	jsonOutput        bool
+}
+
+func newMaestroHygieneCommand(cfg *config.Config) *cobra.Command {
+	defaults := defaultMaestroOptions(cfg)
+	opts := maestroHygieneOptions{
+		repo:              defaults.repo,
+		readyLabel:        defaults.readyLabel,
+		hardExcludeLabels: append([]string(nil), defaults.hardExcludeLabels...),
+		limit:             defaults.limit,
+		sourceBranch:      "main",
+		upstreamBranch:    "origin/main",
+		stalePRDays:       7,
+		deadWorkerMinutes: 30,
+		staleApprovalMins: 15,
+		orphanedWTDays:    7,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "hygiene",
+		Short: "Report stale Maestro PR, worker, approval, checkout, and worktree state",
+		Long: `Report stale Maestro operational state without mutating GitHub,
+Maestro storage, or local worktrees. The report groups recommendations into
+safe next actions and actions that require explicit operator approval.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := runMaestroHygiene(cmd, cfg, opts)
+			if err != nil {
+				return err
+			}
+			if opts.jsonOutput {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(report)
+			}
+			renderMaestroHygieneReport(cmd.OutOrStdout(), report)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.repo, "repo", opts.repo, "GitHub repo owner/name (default: gh infers from cwd)")
+	cmd.Flags().StringVar(&opts.readyLabel, "ready-label", opts.readyLabel, "label required for default issue eligibility")
+	cmd.Flags().StringSliceVar(&opts.hardExcludeLabels, "hard-exclude-label", opts.hardExcludeLabels, "hard-exclude label; repeat or comma-separate")
+	cmd.Flags().IntVar(&opts.limit, "limit", opts.limit, "number of PRs/issues to inspect")
+	cmd.Flags().StringVar(&opts.repoRoot, "repo-root", "", "path to local repository root (default: auto-detect)")
+	cmd.Flags().StringVar(&opts.sourceBranch, "source-branch", opts.sourceBranch, "local source branch checked for origin drift")
+	cmd.Flags().StringVar(&opts.upstreamBranch, "upstream-branch", opts.upstreamBranch, "upstream ref used for source checkout drift")
+	cmd.Flags().StringVar(&opts.worktreeStatePath, "worktree-state", "", "path to worktree inventory JSON (default: ~/.ok-gobot/worktrees.json)")
+	cmd.Flags().IntVar(&opts.stalePRDays, "stale-pr-days", opts.stalePRDays, "age in days before an open PR is considered stale")
+	cmd.Flags().IntVar(&opts.deadWorkerMinutes, "dead-worker-minutes", opts.deadWorkerMinutes, "minutes without live progress before a worker is considered dead")
+	cmd.Flags().IntVar(&opts.staleApprovalMins, "stale-approval-minutes", opts.staleApprovalMins, "minutes before a pending approval is considered stale")
+	cmd.Flags().IntVar(&opts.orphanedWTDays, "orphaned-worktree-days", opts.orphanedWTDays, "age in days before an unlinked worktree is considered orphaned")
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "emit JSON instead of text")
+	return cmd
+}
+
+func runMaestroHygiene(cmd *cobra.Command, cfg *config.Config, opts maestroHygieneOptions) (hygiene.Report, error) {
+	var store *storage.Store
+	if cfg != nil && strings.TrimSpace(cfg.StoragePath) != "" {
+		opened, err := storage.New(cfg.StoragePath)
+		if err != nil {
+			return hygiene.Report{}, fmt.Errorf("open storage: %w", err)
+		}
+		defer opened.Close() //nolint:errcheck
+		store = opened
+	}
+
+	collect := hygiene.CollectOptions{
+		Config:            cfg,
+		Store:             store,
+		Repo:              opts.repo,
+		RepoRoot:          opts.repoRoot,
+		SourceBranch:      opts.sourceBranch,
+		UpstreamBranch:    opts.upstreamBranch,
+		Limit:             opts.limit,
+		ReadyLabel:        opts.readyLabel,
+		HardExcludeLabels: opts.hardExcludeLabels,
+		WorktreeStatePath: opts.worktreeStatePath,
+	}
+	analyze := hygiene.Options{
+		StaleOpenPRAge:      time.Duration(opts.stalePRDays) * 24 * time.Hour,
+		DeadWorkerAge:       time.Duration(opts.deadWorkerMinutes) * time.Minute,
+		StaleApprovalAge:    time.Duration(opts.staleApprovalMins) * time.Minute,
+		OrphanedWorktreeAge: time.Duration(opts.orphanedWTDays) * 24 * time.Hour,
+	}
+	return hygiene.BuildReport(cmd.Context(), collect, analyze)
+}
+
+func renderMaestroHygieneReport(out io.Writer, report hygiene.Report) {
+	fmt.Fprintln(out, "Maestro stale-state hygiene report")
+	fmt.Fprintf(out, "Generated: %s\n", report.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintln(out, "Read-only: no GitHub, Maestro, or worktree cleanup actions were performed.")
+	fmt.Fprintf(out, "Summary: %s (%d finding(s), %d safe, %d approval-required)\n",
+		report.Summary.Status,
+		report.Summary.TotalFindings,
+		report.Summary.SafeActionCount,
+		report.Summary.ApprovalRequiredCount,
+	)
+
+	renderHygieneFindings(out, "Safe next actions", report.SafeActions)
+	renderHygieneFindings(out, "Approval-required actions", report.ApprovalRequired)
+	renderHygieneFindings(out, "Warnings", report.Warnings)
+}
+
+func renderHygieneFindings(out io.Writer, title string, findings []hygiene.Finding) {
+	fmt.Fprintf(out, "\n%s:\n", title)
+	if len(findings) == 0 {
+		fmt.Fprintln(out, "  none")
+		return
+	}
+	for _, finding := range findings {
+		fmt.Fprintf(out, "  - %s [%s]: %s\n", finding.ID, finding.Severity, finding.Title)
+		if strings.TrimSpace(finding.Detail) != "" {
+			fmt.Fprintf(out, "    Detail: %s\n", finding.Detail)
+		}
+		if evidence := formatHygieneEvidence(finding.Evidence); evidence != "" {
+			fmt.Fprintf(out, "    Evidence: %s\n", evidence)
+		}
+		if strings.TrimSpace(finding.Recommendation) != "" {
+			fmt.Fprintf(out, "    Recommendation: %s\n", finding.Recommendation)
+		}
+	}
+}
+
+func formatHygieneEvidence(e hygiene.Evidence) string {
+	parts := make([]string, 0, 6)
+	if e.SessionKey != "" {
+		parts = append(parts, "session="+e.SessionKey)
+	}
+	if e.JobID != "" {
+		parts = append(parts, "job="+e.JobID)
+	}
+	if e.IssueNumber > 0 {
+		parts = append(parts, fmt.Sprintf("issue=#%d", e.IssueNumber))
+	}
+	if e.PRNumber > 0 {
+		parts = append(parts, fmt.Sprintf("pr=#%d", e.PRNumber))
+	}
+	if e.Branch != "" {
+		parts = append(parts, "branch="+e.Branch)
+	}
+	if e.WorktreePath != "" {
+		parts = append(parts, "worktree="+e.WorktreePath)
+	}
+	if !e.StateTimestamp.IsZero() {
+		parts = append(parts, "state_at="+e.StateTimestamp.Format(time.RFC3339))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/cli/maestro_test.go
+++ b/internal/cli/maestro_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
+	"ok-gobot/internal/hygiene"
 	"ok-gobot/internal/maestro"
 )
 
@@ -52,6 +54,53 @@ func TestRenderMaestroDecisionShowsOverride(t *testing.T) {
 		"Override: ENABLED (maintainer override: ops reviewed)",
 		"Selected by maintainer override.",
 		`Override bypassed: missing ready label "ready"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestRenderMaestroHygieneReportGroupsActions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	report := hygiene.Report{
+		GeneratedAt: now,
+		Summary: hygiene.Summary{
+			Status:                "attention_needed",
+			TotalFindings:         2,
+			SafeActionCount:       1,
+			ApprovalRequiredCount: 1,
+		},
+		SafeActions: []hygiene.Finding{{
+			ID:          hygiene.FindingDeadWorker,
+			Severity:    hygiene.SeverityCritical,
+			Title:       "Worker stalled",
+			ActionGroup: hygiene.ActionSafe,
+			Evidence:    hygiene.Evidence{SessionKey: "agent:worker:main", JobID: "job-1", Branch: "work/366", StateTimestamp: now.Add(-time.Hour)},
+		}},
+		ApprovalRequired: []hygiene.Finding{{
+			ID:          hygiene.FindingOrphanedWorktree,
+			Severity:    hygiene.SeverityWarning,
+			Title:       "Worktree orphaned",
+			ActionGroup: hygiene.ActionApprovalRequired,
+			Evidence:    hygiene.Evidence{PRNumber: 42, WorktreePath: "/tmp/wt", StateTimestamp: now.Add(-24 * time.Hour)},
+		}},
+	}
+	var out bytes.Buffer
+	renderMaestroHygieneReport(&out, report)
+
+	got := out.String()
+	for _, want := range []string{
+		"Read-only: no GitHub, Maestro, or worktree cleanup actions were performed.",
+		"Safe next actions:",
+		"dead_worker",
+		"Approval-required actions:",
+		"orphaned_worktree",
+		"session=agent:worker:main",
+		"pr=#42",
+		"worktree=/tmp/wt",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q: %q", want, got)

--- a/internal/control/mission.go
+++ b/internal/control/mission.go
@@ -12,6 +12,7 @@ import (
 	"ok-gobot/internal/agent"
 	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/evidence"
+	"ok-gobot/internal/hygiene"
 	"ok-gobot/internal/memory"
 	"ok-gobot/internal/storage"
 	"ok-gobot/internal/supervisor"
@@ -32,6 +33,12 @@ type MissionSupervisorProvider interface {
 	GetSupervisorStatus() supervisor.Status
 }
 
+// MissionHygieneProvider optionally exposes the latest read-only stale-state
+// hygiene report for Mission Control.
+type MissionHygieneProvider interface {
+	GetHygieneReport(ctx context.Context) (hygiene.Report, error)
+}
+
 // registerMissionRoutes adds mission-control HTTP routes to the mux if the
 // state provider implements MissionProvider.
 func (s *Server) registerMissionRoutes(mux *http.ServeMux) {
@@ -48,6 +55,7 @@ func (s *Server) registerMissionRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/mission/memory", s.corsWrap(missionMemory(mp)))
 	mux.HandleFunc("/api/mission/evidence", s.corsWrap(missionEvidence(mp)))
 	mux.HandleFunc("/api/mission/supervisor", s.corsWrap(missionSupervisor(mp)))
+	mux.HandleFunc("/api/mission/hygiene", s.corsWrap(missionHygiene(mp)))
 	mux.HandleFunc("/api/mission/artifacts/", s.corsWrap(missionArtifactContent(mp, s.artifactRoots)))
 }
 
@@ -470,5 +478,25 @@ func missionSupervisor(mp MissionProvider) http.HandlerFunc {
 			return
 		}
 		writeJSON(w, provider.GetSupervisorStatus())
+	}
+}
+
+func missionHygiene(mp MissionProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeJSONErr(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		provider, ok := mp.(MissionHygieneProvider)
+		if !ok {
+			writeJSON(w, hygiene.Report{})
+			return
+		}
+		report, err := provider.GetHygieneReport(r.Context())
+		if err != nil {
+			writeJSONErr(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, report)
 	}
 }

--- a/internal/control/mission_test.go
+++ b/internal/control/mission_test.go
@@ -8,10 +8,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/ai"
 	"ok-gobot/internal/evidence"
+	"ok-gobot/internal/hygiene"
 	"ok-gobot/internal/memory"
 	"ok-gobot/internal/storage"
 	"ok-gobot/internal/tools"
@@ -38,6 +40,15 @@ type missionStateStub struct {
 func (s missionStateStub) GetStatus() map[string]interface{} { return s.status }
 
 func (s missionStateStub) RespondToApproval(string, bool) error { return nil }
+
+type missionHygieneProvider struct {
+	missionEvidenceProvider
+	report hygiene.Report
+}
+
+func (m missionHygieneProvider) GetHygieneReport(context.Context) (hygiene.Report, error) {
+	return m.report, nil
+}
 
 func TestMissionEvidenceRendersSessionTimeline(t *testing.T) {
 	t.Parallel()
@@ -158,5 +169,49 @@ func TestMissionProvidersIncludesBackendHealth(t *testing.T) {
 	}
 	if got["health"] == nil {
 		t.Fatal("expected health payload")
+	}
+}
+
+func TestMissionHygieneReturnsReadOnlySummary(t *testing.T) {
+	t.Parallel()
+
+	store, err := storage.New(filepath.Join(t.TempDir(), "mission-hygiene.db"))
+	if err != nil {
+		t.Fatalf("storage.New failed: %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	provider := missionHygieneProvider{
+		missionEvidenceProvider: missionEvidenceProvider{store: store},
+		report: hygiene.Report{
+			GeneratedAt: now,
+			Summary: hygiene.Summary{
+				Status:          "attention_needed",
+				TotalFindings:   1,
+				SafeActionCount: 1,
+				GeneratedAt:     now,
+			},
+			SafeActions: []hygiene.Finding{{
+				ID:          hygiene.FindingCheckoutBehind,
+				Severity:    hygiene.SeverityWarning,
+				Title:       "Local main is behind origin/main",
+				ActionGroup: hygiene.ActionSafe,
+			}},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mission/hygiene", nil)
+	rec := httptest.NewRecorder()
+	missionHygiene(provider)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"attention_needed", "checkout_behind_origin", "safe_actions"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
 	}
 }

--- a/internal/hygiene/collect.go
+++ b/internal/hygiene/collect.go
@@ -37,7 +37,7 @@ type CollectOptions struct {
 }
 
 var (
-	prRefRE    = regexp.MustCompile(`(?i)\bpr\s*#?(\d+)`)
+	prRefRE    = regexp.MustCompile(`(?i)\b(?:pr|pull\s+request)\s*#?(\d+)`)
 	issueRefRE = regexp.MustCompile(`(?i)\bissue\s*#?(\d+)|#(\d+)`)
 )
 
@@ -73,13 +73,14 @@ func Collect(ctx context.Context, opts CollectOptions) (Snapshot, error) {
 	}
 
 	prs, err := collectPullRequests(ctx, opts.Runner, repoRoot, opts.Repo, opts.Limit)
+	prsLoaded := err == nil
 	if err != nil {
 		snapshot.Warnings = append(snapshot.Warnings, "GitHub PR state unavailable: "+err.Error())
 	} else {
 		snapshot.PullRequests = prs
 	}
 
-	queue, err := collectQueue(ctx, opts, repoRoot)
+	queue, err := collectQueue(ctx, opts, repoRoot, prs, prsLoaded)
 	if err != nil {
 		snapshot.Warnings = append(snapshot.Warnings, "Maestro queue state unavailable: "+err.Error())
 	} else {
@@ -202,7 +203,7 @@ func collectWorktreeState(statePath string, snapshot *Snapshot) {
 }
 
 func collectPullRequests(ctx context.Context, runner CommandRunner, repoRoot, repo string, limit int) ([]PullRequest, error) {
-	args := []string{"pr", "list", "--state", "all", "--limit", strconv.Itoa(limit), "--json", "number,title,state,headRefName,updatedAt,closingIssuesReferences"}
+	args := []string{"pr", "list", "--state", "all", "--limit", strconv.Itoa(limit), "--json", "number,title,body,state,headRefName,labels,updatedAt,closingIssuesReferences"}
 	if strings.TrimSpace(repo) != "" {
 		args = append(args, "--repo", strings.TrimSpace(repo))
 	}
@@ -211,10 +212,14 @@ func collectPullRequests(ctx context.Context, runner CommandRunner, repoRoot, re
 		return nil, err
 	}
 	var raw []struct {
-		Number                  int    `json:"number"`
-		Title                   string `json:"title"`
-		State                   string `json:"state"`
-		HeadRefName             string `json:"headRefName"`
+		Number      int    `json:"number"`
+		Title       string `json:"title"`
+		Body        string `json:"body"`
+		State       string `json:"state"`
+		HeadRefName string `json:"headRefName"`
+		Labels      []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
 		UpdatedAt               string `json:"updatedAt"`
 		ClosingIssuesReferences []struct {
 			Number int `json:"number"`
@@ -229,27 +234,41 @@ func collectPullRequests(ctx context.Context, runner CommandRunner, repoRoot, re
 		if len(item.ClosingIssuesReferences) > 0 {
 			issue = item.ClosingIssuesReferences[0].Number
 		}
+		labels := make([]string, 0, len(item.Labels))
+		for _, label := range item.Labels {
+			labels = append(labels, label.Name)
+		}
 		prs = append(prs, PullRequest{
 			Number:      item.Number,
 			IssueNumber: issue,
 			Title:       item.Title,
+			Body:        item.Body,
 			State:       strings.ToLower(strings.TrimSpace(item.State)),
 			Branch:      item.HeadRefName,
+			Labels:      labels,
 			UpdatedAt:   parseTime(item.UpdatedAt),
 		})
 	}
 	return prs, nil
 }
 
-func collectQueue(ctx context.Context, opts CollectOptions, repoRoot string) (Queue, error) {
-	decision, err := maestro.DryRun(ctx, maestro.NewGHClient(repoRoot), maestro.Policy{
+func collectQueue(ctx context.Context, opts CollectOptions, repoRoot string, prs []PullRequest, prsLoaded bool) (Queue, error) {
+	resolver := maestro.NewGHClient(repoRoot)
+	policy := maestro.Policy{
 		Repo:              opts.Repo,
 		ReadyLabel:        opts.ReadyLabel,
 		HardExcludeLabels: opts.HardExcludeLabels,
 		Limit:             opts.Limit,
-	})
-	if err != nil {
-		return Queue{}, err
+	}
+	var decision maestro.Decision
+	if prsLoaded {
+		decision = maestro.Evaluate(ctx, issuesFromPullRequests(prs), resolver, policy)
+	} else {
+		var err error
+		decision, err = maestro.DryRun(ctx, resolver, policy)
+		if err != nil {
+			return Queue{}, err
+		}
 	}
 	queue := Queue{SkippedIssues: len(decision.Skipped), CheckedAt: time.Now()}
 	if decision.Next != nil {
@@ -273,6 +292,23 @@ func collectQueue(ctx context.Context, opts CollectOptions, repoRoot string) (Qu
 		queue.Reasons = queue.Reasons[:3]
 	}
 	return queue, nil
+}
+
+func issuesFromPullRequests(prs []PullRequest) []maestro.Issue {
+	issues := make([]maestro.Issue, 0, len(prs))
+	for _, pr := range prs {
+		if !isOpenState(pr.State) {
+			continue
+		}
+		issues = append(issues, maestro.Issue{
+			Number: pr.Number,
+			Title:  pr.Title,
+			Body:   pr.Body,
+			Labels: append([]string(nil), pr.Labels...),
+			State:  pr.State,
+		})
+	}
+	return issues
 }
 
 func collectCheckout(ctx context.Context, runner CommandRunner, repoRoot, branch, upstream string) (Checkout, error) {
@@ -386,15 +422,34 @@ func parseTime(value string) time.Time {
 }
 
 func extractRefs(text string) (issueNumber int, prNumber int) {
-	if match := prRefRE.FindStringSubmatch(text); len(match) == 2 {
-		prNumber, _ = strconv.Atoi(match[1])
+	prMatches := prRefRE.FindAllStringSubmatchIndex(text, -1)
+	if len(prMatches) > 0 && len(prMatches[0]) >= 4 && prMatches[0][2] >= 0 {
+		prNumber, _ = strconv.Atoi(text[prMatches[0][2]:prMatches[0][3]])
 	}
-	if match := issueRefRE.FindStringSubmatch(text); len(match) == 3 {
-		if match[1] != "" {
-			issueNumber, _ = strconv.Atoi(match[1])
-		} else if match[2] != "" {
-			issueNumber, _ = strconv.Atoi(match[2])
+	for _, match := range issueRefRE.FindAllStringSubmatchIndex(text, -1) {
+		if rangesOverlap(match[0], match[1], prMatches) {
+			continue
+		}
+		if len(match) >= 4 && match[2] >= 0 {
+			issueNumber, _ = strconv.Atoi(text[match[2]:match[3]])
+			return issueNumber, prNumber
+		}
+		if len(match) >= 6 && match[4] >= 0 {
+			issueNumber, _ = strconv.Atoi(text[match[4]:match[5]])
+			return issueNumber, prNumber
 		}
 	}
 	return issueNumber, prNumber
+}
+
+func rangesOverlap(start, end int, ranges [][]int) bool {
+	for _, r := range ranges {
+		if len(r) < 2 {
+			continue
+		}
+		if start < r[1] && end > r[0] {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/hygiene/collect.go
+++ b/internal/hygiene/collect.go
@@ -33,6 +33,7 @@ type CollectOptions struct {
 	HardExcludeLabels []string
 	WorktreeStatePath string
 	Approvals         []Approval
+	Workers           []Worker
 	Runner            CommandRunner
 }
 
@@ -47,6 +48,7 @@ func Collect(ctx context.Context, opts CollectOptions) (Snapshot, error) {
 	snapshot := Snapshot{
 		GeneratedAt: now,
 		Approvals:   append([]Approval(nil), opts.Approvals...),
+		Workers:     append([]Worker(nil), opts.Workers...),
 	}
 
 	if opts.Store != nil {

--- a/internal/hygiene/collect.go
+++ b/internal/hygiene/collect.go
@@ -1,0 +1,400 @@
+package hygiene
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"ok-gobot/internal/config"
+	"ok-gobot/internal/maestro"
+	"ok-gobot/internal/storage"
+	"ok-gobot/internal/worker"
+)
+
+type CommandRunner func(ctx context.Context, dir string, name string, args ...string) ([]byte, error)
+
+type CollectOptions struct {
+	Config            *config.Config
+	Store             *storage.Store
+	Repo              string
+	RepoRoot          string
+	SourceBranch      string
+	UpstreamBranch    string
+	Limit             int
+	ReadyLabel        string
+	HardExcludeLabels []string
+	WorktreeStatePath string
+	Approvals         []Approval
+	Runner            CommandRunner
+}
+
+var (
+	prRefRE    = regexp.MustCompile(`(?i)\bpr\s*#?(\d+)`)
+	issueRefRE = regexp.MustCompile(`(?i)\bissue\s*#?(\d+)|#(\d+)`)
+)
+
+func Collect(ctx context.Context, opts CollectOptions) (Snapshot, error) {
+	now := time.Now()
+	opts = normalizeCollectOptions(opts)
+	snapshot := Snapshot{
+		GeneratedAt: now,
+		Approvals:   append([]Approval(nil), opts.Approvals...),
+	}
+
+	if opts.Store != nil {
+		collectStoredState(opts.Store, &snapshot)
+	}
+
+	collectWorktreeState(opts.WorktreeStatePath, &snapshot)
+
+	repoRoot := strings.TrimSpace(opts.RepoRoot)
+	if repoRoot == "" {
+		if root, err := gitRepoRoot(ctx, opts.Runner); err == nil {
+			repoRoot = root
+		} else {
+			snapshot.Warnings = append(snapshot.Warnings, "local git repository root unavailable: "+err.Error())
+		}
+	}
+	if repoRoot != "" {
+		checkout, err := collectCheckout(ctx, opts.Runner, repoRoot, opts.SourceBranch, opts.UpstreamBranch)
+		if err != nil {
+			snapshot.Warnings = append(snapshot.Warnings, "local checkout drift unavailable: "+err.Error())
+		} else {
+			snapshot.Checkout = checkout
+		}
+	}
+
+	prs, err := collectPullRequests(ctx, opts.Runner, repoRoot, opts.Repo, opts.Limit)
+	if err != nil {
+		snapshot.Warnings = append(snapshot.Warnings, "GitHub PR state unavailable: "+err.Error())
+	} else {
+		snapshot.PullRequests = prs
+	}
+
+	queue, err := collectQueue(ctx, opts, repoRoot)
+	if err != nil {
+		snapshot.Warnings = append(snapshot.Warnings, "Maestro queue state unavailable: "+err.Error())
+	} else {
+		snapshot.Queue = queue
+	}
+
+	attachPRContext(&snapshot)
+	return snapshot, nil
+}
+
+func BuildReport(ctx context.Context, collect CollectOptions, analyze Options) (Report, error) {
+	snapshot, err := Collect(ctx, collect)
+	if err != nil {
+		return Report{}, err
+	}
+	if analyze.Now.IsZero() {
+		analyze.Now = snapshot.GeneratedAt
+	}
+	return Analyze(snapshot, analyze), nil
+}
+
+func normalizeCollectOptions(opts CollectOptions) CollectOptions {
+	if opts.Config != nil {
+		if opts.Repo == "" {
+			opts.Repo = opts.Config.Maestro.Repo
+		}
+		if opts.ReadyLabel == "" {
+			opts.ReadyLabel = opts.Config.Maestro.ReadyLabel
+		}
+		if len(opts.HardExcludeLabels) == 0 {
+			opts.HardExcludeLabels = append([]string(nil), opts.Config.Maestro.HardExcludeLabels...)
+		}
+		if opts.Limit <= 0 {
+			opts.Limit = opts.Config.Maestro.Limit
+		}
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = maestro.DefaultLimit
+	}
+	if opts.ReadyLabel == "" {
+		opts.ReadyLabel = maestro.DefaultReadyLabel
+	}
+	if len(opts.HardExcludeLabels) == 0 {
+		opts.HardExcludeLabels = maestro.DefaultHardExcludeLabels()
+	}
+	if opts.SourceBranch == "" {
+		opts.SourceBranch = "main"
+	}
+	if opts.UpstreamBranch == "" {
+		opts.UpstreamBranch = "origin/" + opts.SourceBranch
+	}
+	if opts.WorktreeStatePath == "" {
+		opts.WorktreeStatePath = DefaultWorktreeStatePath()
+	}
+	if opts.Runner == nil {
+		opts.Runner = defaultCommandRunner
+	}
+	return opts
+}
+
+func collectStoredState(store *storage.Store, snapshot *Snapshot) {
+	sessions, err := store.ListSessionsV2(500)
+	if err != nil {
+		snapshot.Warnings = append(snapshot.Warnings, "session state unavailable: "+err.Error())
+	} else {
+		for _, session := range sessions {
+			issue, pr := extractRefs(session.SessionKey + " " + session.LastSummary)
+			snapshot.Sessions = append(snapshot.Sessions, Session{
+				Key:         session.SessionKey,
+				IssueNumber: issue,
+				PRNumber:    pr,
+				UpdatedAt:   parseTime(session.UpdatedAt),
+			})
+		}
+	}
+
+	jobs, err := store.ListJobs(500)
+	if err != nil {
+		snapshot.Warnings = append(snapshot.Warnings, "job state unavailable: "+err.Error())
+		return
+	}
+	for _, job := range jobs {
+		issue, pr := extractRefs(job.Description + " " + job.Summary + " " + job.Error)
+		snapshot.Jobs = append(snapshot.Jobs, Job{
+			JobID:       job.JobID,
+			SessionKey:  job.SessionKey,
+			Status:      job.Status,
+			IssueNumber: issue,
+			PRNumber:    pr,
+			Attempt:     job.Attempt,
+			MaxAttempts: job.MaxAttempts,
+			CreatedAt:   parseTime(job.CreatedAt),
+			StartedAt:   parseTime(job.StartedAt),
+			UpdatedAt:   parseTime(job.UpdatedAt),
+		})
+	}
+}
+
+func collectWorktreeState(statePath string, snapshot *Snapshot) {
+	if strings.TrimSpace(statePath) == "" {
+		return
+	}
+	entries, err := worker.NewWorktreeManager(statePath).List()
+	if err != nil {
+		snapshot.Warnings = append(snapshot.Warnings, "worktree state unavailable: "+err.Error())
+		return
+	}
+	for _, entry := range entries {
+		snapshot.Worktrees = append(snapshot.Worktrees, Worktree{
+			ID:        entry.ID,
+			Branch:    entry.Branch,
+			Path:      entry.Path,
+			RepoRoot:  entry.RepoRoot,
+			Status:    string(entry.Status),
+			PRNumber:  entry.PRNumber,
+			PRState:   entry.PRStatus,
+			CreatedAt: entry.CreatedAt,
+		})
+	}
+}
+
+func collectPullRequests(ctx context.Context, runner CommandRunner, repoRoot, repo string, limit int) ([]PullRequest, error) {
+	args := []string{"pr", "list", "--state", "all", "--limit", strconv.Itoa(limit), "--json", "number,title,state,headRefName,updatedAt,closingIssuesReferences"}
+	if strings.TrimSpace(repo) != "" {
+		args = append(args, "--repo", strings.TrimSpace(repo))
+	}
+	out, err := runner(ctx, repoRoot, "gh", args...)
+	if err != nil {
+		return nil, err
+	}
+	var raw []struct {
+		Number                  int    `json:"number"`
+		Title                   string `json:"title"`
+		State                   string `json:"state"`
+		HeadRefName             string `json:"headRefName"`
+		UpdatedAt               string `json:"updatedAt"`
+		ClosingIssuesReferences []struct {
+			Number int `json:"number"`
+		} `json:"closingIssuesReferences"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse gh pr list: %w", err)
+	}
+	prs := make([]PullRequest, 0, len(raw))
+	for _, item := range raw {
+		issue := 0
+		if len(item.ClosingIssuesReferences) > 0 {
+			issue = item.ClosingIssuesReferences[0].Number
+		}
+		prs = append(prs, PullRequest{
+			Number:      item.Number,
+			IssueNumber: issue,
+			Title:       item.Title,
+			State:       strings.ToLower(strings.TrimSpace(item.State)),
+			Branch:      item.HeadRefName,
+			UpdatedAt:   parseTime(item.UpdatedAt),
+		})
+	}
+	return prs, nil
+}
+
+func collectQueue(ctx context.Context, opts CollectOptions, repoRoot string) (Queue, error) {
+	decision, err := maestro.DryRun(ctx, maestro.NewGHClient(repoRoot), maestro.Policy{
+		Repo:              opts.Repo,
+		ReadyLabel:        opts.ReadyLabel,
+		HardExcludeLabels: opts.HardExcludeLabels,
+		Limit:             opts.Limit,
+	})
+	if err != nil {
+		return Queue{}, err
+	}
+	queue := Queue{SkippedIssues: len(decision.Skipped), CheckedAt: time.Now()}
+	if decision.Next != nil {
+		queue.EligibleIssues = 1
+	}
+	reasons := map[string]struct{}{}
+	for _, skipped := range decision.Skipped {
+		for _, reason := range skipped.SkipReasons {
+			reason = strings.TrimSpace(reason)
+			if reason == "" {
+				continue
+			}
+			reasons[reason] = struct{}{}
+		}
+	}
+	for reason := range reasons {
+		queue.Reasons = append(queue.Reasons, reason)
+	}
+	sort.Strings(queue.Reasons)
+	if len(queue.Reasons) > 3 {
+		queue.Reasons = queue.Reasons[:3]
+	}
+	return queue, nil
+}
+
+func collectCheckout(ctx context.Context, runner CommandRunner, repoRoot, branch, upstream string) (Checkout, error) {
+	refPair := upstream + "..." + branch
+	out, err := runner(ctx, repoRoot, "git", "rev-list", "--left-right", "--count", refPair)
+	if err != nil {
+		return Checkout{}, err
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) < 2 {
+		return Checkout{}, fmt.Errorf("unexpected git rev-list output %q", strings.TrimSpace(string(out)))
+	}
+	behind, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return Checkout{}, fmt.Errorf("parse behind count: %w", err)
+	}
+	ahead, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return Checkout{}, fmt.Errorf("parse ahead count: %w", err)
+	}
+	return Checkout{Branch: branch, Upstream: upstream, BehindBy: behind, AheadBy: ahead, CheckedAt: time.Now()}, nil
+}
+
+func attachPRContext(snapshot *Snapshot) {
+	prByBranch := map[string]PullRequest{}
+	prByNumber := map[int]PullRequest{}
+	for _, pr := range snapshot.PullRequests {
+		if pr.Branch != "" {
+			prByBranch[pr.Branch] = pr
+		}
+		if pr.Number > 0 {
+			prByNumber[pr.Number] = pr
+		}
+	}
+	for i, worktree := range snapshot.Worktrees {
+		if worktree.PRNumber > 0 {
+			if pr, ok := prByNumber[worktree.PRNumber]; ok {
+				snapshot.Worktrees[i].PRState = valueOr(worktree.PRState, pr.State)
+			}
+			continue
+		}
+		if pr, ok := prByBranch[worktree.Branch]; ok {
+			snapshot.Worktrees[i].PRNumber = pr.Number
+			snapshot.Worktrees[i].PRState = valueOr(worktree.PRState, pr.State)
+		}
+	}
+	for i, session := range snapshot.Sessions {
+		if session.PRNumber > 0 {
+			if pr, ok := prByNumber[session.PRNumber]; ok {
+				snapshot.Sessions[i].IssueNumber = firstPositive(session.IssueNumber, pr.IssueNumber)
+				snapshot.Sessions[i].Branch = valueOr(session.Branch, pr.Branch)
+			}
+		}
+	}
+}
+
+func gitRepoRoot(ctx context.Context, runner CommandRunner) (string, error) {
+	out, err := runner(ctx, "", "git", "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", err
+	}
+	root := strings.TrimSpace(string(out))
+	if root == "" {
+		return "", fmt.Errorf("git returned empty repository root")
+	}
+	return root, nil
+}
+
+func defaultCommandRunner(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if strings.TrimSpace(dir) != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, msg)
+	}
+	return out, nil
+}
+
+func DefaultWorktreeStatePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, ".ok-gobot", "worktrees.json")
+}
+
+func parseTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	formats := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05",
+	}
+	for _, format := range formats {
+		if parsed, err := time.Parse(format, value); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+func extractRefs(text string) (issueNumber int, prNumber int) {
+	if match := prRefRE.FindStringSubmatch(text); len(match) == 2 {
+		prNumber, _ = strconv.Atoi(match[1])
+	}
+	if match := issueRefRE.FindStringSubmatch(text); len(match) == 3 {
+		if match[1] != "" {
+			issueNumber, _ = strconv.Atoi(match[1])
+		} else if match[2] != "" {
+			issueNumber, _ = strconv.Atoi(match[2])
+		}
+	}
+	return issueNumber, prNumber
+}

--- a/internal/hygiene/collect_test.go
+++ b/internal/hygiene/collect_test.go
@@ -1,0 +1,55 @@
+package hygiene
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCollectReusesPullRequestSnapshotForQueue(t *testing.T) {
+	t.Parallel()
+
+	var prListCalls int
+	var issueListCalls int
+	runner := func(_ context.Context, _ string, name string, args ...string) ([]byte, error) {
+		switch name {
+		case "git":
+			if len(args) >= 1 && args[0] == "rev-list" {
+				return []byte("0\t0\n"), nil
+			}
+		case "gh":
+			if len(args) >= 2 && args[0] == "pr" && args[1] == "list" {
+				prListCalls++
+				return []byte(`[{"number":42,"title":"ready pr","body":"","state":"OPEN","headRefName":"feat/ready","labels":[{"name":"ready"}],"updatedAt":"2026-05-01T12:00:00Z","closingIssuesReferences":[{"number":366}]}]`), nil
+			}
+			if len(args) >= 2 && args[0] == "issue" && args[1] == "list" {
+				issueListCalls++
+			}
+		}
+		return nil, fmt.Errorf("unexpected command: %s %s", name, strings.Join(args, " "))
+	}
+
+	snapshot, err := Collect(context.Background(), CollectOptions{
+		RepoRoot:          "/repo",
+		WorktreeStatePath: filepath.Join(t.TempDir(), "worktrees.json"),
+		ReadyLabel:        "ready",
+		Runner:            runner,
+	})
+	if err != nil {
+		t.Fatalf("Collect returned error: %v", err)
+	}
+	if prListCalls != 1 {
+		t.Fatalf("gh pr list calls = %d, want 1", prListCalls)
+	}
+	if issueListCalls != 0 {
+		t.Fatalf("gh issue list calls = %d, want 0", issueListCalls)
+	}
+	if snapshot.Queue.EligibleIssues != 1 || snapshot.Queue.SkippedIssues != 0 {
+		t.Fatalf("queue = %+v, want one eligible PR candidate", snapshot.Queue)
+	}
+	if len(snapshot.PullRequests) != 1 || snapshot.PullRequests[0].IssueNumber != 366 || len(snapshot.PullRequests[0].Labels) != 1 {
+		t.Fatalf("pull requests = %+v, want collected PR context", snapshot.PullRequests)
+	}
+}

--- a/internal/hygiene/collect_test.go
+++ b/internal/hygiene/collect_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCollectReusesPullRequestSnapshotForQueue(t *testing.T) {
@@ -51,5 +52,54 @@ func TestCollectReusesPullRequestSnapshotForQueue(t *testing.T) {
 	}
 	if len(snapshot.PullRequests) != 1 || snapshot.PullRequests[0].IssueNumber != 366 || len(snapshot.PullRequests[0].Labels) != 1 {
 		t.Fatalf("pull requests = %+v, want collected PR context", snapshot.PullRequests)
+	}
+}
+
+func TestCollectIncludesLiveWorkersForDeadWorkerSuppression(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	runner := func(_ context.Context, _ string, name string, args ...string) ([]byte, error) {
+		switch name {
+		case "git":
+			if len(args) >= 1 && args[0] == "rev-list" {
+				return []byte("0\t0\n"), nil
+			}
+		case "gh":
+			if len(args) >= 2 && args[0] == "pr" && args[1] == "list" {
+				return []byte(`[]`), nil
+			}
+		}
+		return nil, fmt.Errorf("unexpected command: %s %s", name, strings.Join(args, " "))
+	}
+
+	snapshot, err := Collect(context.Background(), CollectOptions{
+		RepoRoot:          "/repo",
+		WorktreeStatePath: filepath.Join(t.TempDir(), "worktrees.json"),
+		ReadyLabel:        "ready",
+		Workers: []Worker{{
+			SessionKey: "agent:worker:main",
+			Running:    true,
+			Alive:      true,
+			LastSeenAt: now,
+		}},
+		Runner: runner,
+	})
+	if err != nil {
+		t.Fatalf("Collect returned error: %v", err)
+	}
+	if len(snapshot.Workers) != 1 || snapshot.Workers[0].SessionKey != "agent:worker:main" {
+		t.Fatalf("workers = %+v, want supplied live worker", snapshot.Workers)
+	}
+
+	snapshot.Jobs = []Job{{
+		JobID:      "job-1",
+		SessionKey: "agent:worker:main",
+		Status:     "running",
+		StartedAt:  now.Add(-45 * time.Minute),
+	}}
+	report := Analyze(snapshot, Options{Now: now, DeadWorkerAge: 30 * time.Minute})
+	if len(report.SafeActions) != 0 || len(report.ApprovalRequired) != 0 {
+		t.Fatalf("unexpected findings for live worker: safe=%+v approval=%+v", report.SafeActions, report.ApprovalRequired)
 	}
 }

--- a/internal/hygiene/report.go
+++ b/internal/hygiene/report.go
@@ -1,0 +1,560 @@
+package hygiene
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+type ActionGroup string
+
+const (
+	ActionSafe             ActionGroup = "safe"
+	ActionApprovalRequired ActionGroup = "approval_required"
+)
+
+type Severity string
+
+const (
+	SeverityInfo     Severity = "info"
+	SeverityWarning  Severity = "warning"
+	SeverityCritical Severity = "critical"
+)
+
+const (
+	FindingStaleOpenPR           = "stale_open_pr"
+	FindingClosedPRSession       = "closed_pr_leftover_session"
+	FindingDeadWorker            = "dead_worker"
+	FindingCheckoutBehind        = "checkout_behind_origin"
+	FindingStaleApproval         = "stale_approval"
+	FindingOrphanedWorktree      = "orphaned_worktree"
+	FindingEligibleQueueBlocked  = "eligible_queue_exhausted"
+	FindingPartialCollectionData = "partial_collection_data"
+)
+
+type Evidence struct {
+	SessionKey     string    `json:"session_key,omitempty"`
+	JobID          string    `json:"job_id,omitempty"`
+	IssueNumber    int       `json:"issue,omitempty"`
+	PRNumber       int       `json:"pr,omitempty"`
+	Branch         string    `json:"branch,omitempty"`
+	WorktreePath   string    `json:"worktree_path,omitempty"`
+	StateTimestamp time.Time `json:"state_timestamp,omitempty"`
+}
+
+type Finding struct {
+	ID             string      `json:"id"`
+	Severity       Severity    `json:"severity"`
+	Title          string      `json:"title"`
+	Detail         string      `json:"detail"`
+	Recommendation string      `json:"recommendation"`
+	ActionGroup    ActionGroup `json:"action_group"`
+	Evidence       Evidence    `json:"evidence"`
+	DetectedAt     time.Time   `json:"detected_at"`
+}
+
+type Summary struct {
+	Status                string    `json:"status"`
+	TotalFindings         int       `json:"total_findings"`
+	SafeActionCount       int       `json:"safe_action_count"`
+	ApprovalRequiredCount int       `json:"approval_required_count"`
+	GeneratedAt           time.Time `json:"generated_at"`
+}
+
+type Report struct {
+	GeneratedAt      time.Time `json:"generated_at"`
+	Summary          Summary   `json:"summary"`
+	SafeActions      []Finding `json:"safe_actions"`
+	ApprovalRequired []Finding `json:"approval_required_actions"`
+	Warnings         []Finding `json:"warnings,omitempty"`
+}
+
+type PullRequest struct {
+	Number      int
+	IssueNumber int
+	Title       string
+	State       string
+	Branch      string
+	SessionKey  string
+	UpdatedAt   time.Time
+}
+
+type Session struct {
+	Key         string
+	IssueNumber int
+	PRNumber    int
+	Branch      string
+	UpdatedAt   time.Time
+}
+
+type Worker struct {
+	SessionKey string
+	JobID      string
+	Branch     string
+	Running    bool
+	Alive      bool
+	LastSeenAt time.Time
+	LastLogAt  time.Time
+	QueueDepth int
+}
+
+type Job struct {
+	JobID       string
+	SessionKey  string
+	Status      string
+	Branch      string
+	IssueNumber int
+	PRNumber    int
+	Attempt     int
+	MaxAttempts int
+	CreatedAt   time.Time
+	StartedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type Worktree struct {
+	ID        string
+	Branch    string
+	Path      string
+	RepoRoot  string
+	Status    string
+	PRNumber  int
+	PRState   string
+	CreatedAt time.Time
+}
+
+type Checkout struct {
+	Branch    string
+	Upstream  string
+	BehindBy  int
+	AheadBy   int
+	CheckedAt time.Time
+}
+
+type Approval struct {
+	ID           string
+	SessionKey   string
+	Command      string
+	IssueNumber  int
+	PRNumber     int
+	Branch       string
+	WorktreePath string
+	CreatedAt    time.Time
+}
+
+type Queue struct {
+	EligibleIssues int
+	SkippedIssues  int
+	Reasons        []string
+	CheckedAt      time.Time
+}
+
+type Snapshot struct {
+	GeneratedAt  time.Time
+	PullRequests []PullRequest
+	Sessions     []Session
+	Workers      []Worker
+	Jobs         []Job
+	Worktrees    []Worktree
+	Checkout     Checkout
+	Approvals    []Approval
+	Queue        Queue
+	Warnings     []string
+}
+
+type Options struct {
+	Now                 time.Time
+	StaleOpenPRAge      time.Duration
+	DeadWorkerAge       time.Duration
+	StaleApprovalAge    time.Duration
+	OrphanedWorktreeAge time.Duration
+}
+
+func DefaultOptions() Options {
+	return Options{
+		StaleOpenPRAge:      7 * 24 * time.Hour,
+		DeadWorkerAge:       30 * time.Minute,
+		StaleApprovalAge:    15 * time.Minute,
+		OrphanedWorktreeAge: 7 * 24 * time.Hour,
+	}
+}
+
+func Analyze(snapshot Snapshot, opts Options) Report {
+	defaults := DefaultOptions()
+	if opts.StaleOpenPRAge <= 0 {
+		opts.StaleOpenPRAge = defaults.StaleOpenPRAge
+	}
+	if opts.DeadWorkerAge <= 0 {
+		opts.DeadWorkerAge = defaults.DeadWorkerAge
+	}
+	if opts.StaleApprovalAge <= 0 {
+		opts.StaleApprovalAge = defaults.StaleApprovalAge
+	}
+	if opts.OrphanedWorktreeAge <= 0 {
+		opts.OrphanedWorktreeAge = defaults.OrphanedWorktreeAge
+	}
+
+	now := opts.Now
+	if now.IsZero() {
+		now = snapshot.GeneratedAt
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	report := Report{GeneratedAt: now}
+	closedPRs := closedPRMap(snapshot.PullRequests)
+	openPRBranches := openPRBranchSet(snapshot.PullRequests)
+	liveWorkers := liveWorkerKeys(snapshot.Workers)
+
+	for _, pr := range snapshot.PullRequests {
+		if !isOpenState(pr.State) || pr.UpdatedAt.IsZero() || now.Sub(pr.UpdatedAt) < opts.StaleOpenPRAge {
+			continue
+		}
+		report.add(Finding{
+			ID:             FindingStaleOpenPR,
+			Severity:       SeverityWarning,
+			Title:          fmt.Sprintf("Open PR #%d has gone stale", pr.Number),
+			Detail:         fmt.Sprintf("PR #%d %s has not changed for %s.", pr.Number, strings.TrimSpace(pr.Title), roundAge(now.Sub(pr.UpdatedAt))),
+			Recommendation: "Refresh PR metadata, check CI/review state, and restart or steer the worker before spending more queue time.",
+			ActionGroup:    ActionSafe,
+			Evidence: Evidence{
+				SessionKey:     pr.SessionKey,
+				IssueNumber:    pr.IssueNumber,
+				PRNumber:       pr.Number,
+				Branch:         pr.Branch,
+				StateTimestamp: pr.UpdatedAt,
+			},
+			DetectedAt: now,
+		})
+	}
+
+	for _, session := range snapshot.Sessions {
+		pr, ok := closedPRs[session.PRNumber]
+		if !ok || session.PRNumber <= 0 {
+			continue
+		}
+		timestamp := session.UpdatedAt
+		if timestamp.IsZero() {
+			timestamp = pr.UpdatedAt
+		}
+		report.add(Finding{
+			ID:             FindingClosedPRSession,
+			Severity:       SeverityWarning,
+			Title:          fmt.Sprintf("Session still references closed PR #%d", session.PRNumber),
+			Detail:         fmt.Sprintf("Session %s still points at PR #%d after GitHub state became %s.", session.Key, session.PRNumber, normalizeState(pr.State)),
+			Recommendation: "Archive or remove the leftover session only after the operator confirms no follow-up work is needed.",
+			ActionGroup:    ActionApprovalRequired,
+			Evidence: Evidence{
+				SessionKey:     session.Key,
+				IssueNumber:    firstPositive(session.IssueNumber, pr.IssueNumber),
+				PRNumber:       session.PRNumber,
+				Branch:         valueOr(session.Branch, pr.Branch),
+				StateTimestamp: timestamp,
+			},
+			DetectedAt: now,
+		})
+	}
+
+	seenDeadWorkers := map[string]struct{}{}
+	for _, worker := range snapshot.Workers {
+		key := workerKey(worker.SessionKey, worker.JobID)
+		if worker.Alive && (!worker.Running || worker.LastLogAt.IsZero() || now.Sub(worker.LastLogAt) < opts.DeadWorkerAge) {
+			continue
+		}
+		timestamp := worker.LastLogAt
+		if timestamp.IsZero() {
+			timestamp = worker.LastSeenAt
+		}
+		if timestamp.IsZero() || now.Sub(timestamp) < opts.DeadWorkerAge {
+			continue
+		}
+		seenDeadWorkers[key] = struct{}{}
+		report.add(deadWorkerFinding(now, worker.SessionKey, worker.JobID, worker.Branch, timestamp))
+	}
+
+	for _, job := range snapshot.Jobs {
+		if normalizeState(job.Status) != "running" || job.StartedAt.IsZero() || now.Sub(job.StartedAt) < opts.DeadWorkerAge {
+			continue
+		}
+		key := workerKey(job.SessionKey, job.JobID)
+		if _, seen := liveWorkers[key]; seen {
+			continue
+		}
+		if _, seen := liveWorkers[workerKey(job.SessionKey, "")]; seen {
+			continue
+		}
+		if _, seen := seenDeadWorkers[key]; seen {
+			continue
+		}
+		report.add(deadWorkerFinding(now, job.SessionKey, job.JobID, job.Branch, job.StartedAt))
+	}
+
+	if snapshot.Checkout.BehindBy > 0 {
+		branch := valueOr(snapshot.Checkout.Branch, "main")
+		upstream := valueOr(snapshot.Checkout.Upstream, "origin/"+branch)
+		report.add(Finding{
+			ID:             FindingCheckoutBehind,
+			Severity:       SeverityWarning,
+			Title:          fmt.Sprintf("Local %s is behind %s", branch, upstream),
+			Detail:         fmt.Sprintf("%s is %d commit(s) behind %s.", branch, snapshot.Checkout.BehindBy, upstream),
+			Recommendation: "Update the source checkout before dispatching more workers so new branches start from current origin state.",
+			ActionGroup:    ActionSafe,
+			Evidence: Evidence{
+				Branch:         branch,
+				StateTimestamp: snapshot.Checkout.CheckedAt,
+			},
+			DetectedAt: now,
+		})
+	}
+
+	for _, approval := range snapshot.Approvals {
+		if approval.CreatedAt.IsZero() || now.Sub(approval.CreatedAt) < opts.StaleApprovalAge {
+			continue
+		}
+		report.add(Finding{
+			ID:             FindingStaleApproval,
+			Severity:       SeverityCritical,
+			Title:          fmt.Sprintf("Approval %s is stale", approval.ID),
+			Detail:         fmt.Sprintf("Approval %s has waited for %s.", approval.ID, roundAge(now.Sub(approval.CreatedAt))),
+			Recommendation: "Review the command and explicitly approve or deny it; do not let blocked worker state accumulate.",
+			ActionGroup:    ActionApprovalRequired,
+			Evidence: Evidence{
+				SessionKey:     approval.SessionKey,
+				IssueNumber:    approval.IssueNumber,
+				PRNumber:       approval.PRNumber,
+				Branch:         approval.Branch,
+				WorktreePath:   approval.WorktreePath,
+				StateTimestamp: approval.CreatedAt,
+			},
+			DetectedAt: now,
+		})
+	}
+
+	for _, worktree := range snapshot.Worktrees {
+		if !isOrphanedWorktree(now, worktree, openPRBranches, opts.OrphanedWorktreeAge) {
+			continue
+		}
+		state := normalizeState(valueOr(worktree.PRState, worktree.Status))
+		if state == "" {
+			state = "unlinked"
+		}
+		report.add(Finding{
+			ID:             FindingOrphanedWorktree,
+			Severity:       SeverityWarning,
+			Title:          fmt.Sprintf("Worktree %s appears orphaned", valueOr(worktree.ID, worktree.Branch)),
+			Detail:         fmt.Sprintf("Worktree %s on branch %s is %s.", valueOr(worktree.Path, worktree.ID), valueOr(worktree.Branch, "unknown"), state),
+			Recommendation: "Remove the worktree/branch only after explicit operator approval and after checking for unpushed work.",
+			ActionGroup:    ActionApprovalRequired,
+			Evidence: Evidence{
+				PRNumber:       worktree.PRNumber,
+				Branch:         worktree.Branch,
+				WorktreePath:   worktree.Path,
+				StateTimestamp: worktree.CreatedAt,
+			},
+			DetectedAt: now,
+		})
+	}
+
+	if !snapshot.Queue.CheckedAt.IsZero() && snapshot.Queue.EligibleIssues == 0 && snapshot.Queue.SkippedIssues > 0 {
+		detail := fmt.Sprintf("Maestro found no eligible issues and skipped %d candidate(s).", snapshot.Queue.SkippedIssues)
+		if len(snapshot.Queue.Reasons) > 0 {
+			detail += " Top gates: " + strings.Join(snapshot.Queue.Reasons, "; ") + "."
+		}
+		report.add(Finding{
+			ID:             FindingEligibleQueueBlocked,
+			Severity:       SeverityWarning,
+			Title:          "Eligible queue is exhausted by policy",
+			Detail:         detail,
+			Recommendation: "Unblock labels/dependencies or use a documented maintainer override before starting another worker.",
+			ActionGroup:    ActionSafe,
+			Evidence: Evidence{
+				StateTimestamp: snapshot.Queue.CheckedAt,
+			},
+			DetectedAt: now,
+		})
+	}
+
+	for _, warning := range snapshot.Warnings {
+		warning = strings.TrimSpace(warning)
+		if warning == "" {
+			continue
+		}
+		report.Warnings = append(report.Warnings, Finding{
+			ID:             FindingPartialCollectionData,
+			Severity:       SeverityInfo,
+			Title:          "Partial hygiene data",
+			Detail:         warning,
+			Recommendation: "Fix the data source and rerun the read-only hygiene report for a complete view.",
+			ActionGroup:    ActionSafe,
+			DetectedAt:     now,
+		})
+	}
+
+	report.sort()
+	report.Summary = Summary{
+		Status:                reportStatus(report),
+		TotalFindings:         len(report.SafeActions) + len(report.ApprovalRequired),
+		SafeActionCount:       len(report.SafeActions),
+		ApprovalRequiredCount: len(report.ApprovalRequired),
+		GeneratedAt:           now,
+	}
+	return report
+}
+
+func (r *Report) add(f Finding) {
+	if f.DetectedAt.IsZero() {
+		f.DetectedAt = r.GeneratedAt
+	}
+	if f.ActionGroup == ActionApprovalRequired {
+		r.ApprovalRequired = append(r.ApprovalRequired, f)
+		return
+	}
+	f.ActionGroup = ActionSafe
+	r.SafeActions = append(r.SafeActions, f)
+}
+
+func (r *Report) sort() {
+	sortFindings := func(findings []Finding) {
+		sort.SliceStable(findings, func(i, j int) bool {
+			if findings[i].ID != findings[j].ID {
+				return findings[i].ID < findings[j].ID
+			}
+			return evidenceKey(findings[i].Evidence) < evidenceKey(findings[j].Evidence)
+		})
+	}
+	sortFindings(r.SafeActions)
+	sortFindings(r.ApprovalRequired)
+	sortFindings(r.Warnings)
+}
+
+func reportStatus(report Report) string {
+	if len(report.SafeActions)+len(report.ApprovalRequired) == 0 {
+		return "clean"
+	}
+	return "attention_needed"
+}
+
+func closedPRMap(prs []PullRequest) map[int]PullRequest {
+	out := map[int]PullRequest{}
+	for _, pr := range prs {
+		if pr.Number > 0 && isClosedState(pr.State) {
+			out[pr.Number] = pr
+		}
+	}
+	return out
+}
+
+func openPRBranchSet(prs []PullRequest) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, pr := range prs {
+		branch := strings.TrimSpace(pr.Branch)
+		if branch != "" && isOpenState(pr.State) {
+			out[branch] = struct{}{}
+		}
+	}
+	return out
+}
+
+func liveWorkerKeys(workers []Worker) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, worker := range workers {
+		if worker.Alive && worker.Running {
+			out[workerKey(worker.SessionKey, worker.JobID)] = struct{}{}
+			if strings.TrimSpace(worker.SessionKey) != "" {
+				out[workerKey(worker.SessionKey, "")] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+func deadWorkerFinding(now time.Time, sessionKey, jobID, branch string, timestamp time.Time) Finding {
+	target := valueOr(sessionKey, jobID)
+	if target == "" {
+		target = valueOr(branch, "unknown worker")
+	}
+	return Finding{
+		ID:             FindingDeadWorker,
+		Severity:       SeverityCritical,
+		Title:          fmt.Sprintf("Worker %s has no live progress", target),
+		Detail:         fmt.Sprintf("Worker %s has not produced live progress for %s.", target, roundAge(now.Sub(timestamp))),
+		Recommendation: "Inspect the worker log/tmux tail, then safely restart or mark the job blocked before dispatching more work.",
+		ActionGroup:    ActionSafe,
+		Evidence: Evidence{
+			SessionKey:     sessionKey,
+			JobID:          jobID,
+			Branch:         branch,
+			StateTimestamp: timestamp,
+		},
+		DetectedAt: now,
+	}
+}
+
+func isOrphanedWorktree(now time.Time, worktree Worktree, openPRBranches map[string]struct{}, staleAge time.Duration) bool {
+	status := normalizeState(worktree.Status)
+	prState := normalizeState(worktree.PRState)
+	if status == "merged" || status == "closed" || status == "stale" || prState == "merged" || prState == "closed" {
+		return true
+	}
+	if worktree.Branch != "" {
+		if _, ok := openPRBranches[worktree.Branch]; ok {
+			return false
+		}
+	}
+	return worktree.PRNumber == 0 && !worktree.CreatedAt.IsZero() && now.Sub(worktree.CreatedAt) >= staleAge
+}
+
+func workerKey(sessionKey, jobID string) string {
+	return strings.TrimSpace(sessionKey) + "\x00" + strings.TrimSpace(jobID)
+}
+
+func evidenceKey(e Evidence) string {
+	return fmt.Sprintf("%s/%s/%d/%d/%s/%s", e.SessionKey, e.JobID, e.IssueNumber, e.PRNumber, e.Branch, e.WorktreePath)
+}
+
+func normalizeState(state string) string {
+	return strings.ToLower(strings.TrimSpace(state))
+}
+
+func isOpenState(state string) bool {
+	return normalizeState(state) == "open"
+}
+
+func isClosedState(state string) bool {
+	state = normalizeState(state)
+	return state == "closed" || state == "merged"
+}
+
+func roundAge(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	if d >= 24*time.Hour {
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+	if d >= time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	if d >= time.Minute {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%ds", int(d.Seconds()))
+}
+
+func valueOr(value, fallback string) string {
+	if strings.TrimSpace(value) != "" {
+		return strings.TrimSpace(value)
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func firstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/internal/hygiene/report.go
+++ b/internal/hygiene/report.go
@@ -74,8 +74,10 @@ type PullRequest struct {
 	Number      int
 	IssueNumber int
 	Title       string
+	Body        string
 	State       string
 	Branch      string
+	Labels      []string
 	SessionKey  string
 	UpdatedAt   time.Time
 }
@@ -430,6 +432,9 @@ func (r *Report) sort() {
 }
 
 func reportStatus(report Report) string {
+	if len(report.Warnings) > 0 {
+		return "partial_data"
+	}
 	if len(report.SafeActions)+len(report.ApprovalRequired) == 0 {
 		return "clean"
 	}

--- a/internal/hygiene/report_test.go
+++ b/internal/hygiene/report_test.go
@@ -1,0 +1,144 @@
+package hygiene
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAnalyzeDetectsStaleOpenPR(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	report := Analyze(Snapshot{PullRequests: []PullRequest{{
+		Number:      42,
+		IssueNumber: 366,
+		Title:       "stale report",
+		State:       "open",
+		Branch:      "feat/hygiene",
+		SessionKey:  "agent:maestro:main",
+		UpdatedAt:   now.Add(-8 * 24 * time.Hour),
+	}}}, Options{Now: now})
+
+	finding := requireFinding(t, report.SafeActions, FindingStaleOpenPR)
+	if finding.ActionGroup != ActionSafe {
+		t.Fatalf("ActionGroup = %q, want %q", finding.ActionGroup, ActionSafe)
+	}
+	if finding.Evidence.PRNumber != 42 || finding.Evidence.IssueNumber != 366 || finding.Evidence.Branch != "feat/hygiene" {
+		t.Fatalf("unexpected evidence: %+v", finding.Evidence)
+	}
+}
+
+func TestAnalyzeDetectsDeadWorkerFromRunningJob(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	report := Analyze(Snapshot{Jobs: []Job{{
+		JobID:      "job-1",
+		SessionKey: "agent:worker:main",
+		Status:     "running",
+		Branch:     "work/issue-366",
+		StartedAt:  now.Add(-45 * time.Minute),
+	}}}, Options{Now: now})
+
+	finding := requireFinding(t, report.SafeActions, FindingDeadWorker)
+	if finding.Evidence.JobID != "job-1" || finding.Evidence.SessionKey != "agent:worker:main" {
+		t.Fatalf("unexpected evidence: %+v", finding.Evidence)
+	}
+}
+
+func TestAnalyzeDetectsLocalMainBehindOrigin(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	report := Analyze(Snapshot{Checkout: Checkout{
+		Branch:    "main",
+		Upstream:  "origin/main",
+		BehindBy:  3,
+		CheckedAt: now.Add(-time.Minute),
+	}}, Options{Now: now})
+
+	finding := requireFinding(t, report.SafeActions, FindingCheckoutBehind)
+	if finding.Evidence.Branch != "main" {
+		t.Fatalf("Branch = %q, want main", finding.Evidence.Branch)
+	}
+}
+
+func TestAnalyzeDetectsStaleApproval(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	report := Analyze(Snapshot{Approvals: []Approval{{
+		ID:           "approval-1",
+		SessionKey:   "agent:maestro:main",
+		Command:      "rm -rf worktree",
+		IssueNumber:  366,
+		PRNumber:     42,
+		Branch:       "feat/hygiene",
+		WorktreePath: "/tmp/wt",
+		CreatedAt:    now.Add(-20 * time.Minute),
+	}}}, Options{Now: now})
+
+	finding := requireFinding(t, report.ApprovalRequired, FindingStaleApproval)
+	if finding.ActionGroup != ActionApprovalRequired {
+		t.Fatalf("ActionGroup = %q, want %q", finding.ActionGroup, ActionApprovalRequired)
+	}
+	if finding.Evidence.PRNumber != 42 || finding.Evidence.WorktreePath != "/tmp/wt" {
+		t.Fatalf("unexpected evidence: %+v", finding.Evidence)
+	}
+}
+
+func TestAnalyzeDetectsOrphanedWorktree(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	report := Analyze(Snapshot{Worktrees: []Worktree{{
+		ID:        "wt-1",
+		Branch:    "work/closed",
+		Path:      "/tmp/wt-1",
+		Status:    "active",
+		PRNumber:  42,
+		PRState:   "closed",
+		CreatedAt: now.Add(-2 * 24 * time.Hour),
+	}}}, Options{Now: now})
+
+	finding := requireFinding(t, report.ApprovalRequired, FindingOrphanedWorktree)
+	if finding.Evidence.PRNumber != 42 || finding.Evidence.WorktreePath != "/tmp/wt-1" {
+		t.Fatalf("unexpected evidence: %+v", finding.Evidence)
+	}
+}
+
+func TestAnalyzeDetectsEligibleQueueExhaustion(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	report := Analyze(Snapshot{Queue: Queue{
+		EligibleIssues: 0,
+		SkippedIssues:  2,
+		Reasons:        []string{"missing ready label \"ready\""},
+		CheckedAt:      now.Add(-time.Minute),
+	}}, Options{Now: now})
+
+	finding := requireFinding(t, report.SafeActions, FindingEligibleQueueBlocked)
+	if finding.Evidence.StateTimestamp.IsZero() {
+		t.Fatalf("missing queue evidence timestamp: %+v", finding.Evidence)
+	}
+}
+
+func TestAnalyzeNoProblemCaseIsClean(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	report := Analyze(Snapshot{
+		PullRequests: []PullRequest{{Number: 42, State: "open", UpdatedAt: now.Add(-time.Hour)}},
+		Jobs:         []Job{{JobID: "job-1", SessionKey: "agent:worker:main", Status: "running", StartedAt: now.Add(-time.Minute)}},
+		Workers:      []Worker{{JobID: "job-1", SessionKey: "agent:worker:main", Running: true, Alive: true, LastLogAt: now.Add(-time.Minute)}},
+		Checkout:     Checkout{Branch: "main", Upstream: "origin/main", BehindBy: 0, CheckedAt: now},
+		Approvals:    []Approval{{ID: "approval-1", CreatedAt: now.Add(-time.Minute)}},
+		Worktrees:    []Worktree{{ID: "wt-1", Branch: "work/open", Path: "/tmp/wt-1", Status: "active", PRNumber: 42, PRState: "open", CreatedAt: now.Add(-time.Hour)}},
+		Queue:        Queue{EligibleIssues: 1, SkippedIssues: 2, CheckedAt: now},
+	}, Options{Now: now})
+
+	if report.Summary.Status != "clean" || report.Summary.TotalFindings != 0 {
+		t.Fatalf("summary = %+v, want clean with no findings", report.Summary)
+	}
+	if len(report.SafeActions) != 0 || len(report.ApprovalRequired) != 0 {
+		t.Fatalf("unexpected findings: safe=%+v approval=%+v", report.SafeActions, report.ApprovalRequired)
+	}
+}
+
+func requireFinding(t *testing.T, findings []Finding, id string) Finding {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.ID == id {
+			return finding
+		}
+	}
+	t.Fatalf("finding %q not found in %+v", id, findings)
+	return Finding{}
+}

--- a/internal/hygiene/report_test.go
+++ b/internal/hygiene/report_test.go
@@ -132,6 +132,40 @@ func TestAnalyzeNoProblemCaseIsClean(t *testing.T) {
 	}
 }
 
+func TestAnalyzeWarningsSetPartialDataStatus(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	report := Analyze(Snapshot{Warnings: []string{"GitHub PR state unavailable"}}, Options{Now: now})
+
+	if report.Summary.Status != "partial_data" {
+		t.Fatalf("status = %q, want partial_data", report.Summary.Status)
+	}
+	if report.Summary.TotalFindings != 0 || len(report.Warnings) != 1 {
+		t.Fatalf("summary=%+v warnings=%+v, want warning-only partial data", report.Summary, report.Warnings)
+	}
+}
+
+func TestExtractRefsDoesNotTreatPRNumberAsIssue(t *testing.T) {
+	issue, pr := extractRefs("PR #42 closes issue #366")
+	if issue != 366 || pr != 42 {
+		t.Fatalf("extractRefs with linked issue = issue %d pr %d, want issue 366 pr 42", issue, pr)
+	}
+
+	issue, pr = extractRefs("PR #42")
+	if issue != 0 || pr != 42 {
+		t.Fatalf("extractRefs PR only = issue %d pr %d, want issue 0 pr 42", issue, pr)
+	}
+
+	issue, pr = extractRefs("pull request #43")
+	if issue != 0 || pr != 43 {
+		t.Fatalf("extractRefs pull request only = issue %d pr %d, want issue 0 pr 43", issue, pr)
+	}
+
+	issue, pr = extractRefs("fixes #366")
+	if issue != 366 || pr != 0 {
+		t.Fatalf("extractRefs bare issue = issue %d pr %d, want issue 366 pr 0", issue, pr)
+	}
+}
+
 func requireFinding(t *testing.T, findings []Finding, id string) Finding {
 	t.Helper()
 	for _, finding := range findings {


### PR DESCRIPTION
## Summary
- Adds a read-only Maestro hygiene report for stale PRs, dead workers, checkout drift, pending approvals, queue starvation, and orphaned worktrees.
- Exposes the report through `ok-gobot maestro hygiene`, Mission Control, and the HTTP API.
- Adds tests for hygiene detection, CLI rendering, and Mission Control/API endpoints.

## Testing
- `bash .maestro/verify.sh`
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a read-only Maestro hygiene report surfaced through the CLI (`ok-gobot maestro hygiene`), the control-server Mission Control endpoint, and the HTTP API. The three previously-flagged issues (double `gh pr list` call, `snapshot.Workers` never populated, and `reportStatus` not reflecting collection warnings) are all correctly addressed in this implementation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only P2 findings, all related to edge-case silent misses rather than correctness on the happy path

No P0 or P1 issues found. All three bugs called out in previous review threads are fixed. Remaining comments are P2: a hardcoded 500-row storage cap, a contradictory total_findings=0/status=partial_data summary shape, and a false-negative orphaned-worktree edge case when a PR falls outside the fetch limit.

internal/hygiene/collect.go (storage cap), internal/hygiene/report.go (orphaned-worktree and summary shape)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/hygiene/collect.go | New file: data collection layer for hygiene snapshots; `collectStoredState` uses a hardcoded cap of 500 for sessions/jobs regardless of the user-facing `--limit` flag |
| internal/hygiene/report.go | New file: analysis and reporting logic; `reportStatus` correctly returns "partial_data" when warnings exist; `TotalFindings` excludes warnings from count (by design, but subtly inconsistent with status) |
| internal/app/app.go | Wires `stateAdapter.GetHygieneReport` and `hygieneWorkers`; correctly populates Workers from Hub snapshots and Approvals from Telegram pending list |
| internal/api/mission.go | Adds `handleMissionHygiene`; gracefully returns empty report when no provider is set; no caching (noted in previous threads) |
| internal/cli/maestro_hygiene.go | New CLI command for hygiene reporting; clean flag surface, renders safe/approval-required/warning groups; supports `--json` output |
| internal/control/mission.go | Adds `missionHygiene` handler via optional interface assertion on `MissionProvider`; clean pattern consistent with other mission endpoints |
| internal/bot/approval.go | Adds `Pending()` read-only snapshot method on `ApprovalManager` with mutex and deterministic sort; nil guard is safe |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/api/mission.go`, line 141-157 ([link](https://github.com/befeast/ok-gobot/blob/8b81bba057b7985f9e7391595978185fb080a5b0/internal/api/mission.go#L141-L157)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No caching — every GET triggers full network and DB I/O**

   `handleMissionHygiene` calls `s.hygiene.GetHygieneReport(r.Context())` on every request with no result cache. That call runs `collectPullRequests` (`gh pr list`), `collectQueue` (`maestro.DryRun` → another `gh pr list`), `git rev-list`, and two SQLite queries (`ListSessionsV2(500)`, `ListJobs(500)`). If Mission Control auto-refreshes the hygiene panel (or any monitoring tool polls this endpoint), each refresh issues 2+ GitHub API calls. At the default GitHub REST rate limit of 60 req/hour for unauthenticated clients (or 5,000 for authenticated), a 30-second poll interval would exhaust an unauthenticated budget in 15 minutes. Consider caching the report for at least 60 seconds, or making it lazy/on-demand rather than served on every HTTP request.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/api/mission.go
   Line: 141-157

   Comment:
   **No caching — every GET triggers full network and DB I/O**

   `handleMissionHygiene` calls `s.hygiene.GetHygieneReport(r.Context())` on every request with no result cache. That call runs `collectPullRequests` (`gh pr list`), `collectQueue` (`maestro.DryRun` → another `gh pr list`), `git rev-list`, and two SQLite queries (`ListSessionsV2(500)`, `ListJobs(500)`). If Mission Control auto-refreshes the hygiene panel (or any monitoring tool polls this endpoint), each refresh issues 2+ GitHub API calls. At the default GitHub REST rate limit of 60 req/hour for unauthenticated clients (or 5,000 for authenticated), a 30-second poll interval would exhaust an unauthenticated budget in 15 minutes. Consider caching the report for at least 60 seconds, or making it lazy/on-demand rather than served on every HTTP request.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/hygiene/collect.go:937-953
**Hardcoded 500-row cap for sessions and jobs is independent of `--limit`**

`collectStoredState` always calls `ListSessionsV2(500)` and `ListJobs(500)`. The CLI's `--limit` flag (and `Maestro.Limit` in config) controls only the PR/queue analysis — it has no effect on these storage queries. On a long-running instance with many sessions or jobs, findings for closed-PR leftover sessions and dead workers will silently miss any entries beyond position 500 in the result set. Consider either deriving this cap from `CollectOptions.Limit` or documenting the separate bound so operators know the hygiene report only inspects the most-recent 500 stored records.

### Issue 2 of 3
internal/hygiene/report.go:1798-1806
**`TotalFindings` is zero when only warnings are present, but `Status` is `"partial_data"`**

`Summary.TotalFindings` counts only `SafeActions + ApprovalRequired` — it excludes `Warnings`. A caller that checks only `total_findings == 0` to decide "nothing to do" would miss the `"partial_data"` status that indicates some data sources failed. Consumers reading the summary JSON would see `{"status":"partial_data","total_findings":0,...}`, which reads as contradictory. Consider adding a `WarningCount` field to `Summary`, or note this in the API docs, so callers don't need to separately length-check the `warnings` array.

### Issue 3 of 3
internal/hygiene/report.go:1864-1876
**`isOrphanedWorktree` silently skips worktrees with a `PRNumber > 0` whose PR wasn't fetched**

The final `return` condition gates on `worktree.PRNumber == 0`. A worktree that records a `PRNumber` but whose PR wasn't included in the `collectPullRequests` batch (e.g., it falls beyond `--limit`, or `gh pr list` failed) will have an empty `PRState` and a branch not present in `openPRBranches` — and will not be flagged, even if the PR is long-closed. The explicit state checks at the top (`status == "merged"` etc.) only fire when the stored `Status`/`PRState` fields are already populated. Consider also returning `true` when `worktree.PRNumber > 0`, the branch is absent from `openPRBranches`, and there are no PR-list warnings.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: wire live workers into hygiene repo..."](https://github.com/befeast/ok-gobot/commit/d63f54c58e9a61358d5cb0932468aecf9e4682e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30497752)</sub>

<!-- /greptile_comment -->