### PR TITLE
fix: verify role proof artifacts (#369)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -65,7 +65,7 @@ func (s *APIServer) SetHygieneProvider(provider HygieneProvider) {
 
 // SetArtifactRoots configures local roots that artifact file previews may read from.
 func (s *APIServer) SetArtifactRoots(roots []string) {
-	s.roots = artifactview.NormalizeRoots(roots)
+	s.roots = artifactview.ConfiguredRoots(roots)
 }
 
 func (s *APIServer) artifactRoots() []string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -316,6 +316,7 @@ func (a *App) Start(ctx context.Context) error {
 
 	// Initialize durable job service for background work
 	jobService := runtime.NewJobService(a.store)
+	jobService.SetArtifactRoots(a.config.Artifacts.Roots)
 
 	// Initialize cron scheduler
 	a.scheduler = cron.NewScheduler(a.store, func(ctx context.Context, job storage.CronJob, budget *delegation.Job) error {

--- a/internal/artifacts/display.go
+++ b/internal/artifacts/display.go
@@ -1,13 +1,19 @@
 package artifacts
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"mime"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"ok-gobot/internal/storage"
 )
@@ -33,6 +39,7 @@ type Info struct {
 	URL          string          `json:"url,omitempty"`
 	URI          string          `json:"uri,omitempty"`
 	CreatedAt    string          `json:"created_at"`
+	Metadata     *Metadata       `json:"metadata,omitempty"`
 	Display      DisplayMetadata `json:"display"`
 }
 
@@ -45,6 +52,25 @@ type DisplayMetadata struct {
 	Inline  bool   `json:"inline,omitempty"`
 	Href    string `json:"href,omitempty"`
 	Reason  string `json:"reason,omitempty"`
+}
+
+// Metadata stores verification fields that make a persisted artifact auditable
+// without trusting a raw URI by itself.
+type Metadata struct {
+	Kind           string `json:"kind,omitempty"`
+	NormalizedPath string `json:"normalized_path,omitempty"`
+	SizeBytes      *int64 `json:"size_bytes,omitempty"`
+	SHA256         string `json:"sha256,omitempty"`
+	Producer       string `json:"producer,omitempty"`
+	CreatedAt      string `json:"created_at,omitempty"`
+}
+
+type localPathValidation struct {
+	Path   string
+	Info   os.FileInfo
+	Reason string
+	Err    error
+	Safe   bool
 }
 
 // Serializer converts persisted artifact rows into display-safe API objects.
@@ -109,6 +135,7 @@ func (s Serializer) Serialize(artifact storage.JobArtifact) Info {
 	}
 
 	kind := displayKind(artifact)
+	metadata := ParseMetadata(artifact.Metadata)
 	info := Info{
 		ID:           artifact.ID,
 		JobID:        artifact.JobID,
@@ -117,11 +144,9 @@ func (s Serializer) Serialize(artifact storage.JobArtifact) Info {
 		Label:        artifact.Name,
 		Name:         artifact.Name,
 		MimeType:     artifact.MimeType,
-		Content:      artifact.Content,
 		CreatedAt:    artifact.CreatedAt,
 		Display: DisplayMetadata{
 			Kind: kind,
-			Safe: artifact.URI == "",
 		},
 	}
 
@@ -135,10 +160,18 @@ func (s Serializer) Serialize(artifact storage.JobArtifact) Info {
 	rawURI := strings.TrimSpace(artifact.URI)
 	switch {
 	case rawURI == "":
-		if artifact.Content != "" {
-			info.Display.Safe = true
-			info.Display.Inline = true
+		if artifact.Content == "" {
+			hideArtifact(&info, "unsupported artifact kind")
+			break
 		}
+		if reason := verifyContentMetadata(artifact.Content, metadata); reason != "" {
+			hideArtifact(&info, reason)
+			break
+		}
+		info.Content = artifact.Content
+		info.Display.Safe = true
+		info.Display.Inline = true
+		info.Metadata = displayMetadata(metadata, artifact, kind, "", nil)
 	case isSafeRemoteURL(rawURI) || isSafeImageDataURL(rawURI):
 		info.URL = rawURI
 		info.URI = rawURI
@@ -148,26 +181,30 @@ func (s Serializer) Serialize(artifact storage.JobArtifact) Info {
 			info.Display.Kind = KindURL
 		}
 		info.Display.Preview = info.Display.Kind == KindImage || info.Display.Kind == KindURL
+		info.Metadata = displayMetadata(metadata, artifact, info.Display.Kind, "", nil)
 	case isLocalURI(rawURI):
-		path, ok := SafeLocalPath(rawURI, s.Roots)
-		if !ok {
-			info.Display.Safe = false
-			info.Display.Reason = "local artifact is outside configured artifact roots"
+		local := validateLocalPath(rawURI, s.Roots)
+		if !local.Safe {
+			hideArtifact(&info, local.Reason)
 			break
 		}
-		info.Path = path
-		info.URI = path
+		if !supportedLocalArtifactKind(artifact, kind) {
+			hideArtifact(&info, "unsupported artifact kind")
+			break
+		}
+		if reason := verifyLocalMetadata(metadata, local.Path, local.Info); reason != "" {
+			hideArtifact(&info, reason)
+			break
+		}
+		info.Path = local.Path
+		info.URI = local.Path
 		info.Display.Safe = true
 		info.Display.Href = s.contentHref(artifact.ID)
 		info.Display.Preview = info.Display.Kind == KindImage
 		info.Display.Inline = info.Display.Kind == KindTextReport
+		info.Metadata = displayMetadata(metadata, artifact, kind, local.Path, local.Info)
 	default:
-		info.Display.Safe = false
-		info.Display.Reason = "unsupported artifact URI scheme"
-	}
-
-	if artifact.Content != "" && info.Display.Kind == KindTextReport && info.Display.Safe {
-		info.Display.Inline = true
+		hideArtifact(&info, "unsupported artifact URI scheme")
 	}
 
 	return info
@@ -183,6 +220,175 @@ func (s Serializer) SerializeAll(rows []storage.JobArtifact) []Info {
 		out[i] = s.Serialize(row)
 	}
 	return out
+}
+
+func hideArtifact(info *Info, reason string) {
+	if info == nil {
+		return
+	}
+	info.Path = ""
+	info.URL = ""
+	info.URI = ""
+	info.Content = ""
+	info.Metadata = nil
+	info.Display.Safe = false
+	info.Display.Preview = false
+	info.Display.Inline = false
+	info.Display.Href = ""
+	info.Display.Reason = strings.TrimSpace(reason)
+	if info.Display.Reason == "" {
+		info.Display.Reason = "not safe to display"
+	}
+}
+
+func displayMetadata(stored *Metadata, artifact storage.JobArtifact, kind, normalizedPath string, fileInfo os.FileInfo) *Metadata {
+	meta := cloneMetadata(stored)
+	if meta == nil {
+		meta = &Metadata{}
+	}
+	if strings.TrimSpace(kind) != "" {
+		meta.Kind = strings.TrimSpace(kind)
+	}
+	if normalizedPath != "" {
+		meta.NormalizedPath = normalizedPath
+	}
+	if meta.CreatedAt == "" {
+		meta.CreatedAt = strings.TrimSpace(artifact.CreatedAt)
+	}
+	if meta.SizeBytes == nil {
+		switch {
+		case fileInfo != nil:
+			setMetadataSize(meta, fileInfo.Size())
+		case artifact.Content != "":
+			setMetadataSize(meta, int64(len([]byte(artifact.Content))))
+		}
+	}
+	if meta.SHA256 == "" && artifact.Content != "" && normalizedPath == "" {
+		meta.SHA256 = sha256HexString(artifact.Content)
+	}
+	if metadataEmpty(meta) {
+		return nil
+	}
+	return meta
+}
+
+func cloneMetadata(meta *Metadata) *Metadata {
+	if meta == nil {
+		return nil
+	}
+	clone := *meta
+	if meta.SizeBytes != nil {
+		size := *meta.SizeBytes
+		clone.SizeBytes = &size
+	}
+	return &clone
+}
+
+func setMetadataSize(meta *Metadata, size int64) {
+	if meta == nil {
+		return
+	}
+	meta.SizeBytes = new(int64)
+	*meta.SizeBytes = size
+}
+
+func metadataEmpty(meta *Metadata) bool {
+	if meta == nil {
+		return true
+	}
+	return meta.Kind == "" && meta.NormalizedPath == "" && meta.SizeBytes == nil && meta.SHA256 == "" && meta.Producer == "" && meta.CreatedAt == ""
+}
+
+// ParseMetadata extracts known verification metadata fields from a persisted
+// artifact metadata JSON object. Unknown fields are intentionally ignored so
+// callers do not expose arbitrary producer-provided metadata.
+func ParseMetadata(raw string) *Metadata {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var meta Metadata
+	if err := json.Unmarshal([]byte(raw), &meta); err != nil {
+		return nil
+	}
+	meta.Kind = strings.TrimSpace(meta.Kind)
+	meta.NormalizedPath = strings.TrimSpace(meta.NormalizedPath)
+	meta.SHA256 = strings.ToLower(strings.TrimSpace(meta.SHA256))
+	meta.Producer = strings.TrimSpace(meta.Producer)
+	meta.CreatedAt = strings.TrimSpace(meta.CreatedAt)
+	if metadataEmpty(&meta) {
+		return nil
+	}
+	return &meta
+}
+
+// BuildMetadata derives verification metadata for an artifact at persistence
+// time. It hashes inline content and local files when they are available.
+func BuildMetadata(artifact storage.JobArtifact, producer string, createdAt time.Time) Metadata {
+	meta := Metadata{
+		Kind:      displayKind(artifact),
+		Producer:  strings.TrimSpace(producer),
+		CreatedAt: createdAt.UTC().Format(time.RFC3339Nano),
+	}
+
+	if path, info, err := localFileMetadata(artifact.URI); path != "" {
+		meta.NormalizedPath = path
+		if err == nil && info != nil && !info.IsDir() {
+			setMetadataSize(&meta, info.Size())
+			if sum, err := fileSHA256(path); err == nil {
+				meta.SHA256 = sum
+			}
+		}
+		return meta
+	}
+
+	if artifact.Content != "" {
+		setMetadataSize(&meta, int64(len([]byte(artifact.Content))))
+		meta.SHA256 = sha256HexString(artifact.Content)
+	}
+	return meta
+}
+
+func verifyContentMetadata(content string, meta *Metadata) string {
+	if meta == nil {
+		return ""
+	}
+	size := int64(len([]byte(content)))
+	if meta.SizeBytes != nil && *meta.SizeBytes != size {
+		return "artifact metadata size does not match content"
+	}
+	if meta.SHA256 != "" && !strings.EqualFold(meta.SHA256, sha256HexString(content)) {
+		return "artifact metadata hash does not match content"
+	}
+	return ""
+}
+
+func verifyLocalMetadata(meta *Metadata, path string, info os.FileInfo) string {
+	if meta == nil {
+		return ""
+	}
+	if meta.NormalizedPath != "" {
+		normalized, err := existingLocalPath(meta.NormalizedPath)
+		if err != nil {
+			return "artifact metadata path cannot be resolved"
+		}
+		if normalized != path {
+			return "artifact metadata path does not match file"
+		}
+	}
+	if info != nil && meta.SizeBytes != nil && *meta.SizeBytes != info.Size() {
+		return "artifact metadata size does not match file"
+	}
+	if meta.SHA256 != "" {
+		sum, err := fileSHA256(path)
+		if err != nil {
+			return "artifact metadata hash cannot be verified"
+		}
+		if !strings.EqualFold(meta.SHA256, sum) {
+			return "artifact metadata hash does not match file"
+		}
+	}
+	return ""
 }
 
 // FormatProofHints renders artifact references that are safe to show in chat
@@ -280,36 +486,29 @@ func truncateRunes(s string, max int) string {
 // SafeLocalPath returns a canonical local path only when rawURI points inside
 // one of the configured roots.
 func SafeLocalPath(rawURI string, roots []string) (string, bool) {
-	local, ok := localPathFromURI(rawURI)
-	if !ok {
+	result := validateLocalPath(rawURI, roots)
+	if !result.Safe {
 		return "", false
 	}
-	path, err := canonicalPath(local)
-	if err != nil {
-		return "", false
-	}
-	for _, root := range NormalizeRoots(roots) {
-		if pathInsideRoot(path, root) {
-			return path, true
-		}
-	}
-	return "", false
+	return result.Path, true
 }
 
 // ContentPath returns the safe local file path for an artifact content endpoint.
 func ContentPath(artifact storage.JobArtifact, roots []string) (string, error) {
-	path, ok := SafeLocalPath(artifact.URI, roots)
-	if !ok {
-		return "", fmt.Errorf("artifact file is outside configured artifact roots")
+	result := validateLocalPath(artifact.URI, roots)
+	if !result.Safe {
+		if result.Err != nil {
+			return "", result.Err
+		}
+		return "", errors.New(result.Reason)
 	}
-	stat, err := os.Stat(path)
-	if err != nil {
-		return "", err
+	if !supportedLocalArtifactKind(artifact, displayKind(artifact)) {
+		return "", errors.New("unsupported artifact kind")
 	}
-	if stat.IsDir() {
-		return "", fmt.Errorf("artifact path is a directory")
+	if reason := verifyLocalMetadata(ParseMetadata(artifact.Metadata), result.Path, result.Info); reason != "" {
+		return "", errors.New(reason)
 	}
-	return path, nil
+	return result.Path, nil
 }
 
 func (s Serializer) contentHref(id int64) string {
@@ -423,7 +622,95 @@ func localPathFromURI(raw string) (string, bool) {
 	return u.Path, u.Path != ""
 }
 
-func canonicalPath(path string) (string, error) {
+func validateLocalPath(rawURI string, roots []string) localPathValidation {
+	local, ok := localPathFromURI(rawURI)
+	if !ok {
+		return localPathValidation{Reason: "unsupported artifact URI scheme"}
+	}
+	path, err := existingLocalPath(local)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return localPathValidation{Reason: "artifact file not found", Err: fmt.Errorf("artifact file not found: %w", err)}
+		}
+		return localPathValidation{Reason: "artifact path cannot be resolved", Err: fmt.Errorf("artifact path cannot be resolved: %w", err)}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return localPathValidation{Reason: "artifact file not found", Err: fmt.Errorf("artifact file not found: %w", err)}
+		}
+		return localPathValidation{Reason: "artifact path cannot be resolved", Err: fmt.Errorf("artifact path cannot be resolved: %w", err)}
+	}
+	if info.IsDir() {
+		return localPathValidation{Reason: "artifact path is a directory", Err: fmt.Errorf("artifact path is a directory")}
+	}
+	for _, root := range NormalizeRoots(roots) {
+		if pathInsideRoot(path, root) {
+			return localPathValidation{Path: path, Info: info, Safe: true}
+		}
+	}
+	return localPathValidation{Reason: "local artifact is outside configured artifact roots", Err: fmt.Errorf("local artifact is outside configured artifact roots")}
+}
+
+func existingLocalPath(path string) (string, error) {
+	path, err := absoluteCleanPath(path)
+	if err != nil {
+		return "", err
+	}
+	evaluated, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(evaluated), nil
+}
+
+func localFileMetadata(rawURI string) (string, os.FileInfo, error) {
+	local, ok := localPathFromURI(rawURI)
+	if !ok {
+		return "", nil, nil
+	}
+	path, err := absoluteCleanPath(local)
+	if err != nil {
+		return "", nil, err
+	}
+	if evaluated, err := filepath.EvalSymlinks(path); err == nil {
+		path = filepath.Clean(evaluated)
+	}
+	info, err := os.Stat(path)
+	return path, info, err
+}
+
+func supportedLocalArtifactKind(artifact storage.JobArtifact, kind string) bool {
+	typeName := strings.ToLower(strings.TrimSpace(artifact.ArtifactType))
+	switch strings.TrimSpace(kind) {
+	case KindImage, KindTextReport, KindURL:
+		return true
+	case KindArtifact:
+		return typeName == "" || typeName == KindArtifact || typeName == "file"
+	default:
+		return false
+	}
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close() //nolint:errcheck
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func sha256HexString(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func absoluteCleanPath(path string) (string, error) {
 	path = strings.TrimSpace(path)
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()
@@ -436,7 +723,14 @@ func canonicalPath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	abs = filepath.Clean(abs)
+	return filepath.Clean(abs), nil
+}
+
+func canonicalPath(path string) (string, error) {
+	abs, err := absoluteCleanPath(path)
+	if err != nil {
+		return "", err
+	}
 	if evaluated, err := filepath.EvalSymlinks(abs); err == nil {
 		abs = filepath.Clean(evaluated)
 	}

--- a/internal/artifacts/display.go
+++ b/internal/artifacts/display.go
@@ -84,7 +84,7 @@ type Serializer struct {
 // trailing slash, for example "/api/artifacts".
 func NewSerializer(roots []string, contentURLPrefix string) Serializer {
 	return Serializer{
-		Roots:            NormalizeRoots(roots),
+		Roots:            ConfiguredRoots(roots),
 		ContentURLPrefix: strings.TrimRight(strings.TrimSpace(contentURLPrefix), "/"),
 	}
 }
@@ -104,6 +104,29 @@ func DefaultRoots() []string {
 		roots = append(roots, filepath.SplitList(env)...)
 	}
 	return NormalizeRoots(roots)
+}
+
+// ConfiguredRoots returns absolute root values without resolving symlinks when
+// at least one can be canonicalized. Keeping the configured symlink spelling
+// lets path validation accept artifacts under a symlinked root before verifying
+// their symlink-resolved path against canonical roots.
+func ConfiguredRoots(roots []string) []string {
+	out := make([]string, 0, len(roots))
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		path, err := absoluteCleanPath(root)
+		if err != nil {
+			continue
+		}
+		out = append(out, path)
+	}
+	if len(NormalizeRoots(out)) == 0 {
+		return nil
+	}
+	return out
 }
 
 // NormalizeRoots expands and canonicalizes artifact root paths.
@@ -323,19 +346,36 @@ func ParseMetadata(raw string) *Metadata {
 }
 
 // BuildMetadata derives verification metadata for an artifact at persistence
-// time. It hashes inline content and local files when they are available.
+// time. It hashes inline content only; callers that have configured artifact
+// roots should use BuildMetadataForRoots for local files.
 func BuildMetadata(artifact storage.JobArtifact, producer string, createdAt time.Time) Metadata {
+	return buildMetadata(artifact, producer, createdAt, nil)
+}
+
+// BuildMetadataForRoots derives verification metadata for an artifact at
+// persistence time. Local files are hashed only after they resolve inside one
+// of the configured artifact roots.
+func BuildMetadataForRoots(artifact storage.JobArtifact, producer string, createdAt time.Time, roots []string) Metadata {
+	return buildMetadata(artifact, producer, createdAt, effectiveRoots(roots))
+}
+
+func buildMetadata(artifact storage.JobArtifact, producer string, createdAt time.Time, roots []string) Metadata {
 	meta := Metadata{
 		Kind:      displayKind(artifact),
 		Producer:  strings.TrimSpace(producer),
 		CreatedAt: createdAt.UTC().Format(time.RFC3339Nano),
 	}
 
-	if path, info, err := localFileMetadata(artifact.URI); path != "" {
-		meta.NormalizedPath = path
-		if err == nil && info != nil && !info.IsDir() {
+	if isLocalURI(artifact.URI) {
+		if len(roots) == 0 {
+			return meta
+		}
+		local := validateLocalPath(artifact.URI, roots)
+		if local.Safe {
+			meta.NormalizedPath = local.Path
+			info := local.Info
 			setMetadataSize(&meta, info.Size())
-			if sum, err := fileSHA256(path); err == nil {
+			if sum, err := fileSHA256(local.Path); err == nil {
 				meta.SHA256 = sum
 			}
 		}
@@ -347,6 +387,14 @@ func BuildMetadata(artifact storage.JobArtifact, producer string, createdAt time
 		meta.SHA256 = sha256HexString(artifact.Content)
 	}
 	return meta
+}
+
+func effectiveRoots(roots []string) []string {
+	configured := ConfiguredRoots(roots)
+	if len(configured) > 0 {
+		return configured
+	}
+	return DefaultRoots()
 }
 
 func verifyContentMetadata(content string, meta *Metadata) string {
@@ -627,12 +675,25 @@ func validateLocalPath(rawURI string, roots []string) localPathValidation {
 	if !ok {
 		return localPathValidation{Reason: "unsupported artifact URI scheme"}
 	}
-	path, err := existingLocalPath(local)
+	lexicalRoots := cleanRootPaths(roots)
+	normalizedRoots := NormalizeRoots(roots)
+	path, err := absoluteCleanPath(local)
+	if err != nil {
+		return localPathValidation{Reason: "artifact path cannot be resolved", Err: fmt.Errorf("artifact path cannot be resolved: %w", err)}
+	}
+	if !pathInsideAnyRoot(path, lexicalRoots) && !pathInsideAnyRoot(path, normalizedRoots) {
+		return localPathValidation{Reason: "local artifact is outside configured artifact roots", Err: fmt.Errorf("local artifact is outside configured artifact roots")}
+	}
+	evaluated, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return localPathValidation{Reason: "artifact file not found", Err: fmt.Errorf("artifact file not found: %w", err)}
 		}
 		return localPathValidation{Reason: "artifact path cannot be resolved", Err: fmt.Errorf("artifact path cannot be resolved: %w", err)}
+	}
+	path = filepath.Clean(evaluated)
+	if !pathInsideAnyRoot(path, normalizedRoots) {
+		return localPathValidation{Reason: "local artifact is outside configured artifact roots", Err: fmt.Errorf("local artifact is outside configured artifact roots")}
 	}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -644,12 +705,10 @@ func validateLocalPath(rawURI string, roots []string) localPathValidation {
 	if info.IsDir() {
 		return localPathValidation{Reason: "artifact path is a directory", Err: fmt.Errorf("artifact path is a directory")}
 	}
-	for _, root := range NormalizeRoots(roots) {
-		if pathInsideRoot(path, root) {
-			return localPathValidation{Path: path, Info: info, Safe: true}
-		}
+	if !info.Mode().IsRegular() {
+		return localPathValidation{Reason: "artifact path is not a regular file", Err: fmt.Errorf("artifact path is not a regular file")}
 	}
-	return localPathValidation{Reason: "local artifact is outside configured artifact roots", Err: fmt.Errorf("local artifact is outside configured artifact roots")}
+	return localPathValidation{Path: path, Info: info, Safe: true}
 }
 
 func existingLocalPath(path string) (string, error) {
@@ -662,22 +721,6 @@ func existingLocalPath(path string) (string, error) {
 		return "", err
 	}
 	return filepath.Clean(evaluated), nil
-}
-
-func localFileMetadata(rawURI string) (string, os.FileInfo, error) {
-	local, ok := localPathFromURI(rawURI)
-	if !ok {
-		return "", nil, nil
-	}
-	path, err := absoluteCleanPath(local)
-	if err != nil {
-		return "", nil, err
-	}
-	if evaluated, err := filepath.EvalSymlinks(path); err == nil {
-		path = filepath.Clean(evaluated)
-	}
-	info, err := os.Stat(path)
-	return path, info, err
 }
 
 func supportedLocalArtifactKind(artifact storage.JobArtifact, kind string) bool {
@@ -743,4 +786,34 @@ func pathInsideRoot(path, root string) bool {
 		return false
 	}
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+func cleanRootPaths(roots []string) []string {
+	seen := make(map[string]struct{}, len(roots))
+	out := make([]string, 0, len(roots))
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		path, err := absoluteCleanPath(root)
+		if err != nil || path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		out = append(out, path)
+	}
+	return out
+}
+
+func pathInsideAnyRoot(path string, roots []string) bool {
+	for _, root := range roots {
+		if pathInsideRoot(path, root) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/artifacts/display_test.go
+++ b/internal/artifacts/display_test.go
@@ -183,7 +183,7 @@ func TestSerializerVerifiesPersistedLocalArtifactMetadata(t *testing.T) {
 		URI:          path,
 		CreatedAt:    createdAt.Format(time.RFC3339),
 	}
-	metadata := BuildMetadata(row, "role:auditor", createdAt)
+	metadata := BuildMetadataForRoots(row, "role:auditor", createdAt, []string{root})
 	raw, err := json.Marshal(metadata)
 	if err != nil {
 		t.Fatalf("marshal metadata: %v", err)
@@ -214,6 +214,49 @@ func TestSerializerVerifiesPersistedLocalArtifactMetadata(t *testing.T) {
 	}
 	if !strings.Contains(info.Display.Reason, "metadata") {
 		t.Fatalf("expected metadata verification reason, got %+v", info.Display)
+	}
+}
+
+func TestBuildMetadataForRootsDoesNotReadOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write outside artifact: %v", err)
+	}
+	createdAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	meta := BuildMetadataForRoots(storage.JobArtifact{
+		ArtifactType: "file",
+		URI:          outside,
+	}, "role:auditor", createdAt, []string{root})
+
+	if meta.NormalizedPath != "" || meta.SizeBytes != nil || meta.SHA256 != "" {
+		t.Fatalf("outside-root metadata leaked file details: %+v", meta)
+	}
+	if meta.Kind != KindArtifact || meta.Producer != "role:auditor" || meta.CreatedAt == "" {
+		t.Fatalf("expected base audit metadata, got %+v", meta)
+	}
+}
+
+func TestBuildMetadataForRootsDoesNotHashSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write outside artifact: %v", err)
+	}
+	link := filepath.Join(root, "link.txt")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	createdAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	meta := BuildMetadataForRoots(storage.JobArtifact{
+		ArtifactType: "file",
+		URI:          link,
+	}, "role:auditor", createdAt, []string{root})
+
+	if meta.NormalizedPath != "" || meta.SizeBytes != nil || meta.SHA256 != "" {
+		t.Fatalf("symlink escape metadata leaked file details: %+v", meta)
 	}
 }
 

--- a/internal/artifacts/display_test.go
+++ b/internal/artifacts/display_test.go
@@ -1,10 +1,12 @@
 package artifacts
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"ok-gobot/internal/storage"
 )
@@ -61,6 +63,58 @@ func TestSerializerBlocksLocalPathOutsideRoot(t *testing.T) {
 	}
 }
 
+func TestSerializerBlocksMissingLocalArtifact(t *testing.T) {
+	root := t.TempDir()
+	missing := filepath.Join(root, "missing.png")
+
+	info := NewSerializer([]string{root}, "/api/artifacts").Serialize(storage.JobArtifact{
+		ID:           8,
+		JobID:        "job-1",
+		Name:         "missing",
+		ArtifactType: "screenshot",
+		MimeType:     "image/png",
+		URI:          missing,
+	})
+
+	if info.Path != "" || info.URI != "" || info.Display.Href != "" || info.Display.Safe {
+		t.Fatalf("missing local path was exposed: %+v", info)
+	}
+	if !strings.Contains(info.Display.Reason, "not found") {
+		t.Fatalf("expected not found reason, got %+v", info.Display)
+	}
+	if hint := FormatProofHint(info); containsAny(hint, missing, root) || !strings.Contains(hint, "hidden") {
+		t.Fatalf("missing artifact hint leaked path or reason: %q", hint)
+	}
+}
+
+func TestSerializerBlocksPathTraversalOutsideRoot(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	outside := filepath.Join(parent, "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write outside artifact: %v", err)
+	}
+	traversal := filepath.Join(root, "..", "outside.txt")
+
+	info := NewSerializer([]string{root}, "/api/artifacts").Serialize(storage.JobArtifact{
+		ID:           9,
+		JobID:        "job-1",
+		Name:         "traversal",
+		ArtifactType: "file",
+		URI:          traversal,
+	})
+
+	if info.Path != "" || info.URI != "" || info.Display.Href != "" || info.Display.Safe {
+		t.Fatalf("path traversal artifact was exposed: %+v", info)
+	}
+	if !strings.Contains(info.Display.Reason, "outside configured artifact roots") {
+		t.Fatalf("expected outside-root reason, got %+v", info.Display)
+	}
+}
+
 func TestSerializerBlocksSymlinkEscape(t *testing.T) {
 	root := t.TempDir()
 	outside := filepath.Join(t.TempDir(), "secret.png")
@@ -74,6 +128,92 @@ func TestSerializerBlocksSymlinkEscape(t *testing.T) {
 
 	if path, ok := SafeLocalPath(link, []string{root}); ok {
 		t.Fatalf("symlink escape resolved as safe: %s", path)
+	}
+
+	info := NewSerializer([]string{root}, "/api/artifacts").Serialize(storage.JobArtifact{
+		ID:           10,
+		JobID:        "job-1",
+		Name:         "link",
+		ArtifactType: "screenshot",
+		MimeType:     "image/png",
+		URI:          link,
+	})
+	if info.Path != "" || info.URI != "" || info.Display.Href != "" || info.Display.Safe {
+		t.Fatalf("symlink escape artifact was exposed: %+v", info)
+	}
+}
+
+func TestSerializerBlocksUnsupportedLocalArtifactKind(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "proof.bin")
+	if err := os.WriteFile(path, []byte("opaque"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	info := NewSerializer([]string{root}, "/api/artifacts").Serialize(storage.JobArtifact{
+		ID:           11,
+		JobID:        "job-1",
+		Name:         "opaque",
+		ArtifactType: "binary_blob",
+		MimeType:     "application/octet-stream",
+		URI:          path,
+	})
+
+	if info.Path != "" || info.URI != "" || info.Display.Href != "" || info.Display.Safe {
+		t.Fatalf("unsupported local artifact was exposed: %+v", info)
+	}
+	if !strings.Contains(info.Display.Reason, "unsupported artifact kind") {
+		t.Fatalf("expected unsupported-kind reason, got %+v", info.Display)
+	}
+}
+
+func TestSerializerVerifiesPersistedLocalArtifactMetadata(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "proof.txt")
+	if err := os.WriteFile(path, []byte("proof"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	createdAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	row := storage.JobArtifact{
+		ID:           12,
+		JobID:        "job-1",
+		Name:         "proof",
+		ArtifactType: "file",
+		MimeType:     "text/plain",
+		URI:          path,
+		CreatedAt:    createdAt.Format(time.RFC3339),
+	}
+	metadata := BuildMetadata(row, "role:auditor", createdAt)
+	raw, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	row.Metadata = string(raw)
+
+	info := NewSerializer([]string{root}, "/api/artifacts").Serialize(row)
+	if !info.Display.Safe || info.Metadata == nil {
+		t.Fatalf("expected safe artifact metadata, got %+v", info)
+	}
+	expectedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("eval path: %v", err)
+	}
+	if info.Metadata.NormalizedPath != expectedPath || info.Metadata.Producer != "role:auditor" || info.Metadata.SHA256 == "" {
+		t.Fatalf("unexpected metadata: %+v", info.Metadata)
+	}
+	if info.Metadata.SizeBytes == nil || *info.Metadata.SizeBytes != int64(len("proof")) {
+		t.Fatalf("unexpected metadata size: %+v", info.Metadata)
+	}
+
+	if err := os.WriteFile(path, []byte("tampered"), 0o644); err != nil {
+		t.Fatalf("tamper artifact: %v", err)
+	}
+	info = NewSerializer([]string{root}, "/api/artifacts").Serialize(row)
+	if info.Display.Safe || info.Path != "" || info.Metadata != nil {
+		t.Fatalf("tampered artifact was exposed: %+v", info)
+	}
+	if !strings.Contains(info.Display.Reason, "metadata") {
+		t.Fatalf("expected metadata verification reason, got %+v", info.Display)
 	}
 }
 

--- a/internal/bot/role_commands.go
+++ b/internal/bot/role_commands.go
@@ -203,6 +203,7 @@ func (b *Bot) handleRoleRunCommand(c telebot.Context) error {
 	}
 
 	js := runtime.NewJobService(b.store)
+	js.SetArtifactRoots(b.artifactRoots)
 	flusher := b.lifecycleFlush
 	roleName := m.Name
 	runner := rolejob.AgentJobRunner(b.hub, m, input, opts)

--- a/internal/bot/role_commands_test.go
+++ b/internal/bot/role_commands_test.go
@@ -148,6 +148,34 @@ func TestFormatRoleJobFinalSuccessIncludesSummaryAndArtifactHints(t *testing.T) 
 	}
 }
 
+func TestFormatRoleJobFinalHiddenArtifactDoesNotLeakLocalPath(t *testing.T) {
+	unsafePath := "/tmp/ok-gobot-secret/proof.png"
+	out := formatRoleJobFinal(storage.Job{
+		JobID:   "job-unsafe",
+		Status:  "succeeded",
+		Summary: "done",
+	}, []artifactview.Info{{
+		ID:    8,
+		Label: "Secret screenshot",
+		Type:  "screenshot",
+		Path:  unsafePath,
+		Display: artifactview.DisplayMetadata{
+			Kind:   artifactview.KindImage,
+			Safe:   false,
+			Reason: "artifact file not found",
+		},
+	}})
+
+	for _, want := range []string{"Proof artifacts:", "Secret screenshot (#8): hidden (artifact file not found)"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in %q", want, out)
+		}
+	}
+	if strings.Contains(out, unsafePath) || strings.Contains(out, "/tmp/ok-gobot-secret") {
+		t.Fatalf("final notification leaked an unsafe local path: %q", out)
+	}
+}
+
 func TestFormatRoleJobFinalFailureIncludesReason(t *testing.T) {
 	out := formatRoleJobFinal(storage.Job{
 		JobID:  "job-err",

--- a/internal/control/server.go
+++ b/internal/control/server.go
@@ -95,7 +95,7 @@ func (s *Server) SetStore(store *storage.Store) {
 
 // SetArtifactRoots configures local roots that artifact file previews may read from.
 func (s *Server) SetArtifactRoots(roots []string) {
-	s.roots = artifactview.NormalizeRoots(roots)
+	s.roots = artifactview.ConfiguredRoots(roots)
 }
 
 func (s *Server) artifactRoots() []string {

--- a/internal/runtime/artifacts.go
+++ b/internal/runtime/artifacts.go
@@ -270,11 +270,11 @@ func safeLocalArtifactPath(raw string, roots []string) (string, bool) {
 	if raw == "" {
 		return "", false
 	}
-	normalizedRoots := artifactview.NormalizeRoots(roots)
-	if len(normalizedRoots) == 0 {
-		normalizedRoots = artifactview.DefaultRoots()
+	artifactRoots := artifactview.ConfiguredRoots(roots)
+	if len(artifactRoots) == 0 {
+		artifactRoots = artifactview.DefaultRoots()
 	}
-	path, err := artifactview.ContentPath(storage.JobArtifact{URI: raw}, normalizedRoots)
+	path, err := artifactview.ContentPath(storage.JobArtifact{URI: raw}, artifactRoots)
 	if err != nil {
 		return "", false
 	}

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/storage"
@@ -286,19 +287,27 @@ func (s *JobService) AppendEvidence(jobID, eventType, status, summary string, pa
 
 // AddArtifact persists one durable artifact and emits a matching artifact event.
 func (s *JobService) AddArtifact(jobID string, artifact JobArtifactSpec) error {
-	metaJSON, err := marshalPayload(artifact.Metadata)
-	if err != nil {
-		return err
-	}
-	if err := s.store.AddJobArtifact(storage.JobArtifact{
-		JobID:        strings.TrimSpace(jobID),
+	jobID = strings.TrimSpace(jobID)
+	row := storage.JobArtifact{
+		JobID:        jobID,
 		Name:         artifact.Name,
 		ArtifactType: artifact.Type,
 		MimeType:     artifact.MimeType,
 		Content:      artifact.Content,
 		URI:          artifact.URI,
-		Metadata:     metaJSON,
-	}); err != nil {
+	}
+	createdAt := time.Now().UTC()
+	producer := s.artifactProducer(jobID)
+	metadata, err := artifactMetadataPayload(artifact.Metadata, artifactview.BuildMetadata(row, producer, createdAt))
+	if err != nil {
+		return err
+	}
+	metaJSON, err := marshalPayload(metadata)
+	if err != nil {
+		return err
+	}
+	row.Metadata = metaJSON
+	if err := s.store.AddJobArtifact(row); err != nil {
 		return err
 	}
 	return s.AppendEvent(jobID, JobEventArtifactAdded, artifact.Name, map[string]any{
@@ -531,6 +540,92 @@ func (s *JobService) lookupCancel(jobID string) context.CancelFunc {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.active[jobID]
+}
+
+func (s *JobService) artifactProducer(jobID string) string {
+	if s != nil && s.store != nil && strings.TrimSpace(jobID) != "" {
+		if job, err := s.store.GetJob(jobID); err == nil && job != nil {
+			if roleName := strings.TrimSpace(job.RoleName); roleName != "" {
+				return "role:" + roleName
+			}
+			if worker := strings.TrimSpace(job.Worker); worker != "" {
+				return "worker:" + worker
+			}
+			if kind := strings.TrimSpace(job.Kind); kind != "" {
+				return kind
+			}
+		}
+	}
+	if strings.TrimSpace(jobID) != "" {
+		return "job:" + strings.TrimSpace(jobID)
+	}
+	return "job"
+}
+
+func artifactMetadataPayload(existing any, proof artifactview.Metadata) (map[string]any, error) {
+	payload, err := metadataObject(existing)
+	if err != nil {
+		return nil, err
+	}
+	if payload == nil {
+		payload = make(map[string]any)
+	}
+	if proof.Kind != "" {
+		payload["kind"] = proof.Kind
+	}
+	if proof.NormalizedPath != "" {
+		payload["normalized_path"] = proof.NormalizedPath
+	}
+	if proof.SizeBytes != nil {
+		payload["size_bytes"] = *proof.SizeBytes
+	}
+	if proof.SHA256 != "" {
+		payload["sha256"] = proof.SHA256
+	}
+	if proof.Producer != "" {
+		payload["producer"] = proof.Producer
+	}
+	if proof.CreatedAt != "" {
+		payload["created_at"] = proof.CreatedAt
+	}
+	return payload, nil
+}
+
+func metadataObject(existing any) (map[string]any, error) {
+	if existing == nil {
+		return nil, nil
+	}
+	if raw, ok := existing.(string); ok {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return nil, nil
+		}
+		var object map[string]any
+		if err := json.Unmarshal([]byte(raw), &object); err == nil && object != nil {
+			return object, nil
+		}
+		return map[string]any{"source_metadata": raw}, nil
+	}
+	if object, ok := existing.(map[string]any); ok {
+		copy := make(map[string]any, len(object))
+		for k, v := range object {
+			copy[k] = v
+		}
+		return copy, nil
+	}
+	raw, err := json.Marshal(existing)
+	if err != nil {
+		return nil, fmt.Errorf("marshal artifact metadata: %w", err)
+	}
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err == nil && object != nil {
+		return object, nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode artifact metadata: %w", err)
+	}
+	return map[string]any{"source_metadata": value}, nil
 }
 
 func marshalPayload(payload any) (string, error) {

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -117,7 +117,8 @@ func NewPreflightFailure(message string, details []string) error {
 
 // JobService persists and tracks first-class background jobs.
 type JobService struct {
-	store *storage.Store
+	store         *storage.Store
+	artifactRoots []string
 
 	mu     sync.Mutex
 	active map[string]context.CancelFunc
@@ -129,6 +130,16 @@ func NewJobService(store *storage.Store) *JobService {
 		store:  store,
 		active: make(map[string]context.CancelFunc),
 	}
+}
+
+// SetArtifactRoots configures local roots allowed for artifact metadata reads.
+func (s *JobService) SetArtifactRoots(roots []string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.artifactRoots = artifactview.ConfiguredRoots(roots)
+	s.mu.Unlock()
 }
 
 // StartDetached creates a durable job record and executes it in a goroutine.
@@ -287,6 +298,10 @@ func (s *JobService) AppendEvidence(jobID, eventType, status, summary string, pa
 
 // AddArtifact persists one durable artifact and emits a matching artifact event.
 func (s *JobService) AddArtifact(jobID string, artifact JobArtifactSpec) error {
+	return s.addArtifact(jobID, artifact, s.configuredArtifactRoots())
+}
+
+func (s *JobService) addArtifact(jobID string, artifact JobArtifactSpec, roots []string) error {
 	jobID = strings.TrimSpace(jobID)
 	row := storage.JobArtifact{
 		JobID:        jobID,
@@ -298,7 +313,7 @@ func (s *JobService) AddArtifact(jobID string, artifact JobArtifactSpec) error {
 	}
 	createdAt := time.Now().UTC()
 	producer := s.artifactProducer(jobID)
-	metadata, err := artifactMetadataPayload(artifact.Metadata, artifactview.BuildMetadata(row, producer, createdAt))
+	metadata, err := artifactMetadataPayload(artifact.Metadata, artifactview.BuildMetadataForRoots(row, producer, createdAt, roots))
 	if err != nil {
 		return err
 	}
@@ -438,15 +453,18 @@ func (s *JobService) run(parentCtx context.Context, job *storage.Job, spec JobSp
 
 	result, runErr := runner(ctx, job, s)
 	if runErr == nil {
+		artifactRoots := s.configuredArtifactRoots()
+		if len(spec.ArtifactRoots) > 0 {
+			artifactRoots = spec.ArtifactRoots
+		}
+		if len(result.ArtifactRoots) > 0 {
+			artifactRoots = result.ArtifactRoots
+		}
 		if isRoleJob(job) {
-			artifactRoots := spec.ArtifactRoots
-			if len(result.ArtifactRoots) > 0 {
-				artifactRoots = result.ArtifactRoots
-			}
 			result.Artifacts = roleProofArtifacts(result, artifactRoots)
 		}
 		for _, artifact := range result.Artifacts {
-			if err := s.AddArtifact(job.JobID, artifact); err != nil {
+			if err := s.addArtifact(job.JobID, artifact, artifactRoots); err != nil {
 				runErr = fmt.Errorf("persist artifact %q: %w", artifact.Name, err)
 				break
 			}
@@ -540,6 +558,15 @@ func (s *JobService) lookupCancel(jobID string) context.CancelFunc {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.active[jobID]
+}
+
+func (s *JobService) configuredArtifactRoots() []string {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.artifactRoots...)
 }
 
 func (s *JobService) artifactProducer(jobID string) string {

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -320,6 +320,7 @@ func TestJobServiceAddArtifactPersistsVerificationMetadata(t *testing.T) {
 	}
 
 	svc := NewJobService(store)
+	svc.SetArtifactRoots([]string{root})
 	if err := svc.AddArtifact("job-meta", JobArtifactSpec{
 		Name:     "proof",
 		Type:     JobArtifactTypeScreenshot,
@@ -357,6 +358,52 @@ func TestJobServiceAddArtifactPersistsVerificationMetadata(t *testing.T) {
 	}
 	if payload["source"] != "frontend_verify" {
 		t.Fatalf("source metadata was not preserved: %#v", payload)
+	}
+}
+
+func TestJobServiceAddArtifactDoesNotHashOutsideArtifactRoots(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write outside artifact: %v", err)
+	}
+	if err := store.CreateJob(storage.Job{JobID: "job-outside-meta", Kind: "role", Status: "running", Description: "metadata", RoleName: "auditor"}); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	svc := NewJobService(store)
+	svc.SetArtifactRoots([]string{root})
+	if err := svc.AddArtifact("job-outside-meta", JobArtifactSpec{
+		Name:     "outside",
+		Type:     JobArtifactTypeFile,
+		MimeType: "text/plain",
+		URI:      outside,
+	}); err != nil {
+		t.Fatalf("AddArtifact failed: %v", err)
+	}
+
+	artifacts, err := store.ListJobArtifacts("job-outside-meta", 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("artifact count = %d, want 1", len(artifacts))
+	}
+	meta := artifactview.ParseMetadata(artifacts[0].Metadata)
+	if meta == nil {
+		t.Fatalf("missing verification metadata: %q", artifacts[0].Metadata)
+	}
+	if meta.NormalizedPath != "" || meta.SizeBytes != nil || meta.SHA256 != "" {
+		t.Fatalf("outside-root artifact metadata leaked file details: %+v", meta)
+	}
+	info := artifactview.NewSerializer([]string{root}, "/api/artifacts").Serialize(artifacts[0])
+	if info.Display.Safe || info.Path != "" || info.Metadata != nil {
+		t.Fatalf("outside-root artifact was exposed: %+v", info)
 	}
 }
 

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -300,6 +301,62 @@ func TestJobServiceRoleSuccessPersistsSafeScreenshotArtifact(t *testing.T) {
 	info := artifactview.NewSerializer([]string{root}, "/api/artifacts").Serialize(*screenshot)
 	if info.Display.Kind != artifactview.KindImage || !info.Display.Safe || !info.Display.Preview || info.Path != shotPath {
 		t.Fatalf("screenshot is not display-safe: %+v", info)
+	}
+}
+
+func TestJobServiceAddArtifactPersistsVerificationMetadata(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	root := t.TempDir()
+	shotPath := filepath.Join(root, "proof.png")
+	if err := os.WriteFile(shotPath, []byte("png"), 0o644); err != nil {
+		t.Fatalf("write screenshot: %v", err)
+	}
+	if err := store.CreateJob(storage.Job{JobID: "job-meta", Kind: "role", Status: "running", Description: "metadata", RoleName: "auditor"}); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	svc := NewJobService(store)
+	if err := svc.AddArtifact("job-meta", JobArtifactSpec{
+		Name:     "proof",
+		Type:     JobArtifactTypeScreenshot,
+		MimeType: "image/png",
+		URI:      shotPath,
+		Metadata: map[string]any{"source": "frontend_verify"},
+	}); err != nil {
+		t.Fatalf("AddArtifact failed: %v", err)
+	}
+
+	artifacts, err := store.ListJobArtifacts("job-meta", 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("artifact count = %d, want 1", len(artifacts))
+	}
+	meta := artifactview.ParseMetadata(artifacts[0].Metadata)
+	if meta == nil {
+		t.Fatalf("missing verification metadata: %q", artifacts[0].Metadata)
+	}
+	expectedPath, err := filepath.EvalSymlinks(shotPath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks failed: %v", err)
+	}
+	if meta.Kind != artifactview.KindImage || meta.NormalizedPath != expectedPath || meta.Producer != "role:auditor" || meta.SHA256 == "" || meta.CreatedAt == "" {
+		t.Fatalf("unexpected verification metadata: %+v", meta)
+	}
+	if meta.SizeBytes == nil || *meta.SizeBytes != int64(len("png")) {
+		t.Fatalf("unexpected verification metadata size: %+v", meta)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(artifacts[0].Metadata), &payload); err != nil {
+		t.Fatalf("metadata JSON invalid: %v", err)
+	}
+	if payload["source"] != "frontend_verify" {
+		t.Fatalf("source metadata was not preserved: %#v", payload)
 	}
 }
 


### PR DESCRIPTION
Implements #369

## Changes
- Persist verification metadata for job artifacts, including kind, normalized path, size, SHA-256 hash, producer, and creation timestamp when available.
- Require local artifacts to resolve to existing non-directory files under configured safe roots before rendering or serving them.
- Hide missing, out-of-root, symlink-escaped, tampered, and unsupported artifacts with proof-view reasons while keeping Telegram/API/Mission Control on the shared serializer.

## Testing
- `bash .maestro/verify.sh` passed.
- `go test ./internal/artifacts/...`, `go test ./internal/runtime/...`, `go test ./internal/api/...`, `go test ./internal/control/...`, `go test ./internal/bot/...` passed.
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/` passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses the previously flagged issue where `BuildMetadata` could read and hash arbitrary on-disk files before any root validation. It replaces all call-sites with `BuildMetadataForRoots`, introduces a two-phase symlink-aware path validation (`validateLocalPath`), and adds serve-time tamper detection via SHA-256/size/path cross-checks against persisted metadata. The implementation is thorough: `ConfiguredRoots` correctly preserves symlink-spelled root paths for the pre-resolution check while `NormalizeRoots` is used for the post-resolution check, `hideArtifact` clears all sensitive fields before setting the reason, and `artifactMetadataPayload` merges caller metadata non-destructively while letting server-derived proof fields take authority.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are covered by targeted tests and no logic defects were found.

No P0 or P1 findings. The security concern raised in the previous review thread (unguarded file I/O in BuildMetadata) is fully resolved. Path validation, symlink escape prevention, tamper detection, and information hiding are all correct. Tests cover the key failure modes explicitly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/artifacts/display.go | Core of the PR — adds Metadata struct, ConfiguredRoots, validateLocalPath, verifyContentMetadata/verifyLocalMetadata, fileSHA256, and hideArtifact; logic is sound and the symlink-aware two-phase root check correctly gates both persist-time hashing and serve-time validation. |
| internal/runtime/jobs.go | AddArtifact now calls BuildMetadataForRoots so files outside configured roots are never hashed; run() correctly extends spec/result artifact-root overrides to non-role jobs with a proper fallback to s.configuredArtifactRoots(); thread-safety via mu is correct. |
| internal/artifacts/display_test.go | New tests cover missing file, path traversal, symlink escape, unsupported kind, tamper detection, and outside-root metadata; all cases match the intended security model. |
| internal/runtime/jobs_test.go | New tests verify that verification metadata is persisted correctly and that outside-root artifacts produce no hash/path metadata while being blocked at serve time. |
| internal/app/app.go | Wires artifact roots into JobService at startup; straightforward one-liner that mirrors how other servers (API, Mission Control) receive roots. |
| internal/bot/role_commands.go | Passes b.artifactRoots to the per-command JobService so Telegram-triggered role jobs use the same root set as the rest of the application. |
| internal/api/server.go | One-line rename from NormalizeRoots to ConfiguredRoots; consistent with the other server files. |
| internal/control/server.go | One-line rename from NormalizeRoots to ConfiguredRoots; consistent with the other server files. |
| internal/runtime/artifacts.go | NormalizeRoots → ConfiguredRoots in safeLocalArtifactPath; consistent with the refactor across all callers. |
| internal/bot/role_commands_test.go | New test confirms that hidden artifacts with local paths do not leak the filesystem path into Telegram notifications. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: gate artifact metadata reads by roo..."](https://github.com/befeast/ok-gobot/commit/45422d1f9744cd101c92dc1053d89750fd6d7de1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30508949)</sub>

<!-- /greptile_comment -->