### PR TITLE
fix: normalize preflight failure messages (#372)

### DIFF
--- a/internal/batch/runner.go
+++ b/internal/batch/runner.go
@@ -2,6 +2,7 @@ package batch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -232,7 +233,7 @@ func runSubtask(ctx context.Context, cfg Config, idx int, subtask Subtask, adapt
 	if report, ok := worker.RunAdapterPreflight(ctx, adapter, req); ok {
 		fmt.Fprintf(out, "[batch] subtask %d preflight: %s\n", idx, report.Summary())
 		if !report.OK {
-			res.Error = fmt.Errorf("worker preflight failed: %s", report.Summary())
+			res.Error = errors.New(report.Summary())
 			return res
 		}
 	}

--- a/internal/bot/role_commands.go
+++ b/internal/bot/role_commands.go
@@ -376,7 +376,7 @@ func jobStatusIcon(status string) string {
 		return "🏃"
 	case "succeeded":
 		return "✅"
-	case "failed":
+	case "failed", "preflight_failed":
 		return "❌"
 	case "cancelled":
 		return "🛑"

--- a/internal/bot/role_commands_test.go
+++ b/internal/bot/role_commands_test.go
@@ -189,6 +189,23 @@ func TestFormatRoleJobFinalFailureIncludesReason(t *testing.T) {
 	}
 }
 
+func TestFormatRoleJobFinalPreflightFailureUsesNormalizedReason(t *testing.T) {
+	const summary = "preflight failed: [github.auth] GitHub authentication is missing or invalid. Hint: Run gh auth login and ensure the token can create PRs, checks, and reviews."
+	out := formatRoleJobFinal(storage.Job{
+		JobID:  "job-preflight-tg",
+		Status: "preflight_failed",
+		Error:  summary,
+	}, nil)
+	for _, want := range []string{"Role job blocked by preflight", "Reason: " + summary, "Use `/job job-preflight-tg`"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in %q", want, out)
+		}
+	}
+	if strings.Count(out, "preflight failed") != 1 {
+		t.Fatalf("Telegram output repeated preflight headline: %q", out)
+	}
+}
+
 func TestSendRoleJobFinalNotificationRetriesPlainTextWhenMarkdownFails(t *testing.T) {
 	tg := newFakeTelegramAPI(t)
 	tg.failNextMarkdownSend()

--- a/internal/bot/role_job_notifications.go
+++ b/internal/bot/role_job_notifications.go
@@ -142,7 +142,7 @@ func formatRoleJobFinal(job storage.Job, infos []artifactview.Info) string {
 
 func isTerminalRoleJobStatus(status string) bool {
 	switch status {
-	case "succeeded", "failed", "cancelled", "timed_out", "budget_exceeded":
+	case "succeeded", "failed", "preflight_failed", "cancelled", "timed_out", "budget_exceeded":
 		return true
 	default:
 		return false
@@ -155,6 +155,8 @@ func roleJobFinalHeading(status string) string {
 		return "✅ *Role job completed*"
 	case "timed_out":
 		return "⏰ *Role job timed out*"
+	case "preflight_failed":
+		return "❌ *Role job blocked by preflight*"
 	case "cancelled":
 		return "🛑 *Role job cancelled*"
 	case "budget_exceeded":

--- a/internal/cli/jobs.go
+++ b/internal/cli/jobs.go
@@ -77,7 +77,7 @@ func newJobsListCommand(cfg *config.Config) *cobra.Command {
 			return w.Flush()
 		},
 	}
-	cmd.Flags().StringVar(&status, "status", "", "filter by status (pending, running, succeeded, failed, cancelled, timed_out)")
+	cmd.Flags().StringVar(&status, "status", "", "filter by status (pending, running, succeeded, failed, preflight_failed, cancelled, timed_out)")
 	cmd.Flags().IntVar(&limit, "limit", 50, "maximum number of jobs to show")
 	return cmd
 }
@@ -592,7 +592,7 @@ func artifactInspectURI(serializer artifactview.Serializer, artifact storage.Job
 
 func isTerminalStatus(status string) bool {
 	switch status {
-	case "succeeded", "failed", "cancelled", "timed_out":
+	case "succeeded", "failed", "preflight_failed", "cancelled", "timed_out", "budget_exceeded":
 		return true
 	}
 	return false

--- a/internal/cli/jobs_test.go
+++ b/internal/cli/jobs_test.go
@@ -165,6 +165,40 @@ func TestJobsInspect(t *testing.T) {
 	}
 }
 
+func TestJobsInspectPreflightFailureShowsNormalizedError(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+
+	const summary = "preflight failed: [github.auth] GitHub authentication is missing or invalid. Hint: Run gh auth login and ensure the token can create PRs, checks, and reviews."
+	seedJob(t, store, storage.Job{
+		JobID:       "job-preflight-cli",
+		Kind:        "worker_task",
+		Worker:      "claude",
+		Description: "blocked before worker run",
+		Status:      "preflight_failed",
+		Error:       summary,
+		Attempt:     1,
+		MaxAttempts: 1,
+	})
+
+	cmd := newJobsCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"inspect", "job-preflight-cli"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, summary) {
+		t.Fatalf("normalized preflight summary missing from CLI output: %q", output)
+	}
+	if strings.Count(output, "preflight failed") != 1 {
+		t.Fatalf("CLI output repeated preflight headline: %q", output)
+	}
+}
+
 func TestJobsInspect_EvidenceFailureDoesNotAbort(t *testing.T) {
 	t.Parallel()
 	store, cfg := newTestStore(t)

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -378,6 +378,7 @@ func isRoleJobTerminal(status string) bool {
 	switch status {
 	case string(runtime.JobStatusSucceeded),
 		string(runtime.JobStatusFailed),
+		string(runtime.JobStatusPreflightFailed),
 		string(runtime.JobStatusCancelled),
 		string(runtime.JobStatusTimedOut),
 		string(runtime.JobStatusBudgetExceeded):

--- a/internal/control/mission_test.go
+++ b/internal/control/mission_test.go
@@ -102,6 +102,45 @@ func TestMissionEvidenceRequiresSessionKey(t *testing.T) {
 	}
 }
 
+func TestMissionRunsReturnsNormalizedPreflightError(t *testing.T) {
+	t.Parallel()
+
+	store, err := storage.New(filepath.Join(t.TempDir(), "mission-runs-preflight.db"))
+	if err != nil {
+		t.Fatalf("storage.New failed: %v", err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	const summary = "preflight failed: [network.allowlist] required network target is not allowed by the network allowlist. Hint: Add the required GitHub/backend hosts to the network allowlist."
+	if err := store.CreateJob(storage.Job{
+		JobID:       "job-preflight-mission",
+		Kind:        "worker_task",
+		Worker:      "codex",
+		Description: "blocked before worker run",
+		Status:      "preflight_failed",
+		Error:       summary,
+		Attempt:     1,
+		MaxAttempts: 1,
+	}); err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mission/runs?status=preflight_failed", nil)
+	w := httptest.NewRecorder()
+	missionRuns(missionEvidenceProvider{store: store})(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, summary) {
+		t.Fatalf("normalized preflight summary missing from Mission Control response: %s", body)
+	}
+	if strings.Count(body, "preflight failed") != 1 {
+		t.Fatalf("Mission Control response repeated preflight headline: %s", body)
+	}
+}
+
 func TestMissionEvidenceListFailureUsesGenericError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/bridge_test.go
+++ b/internal/worker/bridge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -177,10 +178,11 @@ func TestAdapterJobRunnerPreflightFailureRefusesWorker(t *testing.T) {
 	}
 
 	repo := newPreflightRepo(t)
+	secret := "ghp_abcdefghijklmnopqrstuvwxyz123456"
 	opts := passingPreflightOptions(repo)
 	opts.CommandRunner = func(_ context.Context, _ string, name string, args ...string) CommandResult {
 		if name == "gh" {
-			return CommandResult{Stderr: "not authenticated", Err: errors.New("exit status 1")}
+			return CommandResult{Stderr: "not authenticated token=" + secret, Err: errors.New("exit status 1")}
 		}
 		return passingCommandResult(repo, name, args...)
 	}
@@ -208,6 +210,17 @@ func TestAdapterJobRunnerPreflightFailureRefusesWorker(t *testing.T) {
 	if finished.Error == "" {
 		t.Fatal("expected preflight error to be stored")
 	}
+	if strings.Count(finished.Error, "preflight failed") != 1 {
+		t.Fatalf("preflight error repeated headline: %q", finished.Error)
+	}
+	for _, want := range []string{"[github.auth] GitHub authentication is missing or invalid", "Hint: Run gh auth login"} {
+		if !strings.Contains(finished.Error, want) {
+			t.Fatalf("preflight error missing %q: %q", want, finished.Error)
+		}
+	}
+	if strings.Contains(finished.Error, secret) {
+		t.Fatalf("preflight error leaked secret: %q", finished.Error)
+	}
 
 	artifacts, err := store.ListJobArtifacts(job.JobID, 10)
 	if err != nil {
@@ -215,6 +228,14 @@ func TestAdapterJobRunnerPreflightFailureRefusesWorker(t *testing.T) {
 	}
 	if len(artifacts) != 1 || artifacts[0].Name != "preflight.json" || artifacts[0].ArtifactType != "preflight_evidence" {
 		t.Fatalf("unexpected preflight artifacts: %+v", artifacts)
+	}
+	for _, want := range []string{`"id": "github.auth"`, `"reason": "GitHub authentication is missing or invalid"`, `"remediation": "Run gh auth login`} {
+		if !strings.Contains(artifacts[0].Content, want) {
+			t.Fatalf("preflight artifact missing %q: %s", want, artifacts[0].Content)
+		}
+	}
+	if strings.Contains(artifacts[0].Content, secret) {
+		t.Fatalf("preflight artifact leaked secret: %s", artifacts[0].Content)
 	}
 
 	events, err := store.ListJobEvents(job.JobID, 20)

--- a/internal/worker/preflight.go
+++ b/internal/worker/preflight.go
@@ -26,10 +26,45 @@ const (
 
 // PreflightCheck is one redacted readiness check result.
 type PreflightCheck struct {
+	ID          string          `json:"id"`
 	Name        string          `json:"name"`
 	Status      PreflightStatus `json:"status"`
+	Reason      string          `json:"reason,omitempty"`
 	Detail      string          `json:"detail,omitempty"`
 	Remediation string          `json:"remediation,omitempty"`
+}
+
+// PreflightFailure is the normalized operator-facing form for one failed check.
+type PreflightFailure struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Reason      string `json:"reason"`
+	Remediation string `json:"remediation,omitempty"`
+	Detail      string `json:"detail,omitempty"`
+}
+
+// Summary renders a concise, redacted failure line for chat, CLI, and dashboards.
+func (f PreflightFailure) Summary() string {
+	reason := strings.TrimSpace(f.Reason)
+	if reason == "" {
+		reason = strings.TrimSpace(f.Detail)
+	}
+	if reason == "" {
+		reason = strings.TrimSpace(f.Name)
+	}
+
+	var b strings.Builder
+	if id := strings.TrimSpace(f.ID); id != "" {
+		b.WriteString("[")
+		b.WriteString(id)
+		b.WriteString("] ")
+	}
+	b.WriteString(reason)
+	if remediation := strings.TrimSpace(f.Remediation); remediation != "" {
+		b.WriteString(" Hint: ")
+		b.WriteString(remediation)
+	}
+	return RedactSecrets(b.String())
 }
 
 // PreflightReport is the session evidence emitted before a worker starts.
@@ -45,18 +80,37 @@ type PreflightReport struct {
 	CompletedAt  time.Time        `json:"completed_at"`
 }
 
-// FailureReasons returns concise, redacted failure details for status events.
-func (r PreflightReport) FailureReasons() []string {
-	reasons := make([]string, 0)
+// Failures returns normalized, redacted failed checks for status events.
+func (r PreflightReport) Failures() []PreflightFailure {
+	failures := make([]PreflightFailure, 0)
 	for _, check := range r.Checks {
 		if check.Status != PreflightFailed {
 			continue
 		}
-		reason := check.Name
-		if check.Detail != "" {
-			reason += ": " + check.Detail
+		reason := strings.TrimSpace(check.Reason)
+		if reason == "" {
+			reason = strings.TrimSpace(check.Detail)
 		}
-		reasons = append(reasons, RedactSecrets(reason))
+		if reason == "" {
+			reason = strings.TrimSpace(check.Name)
+		}
+		failures = append(failures, PreflightFailure{
+			ID:          RedactSecrets(strings.TrimSpace(check.ID)),
+			Name:        RedactSecrets(strings.TrimSpace(check.Name)),
+			Reason:      RedactSecrets(reason),
+			Remediation: RedactSecrets(strings.TrimSpace(check.Remediation)),
+			Detail:      RedactSecrets(strings.TrimSpace(check.Detail)),
+		})
+	}
+	return failures
+}
+
+// FailureReasons returns concise, redacted failure details for status events.
+func (r PreflightReport) FailureReasons() []string {
+	failures := r.Failures()
+	reasons := make([]string, 0, len(failures))
+	for _, failure := range failures {
+		reasons = append(reasons, failure.Summary())
 	}
 	return reasons
 }
@@ -71,7 +125,7 @@ func (r PreflightReport) Summary() string {
 		return "preflight failed"
 	}
 	if len(reasons) > 3 {
-		reasons = append(reasons[:3], fmt.Sprintf("%d more failure(s)", len(reasons)-3))
+		reasons = append(append([]string{}, reasons[:3]...), fmt.Sprintf("%d more failure(s)", len(reasons)-3))
 	}
 	return "preflight failed: " + strings.Join(reasons, "; ")
 }
@@ -179,17 +233,19 @@ func RunPreflight(ctx context.Context, opts PreflightOptions) PreflightReport {
 	}
 
 	report := PreflightReport{
-		Backend:   strings.TrimSpace(opts.Backend),
+		Backend:   RedactSecrets(strings.TrimSpace(opts.Backend)),
 		Model:     RedactSecrets(model),
 		SourceDir: RedactSecrets(sourceDir),
 		WorkDir:   RedactSecrets(workDir),
 		StartedAt: started,
 	}
 
-	add := func(name string, status PreflightStatus, detail, remediation string) {
+	add := func(id, name string, status PreflightStatus, reason, detail, remediation string) {
 		report.Checks = append(report.Checks, PreflightCheck{
-			Name:        name,
+			ID:          normalizeCheckID(id, name),
+			Name:        RedactSecrets(strings.TrimSpace(name)),
 			Status:      status,
+			Reason:      RedactSecrets(strings.TrimSpace(reason)),
 			Detail:      RedactSecrets(detail),
 			Remediation: RedactSecrets(remediation),
 		})
@@ -198,25 +254,26 @@ func RunPreflight(ctx context.Context, opts PreflightOptions) PreflightReport {
 	tools := requiredTools(opts, sourceDir)
 	missingTools := map[string]bool{}
 	for _, tool := range tools {
+		toolName := toolDisplayName(tool)
 		if _, err := lookPath(tool); err != nil {
 			missingTools[tool] = true
-			add("tool: "+tool, PreflightFailed, "not found in PATH", fmt.Sprintf("Install %s or configure its binary path before starting the worker.", tool))
+			add(toolCheckID(tool), "tool: "+tool, PreflightFailed, fmt.Sprintf("%s is not available in PATH", toolName), "not found in PATH", fmt.Sprintf("Install %s or configure its binary path before starting the worker.", toolName))
 			continue
 		}
-		add("tool: "+tool, PreflightPassed, "available", "")
+		add(toolCheckID(tool), "tool: "+tool, PreflightPassed, fmt.Sprintf("%s is available", toolName), "available", "")
 	}
 
 	if opts.RequireBrowser {
 		if browser := firstAvailable(lookPath, []string{"google-chrome", "chromium", "chromium-browser", "chrome"}); browser == "" {
-			add("browser tooling", PreflightFailed, "no Chrome/Chromium binary found", "Install Chrome/Chromium or configure browser.chrome_path before running browser tasks.")
+			add("browser.tooling", "browser tooling", PreflightFailed, "Chrome/Chromium browser tooling is not available", "no Chrome/Chromium binary found", "Install Chrome/Chromium or configure browser.chrome_path before running browser tasks.")
 		} else {
-			add("browser tooling", PreflightPassed, browser+" available", "")
+			add("browser.tooling", "browser tooling", PreflightPassed, "Chrome/Chromium browser tooling is available", browser+" available", "")
 		}
 	}
 
 	checkGitHubAuth(ctx, opts, runner, workDir, missingTools, add)
-	checkWritablePath("source path writable", sourceDir, add)
-	checkWritablePath("worktree path writable", workDir, add)
+	checkWritablePath("path.source.writable", "source path writable", sourceDir, add)
+	checkWritablePath("path.worktree.writable", "worktree path writable", workDir, add)
 	checkGitTrust(ctx, runner, workDir, missingTools, add)
 	checkNetwork(opts, add)
 
@@ -226,9 +283,9 @@ func RunPreflight(ctx context.Context, opts PreflightOptions) PreflightReport {
 	}
 	report.TestCommands = testCommands
 	if len(testCommands) == 0 {
-		add("repo test command discovery", PreflightSkipped, "no repo-specific test command detected", "")
+		add("repo.test_command", "repo test command discovery", PreflightSkipped, "no repo-specific test command was detected", "no repo-specific test command detected", "Add go.mod, package.json, bun.lock, or a configured build target so workers know how to verify changes.")
 	} else {
-		add("repo test command discovery", PreflightPassed, strings.Join(testCommands, "; "), "")
+		add("repo.test_command", "repo test command discovery", PreflightPassed, "repo-specific test command was detected", strings.Join(testCommands, "; "), "")
 	}
 
 	report.CompletedAt = now()
@@ -276,6 +333,8 @@ var secretRedactors = []struct {
 	{regexp.MustCompile(`(?i)((?:api[_-]?key|token|authorization|password|secret)\s*[:=]\s*)[^\s,;]+`), "${1}[REDACTED]"},
 }
 
+var checkIDUnsafeRE = regexp.MustCompile(`[^a-z0-9._-]+`)
+
 // RedactSecrets masks token-shaped values before writing preflight evidence.
 func RedactSecrets(s string) string {
 	out := s
@@ -283,6 +342,35 @@ func RedactSecrets(s string) string {
 		out = redactor.re.ReplaceAllString(out, redactor.repl)
 	}
 	return out
+}
+
+func normalizeCheckID(id, fallback string) string {
+	id = strings.TrimSpace(strings.ToLower(id))
+	if id == "" {
+		id = strings.TrimSpace(strings.ToLower(fallback))
+	}
+	id = checkIDUnsafeRE.ReplaceAllString(id, ".")
+	id = strings.Trim(id, ".-_")
+	if id == "" {
+		return "preflight.check"
+	}
+	return id
+}
+
+func toolCheckID(tool string) string {
+	return "tool." + normalizeCheckID(toolDisplayName(tool), "binary")
+}
+
+func toolDisplayName(tool string) string {
+	tool = strings.TrimSpace(tool)
+	if tool == "" {
+		return "tool"
+	}
+	base := filepath.Base(tool)
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		return tool
+	}
+	return base
 }
 
 func defaultCommandRunner(ctx context.Context, dir, name string, args ...string) CommandResult {
@@ -328,13 +416,13 @@ func requiredTools(opts PreflightOptions, repoDir string) []string {
 	return tools
 }
 
-func checkGitHubAuth(ctx context.Context, opts PreflightOptions, runner CommandRunner, workDir string, missingTools map[string]bool, add func(string, PreflightStatus, string, string)) {
+func checkGitHubAuth(ctx context.Context, opts PreflightOptions, runner CommandRunner, workDir string, missingTools map[string]bool, add func(string, string, PreflightStatus, string, string, string)) {
 	if !opts.RequireGitHubAuth {
-		add("github auth", PreflightSkipped, "not required", "")
+		add("github.auth", "github auth", PreflightSkipped, "GitHub authentication is not required", "not required", "")
 		return
 	}
 	if missingTools["gh"] {
-		add("github auth", PreflightFailed, "gh CLI is not available", "Install gh and run gh auth login with PR/check/review permissions.")
+		add("github.auth", "github auth", PreflightFailed, "GitHub authentication cannot be checked because gh is missing", "gh CLI is not available", "Install gh and run gh auth login with PR/check/review permissions.")
 		return
 	}
 
@@ -345,45 +433,47 @@ func checkGitHubAuth(ctx context.Context, opts PreflightOptions, runner CommandR
 		if detail == "" {
 			detail = res.Err.Error()
 		}
-		add("github auth", PreflightFailed, detail, "Run gh auth login and ensure the token can create PRs, checks, and reviews.")
+		add("github.auth", "github auth", PreflightFailed, "GitHub authentication is missing or invalid", detail, "Run gh auth login and ensure the token can create PRs, checks, and reviews.")
 		return
 	}
 
 	scopes, foundScopes := parseGitHubScopes(combined)
 	missingScopes := missingGitHubScopes(scopes, opts.RequiredGitHubScopes)
 	if foundScopes && len(missingScopes) > 0 {
-		add("github auth", PreflightFailed, "missing required scope(s): "+strings.Join(missingScopes, ", "), "Refresh gh auth with the required GitHub scopes.")
+		detail := "missing required scope(s): " + strings.Join(missingScopes, ", ")
+		add("github.auth", "github auth", PreflightFailed, "GitHub authentication is missing required scope(s): "+strings.Join(missingScopes, ", "), detail, "Refresh gh auth with the required GitHub scopes.")
 		return
 	}
 	if foundScopes {
-		add("github auth", PreflightPassed, "authenticated with required scopes", "")
+		add("github.auth", "github auth", PreflightPassed, "GitHub authentication has the required scopes", "authenticated with required scopes", "")
 		return
 	}
-	add("github auth", PreflightPassed, "authenticated; scope header unavailable", "")
+	add("github.auth", "github auth", PreflightPassed, "GitHub authentication is available", "authenticated; scope header unavailable", "")
 }
 
-func checkWritablePath(name, path string, add func(string, PreflightStatus, string, string)) {
+func checkWritablePath(id, name, path string, add func(string, string, PreflightStatus, string, string, string)) {
+	label := strings.TrimSuffix(name, " writable")
 	path = strings.TrimSpace(path)
 	if path == "" {
-		add(name, PreflightFailed, "path is empty", "Configure a valid source/worktree path before starting the worker.")
+		add(id, name, PreflightFailed, label+" is not configured", "path is empty", "Configure a valid source/worktree path before starting the worker.")
 		return
 	}
 	info, err := os.Stat(path)
 	if err != nil {
-		add(name, PreflightFailed, err.Error(), "Create the path or fix permissions before starting the worker.")
+		add(id, name, PreflightFailed, label+" does not exist or cannot be inspected", err.Error(), "Create the path or fix permissions before starting the worker.")
 		return
 	}
 	if !info.IsDir() {
-		add(name, PreflightFailed, "path is not a directory", "Configure a directory path before starting the worker.")
+		add(id, name, PreflightFailed, label+" is not a directory", "path is not a directory", "Configure a directory path before starting the worker.")
 		return
 	}
 	if info.Mode().Perm()&0o222 == 0 {
-		add(name, PreflightFailed, "directory has no write permission bits", "Make the directory writable before starting the worker.")
+		add(id, name, PreflightFailed, label+" is not writable", "directory has no write permission bits", "Make the directory writable before starting the worker.")
 		return
 	}
 	tmp, err := os.CreateTemp(path, ".ok-gobot-preflight-*")
 	if err != nil {
-		add(name, PreflightFailed, err.Error(), "Make the directory writable before starting the worker.")
+		add(id, name, PreflightFailed, label+" is not writable", err.Error(), "Make the directory writable before starting the worker.")
 		return
 	}
 	tmpName := tmp.Name()
@@ -392,14 +482,14 @@ func checkWritablePath(name, path string, add func(string, PreflightStatus, stri
 		if cleanupDetail := cleanupPreflightTemp(tmpName); cleanupDetail != "" {
 			detail += "; " + cleanupDetail
 		}
-		add(name, PreflightFailed, detail, "Fix filesystem permissions before starting the worker.")
+		add(id, name, PreflightFailed, label+" could not be verified as writable", detail, "Fix filesystem permissions before starting the worker.")
 		return
 	}
 	detail := "writable"
 	if cleanupDetail := cleanupPreflightTemp(tmpName); cleanupDetail != "" {
 		detail += "; " + cleanupDetail
 	}
-	add(name, PreflightPassed, detail, "")
+	add(id, name, PreflightPassed, label+" is writable", detail, "")
 }
 
 func cleanupPreflightTemp(path string) string {
@@ -417,9 +507,9 @@ func filesystemErrorDetail(err error) string {
 	return err.Error()
 }
 
-func checkGitTrust(ctx context.Context, runner CommandRunner, workDir string, missingTools map[string]bool, add func(string, PreflightStatus, string, string)) {
+func checkGitTrust(ctx context.Context, runner CommandRunner, workDir string, missingTools map[string]bool, add func(string, string, PreflightStatus, string, string, string)) {
 	if missingTools["git"] {
-		add("git trust", PreflightFailed, "git is not available", "Install git before starting the worker.")
+		add("git.trust", "git trust", PreflightFailed, "git is not available", "git is not available", "Install git before starting the worker.")
 		return
 	}
 	root := runner(ctx, workDir, "git", "-C", workDir, "rev-parse", "--show-toplevel")
@@ -432,34 +522,36 @@ func checkGitTrust(ctx context.Context, runner CommandRunner, workDir string, mi
 		addGitFailure("git trust", status, add)
 		return
 	}
-	add("git trust", PreflightPassed, "git status succeeded", "")
+	add("git.trust", "git trust", PreflightPassed, "git repository trust check passed", "git status succeeded", "")
 }
 
-func addGitFailure(name string, result CommandResult, add func(string, PreflightStatus, string, string)) {
+func addGitFailure(name string, result CommandResult, add func(string, string, PreflightStatus, string, string, string)) {
 	detail := strings.TrimSpace(result.Stdout + "\n" + result.Stderr)
 	if detail == "" && result.Err != nil {
 		detail = result.Err.Error()
 	}
+	reason := "git repository trust check failed"
 	remediation := "Fix the repository or git configuration before starting the worker."
 	if strings.Contains(strings.ToLower(detail), "safe.directory") || strings.Contains(strings.ToLower(detail), "dubious ownership") {
+		reason = "repository is not trusted by git"
 		remediation = "Add the repository to git safe.directory after verifying ownership."
 	}
-	add(name, PreflightFailed, detail, remediation)
+	add("git.trust", name, PreflightFailed, reason, detail, remediation)
 }
 
-func checkNetwork(opts PreflightOptions, add func(string, PreflightStatus, string, string)) {
+func checkNetwork(opts PreflightOptions, add func(string, string, PreflightStatus, string, string, string)) {
 	if opts.NetworkDisabled {
-		add("network allowlist", PreflightFailed, "network operations are disabled", "Enable network access for GitHub and model backend operations.")
+		add("network.allowlist", "network allowlist", PreflightFailed, "network access is disabled", "network operations are disabled", "Enable network access for GitHub and model backend operations.")
 		return
 	}
 	requiredHosts := uniqueStrings(opts.RequiredNetworkHosts)
 	allowlist := uniqueStrings(opts.NetworkAllowlist)
 	if len(requiredHosts) == 0 {
-		add("network allowlist", PreflightSkipped, "no required hosts configured", "")
+		add("network.allowlist", "network allowlist", PreflightSkipped, "no required network hosts are configured", "no required hosts configured", "")
 		return
 	}
 	if len(allowlist) == 0 {
-		add("network allowlist", PreflightPassed, "all public hosts allowed", "")
+		add("network.allowlist", "network allowlist", PreflightPassed, "required public network hosts are allowed", "all public hosts allowed", "")
 		return
 	}
 	var blocked []string
@@ -469,10 +561,11 @@ func checkNetwork(opts PreflightOptions, add func(string, PreflightStatus, strin
 		}
 	}
 	if len(blocked) > 0 {
-		add("network allowlist", PreflightFailed, "missing host(s): "+strings.Join(blocked, ", "), "Add the required GitHub/backend hosts to network_allowlist.")
+		detail := "missing host(s): " + strings.Join(blocked, ", ")
+		add("network.allowlist", "network allowlist", PreflightFailed, "required network target is not allowed by the network allowlist", detail, "Add the required GitHub/backend hosts to the network allowlist.")
 		return
 	}
-	add("network allowlist", PreflightPassed, "required hosts allowed", "")
+	add("network.allowlist", "network allowlist", PreflightPassed, "required network hosts are allowed", "required hosts allowed", "")
 }
 
 func parseGitHubScopes(output string) ([]string, bool) {

--- a/internal/worker/preflight_test.go
+++ b/internal/worker/preflight_test.go
@@ -60,6 +60,22 @@ func TestRunPreflightMissingTool(t *testing.T) {
 	if !hasCheck(report, "tool: go", PreflightFailed) {
 		t.Fatalf("expected missing go failure: %+v", report.Checks)
 	}
+	check, ok := findCheckByID(report, "tool.go")
+	if !ok {
+		t.Fatalf("expected stable tool.go check id: %+v", report.Checks)
+	}
+	if check.Reason != "go is not available in PATH" || !strings.Contains(check.Remediation, "Install go") {
+		t.Fatalf("unexpected missing tool check: %+v", check)
+	}
+	summary := report.Summary()
+	for _, want := range []string{"preflight failed: [tool.go] go is not available in PATH", "Hint: Install go"} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("summary missing %q: %s", want, summary)
+		}
+	}
+	if strings.Count(summary, "preflight failed") != 1 {
+		t.Fatalf("summary repeated preflight prefix: %s", summary)
+	}
 }
 
 func TestRunPreflightMissingAuth(t *testing.T) {
@@ -80,8 +96,21 @@ func TestRunPreflightMissingAuth(t *testing.T) {
 	if !hasCheck(report, "github auth", PreflightFailed) {
 		t.Fatalf("expected github auth failure: %+v", report.Checks)
 	}
+	check, ok := findCheckByID(report, "github.auth")
+	if !ok {
+		t.Fatalf("expected stable github.auth check id: %+v", report.Checks)
+	}
+	if check.Reason != "GitHub authentication is missing or invalid" || !strings.Contains(check.Remediation, "gh auth login") {
+		t.Fatalf("unexpected auth check: %+v", check)
+	}
 	if strings.Contains(report.Summary(), secret) || strings.Contains(report.EvidenceJSON(), secret) {
 		t.Fatalf("preflight output leaked secret: %s", report.EvidenceJSON())
+	}
+	for _, want := range []string{"[github.auth] GitHub authentication is missing or invalid", "Hint: Run gh auth login", `"id": "github.auth"`, `"reason": "GitHub authentication is missing or invalid"`} {
+		combined := report.Summary() + "\n" + report.EvidenceJSON()
+		if !strings.Contains(combined, want) {
+			t.Fatalf("preflight output missing %q:\n%s", want, combined)
+		}
 	}
 }
 
@@ -101,6 +130,56 @@ func TestRunPreflightNonWritableWorktree(t *testing.T) {
 	}
 	if !hasCheck(report, "worktree path writable", PreflightFailed) {
 		t.Fatalf("expected worktree writable failure: %+v", report.Checks)
+	}
+	check, ok := findCheckByID(report, "path.worktree.writable")
+	if !ok {
+		t.Fatalf("expected stable path.worktree.writable check id: %+v", report.Checks)
+	}
+	if check.Reason != "worktree path is not writable" || !strings.Contains(check.Remediation, "writable") {
+		t.Fatalf("unexpected writable path check: %+v", check)
+	}
+}
+
+func TestRunPreflightNetworkFailureHasRemediation(t *testing.T) {
+	repo := newPreflightRepo(t)
+	opts := passingPreflightOptions(repo)
+	opts.NetworkAllowlist = []string{"github.com"}
+
+	report := RunPreflight(context.Background(), opts)
+	if report.OK {
+		t.Fatalf("preflight unexpectedly passed")
+	}
+	check, ok := findCheckByID(report, "network.allowlist")
+	if !ok {
+		t.Fatalf("expected network.allowlist failure: %+v", report.Checks)
+	}
+	if check.Status != PreflightFailed || check.Reason != "required network target is not allowed by the network allowlist" || !strings.Contains(check.Remediation, "network allowlist") {
+		t.Fatalf("unexpected network check: %+v", check)
+	}
+}
+
+func TestRunPreflightMissingTestCommandHasSkippedRemediation(t *testing.T) {
+	repo := t.TempDir()
+	opts := WorkerPreflightOptions("claude", "claude", "claude-sonnet-test", repo, nil)
+	opts.SourceDir = repo
+	opts.RequireGitHubAuth = false
+	opts.LookPath = func(name string) (string, error) {
+		return "/usr/bin/" + filepath.Base(name), nil
+	}
+	opts.CommandRunner = func(_ context.Context, _ string, name string, args ...string) CommandResult {
+		return passingCommandResult(repo, name, args...)
+	}
+
+	report := RunPreflight(context.Background(), opts)
+	if !report.OK {
+		t.Fatalf("preflight failed: %s", report.Summary())
+	}
+	check, ok := findCheckByID(report, "repo.test_command")
+	if !ok {
+		t.Fatalf("expected repo.test_command check: %+v", report.Checks)
+	}
+	if check.Status != PreflightSkipped || check.Reason != "no repo-specific test command was detected" || !strings.Contains(check.Remediation, "go.mod") {
+		t.Fatalf("unexpected test command check: %+v", check)
 	}
 }
 
@@ -173,6 +252,15 @@ func hasCheck(report PreflightReport, name string, status PreflightStatus) bool 
 		}
 	}
 	return false
+}
+
+func findCheckByID(report PreflightReport, id string) (PreflightCheck, bool) {
+	for _, check := range report.Checks {
+		if check.ID == id {
+			return check, true
+		}
+	}
+	return PreflightCheck{}, false
 }
 
 func containsString(values []string, want string) bool {


### PR DESCRIPTION
Implements #372

## Changes
- Added stable preflight check ids, concise reasons, and remediation hints to worker preflight reports and summaries.
- Removed duplicate batch preflight failure wording and surfaced preflight_failed as terminal in CLI/Telegram job views.
- Added focused coverage for formatting consistency across CLI, Telegram, Mission Control, job errors, and redacted artifacts.

## Testing
- bash .maestro/verify.sh
- git fetch origin
- git rebase origin/main
- go fmt ./...
- go vet ./...
- go test ./...
- go build ./cmd/ok-gobot/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR normalizes preflight failure messaging by introducing structured `PreflightFailure` and `PreflightReport` types with stable check IDs, concise reasons, and remediation hints. It removes the double-prefixing that occurred when `batch/runner.go` wrapped `report.Summary()` with an additional `"worker preflight failed: "` label, and propagates `preflight_failed` as an explicit terminal status across the CLI tail loop, Telegram notifications, and `jobStatusIcon`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are consistent, well-tested, and introduce no logic regressions

All changed surfaces (batch runner, CLI, Telegram, Mission Control) are updated consistently for the new preflight_failed terminal status. The duplicate-prefix removal in batch/runner.go is correct. Tests cover the no-duplicate-prefix invariant, secret redaction, stable check IDs, and end-to-end job lifecycle. No logic bugs found.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/preflight.go | New structured PreflightFailure/PreflightReport types with stable IDs, redaction, and remediation hints; clean and well-tested |
| internal/batch/runner.go | Drops the now-redundant "worker preflight failed:" wrapper since report.Summary() already carries the full normalized message |
| internal/bot/role_job_notifications.go | Adds preflight_failed to isTerminalRoleJobStatus, roleJobFinalHeading, and dedicated heading/reason formatting; consistent with other terminal statuses |
| internal/bot/role_commands.go | Adds preflight_failed to the ❌ icon case in jobStatusIcon; straightforward one-line fix |
| internal/cli/jobs.go | Adds preflight_failed to isTerminalStatus and filter flag help text; no issues |
| internal/cli/roles.go | isRoleJobTerminal uses the runtime.JobStatusPreflightFailed constant, consistent with all other terminal-status checks |
| internal/worker/preflight_test.go | Thorough coverage of stable IDs, redaction, remediation hints, and no-duplicate-prefix invariant |
| internal/worker/bridge_test.go | New integration test verifies preflight_failed job event, stored error format, and artifact redaction end-to-end |
| internal/cli/jobs_test.go | New TestJobsInspectPreflightFailureShowsNormalizedError validates the normalized error format and single-prefix invariant in the CLI |
| internal/bot/role_commands_test.go | Adds Telegram-specific test for preflight_failed heading and reason formatting |
| internal/control/mission_test.go | Adds Mission Control test for preflight_failed run filtering; no issues |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: normalize worker preflight failures..."](https://github.com/befeast/ok-gobot/commit/199e8343c48811f14762f521f71b1c2002d80892) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30518816)</sub>

<!-- /greptile_comment -->