### PR TITLE
feat: surface stale PR blockers (#370)

### DIFF
--- a/docs/MISSION-CONTROL.md
+++ b/docs/MISSION-CONTROL.md
@@ -30,7 +30,7 @@ api:
 | `/api/mission/providers` | GET | Active AI provider, backend identity, model tier/effort, health, and fallback decision |
 | `/api/mission/memory` | GET | Memory health: enabled state, backend, watcher, counts, freshness, and last error |
 | `/api/mission/evidence?session_key=...` | GET | Concise structured evidence timeline for a session, including Markdown rendering |
-| `/api/mission/supervisor` | GET | Current supervisor recovery decision and last safe action |
+| `/api/mission/supervisor` | GET | Current supervisor recovery decision, stale PR blockers, and last safe action |
 | `/api/mission/hygiene` | GET | Read-only Maestro stale-state hygiene summary with safe and approval-required recommendations |
 
 Job detail responses from `/api/jobs/{id}` include proof artifacts with `type`,
@@ -55,7 +55,7 @@ Run query parameters: `limit` (1-200), `status` (filter by run status). Stats qu
 - **Stats** -- aggregate token usage and message counts
 - **Controls** -- emergency-stop state plus active provider/model/backend health
 - **Memory** -- whether the memory index is enabled, fresh, watched, and error-free
-- **Supervisor** -- the current stuck-state decision, reason, planned approval action, and most recent safe recovery action
+- **Supervisor** -- the current stuck-state decision, stale or blocked PR reason, planned approval action, and most recent safe recovery action
 - **Hygiene** -- stale PRs, dead workers, stale approvals, checkout drift, orphaned worktrees, and policy-exhausted queues
 
 ## Architecture
@@ -90,6 +90,8 @@ Mission Control artifact browsing is read-only. It does not modify roles, start 
 Use `ok-gobot maestro dry-run` before starting a worker from GitHub issues. The command reports the next eligible issue and every skipped candidate with a reason. By default, only issues with `maestro.ready_label` are eligible, and issues labeled `blocked`, `epic`, `meta`, `question`, `wontfix`, `duplicate`, or `invalid` are skipped.
 
 Use `ok-gobot maestro status` when no worker is running. It explains whether a worker is idle because there is no eligible issue, or which issue would be selected next. Dependency lines such as `Depends on: #353` block intake until the dependency is closed or a referenced PR is merge-ready. Inline-code snippets, fenced examples, and example sections are ignored.
+
+`maestro status` also performs a read-only scan of open pull requests and prints concise blockers such as stale updates, non-mergeable merge state, failing CI, unresolved review feedback, or Greptile findings. Each line includes the PR number, state, last updated timestamp, relative age, and primary reason. It does not close, merge, delete branches, force-push, or bypass the intake policy.
 
 Maintainers can use `--override --override-reason "..."` to force the first open issue through the dry-run/status selection. The output and logs show that the maintainer override was used and list the gates it bypassed.
 

--- a/internal/cli/maestro.go
+++ b/internal/cli/maestro.go
@@ -5,11 +5,13 @@ import (
 	"io"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"ok-gobot/internal/config"
 	"ok-gobot/internal/maestro"
+	"ok-gobot/internal/prhygiene"
 )
 
 type maestroOptions struct {
@@ -19,6 +21,13 @@ type maestroOptions struct {
 	limit             int
 	override          bool
 	overrideReason    string
+}
+
+type maestroStatus struct {
+	Decision       maestro.Decision
+	PRBlockers     []prhygiene.Blocker
+	PRBlockerError string
+	Now            time.Time
 }
 
 func newMaestroCommand(cfg *config.Config) *cobra.Command {
@@ -56,12 +65,11 @@ func newMaestroStatusCommand(cfg *config.Config) *cobra.Command {
 		Use:   "status",
 		Short: "Explain why no Maestro worker is running",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Status reuses the intake dry-run until worker runtime state is tracked.
-			decision, err := runMaestroDryRun(cmd, opts)
+			status, err := runMaestroStatus(cmd, opts)
 			if err != nil {
 				return err
 			}
-			renderMaestroDecision(cmd.OutOrStdout(), decision, "status")
+			renderMaestroStatus(cmd.OutOrStdout(), status)
 			return nil
 		},
 	}
@@ -97,20 +105,13 @@ func bindMaestroFlags(cmd *cobra.Command, opts *maestroOptions) {
 	cmd.Flags().StringVar(&opts.repo, "repo", opts.repo, "GitHub repo owner/name (default: gh infers from cwd)")
 	cmd.Flags().StringVar(&opts.readyLabel, "ready-label", opts.readyLabel, "label required for default issue eligibility")
 	cmd.Flags().StringSliceVar(&opts.hardExcludeLabels, "hard-exclude-label", opts.hardExcludeLabels, "hard-exclude label; repeat or comma-separate")
-	cmd.Flags().IntVar(&opts.limit, "limit", opts.limit, "number of open issues to inspect")
+	cmd.Flags().IntVar(&opts.limit, "limit", opts.limit, "number of open issues and PRs to inspect")
 	cmd.Flags().BoolVar(&opts.override, "override", false, "maintainer override: select the first open issue despite intake gates")
 	cmd.Flags().StringVar(&opts.overrideReason, "override-reason", "", "visible reason for maintainer override")
 }
 
 func runMaestroDryRun(cmd *cobra.Command, opts maestroOptions) (maestro.Decision, error) {
-	policy := maestro.Policy{
-		Repo:              opts.repo,
-		ReadyLabel:        opts.readyLabel,
-		HardExcludeLabels: opts.hardExcludeLabels,
-		Limit:             opts.limit,
-		Override:          opts.override,
-		OverrideReason:    opts.overrideReason,
-	}
+	policy := maestroPolicy(opts)
 	if opts.override {
 		reason := strings.TrimSpace(opts.overrideReason)
 		if reason == "" {
@@ -119,6 +120,41 @@ func runMaestroDryRun(cmd *cobra.Command, opts maestroOptions) (maestro.Decision
 		log.Printf("[maestro] maintainer override enabled for intake dry-run: %s", reason)
 	}
 	return maestro.DryRun(cmd.Context(), maestro.NewGHClient(""), policy)
+}
+
+func runMaestroStatus(cmd *cobra.Command, opts maestroOptions) (maestroStatus, error) {
+	policy := maestroPolicy(opts)
+	client := maestro.NewGHClient("")
+	decision, err := maestro.DryRun(cmd.Context(), client, policy)
+	if err != nil {
+		return maestroStatus{}, err
+	}
+	now := time.Now()
+	blockers, blockerErr := client.ListOpenPullRequestBlockers(cmd.Context(), policy.Repo, policy.Limit, prhygiene.Options{
+		Now:        now,
+		StaleAfter: prhygiene.DefaultStaleAfter,
+	})
+	status := maestroStatus{Decision: decision, PRBlockers: blockers, Now: now}
+	if blockerErr != nil {
+		status.PRBlockerError = blockerErr.Error()
+	}
+	return status, nil
+}
+
+func maestroPolicy(opts maestroOptions) maestro.Policy {
+	return maestro.Policy{
+		Repo:              opts.repo,
+		ReadyLabel:        opts.readyLabel,
+		HardExcludeLabels: opts.hardExcludeLabels,
+		Limit:             opts.limit,
+		Override:          opts.override,
+		OverrideReason:    opts.overrideReason,
+	}
+}
+
+func renderMaestroStatus(out io.Writer, status maestroStatus) {
+	renderMaestroDecision(out, status.Decision, "status")
+	renderPRBlockers(out, status.PRBlockers, status.PRBlockerError, status.Now)
 }
 
 func renderMaestroDecision(out io.Writer, decision maestro.Decision, mode string) {
@@ -163,4 +199,33 @@ func renderMaestroDecision(out io.Writer, decision maestro.Decision, mode string
 		}
 		fmt.Fprintf(out, "  #%d %s - %s\n", skipped.Issue.Number, skipped.Issue.Title, reasons)
 	}
+}
+
+func renderPRBlockers(out io.Writer, blockers []prhygiene.Blocker, blockerErr string, now time.Time) {
+	if strings.TrimSpace(blockerErr) != "" {
+		fmt.Fprintf(out, "Pull request blockers: unavailable (%s)\n", blockerErr)
+		return
+	}
+	if len(blockers) == 0 {
+		fmt.Fprintln(out, "Pull request blockers: none")
+		return
+	}
+	fmt.Fprintln(out, "Pull request blockers:")
+	for _, blocker := range blockers {
+		fmt.Fprintf(out, "  %s\n", formatPRBlocker(blocker, now))
+	}
+}
+
+func formatPRBlocker(blocker prhygiene.Blocker, now time.Time) string {
+	updated := "unknown"
+	age := "unknown"
+	if !blocker.UpdatedAt.IsZero() {
+		updated = blocker.UpdatedAt.UTC().Format(time.RFC3339)
+		age = prhygiene.FormatAge(now, blocker.UpdatedAt)
+	}
+	state := strings.TrimSpace(blocker.State)
+	if state == "" {
+		state = "OPEN"
+	}
+	return fmt.Sprintf("#%d %s updated %s (%s ago) - %s", blocker.Number, state, updated, age, blocker.Reason)
 }

--- a/internal/cli/maestro_test.go
+++ b/internal/cli/maestro_test.go
@@ -8,6 +8,7 @@ import (
 
 	"ok-gobot/internal/hygiene"
 	"ok-gobot/internal/maestro"
+	"ok-gobot/internal/prhygiene"
 )
 
 func TestRenderMaestroDecisionExplainsNoWorker(t *testing.T) {
@@ -101,6 +102,35 @@ func TestRenderMaestroHygieneReportGroupsActions(t *testing.T) {
 		"session=agent:worker:main",
 		"pr=#42",
 		"worktree=/tmp/wt",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestRenderMaestroStatusShowsPRBlockers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	status := maestroStatus{
+		Decision: maestro.Decision{Policy: maestro.Policy{ReadyLabel: "ready"}},
+		Now:      now,
+		PRBlockers: []prhygiene.Blocker{{
+			Number:    279,
+			State:     "OPEN",
+			Kind:      prhygiene.KindStale,
+			Reason:    "stale: last updated 2026-03-30T20:20:23Z",
+			UpdatedAt: time.Date(2026, 3, 30, 20, 20, 23, 0, time.UTC),
+		}},
+	}
+	var out bytes.Buffer
+	renderMaestroStatus(&out, status)
+
+	got := out.String()
+	for _, want := range []string{
+		"Pull request blockers:",
+		"#279 OPEN updated 2026-03-30T20:20:23Z (31d ago) - stale: last updated 2026-03-30T20:20:23Z",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("output missing %q: %q", want, got)

--- a/internal/control/mission_supervisor_test.go
+++ b/internal/control/mission_supervisor_test.go
@@ -24,8 +24,10 @@ func TestMissionSupervisorReturnsCurrentDecisionAndLastSafeAction(t *testing.T) 
 				Subject:   "issue-356",
 				PRNumber:  42,
 				Reason:    "PR #42 has failing checks",
+				PRBlocker: &supervisor.PullRequestBlocker{Number: 42, State: "OPEN", Kind: supervisor.PRBlockerKindCI, Reason: "ci checks failing", UpdatedAt: now},
 				DecidedAt: now,
 			},
+			PRBlockers: []supervisor.PullRequestBlocker{{Number: 42, State: "OPEN", Kind: supervisor.PRBlockerKindCI, Reason: "ci checks failing", UpdatedAt: now}},
 			LastSafeAction: &supervisor.ActionRecord{
 				Subject:   "issue-356",
 				State:     supervisor.StatePRChecksFailing,
@@ -52,6 +54,9 @@ func TestMissionSupervisorReturnsCurrentDecisionAndLastSafeAction(t *testing.T) 
 	}
 	if got.LastSafeAction == nil || got.LastSafeAction.Action.Kind != supervisor.ActionCommentBlocker {
 		t.Fatalf("last safe action = %+v, want comment blocker", got.LastSafeAction)
+	}
+	if len(got.PRBlockers) != 1 || got.PRBlockers[0].Number != 42 || got.PRBlockers[0].Kind != supervisor.PRBlockerKindCI {
+		t.Fatalf("PR blockers = %+v, want CI blocker for #42", got.PRBlockers)
 	}
 }
 

--- a/internal/maestro/gh.go
+++ b/internal/maestro/gh.go
@@ -7,6 +7,9 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
+
+	"ok-gobot/internal/prhygiene"
 )
 
 // GHClient reads issue state through the GitHub CLI.
@@ -87,6 +90,38 @@ func (c *GHClient) ResolveDependency(ctx context.Context, defaultRepo string, re
 	return status, nil
 }
 
+func (c *GHClient) ListOpenPullRequests(ctx context.Context, repo string, limit int) ([]prhygiene.PullRequest, error) {
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+	args := []string{
+		"pr", "list",
+		"--state", "open",
+		"--limit", strconv.Itoa(limit),
+		"--json", "number,title,state,isDraft,createdAt,updatedAt,mergeStateStatus,reviewDecision,statusCheckRollup,latestReviews,comments,url",
+	}
+	if strings.TrimSpace(repo) != "" {
+		args = append(args, "--repo", repo)
+	}
+	out, err := c.run(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	prs, err := parsePullRequests(out)
+	if err != nil {
+		return nil, err
+	}
+	return prs, nil
+}
+
+func (c *GHClient) ListOpenPullRequestBlockers(ctx context.Context, repo string, limit int, opts prhygiene.Options) ([]prhygiene.Blocker, error) {
+	prs, err := c.ListOpenPullRequests(ctx, repo, limit)
+	if err != nil {
+		return nil, err
+	}
+	return prhygiene.DiagnoseAll(prs, opts), nil
+}
+
 func (c *GHClient) issueState(ctx context.Context, repo string, number int) (string, error) {
 	args := []string{"issue", "view", strconv.Itoa(number), "--json", "state", "--jq", ".state"}
 	if repo != "" {
@@ -125,6 +160,100 @@ func (c *GHClient) prStatus(ctx context.Context, repo string, number int) (Depen
 		MergeState:    mergeState,
 		Draft:         raw.IsDraft,
 	}, nil
+}
+
+func parsePullRequests(out []byte) ([]prhygiene.PullRequest, error) {
+	var raw []struct {
+		Number           int               `json:"number"`
+		Title            string            `json:"title"`
+		State            string            `json:"state"`
+		URL              string            `json:"url"`
+		IsDraft          bool              `json:"isDraft"`
+		MergeStateStatus string            `json:"mergeStateStatus"`
+		ReviewDecision   string            `json:"reviewDecision"`
+		CreatedAt        time.Time         `json:"createdAt"`
+		UpdatedAt        time.Time         `json:"updatedAt"`
+		StatusRollup     []json.RawMessage `json:"statusCheckRollup"`
+		LatestReviews    []struct {
+			State  string `json:"state"`
+			Body   string `json:"body"`
+			Author struct {
+				Login string `json:"login"`
+			} `json:"author"`
+		} `json:"latestReviews"`
+		Comments []struct {
+			Body   string `json:"body"`
+			Author struct {
+				Login string `json:"login"`
+			} `json:"author"`
+		} `json:"comments"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse gh pr list: %w", err)
+	}
+
+	prs := make([]prhygiene.PullRequest, 0, len(raw))
+	for _, item := range raw {
+		pr := prhygiene.PullRequest{
+			Number:         item.Number,
+			Title:          item.Title,
+			State:          item.State,
+			URL:            item.URL,
+			Draft:          item.IsDraft,
+			MergeState:     item.MergeStateStatus,
+			ReviewDecision: item.ReviewDecision,
+			CreatedAt:      item.CreatedAt,
+			UpdatedAt:      item.UpdatedAt,
+			Checks:         parseStatusRollup(item.StatusRollup),
+		}
+		for _, review := range item.LatestReviews {
+			pr.Reviews = append(pr.Reviews, prhygiene.Review{
+				Author: review.Author.Login,
+				State:  review.State,
+				Body:   review.Body,
+			})
+		}
+		for _, comment := range item.Comments {
+			pr.Comments = append(pr.Comments, prhygiene.Comment{
+				Author: comment.Author.Login,
+				Body:   comment.Body,
+			})
+		}
+		prs = append(prs, pr)
+	}
+	return prs, nil
+}
+
+func parseStatusRollup(raw []json.RawMessage) []prhygiene.Check {
+	checks := make([]prhygiene.Check, 0, len(raw))
+	for _, item := range raw {
+		var fields map[string]interface{}
+		if err := json.Unmarshal(item, &fields); err != nil {
+			continue
+		}
+		check := prhygiene.Check{
+			Name:         stringField(fields, "name"),
+			WorkflowName: stringField(fields, "workflowName"),
+			Status:       stringField(fields, "status"),
+			Conclusion:   stringField(fields, "conclusion"),
+		}
+		if check.Name == "" {
+			check.Name = stringField(fields, "context")
+		}
+		if check.Conclusion == "" {
+			check.Conclusion = stringField(fields, "state")
+		}
+		if check.Status == "" {
+			check.Status = stringField(fields, "state")
+		}
+		checks = append(checks, check)
+	}
+	return checks
+}
+
+func stringField(fields map[string]interface{}, key string) string {
+	value, _ := fields[key].(string)
+	return value
 }
 
 func refFromNumber(repo string, number int) DependencyRef {

--- a/internal/maestro/gh_test.go
+++ b/internal/maestro/gh_test.go
@@ -1,0 +1,60 @@
+package maestro
+
+import (
+	"strings"
+	"testing"
+
+	"ok-gobot/internal/prhygiene"
+)
+
+func TestParsePullRequestsMapsGitHubStatusMetadata(t *testing.T) {
+	jsonBody := `[
+		{
+			"number": 242,
+			"title": "feat: implement Verification Gate and Paranoid Protocol (#195)",
+			"state": "OPEN",
+			"url": "https://github.com/BeFeast/ok-gobot/pull/242",
+			"isDraft": false,
+			"createdAt": "2026-03-25T13:49:32Z",
+			"updatedAt": "2026-03-25T13:56:42Z",
+			"mergeStateStatus": "DIRTY",
+			"reviewDecision": "",
+			"statusCheckRollup": [
+				{"__typename":"CheckRun","name":"Greptile Review","workflowName":"","status":"COMPLETED","conclusion":"SUCCESS"},
+				{"__typename":"StatusContext","context":"ci/test","state":"FAILURE"}
+			],
+			"latestReviews": [
+				{"author":{"login":"reviewer"},"state":"CHANGES_REQUESTED","body":"Please address this."}
+			],
+			"comments": [
+				{"author":{"login":"greptile-apps"},"body":"1 finding requires attention"}
+			]
+		}
+	]`
+
+	prs, err := parsePullRequests([]byte(jsonBody))
+	if err != nil {
+		t.Fatalf("parsePullRequests failed: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("PR count = %d, want 1", len(prs))
+	}
+	pr := prs[0]
+	if pr.Number != 242 || pr.MergeState != "DIRTY" || pr.URL == "" || pr.UpdatedAt.IsZero() {
+		t.Fatalf("unexpected PR metadata: %+v", pr)
+	}
+	if len(pr.Checks) != 2 || pr.Checks[1].Name != "ci/test" || pr.Checks[1].Conclusion != "FAILURE" {
+		t.Fatalf("checks not mapped: %+v", pr.Checks)
+	}
+	if len(pr.Reviews) != 1 || pr.Reviews[0].State != "CHANGES_REQUESTED" {
+		t.Fatalf("reviews not mapped: %+v", pr.Reviews)
+	}
+	if len(pr.Comments) != 1 || !strings.Contains(pr.Comments[0].Body, "requires attention") {
+		t.Fatalf("comments not mapped: %+v", pr.Comments)
+	}
+
+	blocker, ok := prhygiene.Diagnose(pr, prhygiene.Options{})
+	if !ok || blocker.Kind != prhygiene.KindGreptile {
+		t.Fatalf("blocker = %+v, want Greptile blocker", blocker)
+	}
+}

--- a/internal/prhygiene/hygiene.go
+++ b/internal/prhygiene/hygiene.go
@@ -1,0 +1,336 @@
+package prhygiene
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DefaultStaleAfter is the default age for surfacing an otherwise quiet open PR.
+const DefaultStaleAfter = 14 * 24 * time.Hour
+
+// Kind identifies the primary merge-readiness blocker for an open PR.
+type Kind string
+
+const (
+	KindGreptile     Kind = "greptile"
+	KindCI           Kind = "ci"
+	KindReview       Kind = "review"
+	KindNonMergeable Kind = "non_mergeable"
+	KindStale        Kind = "stale"
+)
+
+// PullRequest is the read-only GitHub metadata needed for PR hygiene diagnosis.
+type PullRequest struct {
+	Number         int
+	Title          string
+	State          string
+	URL            string
+	Draft          bool
+	MergeState     string
+	ReviewDecision string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	Checks         []Check
+	Reviews        []Review
+	Comments       []Comment
+}
+
+// Check is one CI or app check from a PR status rollup.
+type Check struct {
+	Name         string
+	WorkflowName string
+	Status       string
+	Conclusion   string
+}
+
+// Review is one PR review summary.
+type Review struct {
+	Author string
+	State  string
+	Body   string
+}
+
+// Comment is one PR timeline or review comment summary.
+type Comment struct {
+	Author string
+	Body   string
+}
+
+// Options controls blocker diagnosis.
+type Options struct {
+	Now        time.Time
+	StaleAfter time.Duration
+}
+
+// Blocker is the concise operator-facing reason a PR needs attention.
+type Blocker struct {
+	Number    int       `json:"number"`
+	Title     string    `json:"title,omitempty"`
+	URL       string    `json:"url,omitempty"`
+	State     string    `json:"state,omitempty"`
+	Kind      Kind      `json:"kind"`
+	Reason    string    `json:"reason"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+// Diagnose returns the primary blocker for one open PR, if any.
+func Diagnose(pr PullRequest, opts Options) (Blocker, bool) {
+	if pr.Number <= 0 || !isOpen(pr.State) {
+		return Blocker{}, false
+	}
+	opts = normalizeOptions(opts)
+
+	if name, ok := greptileBlocker(pr); ok {
+		return makeBlocker(pr, KindGreptile, fmt.Sprintf("greptile findings require attention (%s)", name)), true
+	}
+	if name, ok := failingCICheck(pr); ok {
+		return makeBlocker(pr, KindCI, fmt.Sprintf("ci checks failing (%s)", name)), true
+	}
+	if reviewBlocked(pr) {
+		return makeBlocker(pr, KindReview, "unresolved review feedback"), true
+	}
+	if reason, ok := nonMergeableReason(pr); ok {
+		return makeBlocker(pr, KindNonMergeable, reason), true
+	}
+	if stale(pr, opts) {
+		updated := lastUpdated(pr)
+		return makeBlocker(pr, KindStale, fmt.Sprintf("stale: last updated %s", updated.UTC().Format(time.RFC3339))), true
+	}
+
+	return Blocker{}, false
+}
+
+// DiagnoseAll returns deterministic blocker results for open PRs.
+func DiagnoseAll(prs []PullRequest, opts Options) []Blocker {
+	blockers := make([]Blocker, 0, len(prs))
+	for _, pr := range prs {
+		blocker, ok := Diagnose(pr, opts)
+		if ok {
+			blockers = append(blockers, blocker)
+		}
+	}
+	sort.SliceStable(blockers, func(i, j int) bool {
+		pi := kindPriority(blockers[i].Kind)
+		pj := kindPriority(blockers[j].Kind)
+		if pi != pj {
+			return pi < pj
+		}
+		if !blockers[i].UpdatedAt.Equal(blockers[j].UpdatedAt) {
+			if blockers[i].UpdatedAt.IsZero() {
+				return false
+			}
+			if blockers[j].UpdatedAt.IsZero() {
+				return true
+			}
+			return blockers[i].UpdatedAt.Before(blockers[j].UpdatedAt)
+		}
+		return blockers[i].Number < blockers[j].Number
+	})
+	return blockers
+}
+
+// Fingerprint is stable across repeated polls while the PR metadata is unchanged.
+func (b Blocker) Fingerprint() string {
+	updated := ""
+	if !b.UpdatedAt.IsZero() {
+		updated = b.UpdatedAt.UTC().Format(time.RFC3339)
+	}
+	return fmt.Sprintf("#%d:%s:%s:%s", b.Number, strings.ToUpper(strings.TrimSpace(b.State)), b.Kind, updated)
+}
+
+// FormatAge returns a compact relative age for status output.
+func FormatAge(now, then time.Time) string {
+	if then.IsZero() {
+		return "unknown"
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	d := now.Sub(then)
+	if d < 0 {
+		d = 0
+	}
+	if d >= 48*time.Hour {
+		return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
+	}
+	if d >= 2*time.Hour {
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	}
+	if d >= 2*time.Minute {
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	}
+	return fmt.Sprintf("%ds", int(d/time.Second))
+}
+
+func normalizeOptions(opts Options) Options {
+	if opts.Now.IsZero() {
+		opts.Now = time.Now()
+	}
+	if opts.StaleAfter <= 0 {
+		opts.StaleAfter = DefaultStaleAfter
+	}
+	return opts
+}
+
+func makeBlocker(pr PullRequest, kind Kind, reason string) Blocker {
+	return Blocker{
+		Number:    pr.Number,
+		Title:     strings.TrimSpace(pr.Title),
+		URL:       strings.TrimSpace(pr.URL),
+		State:     normalizedState(pr.State),
+		Kind:      kind,
+		Reason:    reason,
+		CreatedAt: pr.CreatedAt,
+		UpdatedAt: lastUpdated(pr),
+	}
+}
+
+func isOpen(state string) bool {
+	state = strings.TrimSpace(state)
+	return state == "" || strings.EqualFold(state, "open")
+}
+
+func normalizedState(state string) string {
+	state = strings.TrimSpace(state)
+	if state == "" {
+		return "OPEN"
+	}
+	return strings.ToUpper(state)
+}
+
+func greptileBlocker(pr PullRequest) (string, bool) {
+	for _, check := range pr.Checks {
+		if !mentionsGreptile(check.Name, check.WorkflowName) || !checkFailing(check) {
+			continue
+		}
+		return checkLabel(check), true
+	}
+	for _, review := range pr.Reviews {
+		if !mentionsGreptile(review.Author, review.Body) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(review.State), "CHANGES_REQUESTED") || bodySuggestsFindings(review.Body) {
+			return "Greptile review", true
+		}
+	}
+	for _, comment := range pr.Comments {
+		if mentionsGreptile(comment.Author, comment.Body) && bodySuggestsFindings(comment.Body) {
+			return "Greptile comment", true
+		}
+	}
+	return "", false
+}
+
+func failingCICheck(pr PullRequest) (string, bool) {
+	for _, check := range pr.Checks {
+		if mentionsGreptile(check.Name, check.WorkflowName) || !checkFailing(check) {
+			continue
+		}
+		return checkLabel(check), true
+	}
+	return "", false
+}
+
+func checkFailing(check Check) bool {
+	conclusion := strings.ToLower(strings.TrimSpace(check.Conclusion))
+	status := strings.ToLower(strings.TrimSpace(check.Status))
+	switch conclusion {
+	case "failure", "failed", "error", "timed_out", "action_required", "startup_failure", "cancelled", "stale":
+		return true
+	case "":
+		switch status {
+		case "failure", "failed", "error":
+			return true
+		}
+	}
+	return false
+}
+
+func reviewBlocked(pr PullRequest) bool {
+	if strings.EqualFold(strings.TrimSpace(pr.ReviewDecision), "CHANGES_REQUESTED") {
+		return true
+	}
+	for _, review := range pr.Reviews {
+		if strings.EqualFold(strings.TrimSpace(review.State), "CHANGES_REQUESTED") {
+			return true
+		}
+	}
+	return false
+}
+
+func nonMergeableReason(pr PullRequest) (string, bool) {
+	if pr.Draft {
+		return "not mergeable: draft PR", true
+	}
+	mergeState := strings.ToUpper(strings.TrimSpace(pr.MergeState))
+	switch mergeState {
+	case "", "UNKNOWN", "CLEAN", "HAS_HOOKS":
+		return "", false
+	default:
+		return fmt.Sprintf("not mergeable: merge_state=%s", mergeState), true
+	}
+}
+
+func stale(pr PullRequest, opts Options) bool {
+	updated := lastUpdated(pr)
+	return !updated.IsZero() && opts.Now.Sub(updated) >= opts.StaleAfter
+}
+
+func lastUpdated(pr PullRequest) time.Time {
+	if !pr.UpdatedAt.IsZero() {
+		return pr.UpdatedAt
+	}
+	return pr.CreatedAt
+}
+
+func mentionsGreptile(values ...string) bool {
+	for _, value := range values {
+		if strings.Contains(strings.ToLower(value), "greptile") {
+			return true
+		}
+	}
+	return false
+}
+
+func bodySuggestsFindings(body string) bool {
+	body = strings.ToLower(body)
+	if strings.Contains(body, "no finding") || strings.Contains(body, "no issue") {
+		return false
+	}
+	for _, marker := range []string{"requires attention", "require attention", "finding", "issue found", "issues found", "unresolved"} {
+		if strings.Contains(body, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func checkLabel(check Check) string {
+	if name := strings.TrimSpace(check.Name); name != "" {
+		return name
+	}
+	if workflow := strings.TrimSpace(check.WorkflowName); workflow != "" {
+		return workflow
+	}
+	return "unknown check"
+}
+
+func kindPriority(kind Kind) int {
+	switch kind {
+	case KindGreptile:
+		return 0
+	case KindCI:
+		return 1
+	case KindReview:
+		return 2
+	case KindNonMergeable:
+		return 3
+	case KindStale:
+		return 4
+	default:
+		return 5
+	}
+}

--- a/internal/prhygiene/hygiene.go
+++ b/internal/prhygiene/hygiene.go
@@ -209,10 +209,16 @@ func greptileBlocker(pr PullRequest) (string, bool) {
 		return checkLabel(check), true
 	}
 	for _, review := range pr.Reviews {
-		if !mentionsGreptile(review.Author, review.Body) {
+		if mentionsGreptile(review.Author) {
+			if strings.EqualFold(strings.TrimSpace(review.State), "CHANGES_REQUESTED") || bodySuggestsFindings(review.Body) {
+				return "Greptile review", true
+			}
 			continue
 		}
-		if strings.EqualFold(strings.TrimSpace(review.State), "CHANGES_REQUESTED") || bodySuggestsFindings(review.Body) {
+		if strings.EqualFold(strings.TrimSpace(review.State), "CHANGES_REQUESTED") {
+			continue
+		}
+		if mentionsGreptile(review.Body) && bodySuggestsFindings(review.Body) {
 			return "Greptile review", true
 		}
 	}

--- a/internal/prhygiene/hygiene_test.go
+++ b/internal/prhygiene/hygiene_test.go
@@ -61,6 +61,24 @@ func TestDiagnoseIgnoresHealthyRecentPR(t *testing.T) {
 	}
 }
 
+func TestDiagnoseTreatsHumanGreptileMentionAsReviewFeedback(t *testing.T) {
+	blocker, ok := Diagnose(PullRequest{
+		Number: 370,
+		State:  "OPEN",
+		Reviews: []Review{{
+			Author: "human-reviewer",
+			State:  "CHANGES_REQUESTED",
+			Body:   "Please also address the Greptile findings.",
+		}},
+	}, Options{})
+	if !ok {
+		t.Fatal("expected review blocker")
+	}
+	if blocker.Kind != KindReview {
+		t.Fatalf("blocker kind = %q, want %q", blocker.Kind, KindReview)
+	}
+}
+
 func TestBlockerFingerprintIsStableAcrossPolls(t *testing.T) {
 	updated := time.Date(2026, 3, 30, 20, 20, 23, 0, time.UTC)
 	pr := PullRequest{Number: 279, State: "OPEN", MergeState: "CLEAN", UpdatedAt: updated}

--- a/internal/prhygiene/hygiene_test.go
+++ b/internal/prhygiene/hygiene_test.go
@@ -1,0 +1,97 @@
+package prhygiene
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDiagnoseAllDistinguishesPRBlockers(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	prs := []PullRequest{
+		{
+			Number:     242,
+			Title:      "feat: implement Verification Gate and Paranoid Protocol (#195)",
+			State:      "OPEN",
+			MergeState: "DIRTY",
+			UpdatedAt:  time.Date(2026, 3, 25, 13, 56, 42, 0, time.UTC),
+		},
+		{
+			Number:     279,
+			Title:      "test(agent): expand reflection test coverage (#243)",
+			State:      "OPEN",
+			MergeState: "CLEAN",
+			UpdatedAt:  time.Date(2026, 3, 30, 20, 20, 23, 0, time.UTC),
+		},
+		{
+			Number: 301,
+			State:  "OPEN",
+			Checks: []Check{{Name: "test", Conclusion: "failure"}},
+		},
+		{
+			Number:         302,
+			State:          "OPEN",
+			ReviewDecision: "CHANGES_REQUESTED",
+		},
+		{
+			Number: 303,
+			State:  "OPEN",
+			Checks: []Check{{Name: "Greptile Review", Conclusion: "failure"}},
+		},
+	}
+
+	blockers := DiagnoseAll(prs, Options{Now: now, StaleAfter: DefaultStaleAfter})
+	assertBlockerKind(t, blockers, 242, KindNonMergeable)
+	assertBlockerKind(t, blockers, 279, KindStale)
+	assertBlockerKind(t, blockers, 301, KindCI)
+	assertBlockerKind(t, blockers, 302, KindReview)
+	assertBlockerKind(t, blockers, 303, KindGreptile)
+}
+
+func TestDiagnoseIgnoresHealthyRecentPR(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	_, ok := Diagnose(PullRequest{
+		Number:     44,
+		State:      "OPEN",
+		MergeState: "CLEAN",
+		UpdatedAt:  now.Add(-time.Hour),
+		Checks:     []Check{{Name: "test", Conclusion: "success"}},
+	}, Options{Now: now})
+	if ok {
+		t.Fatal("expected no blocker for healthy recent PR")
+	}
+}
+
+func TestBlockerFingerprintIsStableAcrossPolls(t *testing.T) {
+	updated := time.Date(2026, 3, 30, 20, 20, 23, 0, time.UTC)
+	pr := PullRequest{Number: 279, State: "OPEN", MergeState: "CLEAN", UpdatedAt: updated}
+	first, ok := Diagnose(pr, Options{Now: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)})
+	if !ok {
+		t.Fatal("expected stale blocker")
+	}
+	second, ok := Diagnose(pr, Options{Now: time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)})
+	if !ok {
+		t.Fatal("expected stale blocker on second poll")
+	}
+	if first.Fingerprint() != second.Fingerprint() {
+		t.Fatalf("fingerprint changed: %q vs %q", first.Fingerprint(), second.Fingerprint())
+	}
+	if first.Reason != second.Reason {
+		t.Fatalf("reason changed: %q vs %q", first.Reason, second.Reason)
+	}
+}
+
+func assertBlockerKind(t *testing.T, blockers []Blocker, number int, kind Kind) {
+	t.Helper()
+	for _, blocker := range blockers {
+		if blocker.Number == number {
+			if blocker.Kind != kind {
+				t.Fatalf("PR #%d kind = %q, want %q", number, blocker.Kind, kind)
+			}
+			if blocker.State != "OPEN" || blocker.Reason == "" {
+				t.Fatalf("PR #%d blocker missing state/reason: %+v", number, blocker)
+			}
+			return
+		}
+	}
+	t.Fatalf("PR #%d not found in blockers: %+v", number, blockers)
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"ok-gobot/internal/prhygiene"
 )
 
 // StuckState is the supervisor's normalized view of one recoverable stuck state.
@@ -18,7 +21,9 @@ const (
 	StateBranchWithoutPR      StuckState = "dead_worker_branch_without_pr"
 	StatePRChecksFailing      StuckState = "pr_checks_failing"
 	StatePRReviewFeedback     StuckState = "pr_review_feedback"
+	StatePRGreptileFindings   StuckState = "pr_greptile_findings"
 	StatePRBranchDirty        StuckState = "pr_branch_behind_or_dirty"
+	StatePRStale              StuckState = "stale_open_pr"
 	StateRetryExhaustedOpenPR StuckState = "retry_exhausted_open_pr"
 	StateReadyForMerge        StuckState = "checks_green_waiting_for_merge_approval"
 )
@@ -62,16 +67,34 @@ const (
 	ApprovalMergePR ApprovalKind = "merge_pr"
 )
 
-const defaultStaleAfter = 30 * time.Minute
+const (
+	defaultStaleAfter   = 30 * time.Minute
+	defaultPRStaleAfter = prhygiene.DefaultStaleAfter
+)
+
+// PullRequestBlocker is the Mission Control PR hygiene payload.
+type PullRequestBlocker = prhygiene.Blocker
+
+// PRBlockerKind identifies the primary class of a pull request blocker.
+type PRBlockerKind = prhygiene.Kind
+
+const (
+	PRBlockerKindGreptile     PRBlockerKind = prhygiene.KindGreptile
+	PRBlockerKindCI           PRBlockerKind = prhygiene.KindCI
+	PRBlockerKindReview       PRBlockerKind = prhygiene.KindReview
+	PRBlockerKindNonMergeable PRBlockerKind = prhygiene.KindNonMergeable
+	PRBlockerKindStale        PRBlockerKind = prhygiene.KindStale
+)
 
 // Observation is a single issue/worker/PR snapshot supplied to the supervisor.
 type Observation struct {
-	Subject     string
-	IssueNumber int
-	Now         time.Time
-	StaleAfter  time.Duration
-	Worker      WorkerSnapshot
-	PR          *PullRequestSnapshot
+	Subject      string
+	IssueNumber  int
+	Now          time.Time
+	StaleAfter   time.Duration
+	PRStaleAfter time.Duration
+	Worker       WorkerSnapshot
+	PR           *PullRequestSnapshot
 }
 
 // WorkerSnapshot describes the local worker and branch state for one issue.
@@ -88,12 +111,20 @@ type WorkerSnapshot struct {
 
 // PullRequestSnapshot describes the metadata the supervisor needs from GitHub.
 type PullRequestSnapshot struct {
-	Number       int
-	Open         bool
-	Checks       CheckState
-	Review       ReviewState
-	BranchBehind bool
-	DirtyMerge   bool
+	Number           int
+	Title            string
+	State            string
+	URL              string
+	Open             bool
+	Draft            bool
+	MergeState       string
+	Checks           CheckState
+	Review           ReviewState
+	GreptileFindings bool
+	BranchBehind     bool
+	DirtyMerge       bool
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
 }
 
 // Action is a safe recovery operation selected by the supervisor.
@@ -112,15 +143,16 @@ type ApprovalAction struct {
 
 // Decision is the supervisor's current recovery decision for one subject.
 type Decision struct {
-	State           StuckState       `json:"state"`
-	Subject         string           `json:"subject"`
-	IssueNumber     int              `json:"issue_number,omitempty"`
-	PRNumber        int              `json:"pr_number,omitempty"`
-	Branch          string           `json:"branch,omitempty"`
-	Reason          string           `json:"reason,omitempty"`
-	SafeActions     []Action         `json:"safe_actions,omitempty"`
-	ApprovalActions []ApprovalAction `json:"approval_actions,omitempty"`
-	DecidedAt       time.Time        `json:"decided_at,omitempty"`
+	State           StuckState         `json:"state"`
+	Subject         string             `json:"subject"`
+	IssueNumber     int                `json:"issue_number,omitempty"`
+	PRNumber        int                `json:"pr_number,omitempty"`
+	Branch          string             `json:"branch,omitempty"`
+	Reason          string             `json:"reason,omitempty"`
+	PRBlocker       *prhygiene.Blocker `json:"pr_blocker,omitempty"`
+	SafeActions     []Action           `json:"safe_actions,omitempty"`
+	ApprovalActions []ApprovalAction   `json:"approval_actions,omitempty"`
+	DecidedAt       time.Time          `json:"decided_at,omitempty"`
 }
 
 // ActionRecord records a safe action run by the supervisor.
@@ -135,6 +167,7 @@ type ActionRecord struct {
 type Status struct {
 	CurrentDecision  *Decision           `json:"current_decision,omitempty"`
 	CurrentDecisions map[string]Decision `json:"current_decisions,omitempty"`
+	PRBlockers       []prhygiene.Blocker `json:"pr_blockers,omitempty"`
 	LastSafeAction   *ActionRecord       `json:"last_safe_action,omitempty"`
 	UpdatedAt        time.Time           `json:"updated_at,omitempty"`
 }
@@ -280,6 +313,10 @@ func Evaluate(observation Observation) Decision {
 	if staleAfter <= 0 {
 		staleAfter = defaultStaleAfter
 	}
+	prStaleAfter := observation.PRStaleAfter
+	if prStaleAfter <= 0 {
+		prStaleAfter = defaultPRStaleAfter
+	}
 
 	worker := observation.Worker
 	pr := observation.PR
@@ -299,6 +336,11 @@ func Evaluate(observation Observation) Decision {
 			}},
 			DecidedAt: now,
 		}
+	}
+	withPRBlocker := func(decision Decision, kind prhygiene.Kind, reason string) Decision {
+		blocker := prBlocker(pr, kind, reason)
+		decision.PRBlocker = &blocker
+		return decision
 	}
 
 	if worker.Running && !worker.LastLogAt.IsZero() && now.Sub(worker.LastLogAt) >= staleAfter {
@@ -338,9 +380,18 @@ func Evaluate(observation Observation) Decision {
 		return decision
 	}
 
+	if hasOpenPR(pr) && pr.GreptileFindings {
+		reason := fmt.Sprintf("PR #%d has Greptile findings requiring attention", pr.Number)
+		decision := base(StatePRGreptileFindings, reason)
+		decision = withPRBlocker(decision, prhygiene.KindGreptile, "greptile findings require attention")
+		decision.SafeActions = append(decision.SafeActions, Action{Kind: ActionRefreshMetadata, Target: prTarget(pr), Reason: reason})
+		return decision
+	}
+
 	if hasOpenPR(pr) && pr.Checks == ChecksFailing {
 		reason := fmt.Sprintf("PR #%d has failing checks", pr.Number)
 		decision := base(StatePRChecksFailing, reason)
+		decision = withPRBlocker(decision, prhygiene.KindCI, "ci checks failing")
 		decision.SafeActions = append(decision.SafeActions,
 			Action{Kind: ActionRefreshMetadata, Target: prTarget(pr), Reason: reason},
 			Action{Kind: ActionCommentBlocker, Target: prTarget(pr), Reason: reason},
@@ -352,6 +403,7 @@ func Evaluate(observation Observation) Decision {
 	if hasOpenPR(pr) && pr.Review == ReviewActionable {
 		reason := fmt.Sprintf("PR #%d has actionable review feedback", pr.Number)
 		decision := base(StatePRReviewFeedback, reason)
+		decision = withPRBlocker(decision, prhygiene.KindReview, "unresolved review feedback")
 		decision.SafeActions = append(decision.SafeActions,
 			Action{Kind: ActionRefreshMetadata, Target: prTarget(pr), Reason: reason},
 			Action{Kind: ActionCommentBlocker, Target: prTarget(pr), Reason: reason},
@@ -360,14 +412,27 @@ func Evaluate(observation Observation) Decision {
 		return decision
 	}
 
-	if hasOpenPR(pr) && (pr.BranchBehind || pr.DirtyMerge) {
-		reason := fmt.Sprintf("PR #%d branch is behind or has a dirty merge state", pr.Number)
+	if hasOpenPR(pr) && (pr.BranchBehind || pr.DirtyMerge || prNonMergeable(pr)) {
+		reason := fmt.Sprintf("PR #%d is not mergeable", pr.Number)
+		if mergeState := strings.TrimSpace(pr.MergeState); mergeState != "" {
+			reason = fmt.Sprintf("PR #%d is not mergeable (merge_state=%s)", pr.Number, strings.ToUpper(mergeState))
+		}
 		decision := base(StatePRBranchDirty, reason)
+		decision = withPRBlocker(decision, prhygiene.KindNonMergeable, reason)
 		decision.SafeActions = append(decision.SafeActions,
 			Action{Kind: ActionRefreshMetadata, Target: prTarget(pr), Reason: reason},
 			Action{Kind: ActionCommentBlocker, Target: prTarget(pr), Reason: reason},
 			Action{Kind: ActionLabelBlocked, Target: subject, Reason: reason},
 		)
+		return decision
+	}
+
+	if hasOpenPR(pr) && prStale(pr, now, prStaleAfter) {
+		updated := prUpdatedAt(pr)
+		reason := fmt.Sprintf("PR #%d is stale: last updated %s", pr.Number, updated.UTC().Format(time.RFC3339))
+		decision := base(StatePRStale, reason)
+		decision = withPRBlocker(decision, prhygiene.KindStale, reason)
+		decision.SafeActions = append(decision.SafeActions, Action{Kind: ActionRefreshMetadata, Target: prTarget(pr), Reason: reason})
 		return decision
 	}
 
@@ -394,6 +459,7 @@ func (s *Supervisor) recordHealthy(decision Decision) {
 	delete(s.lastState, decision.Subject)
 	delete(s.activeDecisions, decision.Subject)
 	s.status.CurrentDecisions = cloneDecisionMap(s.activeDecisions)
+	s.status.PRBlockers = blockerList(s.activeDecisions)
 
 	if s.status.CurrentDecision == nil || s.status.CurrentDecision.State == StateNone || s.status.CurrentDecision.Subject == decision.Subject {
 		if replacement, ok := newestDecision(s.activeDecisions); ok {
@@ -417,6 +483,7 @@ func (s *Supervisor) recordDecision(decision Decision) bool {
 	decisionCopy := cloneDecision(decision)
 	s.status.CurrentDecision = &decisionCopy
 	s.status.CurrentDecisions = cloneDecisionMap(s.activeDecisions)
+	s.status.PRBlockers = blockerList(s.activeDecisions)
 	s.status.UpdatedAt = decision.DecidedAt
 	return transition
 }
@@ -477,6 +544,76 @@ func prTarget(pr *PullRequestSnapshot) string {
 	return fmt.Sprintf("#%d", pr.Number)
 }
 
+func prNonMergeable(pr *PullRequestSnapshot) bool {
+	if pr == nil {
+		return false
+	}
+	if pr.Draft {
+		return true
+	}
+	switch strings.ToUpper(strings.TrimSpace(pr.MergeState)) {
+	case "", "UNKNOWN", "CLEAN", "HAS_HOOKS":
+		return false
+	default:
+		return true
+	}
+}
+
+func prStale(pr *PullRequestSnapshot, now time.Time, staleAfter time.Duration) bool {
+	updated := prUpdatedAt(pr)
+	return !updated.IsZero() && now.Sub(updated) >= staleAfter
+}
+
+func prUpdatedAt(pr *PullRequestSnapshot) time.Time {
+	if pr == nil {
+		return time.Time{}
+	}
+	if !pr.UpdatedAt.IsZero() {
+		return pr.UpdatedAt
+	}
+	return pr.CreatedAt
+}
+
+func prBlocker(pr *PullRequestSnapshot, kind prhygiene.Kind, reason string) prhygiene.Blocker {
+	state := "OPEN"
+	if pr != nil && strings.TrimSpace(pr.State) != "" {
+		state = strings.ToUpper(strings.TrimSpace(pr.State))
+	}
+	blocker := prhygiene.Blocker{Kind: kind, State: state, Reason: reason}
+	if pr == nil {
+		return blocker
+	}
+	blocker.Number = pr.Number
+	blocker.Title = strings.TrimSpace(pr.Title)
+	blocker.URL = strings.TrimSpace(pr.URL)
+	blocker.CreatedAt = pr.CreatedAt
+	blocker.UpdatedAt = prUpdatedAt(pr)
+	return blocker
+}
+
+func blockerList(decisions map[string]Decision) []prhygiene.Blocker {
+	if len(decisions) == 0 {
+		return nil
+	}
+	blockers := make([]prhygiene.Blocker, 0, len(decisions))
+	for _, decision := range decisions {
+		if decision.PRBlocker == nil {
+			continue
+		}
+		blockers = append(blockers, *decision.PRBlocker)
+	}
+	if len(blockers) == 0 {
+		return nil
+	}
+	sort.SliceStable(blockers, func(i, j int) bool {
+		if blockers[i].Number != blockers[j].Number {
+			return blockers[i].Number < blockers[j].Number
+		}
+		return blockers[i].Kind < blockers[j].Kind
+	})
+	return blockers
+}
+
 func workerLabel(worker WorkerSnapshot) string {
 	if id := strings.TrimSpace(worker.ID); id != "" {
 		return id
@@ -491,6 +628,9 @@ func cloneStatus(status Status) Status {
 		out.CurrentDecision = &decision
 	}
 	out.CurrentDecisions = cloneDecisionMap(status.CurrentDecisions)
+	if status.PRBlockers != nil {
+		out.PRBlockers = append([]prhygiene.Blocker(nil), status.PRBlockers...)
+	}
 	if status.LastSafeAction != nil {
 		action := *status.LastSafeAction
 		out.LastSafeAction = &action
@@ -523,6 +663,10 @@ func cloneDecisionMap(decisions map[string]Decision) map[string]Decision {
 
 func cloneDecision(decision Decision) Decision {
 	out := decision
+	if decision.PRBlocker != nil {
+		blocker := *decision.PRBlocker
+		out.PRBlocker = &blocker
+	}
 	if decision.SafeActions != nil {
 		out.SafeActions = append([]Action(nil), decision.SafeActions...)
 	}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"ok-gobot/internal/prhygiene"
 )
 
 func TestEvaluateCoversStuckStates(t *testing.T) {
@@ -70,14 +72,43 @@ func TestEvaluateCoversStuckStates(t *testing.T) {
 			wantAction: ActionCommentBlocker,
 		},
 		{
-			name: "open PR behind base comments blocker",
+			name: "open PR with dirty merge state comments blocker",
 			obs: Observation{
-				Subject: "issue-356",
+				Subject: "issue-242",
 				Now:     now,
-				PR:      &PullRequestSnapshot{Number: 42, Open: true, Checks: ChecksPending, BranchBehind: true},
+				PR:      &PullRequestSnapshot{Number: 242, Open: true, State: "OPEN", Checks: ChecksPending, MergeState: "DIRTY"},
 			},
 			wantState:  StatePRBranchDirty,
 			wantAction: ActionCommentBlocker,
+		},
+		{
+			name: "stale open PR refreshes metadata without write action",
+			obs: Observation{
+				Subject:      "issue-279",
+				Now:          now,
+				PRStaleAfter: 14 * 24 * time.Hour,
+				PR: &PullRequestSnapshot{
+					Number:     279,
+					Open:       true,
+					State:      "OPEN",
+					Checks:     ChecksGreen,
+					Review:     ReviewApproved,
+					MergeState: "CLEAN",
+					UpdatedAt:  now.Add(-31 * 24 * time.Hour),
+				},
+			},
+			wantState:  StatePRStale,
+			wantAction: ActionRefreshMetadata,
+		},
+		{
+			name: "open PR with Greptile findings refreshes metadata",
+			obs: Observation{
+				Subject: "issue-303",
+				Now:     now,
+				PR:      &PullRequestSnapshot{Number: 303, Open: true, State: "OPEN", GreptileFindings: true},
+			},
+			wantState:  StatePRGreptileFindings,
+			wantAction: ActionRefreshMetadata,
 		},
 		{
 			name: "retry exhausted while PR remains open blocks issue",
@@ -107,6 +138,9 @@ func TestEvaluateCoversStuckStates(t *testing.T) {
 			decision := Evaluate(tt.obs)
 			if decision.State != tt.wantState {
 				t.Fatalf("state = %q, want %q", decision.State, tt.wantState)
+			}
+			if isPRBlockerState(tt.wantState) && decision.PRBlocker == nil {
+				t.Fatalf("expected PR blocker metadata for %q", tt.wantState)
 			}
 			if !hasAction(decision.SafeActions, ActionUpdateMissionReason) {
 				t.Fatalf("expected mission-control reason update action, got %+v", decision.SafeActions)
@@ -224,15 +258,57 @@ func TestSupervisorStatusExposesDecisionAndLastSafeAction(t *testing.T) {
 	if status.CurrentDecisions["issue-356"].State != StateReadyForMerge {
 		t.Fatalf("current decisions = %+v, want issue-356 ready for merge", status.CurrentDecisions)
 	}
+	if len(status.PRBlockers) != 0 {
+		t.Fatalf("PR blockers = %+v, want none for ready PR", status.PRBlockers)
+	}
 
 	status.CurrentDecision.State = StatePRChecksFailing
 	status.CurrentDecisions["issue-356"] = Decision{State: StatePRChecksFailing, Subject: "issue-356"}
+	status.PRBlockers = append(status.PRBlockers, prhygiene.Blocker{Number: 1})
 	status2 := sup.Status()
 	if status2.CurrentDecision.State != StateReadyForMerge {
 		t.Fatalf("status was not cloned: got %q", status2.CurrentDecision.State)
 	}
 	if status2.CurrentDecisions["issue-356"].State != StateReadyForMerge {
 		t.Fatalf("status decision map was not cloned: got %q", status2.CurrentDecisions["issue-356"].State)
+	}
+	if len(status2.PRBlockers) != 0 {
+		t.Fatalf("status PR blocker slice was not cloned: %+v", status2.PRBlockers)
+	}
+}
+
+func TestSupervisorStatusExposesStalePRBlocker(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	sup := New()
+	obs := Observation{
+		Subject:      "issue-279",
+		Now:          now,
+		PRStaleAfter: 14 * 24 * time.Hour,
+		PR: &PullRequestSnapshot{
+			Number:    279,
+			Open:      true,
+			State:     "OPEN",
+			Title:     "test(agent): expand reflection test coverage (#243)",
+			URL:       "https://github.com/BeFeast/ok-gobot/pull/279",
+			Checks:    ChecksGreen,
+			Review:    ReviewApproved,
+			UpdatedAt: time.Date(2026, 3, 30, 20, 20, 23, 0, time.UTC),
+		},
+	}
+
+	if _, err := sup.Reconcile(context.Background(), []Observation{obs}); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+	status := sup.Status()
+	if len(status.PRBlockers) != 1 {
+		t.Fatalf("PR blockers = %+v, want one", status.PRBlockers)
+	}
+	blocker := status.PRBlockers[0]
+	if blocker.Number != 279 || blocker.Kind != prhygiene.KindStale || blocker.State != "OPEN" || blocker.UpdatedAt.IsZero() {
+		t.Fatalf("unexpected stale PR blocker: %+v", blocker)
+	}
+	if status.CurrentDecision == nil || status.CurrentDecision.PRBlocker == nil || status.CurrentDecision.PRBlocker.Number != 279 {
+		t.Fatalf("current decision missing PR blocker: %+v", status.CurrentDecision)
 	}
 }
 
@@ -285,6 +361,15 @@ func hasAction(actions []Action, want ActionKind) bool {
 		}
 	}
 	return false
+}
+
+func isPRBlockerState(state StuckState) bool {
+	switch state {
+	case StatePRChecksFailing, StatePRReviewFeedback, StatePRGreptileFindings, StatePRBranchDirty, StatePRStale:
+		return true
+	default:
+		return false
+	}
 }
 
 type fakeNotifier struct {


### PR DESCRIPTION
Implements #370

## Changes
- Adds read-only open PR blocker diagnosis for stale, non-mergeable, failing CI, unresolved review, and Greptile metadata.
- Surfaces blocker details in Maestro status output and Supervisor/Mission Control status payloads.
- Covers old PR fixtures #242 and #279 plus idempotent stale detection in focused tests.

## Testing
- `bash .maestro/verify.sh`
- `git fetch origin && git rebase origin/main` (rebased the #370 commit onto updated main)
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds read-only open-PR blocker diagnosis (`prhygiene` package) covering stale age, non-mergeable merge state, failing CI, unresolved reviews, and Greptile findings, then surfaces that data in `maestro status` output and the Supervisor/Mission Control status payload. The implementation is clean and well-tested; two logic edge-cases in `hygiene.go` are worth addressing before relying on the output in production.

<h3>Confidence Score: 5/5</h3>

Safe to merge; both findings are P2 display-accuracy issues in the new read-only diagnosis path and do not affect supervisor recovery decisions.

No P0/P1 bugs found. The two P2 findings (over-broad bodySuggestsFindings marker and transient check conclusions treated as failures) affect only the prhygiene display layer, not the supervisor's Evaluate logic which uses the independently-supplied PullRequestSnapshot.GreptileFindings field.

internal/prhygiene/hygiene.go — bodySuggestsFindings and checkFailing logic

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/prhygiene/hygiene.go | New package implementing PR blocker diagnosis (greptile, CI, review, non-mergeable, stale); well-structured with priority-ordered Diagnose, but `bodySuggestsFindings` is too broad and `checkFailing` treats transient GitHub states as failures. |
| internal/supervisor/supervisor.go | Adds StatePRGreptileFindings, StatePRStale, PRStaleAfter, and PRBlocker fields to Decision/Status; blockerList and prBlocker helpers are clean, cloning logic updated correctly. |
| internal/maestro/gh.go | Adds ListOpenPullRequests/ListOpenPullRequestBlockers and parsePullRequests/parseStatusRollup; correctly handles dual CheckRun/StatusContext JSON shapes by falling back to the `state` field. |
| internal/cli/maestro.go | Refactors status command to runMaestroStatus + renderMaestroStatus; blockerErr is non-fatal (surfaced as text, not exit error), which is correct read-only behaviour. |
| internal/prhygiene/hygiene_test.go | Good coverage: individual kind assertions, healthy-PR no-op, human-greptile-mention disambiguation, and fingerprint stability across polls. |
| internal/supervisor/supervisor_test.go | Adds stale PR and Greptile-findings states, verifies PRBlocker metadata presence, and confirms Status clone isolation for the new PRBlockers slice. |
| internal/maestro/gh_test.go | New test round-trips a realistic gh JSON fixture through parsePullRequests and Diagnose; covers both CheckRun and StatusContext shapes. |
| internal/control/mission_supervisor_test.go | Extends existing test to assert PRBlocker metadata is surfaced in Status.PRBlockers; straightforward and correct. |
| internal/cli/maestro_test.go | New test exercises renderMaestroStatus with a stale blocker, asserting formatted output with age and reason. |
| docs/MISSION-CONTROL.md | Doc updates reflect the new supervisor status fields and maestro status PR scan behaviour; accurate and concise. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/prhygiene/hygiene.go:776-786
**`"finding"` marker matches resolved-findings comments**

The bare `"finding"` substring fires on positive contexts: a reviewer who writes *"the greptile finding was addressed"* or *"all greptile findings look good"* will satisfy both `mentionsGreptile(review.Body)` and `bodySuggestsFindings(review.Body)`, returning a spurious `KindGreptile` blocker for an otherwise healthy, approved PR. The negative guard only matches `"no finding"` and `"no issue"`, so any sentence that uses the word "finding" without those exact prefixes returns `true`.

Replacing the catch-all `"finding"` with more specific phrases (e.g. `"finding requires"`, `"findings require"`) would eliminate the false positive while preserving the intended detection of Greptile's standard phrasing.

```suggestion
	for _, marker := range []string{"requires attention", "require attention", "findings require", "finding requires", "issue found", "issues found", "unresolved"} {
```

### Issue 2 of 2
internal/prhygiene/hygiene.go:715-728
**Transient GitHub states treated as permanent failures**

`"stale"` and `"cancelled"` are transient conclusions GitHub sets automatically when a newer push supersedes a previous check run — they are not authoritatively "failed." During the brief window between a push and new check runs starting, every cancelled (or legacy-stale) run still appears in `statusCheckRollup`, causing `failingCICheck` to return a CI blocker that resolves only once new runs report a conclusion. For long-lived PRs using legacy commit statuses, a `stale` conclusion may persist indefinitely.

Consider omitting or separately classifying these two values so operators can distinguish a transient re-run state from a genuine failure.

```suggestion
	switch conclusion {
	case "failure", "failed", "error", "timed_out", "action_required", "startup_failure":
		return true
	case "cancelled", "stale":
		// transient: superseded by a newer push; treat as pending, not failed
		return false
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: classify human PR reviews correctly..."](https://github.com/befeast/ok-gobot/commit/e8745d44fd20e53d880a0c814404f173496bc41f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30513601)</sub>

<!-- /greptile_comment -->