### PR TITLE
feat: gate memory retrieval eval (#368)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Test
         run: go test ./...
+
+      - name: Memory retrieval eval
+        run: go run ./cmd/ok-gobot memory eval

--- a/.maestro/verify.sh
+++ b/.maestro/verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo '=== Go vet ==='
+go vet ./...
+
+echo '=== Go test ==='
+go test ./...
+
+echo '=== Memory retrieval eval ==='
+go run ./cmd/ok-gobot memory eval
+
+echo '=== Build ok-gobot ==='
+go build ./cmd/ok-gobot/
+
+echo 'All verifications passed.'

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -199,6 +199,18 @@ Force a rebuild of the managed markdown sources:
 ok-gobot memory index --force
 ```
 
+Run the deterministic retrieval reliability gate locally:
+
+```bash
+ok-gobot memory eval
+```
+
+The eval uses embedded fixture memory only and does not call external LLM,
+embedding, or QMD services. It fails on scoped recall regressions, privacy
+leaks, missing required citations, freshness failures, unexpected fallback
+behavior, backend errors, or per-query latency over the configured threshold.
+Maestro and CI run the same gate via `go run ./cmd/ok-gobot memory eval`.
+
 When `memory.enabled: true`, bot startup automatically indexes:
 
 - `MEMORY.md`

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -162,6 +162,20 @@ func TestMemoryEvalCommandEmitsReport(t *testing.T) {
 	}
 }
 
+func TestMemoryEvalGateWiring(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{"../../.github/workflows/ci.yml", "../../.maestro/verify.sh"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%s): %v", path, err)
+		}
+		if !strings.Contains(string(data), "go run ./cmd/ok-gobot memory eval") {
+			t.Fatalf("%s does not run memory retrieval eval", path)
+		}
+	}
+}
+
 func writeCLITestFile(t *testing.T, path, data string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/memory/qmd.go
+++ b/internal/memory/qmd.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -26,6 +27,8 @@ const (
 	DefaultQMDIndex      = "index"
 	DefaultQMDSearchMode = "search"
 	DefaultQMDTimeout    = 10 * time.Second
+
+	qmdExecBusyRetries = 3
 )
 
 var qmdHunkLineRegexp = regexp.MustCompile(`@@\s+-(\d+)(?:,(\d+))?`)
@@ -315,16 +318,25 @@ func (b *QMDBackend) run(ctx context.Context, args ...string) ([]byte, error) {
 	runCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(runCtx, path, args...)
-	cmd.Env = append(os.Environ(), "NO_COLOR=1")
-	if cfg.IndexPath != "" {
-		cmd.Env = append(cmd.Env, "INDEX_PATH="+expandUserPath(cfg.IndexPath))
-	}
-	out, err := cmd.CombinedOutput()
-	if runCtx.Err() != nil {
-		return nil, fmt.Errorf("qmd command timed out after %s", cfg.Timeout)
-	}
-	if err != nil {
+	var out []byte
+	for attempt := 0; ; attempt++ {
+		cmd := exec.CommandContext(runCtx, path, args...)
+		cmd.Env = append(os.Environ(), "NO_COLOR=1")
+		if cfg.IndexPath != "" {
+			cmd.Env = append(cmd.Env, "INDEX_PATH="+expandUserPath(cfg.IndexPath))
+		}
+		var err error
+		out, err = cmd.CombinedOutput()
+		if runCtx.Err() != nil {
+			return nil, fmt.Errorf("qmd command timed out after %s", cfg.Timeout)
+		}
+		if err == nil {
+			break
+		}
+		if errors.Is(err, syscall.ETXTBSY) && attempt < qmdExecBusyRetries {
+			time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+			continue
+		}
 		return nil, fmt.Errorf("qmd command failed: %w: %s", err, truncateForError(strings.TrimSpace(string(out)), 1200))
 	}
 	return out, nil

--- a/internal/memory/qmd.go
+++ b/internal/memory/qmd.go
@@ -334,7 +334,11 @@ func (b *QMDBackend) run(ctx context.Context, args ...string) ([]byte, error) {
 			break
 		}
 		if errors.Is(err, syscall.ETXTBSY) && attempt < qmdExecBusyRetries {
-			time.Sleep(time.Duration(attempt+1) * 10 * time.Millisecond)
+			select {
+			case <-time.After(time.Duration(attempt+1) * 10 * time.Millisecond):
+			case <-runCtx.Done():
+				return nil, fmt.Errorf("qmd command timed out after %s", cfg.Timeout)
+			}
 			continue
 		}
 		return nil, fmt.Errorf("qmd command failed: %w: %s", err, truncateForError(strings.TrimSpace(string(out)), 1200))

--- a/internal/memory/retrieval_eval.go
+++ b/internal/memory/retrieval_eval.go
@@ -62,6 +62,7 @@ type RetrievalEvalQuery struct {
 	RequiredContent  []RetrievalEvalContentRule
 	ForbiddenContent []RetrievalEvalContentRule
 	WantFallback     bool
+	AllowFallback    bool
 }
 
 // RetrievalEvalCitation identifies a specific indexed memory chunk.
@@ -190,10 +191,11 @@ func DefaultRetrievalEvalQueries() []RetrievalEvalQuery {
 
 	return []RetrievalEvalQuery{
 		{
-			Name:  "exact-lexical-release-codename",
-			Mode:  RetrievalEvalModeFTSBM25,
-			Query: "capybara release codename",
-			TopK:  3,
+			Name:          "exact-lexical-release-codename",
+			Mode:          RetrievalEvalModeFTSBM25,
+			Query:         "capybara release codename",
+			TopK:          3,
+			AllowFallback: true,
 			Expected: []RetrievalEvalCitation{{
 				SourceFile:   "MEMORY.md",
 				HeaderPath:   "Memory > Projects > Ok Gobot > Release Facts",
@@ -235,10 +237,11 @@ func DefaultRetrievalEvalQueries() []RetrievalEvalQuery {
 			}},
 		},
 		{
-			Name:  "transcript-lexical-parser-blocker",
-			Mode:  RetrievalEvalModeFTSBM25,
-			Query: "standup transcript slash escaping command parser blocker",
-			TopK:  3,
+			Name:          "transcript-lexical-parser-blocker",
+			Mode:          RetrievalEvalModeFTSBM25,
+			Query:         "standup transcript slash escaping command parser blocker",
+			TopK:          3,
+			AllowFallback: true,
 			Expected: []RetrievalEvalCitation{{
 				SourceFile:   "transcripts/2026-04-12-standup.md",
 				HeaderPath:   "Transcript > Standup Snippet",
@@ -257,10 +260,11 @@ func DefaultRetrievalEvalQueries() []RetrievalEvalQuery {
 			}},
 		},
 		{
-			Name:  "daily-note-lexical-accessibility-reminder",
-			Mode:  RetrievalEvalModeFTSBM25,
-			Query: "Friday accessibility audit contrast keyboard focus",
-			TopK:  3,
+			Name:          "daily-note-lexical-accessibility-reminder",
+			Mode:          RetrievalEvalModeFTSBM25,
+			Query:         "Friday accessibility audit contrast keyboard focus",
+			TopK:          3,
+			AllowFallback: true,
 			Expected: []RetrievalEvalCitation{{
 				SourceFile:   "memory/2026-04-10.md",
 				HeaderPath:   "Daily Memory: 2026-04-10 > Reminders",
@@ -578,7 +582,10 @@ func (h *retrievalEvalHarness) evaluateQuery(ctx context.Context, query Retrieva
 		result.addFailure("latency")
 	}
 	if query.WantFallback && !result.FallbackUsed {
-		result.addFailure("fallback")
+		result.addFailure("missing_fallback")
+	}
+	if !query.WantFallback && !query.AllowFallback && result.FallbackUsed {
+		result.addFailure("unexpected_fallback")
 	}
 
 	result.Precision = retrievalEvalRatio(relevantRetrievalEvalHits(query.Expected, result.Hits), len(result.Hits))
@@ -677,7 +684,7 @@ func (r *RetrievalEvalReport) addQueryResult(result RetrievalEvalQueryResult) {
 			r.FreshnessFailures++
 		case "latency":
 			r.LatencyFailures++
-		case "fallback":
+		case "fallback", "missing_fallback", "unexpected_fallback":
 			r.FallbackFailures++
 		}
 	}
@@ -717,13 +724,13 @@ func (r RetrievalEvalReport) FormatText() string {
 	fmt.Fprintf(&b, "Backend errors: %d\n", r.BackendErrors)
 	fmt.Fprintf(&b, "Failure classes: %s\n", retrievalEvalFailureClassSummary(r.FailureClasses))
 
+	fmt.Fprintf(&b, "\nQuery results:\n")
 	for _, result := range r.QueryResults {
-		b.WriteByte('\n')
 		state := "PASS"
 		if len(result.Failures) > 0 {
 			state = "FAIL"
 		}
-		fmt.Fprintf(&b, "%s %s [%s@%d] backend=%s recall=%.2f precision=%.2f latency=%s\n",
+		fmt.Fprintf(&b, "%s %s [%s@%d] backend=%s recall=%.2f precision-ish=%.2f fallback=%s latency=%s failures=%s\n",
 			state,
 			result.Name,
 			result.Mode,
@@ -731,13 +738,12 @@ func (r RetrievalEvalReport) FormatText() string {
 			valueOr(result.Backend, "unknown"),
 			result.Recall,
 			result.Precision,
+			retrievalEvalFallbackSummary(result),
 			retrievalEvalDurationString(result.Duration),
+			retrievalEvalQueryFailureSummary(result.Failures),
 		)
-		if result.FallbackUsed || result.FallbackReason != "" {
-			fmt.Fprintf(&b, "  fallback: used=%t reason=%s\n", result.FallbackUsed, valueOr(result.FallbackReason, "none"))
-		}
-		if len(result.Failures) > 0 {
-			fmt.Fprintf(&b, "  failure_classes: %s\n", strings.Join(result.Failures, ", "))
+		if len(result.Failures) == 0 {
+			continue
 		}
 		if result.Error != "" {
 			fmt.Fprintf(&b, "  error: %s\n", result.Error)
@@ -752,6 +758,23 @@ func (r RetrievalEvalReport) FormatText() string {
 	}
 
 	return strings.TrimRight(b.String(), "\n") + "\n"
+}
+
+func retrievalEvalFallbackSummary(result RetrievalEvalQueryResult) string {
+	if !result.FallbackUsed && result.FallbackReason == "" {
+		return "none"
+	}
+	if result.FallbackReason == "" {
+		return "used"
+	}
+	return "used:" + strings.ReplaceAll(result.FallbackReason, " ", "_")
+}
+
+func retrievalEvalQueryFailureSummary(failures []string) string {
+	if len(failures) == 0 {
+		return "none"
+	}
+	return strings.Join(failures, ",")
 }
 
 func writeRetrievalEvalCitationList(b *strings.Builder, label string, citations []RetrievalEvalCitation) {

--- a/internal/memory/retrieval_eval_test.go
+++ b/internal/memory/retrieval_eval_test.go
@@ -89,3 +89,50 @@ func TestRetrievalEvalReportShowsMissingCitationAndFreshnessFailures(t *testing.
 		}
 	}
 }
+
+func TestRetrievalEvalUnexpectedFallbackFailsReport(t *testing.T) {
+	report, err := RunRetrievalEval(context.Background(), RetrievalEvalOptions{
+		Queries: []RetrievalEvalQuery{{
+			Name:  "unexpected-fallback-control",
+			Mode:  RetrievalEvalModeVectorUnavailable,
+			Query: "deterministic offline embeddings remote model downloads",
+			TopK:  3,
+			Expected: []RetrievalEvalCitation{{
+				SourceFile:   "MEMORY.md",
+				HeaderPath:   "Memory > Projects > Ok Gobot > Offline Policy",
+				ChunkOrdinal: 0,
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("RunRetrievalEval failed: %v", err)
+	}
+	text := report.FormatText()
+	if report.Passed() || report.FallbackFailures == 0 {
+		t.Fatalf("expected unexpected fallback failure, got:\n%s", text)
+	}
+	for _, want := range []string{"unexpected-fallback-control", "unexpected_fallback", "Fallback failures: 1"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in report:\n%s", want, text)
+		}
+	}
+}
+
+func TestRetrievalEvalPassingReportIsConcise(t *testing.T) {
+	report, err := RunRetrievalEval(context.Background(), RetrievalEvalOptions{})
+	if err != nil {
+		t.Fatalf("RunRetrievalEval failed: %v", err)
+	}
+	text := report.FormatText()
+	if !report.Passed() {
+		t.Fatalf("expected passing report:\n%s", text)
+	}
+	if strings.Contains(text, "  hits:") {
+		t.Fatalf("passing report should not include verbose hit details:\n%s", text)
+	}
+	for _, want := range []string{"Query results:", "precision-ish=", "fallback=", "failures=none"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in concise report:\n%s", want, text)
+		}
+	}
+}


### PR DESCRIPTION
Implements #368

## Changes
- Runs `ok-gobot memory eval` from CI and `.maestro/verify.sh`.
- Makes passing eval output concise while preserving actionable per-query failure details.
- Fails unexpected fallback behavior and covers gate wiring/report behavior with tests.
- Retries transient QMD `ETXTBSY` exec failures observed in the previous CI failure path.
- Documents local operator usage for the deterministic offline eval.

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./cmd/ok-gobot/`
- `./.maestro/verify.sh`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates the memory retrieval eval in both CI and `.maestro/verify.sh`, adds an `AllowFallback` field to tolerate expected fallback on FTS queries, renames failure keys to `missing_fallback`/`unexpected_fallback` for clarity, makes passing-report output concise, and adds ETXTBSY retry logic with a context-aware backoff. All changes are well-tested and consistent across the eval harness, report formatter, and gate-wiring assertions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic defects found in any changed path.

All changes are well-scoped: the AllowFallback gate, renamed failure keys, concise formatter, and ETXTBSY retry loop are each correct and tested. No P1 or P0 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/memory/retrieval_eval.go | Adds AllowFallback field, renames failure keys to missing_fallback/unexpected_fallback, makes FormatText concise while preserving failure detail lines; logic is correct and consistent with addQueryResult case matching. |
| internal/memory/qmd.go | Adds retry loop for ETXTBSY exec failures with context-aware sleep; errors.Is unwraps through *os.PathError correctly, retry limit and backoff are sensible. |
| internal/memory/retrieval_eval_test.go | Adds tests for unexpected fallback failure path and concise passing-report format; good coverage of the new AllowFallback gate wiring. |
| internal/cli/memory_test.go | Adds TestMemoryEvalGateWiring which reads CI and verify.sh at relative paths to assert the eval command is wired up; relative paths resolve correctly under go test. |
| .github/workflows/ci.yml | Adds memory eval step to CI using go run; matches the string asserted in TestMemoryEvalGateWiring. |
| .maestro/verify.sh | New script wrapping vet, test, eval, and build in order; uses set -euo pipefail correctly. |
| docs/MEMORY.md | Documents the deterministic offline eval command with accurate description of what it checks. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: respect qmd retry cancellation (#36..."](https://github.com/befeast/ok-gobot/commit/e2c9773661c2a59f6a823ccfa7f987f4d0589649) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30505124)</sub>

<!-- /greptile_comment -->