### PR TITLE
fix: harden evidence ledger edge cases (#371)

### DIFF
--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -74,6 +74,28 @@ func TestRenderMarkdownCompactsEvidenceTimeline(t *testing.T) {
 	}
 }
 
+func TestRenderMarkdownSanitizesDerivedPayloadSummary(t *testing.T) {
+	longCommand := "deploy --token sk-1234567890abcdefghijklmnop " + strings.Repeat("--verbose ", 80)
+	md := RenderMarkdown([]Event{{
+		Type:   EventCommand,
+		Status: "failed",
+		Payload: map[string]any{
+			"command":     longCommand,
+			"exit_status": 1,
+		},
+	}}, RenderOptions{Limit: 1, MaxSummaryRune: 90})
+
+	if strings.Contains(md, "abcdefghijklmnop") {
+		t.Fatalf("rendered evidence leaked secret: %s", md)
+	}
+	if !strings.Contains(md, "sk-123456***") {
+		t.Fatalf("rendered evidence did not include redacted token prefix: %s", md)
+	}
+	if !strings.Contains(md, "[truncated]") {
+		t.Fatalf("rendered evidence was not bounded: %s", md)
+	}
+}
+
 func TestJSONLineSanitizesEvent(t *testing.T) {
 	line, err := JSONLine(Event{
 		Type:    EventPullRequest,

--- a/internal/runtime/jobs.go
+++ b/internal/runtime/jobs.go
@@ -401,22 +401,21 @@ func (s *JobService) createJob(spec JobSpec) (*storage.Job, error) {
 		return nil, err
 	}
 
-	hasEvidenceSession := strings.TrimSpace(spec.SessionKey) != "" || strings.TrimSpace(spec.DeliverySessionKey) != ""
-	if hasEvidenceSession && (strings.TrimSpace(spec.Worker) != "" || strings.TrimSpace(spec.ModelTier) != "" || strings.TrimSpace(spec.RoleName) != "") {
+	if strings.TrimSpace(spec.Worker) != "" || strings.TrimSpace(spec.ModelTier) != "" || strings.TrimSpace(spec.RoleName) != "" {
 		if err := s.AppendEvidence(jobID, evidence.EventBackendModel, "selected", "selected backend/model", map[string]any{
 			"backend":    strings.TrimSpace(spec.Worker),
 			"model_tier": strings.TrimSpace(spec.ModelTier),
 			"role":       strings.TrimSpace(spec.RoleName),
 		}); err != nil {
-			log.Printf("[evidence] failed to append backend/model evidence for job %s: %v", jobID, err)
+			log.Printf("[evidence] warning: failed to append backend/model evidence for job %s: %v", jobID, err)
 		}
 	}
-	if hasEvidenceSession && (strings.TrimSpace(spec.Branch) != "" || strings.TrimSpace(spec.WorktreePath) != "") {
+	if strings.TrimSpace(spec.Branch) != "" || strings.TrimSpace(spec.WorktreePath) != "" {
 		if err := s.AppendEvidence(jobID, evidence.EventWorkspace, "selected", "selected branch/worktree", map[string]any{
 			"branch":        strings.TrimSpace(spec.Branch),
 			"worktree_path": strings.TrimSpace(spec.WorktreePath),
 		}); err != nil {
-			log.Printf("[evidence] failed to append workspace evidence for job %s: %v", jobID, err)
+			log.Printf("[evidence] warning: failed to append workspace evidence for job %s: %v", jobID, err)
 		}
 	}
 

--- a/internal/runtime/jobs_test.go
+++ b/internal/runtime/jobs_test.go
@@ -13,6 +13,7 @@ import (
 
 	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/delegation"
+	"ok-gobot/internal/evidence"
 	"ok-gobot/internal/storage"
 )
 
@@ -142,6 +143,48 @@ func TestJobServiceStartDetachedIgnoresInitialEvidenceFailure(t *testing.T) {
 	for i, want := range wantEvents {
 		if events[i].EventType != want {
 			t.Fatalf("event[%d] = %q want %q", i, events[i].EventType, want)
+		}
+	}
+}
+
+func TestJobServiceSessionlessJobRecordsJobScopedEvidence(t *testing.T) {
+	t.Parallel()
+
+	store := newRuntimeTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	svc := NewJobService(store)
+	job, err := svc.StartDetached(context.Background(), JobSpec{
+		Kind:         "background_task",
+		Worker:       "test_runner",
+		Description:  "collect diagnostics without a session",
+		ModelTier:    "fast",
+		Branch:       "feature/sessionless",
+		WorktreePath: "/tmp/ok-gobot-sessionless",
+		Timeout:      2 * time.Second,
+	}, func(ctx context.Context, job *storage.Job, svc *JobService) (JobRunResult, error) {
+		return JobRunResult{Summary: "done"}, nil
+	})
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	waitForJobStatus(t, store, job.JobID, string(JobStatusSucceeded))
+	events, err := store.ListEvidenceEventsForJob(job.JobID, 20)
+	if err != nil {
+		t.Fatalf("ListEvidenceEventsForJob failed: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, event := range events {
+		if event.SessionKey != "" {
+			t.Fatalf("sessionless evidence event has session_key %q: %+v", event.SessionKey, event)
+		}
+		seen[event.Type] = true
+	}
+	for _, want := range []string{evidence.EventBackendModel, evidence.EventWorkspace, evidence.EventFinalDecision} {
+		if !seen[want] {
+			t.Fatalf("missing %s evidence in job-scoped events: %+v", want, events)
 		}
 	}
 }

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -1851,13 +1851,16 @@ func (s *Store) AddJobEvent(event JobEvent) error {
 	if err != nil {
 		return err
 	}
+	// Evidence mirroring is observability-only. The job_event row above is the
+	// durable lifecycle record, so mirror failures are warnings and never make
+	// callers retry or roll back core job state.
 	if err := s.addEvidenceForJobEvent(JobEvent{
 		JobID:     jobID,
 		EventType: eventType,
 		Message:   event.Message,
 		Payload:   event.Payload,
 	}); err != nil {
-		log.Printf("[evidence] failed to mirror job event evidence for job %s: %v", jobID, err)
+		log.Printf("[evidence] warning: failed to mirror job event evidence for job %s: %v", jobID, err)
 	}
 	return nil
 }
@@ -1895,10 +1898,17 @@ func (s *Store) ListJobEvents(jobID string, limit int) ([]JobEvent, error) {
 }
 
 // AddEvidenceEvent appends one structured evidence ledger row.
+// Evidence must be scoped to either a session_key or a job_id. Sessionless jobs
+// are valid: they are persisted with an empty session_key and remain queryable
+// through ListEvidenceEventsForJob. Completely unscoped evidence is rejected so
+// accidental writes cannot disappear into an ambiguous empty-session bucket.
 func (s *Store) AddEvidenceEvent(event evidence.Event) error {
 	event = evidence.SanitizeEvent(event)
 	if strings.TrimSpace(event.Type) == "" {
 		return fmt.Errorf("evidence event type is required")
+	}
+	if event.SessionKey == "" && event.JobID == "" {
+		return fmt.Errorf("evidence session_key or job_id is required")
 	}
 	payload, err := evidence.MarshalPayload(event.Payload)
 	if err != nil {
@@ -1920,6 +1930,10 @@ func (s *Store) AddEvidenceEvent(event evidence.Event) error {
 
 // ListEvidenceEvents returns the newest evidence rows for a session in chronological order.
 func (s *Store) ListEvidenceEvents(sessionKey string, limit int) ([]evidence.Event, error) {
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return nil, fmt.Errorf("evidence session_key is required")
+	}
 	if limit <= 0 {
 		limit = 50
 	}
@@ -1933,7 +1947,7 @@ func (s *Store) ListEvidenceEvents(sessionKey string, limit int) ([]evidence.Eve
 			LIMIT ?
 		)
 		ORDER BY created_at ASC, id ASC
-	`, strings.TrimSpace(sessionKey), limit)
+	`, sessionKey, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -1943,6 +1957,10 @@ func (s *Store) ListEvidenceEvents(sessionKey string, limit int) ([]evidence.Eve
 
 // ListEvidenceEventsForJob returns the newest evidence rows for a job in chronological order.
 func (s *Store) ListEvidenceEventsForJob(jobID string, limit int) ([]evidence.Event, error) {
+	jobID = strings.TrimSpace(jobID)
+	if jobID == "" {
+		return nil, fmt.Errorf("evidence job_id is required")
+	}
 	if limit <= 0 {
 		limit = 50
 	}
@@ -1956,7 +1974,7 @@ func (s *Store) ListEvidenceEventsForJob(jobID string, limit int) ([]evidence.Ev
 			LIMIT ?
 		)
 		ORDER BY created_at ASC, id ASC
-	`, strings.TrimSpace(jobID), limit)
+	`, jobID, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -2033,9 +2051,6 @@ func (s *Store) addEvidenceForJobEvent(event JobEvent) error {
 		if value, ok := payload["session_key"].(string); ok {
 			sessionKey = strings.TrimSpace(value)
 		}
-	}
-	if sessionKey == "" {
-		return nil
 	}
 	return s.AddEvidenceEvent(evidence.Event{
 		SessionKey: sessionKey,

--- a/internal/storage/sqlite_schema_test.go
+++ b/internal/storage/sqlite_schema_test.go
@@ -513,6 +513,75 @@ func TestEvidenceLedgerAppendListAndJobEventMirror(t *testing.T) {
 	}
 }
 
+func TestEvidenceLedgerRejectsUnscopedWritesAndAllowsJobScopedEvents(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	err := store.AddEvidenceEvent(evidence.Event{
+		Type:    evidence.EventCommand,
+		Summary: "missing session and job",
+	})
+	if err == nil || !strings.Contains(err.Error(), "session_key or job_id") {
+		t.Fatalf("AddEvidenceEvent unscoped error = %v, want scope error", err)
+	}
+	if _, err := store.ListEvidenceEvents("", 10); err == nil || !strings.Contains(err.Error(), "session_key is required") {
+		t.Fatalf("ListEvidenceEvents empty session error = %v, want required error", err)
+	}
+
+	if err := store.AddEvidenceEvent(evidence.Event{
+		JobID:   "job-sessionless-evidence",
+		Type:    evidence.EventCommand,
+		Status:  "failed",
+		Summary: "command failed",
+	}); err != nil {
+		t.Fatalf("AddEvidenceEvent job-scoped failed: %v", err)
+	}
+
+	events, err := store.ListEvidenceEventsForJob("job-sessionless-evidence", 10)
+	if err != nil {
+		t.Fatalf("ListEvidenceEventsForJob failed: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("job-scoped evidence count = %d, want 1: %+v", len(events), events)
+	}
+	if events[0].SessionKey != "" || events[0].JobID != "job-sessionless-evidence" {
+		t.Fatalf("unexpected job-scoped event: %+v", events[0])
+	}
+}
+
+func TestJobEventMirrorFailureDoesNotFailLifecycleEvent(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	job := Job{JobID: "job-mirror-failure", Kind: "task", Status: "running", SessionKey: "agent:test:main"}
+	if err := store.CreateJob(job); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+	if _, err := store.DB().Exec(`DROP TABLE evidence_events`); err != nil {
+		t.Fatalf("drop evidence_events failed: %v", err)
+	}
+
+	if err := store.AddJobEvent(JobEvent{
+		JobID:     job.JobID,
+		EventType: "progress",
+		Message:   "core lifecycle event survives evidence mirror failure",
+	}); err != nil {
+		t.Fatalf("AddJobEvent should ignore evidence mirror failure, got: %v", err)
+	}
+
+	events, err := store.ListJobEvents(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobEvents failed: %v", err)
+	}
+	if len(events) != 1 || events[0].EventType != "progress" {
+		t.Fatalf("unexpected lifecycle events after mirror failure: %+v", events)
+	}
+}
+
 func TestJobArtifactCountsAreAccurateAndBatchable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Implements #371

## Changes
- Require evidence rows to be scoped by `session_key` or `job_id`, while allowing sessionless job-scoped evidence.
- Mirror job events for sessionless jobs and keep evidence failures as logged warnings after lifecycle events are persisted.
- Add storage/runtime/evidence tests for invalid/sessionless evidence, mirror failure, and redacted/bounded rendering.

## Testing
- `.maestro/verify.sh`
- `git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the evidence ledger by (1) rejecting completely unscoped evidence rows (both `session_key` and `job_id` absent), (2) removing the early bail-out in `addEvidenceForJobEvent` so sessionless jobs now mirror job lifecycle events into the ledger, and (3) adding non-empty guards to both `ListEvidenceEvents` and `ListEvidenceEventsForJob`. Companion tests cover the unscoped-write rejection, job-scoped evidence round-trip, mirror-failure isolation, and redacted/truncated rendering.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are well-tested and logically consistent with no critical defects identified.

All P0/P1 severity paths are covered by tests. The key behavioral changes (scope validation, sessionless mirror, list guards) follow logically from the stated goals and are thoroughly exercised. No regressions detected in the existing evidence or lifecycle-event paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/storage/sqlite.go | Core evidence ledger changes: adds scope validation to AddEvidenceEvent, removes early-bail for sessionless jobs in addEvidenceForJobEvent, adds non-empty guards to ListEvidenceEvents/ListEvidenceEventsForJob, and elevates mirror failures to warnings-only. Logic is consistent and well-commented. |
| internal/runtime/jobs.go | Removes hasEvidenceSession guard so backend/model and workspace evidence is always appended for all jobs including sessionless ones; AppendEvidence passes job.JobID so the new scope validation in AddEvidenceEvent is satisfied. |
| internal/runtime/jobs_test.go | Adds TestJobServiceSessionlessJobRecordsJobScopedEvidence verifying that EventBackendModel, EventWorkspace, and EventFinalDecision all appear as job-scoped evidence with no session_key for sessionless jobs. |
| internal/storage/sqlite_schema_test.go | Adds two new tests: unscoped-write rejection / job-scoped evidence round-trip, and mirror-failure isolation (dropping evidence_events table to confirm AddJobEvent still succeeds). Both tests are well-scoped. |
| internal/evidence/evidence_test.go | Adds TestRenderMarkdownSanitizesDerivedPayloadSummary, checking that RenderMarkdown redacts secrets and truncates long payload-derived summaries during rendering; tests existing RenderMarkdown behaviour not changed in this PR. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden evidence ledger edge cases (..."](https://github.com/befeast/ok-gobot/commit/75f54f591f99e09679845dd077d7470c02eada45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30516726)</sub>

<!-- /greptile_comment -->