### PR TITLE
fix: harden frontend verify for role-job demos (#343)

### DIFF
--- a/internal/artifacts/display.go
+++ b/internal/artifacts/display.go
@@ -559,6 +559,31 @@ func ContentPath(artifact storage.JobArtifact, roots []string) (string, error) {
 	return result.Path, nil
 }
 
+// GeneratedLocalPath returns a path for a new local artifact file under the
+// first configured safe root. The filename must be a plain basename so callers
+// cannot accidentally escape the artifact root with path traversal.
+func GeneratedLocalPath(roots []string, filename string) (string, error) {
+	filename = strings.TrimSpace(filename)
+	if filename == "" || filename != filepath.Base(filename) || filename == "." || filename == string(os.PathSeparator) {
+		return "", fmt.Errorf("artifact filename must be a plain filename")
+	}
+
+	normalizedRoots := NormalizeRoots(roots)
+	if len(normalizedRoots) == 0 {
+		normalizedRoots = DefaultRoots()
+	}
+	if len(normalizedRoots) == 0 {
+		return "", fmt.Errorf("no configured artifact root is available")
+	}
+
+	root := normalizedRoots[0]
+	path := filepath.Clean(filepath.Join(root, filename))
+	if !pathInsideRoot(path, root) {
+		return "", fmt.Errorf("generated artifact path escapes configured artifact root")
+	}
+	return path, nil
+}
+
 func (s Serializer) contentHref(id int64) string {
 	if s.ContentURLPrefix == "" || id <= 0 {
 		return ""

--- a/internal/artifacts/display_test.go
+++ b/internal/artifacts/display_test.go
@@ -260,6 +260,29 @@ func TestBuildMetadataForRootsDoesNotHashSymlinkEscape(t *testing.T) {
 	}
 }
 
+func TestGeneratedLocalPathStaysUnderConfiguredRoot(t *testing.T) {
+	root := t.TempDir()
+
+	path, err := GeneratedLocalPath([]string{root}, "frontend_verify_20260502_120000.png")
+	if err != nil {
+		t.Fatalf("GeneratedLocalPath failed: %v", err)
+	}
+	if !strings.HasPrefix(path, root+string(os.PathSeparator)) {
+		t.Fatalf("generated path %q is outside root %q", path, root)
+	}
+	if filepath.Base(path) != "frontend_verify_20260502_120000.png" {
+		t.Fatalf("generated path = %q", path)
+	}
+}
+
+func TestGeneratedLocalPathRejectsTraversalFilename(t *testing.T) {
+	root := t.TempDir()
+
+	if path, err := GeneratedLocalPath([]string{root}, "../escape.png"); err == nil {
+		t.Fatalf("GeneratedLocalPath accepted traversal path %q", path)
+	}
+}
+
 func TestSerializerClassifiesURLAndTextReport(t *testing.T) {
 	serializer := NewSerializer([]string{t.TempDir()}, "/api/artifacts")
 

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -976,6 +976,23 @@ func (b *Bot) SetRolesPath(path string) {
 // SetArtifactRoots sets local roots allowed for role proof artifacts.
 func (b *Bot) SetArtifactRoots(roots []string) {
 	b.artifactRoots = append([]string(nil), roots...)
+	if b.toolRegistry == nil {
+		return
+	}
+	tool, ok := b.toolRegistry.Get("frontend_verify")
+	if !ok {
+		return
+	}
+	for {
+		wrapped, ok := tool.(interface{ Unwrap() tools.Tool })
+		if !ok {
+			break
+		}
+		tool = wrapped.Unwrap()
+	}
+	if verifier, ok := tool.(*tools.FrontendVerifyTool); ok {
+		verifier.SetArtifactRoots(roots)
+	}
 }
 
 // SubagentHub returns the runtime Hub used for sub-agent completion routing.

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -311,6 +311,7 @@ func newRoleRunSubmitter(cfg *config.Config, store *storage.Store) (rolejob.Agen
 		ChromePath:      cfg.Browser.ChromePath,
 		BrowserProfile:  cfg.Browser.ProfilePath,
 		BrowserDebugURL: cfg.Browser.DebugURL,
+		ArtifactRoots:   cfg.Artifacts.Roots,
 		PatternStore:    store,
 		EmergencyStop:   store,
 		AIClient:        aiClient,

--- a/internal/rolejob/runner.go
+++ b/internal/rolejob/runner.go
@@ -182,28 +182,105 @@ func extractToolArtifacts(event agent.ToolEvent) []jobruntime.JobArtifactSpec {
 	}
 
 	var out struct {
-		ScreenshotPath string `json:"screenshot_path"`
+		ScreenshotPath     string `json:"screenshot_path"`
+		ScreenshotURI      string `json:"screenshot_uri"`
+		TargetURL          string `json:"target_url"`
+		URL                string `json:"url"`
+		VerificationStatus string `json:"verification_status"`
+		Status             string `json:"status"`
+		TextReport         string `json:"text_report"`
+		Feedback           string `json:"feedback"`
+		Match              bool   `json:"match"`
 	}
 	output := strings.TrimSpace(event.FullOutput)
 	if output == "" {
 		output = event.Output
 	}
-	if err := json.Unmarshal([]byte(output), &out); err != nil || strings.TrimSpace(out.ScreenshotPath) == "" {
+	if err := json.Unmarshal([]byte(output), &out); err != nil {
 		return nil
 	}
 
-	path := strings.TrimSpace(out.ScreenshotPath)
-	mimeType := mime.TypeByExtension(strings.ToLower(filepath.Ext(path)))
-	if mimeType == "" {
-		mimeType = "image/png"
+	var artifacts []jobruntime.JobArtifactSpec
+	targetURL := firstNonEmpty(out.TargetURL, out.URL)
+	status := firstNonEmpty(out.VerificationStatus, out.Status)
+	if status == "" {
+		if out.Match {
+			status = "passed"
+		} else {
+			status = "failed"
+		}
 	}
-	return []jobruntime.JobArtifactSpec{{
-		Name:     "frontend-verify-screenshot",
-		Type:     jobruntime.JobArtifactTypeScreenshot,
-		MimeType: mimeType,
-		URI:      path,
-		Metadata: map[string]any{"source": "frontend_verify"},
-	}}
+	metadata := map[string]any{"source": "frontend_verify"}
+	if targetURL != "" {
+		metadata["target_url"] = targetURL
+	}
+	if status != "" {
+		metadata["verification_status"] = status
+	}
+
+	path := strings.TrimSpace(out.ScreenshotPath)
+	if path == "" {
+		path = strings.TrimSpace(out.ScreenshotURI)
+	}
+	if path != "" {
+		mimeType := mime.TypeByExtension(strings.ToLower(filepath.Ext(path)))
+		if mimeType == "" {
+			mimeType = "image/png"
+		}
+		artifacts = append(artifacts, jobruntime.JobArtifactSpec{
+			Name:     "frontend-verify-screenshot",
+			Type:     jobruntime.JobArtifactTypeScreenshot,
+			MimeType: mimeType,
+			URI:      path,
+			Metadata: metadata,
+		})
+	}
+	if targetURL != "" {
+		artifacts = append(artifacts, jobruntime.JobArtifactSpec{
+			Name:     "frontend-verify-url",
+			Type:     jobruntime.JobArtifactTypeURL,
+			URI:      targetURL,
+			Metadata: metadata,
+		})
+	}
+	if report := frontendVerifyArtifactReport(out.TextReport, status, targetURL, out.Feedback); report != "" {
+		artifacts = append(artifacts, jobruntime.JobArtifactSpec{
+			Name:     "frontend-verify-report",
+			Type:     jobruntime.JobArtifactTypeTextReport,
+			MimeType: "text/markdown",
+			Content:  report,
+			Metadata: metadata,
+		})
+	}
+	return artifacts
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func frontendVerifyArtifactReport(textReport, status, targetURL, feedback string) string {
+	if report := strings.TrimSpace(textReport); report != "" {
+		return report
+	}
+	feedback = strings.Join(strings.Fields(strings.TrimSpace(feedback)), " ")
+	if feedback == "" {
+		return ""
+	}
+	status = strings.TrimSpace(status)
+	if status == "" {
+		status = "completed"
+	}
+	targetURL = strings.TrimSpace(targetURL)
+	if targetURL == "" {
+		return fmt.Sprintf("frontend_verify %s: %s", status, feedback)
+	}
+	return fmt.Sprintf("frontend_verify %s for %s: %s", status, targetURL, feedback)
 }
 
 func roleRunSessionKey(job *storage.Job, m *role.Manifest, opts Options) agent.SessionKey {

--- a/internal/rolejob/runner_test.go
+++ b/internal/rolejob/runner_test.go
@@ -163,7 +163,7 @@ func TestAgentJobRunnerPersistsFrontendVerifyScreenshot(t *testing.T) {
 	if err := os.WriteFile(shotPath, []byte("png"), 0o644); err != nil {
 		t.Fatalf("write screenshot: %v", err)
 	}
-	fullOutput := `{"match":true,"feedback":"` + strings.Repeat("verbose ", 60) + `","screenshot_path":"` + shotPath + `"}`
+	fullOutput := `{"match":true,"target_url":"http://127.0.0.1:5173","verification_status":"passed","text_report":"frontend_verify passed for http://127.0.0.1:5173","feedback":"` + strings.Repeat("verbose ", 60) + `","screenshot_path":"` + shotPath + `"}`
 	truncatedOutput := fullOutput[:300] + "…"
 
 	manifest := &role.Manifest{Name: "prototype", Prompt: "Build and verify UI", Worker: "standard"}
@@ -193,17 +193,31 @@ func TestAgentJobRunnerPersistsFrontendVerifyScreenshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListJobArtifacts failed: %v", err)
 	}
-	found := false
+	foundScreenshot := false
+	foundURL := false
+	foundReport := false
 	for _, artifact := range artifacts {
 		if artifact.ArtifactType == jobruntime.JobArtifactTypeScreenshot {
-			found = true
+			foundScreenshot = true
 			if artifact.URI != shotPath || artifact.Content != "" {
 				t.Fatalf("unexpected screenshot artifact: %+v", artifact)
 			}
 		}
+		if artifact.ArtifactType == jobruntime.JobArtifactTypeURL && artifact.URI == "http://127.0.0.1:5173" {
+			foundURL = true
+		}
+		if artifact.ArtifactType == jobruntime.JobArtifactTypeTextReport && strings.Contains(artifact.Content, "frontend_verify passed") {
+			foundReport = true
+		}
 	}
-	if !found {
+	if !foundScreenshot {
 		t.Fatalf("missing screenshot artifact: %+v", artifacts)
+	}
+	if !foundURL {
+		t.Fatalf("missing frontend_verify URL artifact: %+v", artifacts)
+	}
+	if !foundReport {
+		t.Fatalf("missing frontend_verify text report artifact: %+v", artifacts)
 	}
 }
 

--- a/internal/tools/frontend_verify.go
+++ b/internal/tools/frontend_verify.go
@@ -6,15 +6,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/chromedp/chromedp"
 
 	"ok-gobot/internal/ai"
+	artifactview "ok-gobot/internal/artifacts"
 	"ok-gobot/internal/browser"
 	"ok-gobot/internal/logger"
 )
@@ -25,6 +28,7 @@ const (
 	frontendVerifyRetryDelay         = 2 * time.Second
 	frontendVerifyOpTimeout          = 60 * time.Second
 	frontendVerifyHealthInterval     = 500 * time.Millisecond
+	frontendVerifyAutoCommand        = "auto"
 )
 
 // FrontendVerifyTool starts a local dev server, captures a screenshot via CDP,
@@ -35,6 +39,7 @@ type FrontendVerifyTool struct {
 	manager       *browser.Manager
 	aiClient      ai.Client // nil = no LLM comparison, returns screenshot path only
 	screenshotDir string
+	artifactRoots []string
 
 	mu         sync.Mutex
 	devServers map[string]*devServerProc // key: workDir
@@ -43,16 +48,26 @@ type FrontendVerifyTool struct {
 type devServerProc struct {
 	cmd    *exec.Cmd
 	cancel context.CancelFunc
+	done   chan error
+
+	mu     sync.Mutex
+	exited bool
+	err    error
 }
 
 // FrontendVerifyResult is the structured response from the tool.
 type FrontendVerifyResult struct {
-	Match          bool   `json:"match"`
-	Score          string `json:"score,omitempty"`
-	Feedback       string `json:"feedback"`
-	Suggestions    string `json:"suggestions,omitempty"`
-	ScreenshotPath string `json:"screenshot_path"`
-	ServerRunning  bool   `json:"server_running"`
+	Match              bool   `json:"match"`
+	Score              string `json:"score,omitempty"`
+	Feedback           string `json:"feedback"`
+	Suggestions        string `json:"suggestions,omitempty"`
+	ScreenshotPath     string `json:"screenshot_path"`
+	ScreenshotURI      string `json:"screenshot_uri,omitempty"`
+	TargetURL          string `json:"target_url,omitempty"`
+	VerificationStatus string `json:"verification_status,omitempty"`
+	TextReport         string `json:"text_report,omitempty"`
+	DevCommand         string `json:"dev_command,omitempty"`
+	ServerRunning      bool   `json:"server_running"`
 }
 
 // NewFrontendVerifyTool creates a FrontendVerifyTool with its own browser.Manager instance.
@@ -78,6 +93,7 @@ func (t *FrontendVerifyTool) Name() string { return "frontend_verify" }
 func (t *FrontendVerifyTool) Description() string {
 	return "Verify frontend UI output: optionally start a local dev server, take a CDP screenshot, " +
 		"and compare the result against an expected description using LLM vision. " +
+		"Use command=auto to detect npm, pnpm, yarn, or bun when practical. " +
 		"Call repeatedly after code changes to iterate until the UI matches."
 }
 
@@ -93,13 +109,19 @@ func (t *FrontendVerifyTool) Execute(ctx context.Context, args ...string) (strin
 }
 
 func (t *FrontendVerifyTool) ExecuteJSON(ctx context.Context, params map[string]string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	rawURL := params["url"]
 	if rawURL == "" {
 		return "", fmt.Errorf("url is required")
 	}
+	if err := validateFrontendVerifyURL(ctx, rawURL); err != nil {
+		return "", err
+	}
 
 	description := params["description"]
-	command := params["command"]
+	command := strings.TrimSpace(params["command"])
 	workDir := params["work_dir"]
 
 	waitTimeout := frontendVerifyDefaultWaitTimeout
@@ -124,24 +146,37 @@ func (t *FrontendVerifyTool) ExecuteJSON(ctx context.Context, params map[string]
 		return `{"stopped":true}`, nil
 	}
 
-	// Start dev server if a command was provided.
+	if command == "" && parseFrontendVerifyBool(params["auto_start"]) {
+		command = frontendVerifyAutoCommand
+	}
+
+	// Start dev server if a command was provided or auto-detection was requested.
+	resolvedCommand := ""
 	if command != "" {
-		if err := t.ensureDevServer(ctx, command, workDir); err != nil {
+		var err error
+		resolvedCommand, err = resolveFrontendDevCommand(command, workDir)
+		if err != nil {
+			return "", err
+		}
+		if err := t.ensureDevServer(ctx, resolvedCommand, workDir); err != nil {
 			return "", fmt.Errorf("failed to start dev server: %w", err)
 		}
 	}
 
-	serverRunning := command != "" || t.isDevServerRunning(workDir)
+	serverRunning := t.isDevServerRunning(workDir)
 
 	// Wait for the URL to become accessible.
 	if err := t.waitForURL(ctx, rawURL, waitTimeout); err != nil {
 		result := FrontendVerifyResult{
 			Match:         false,
 			Feedback:      fmt.Sprintf("URL %s did not become accessible within %s: %v", rawURL, waitTimeout, err),
-			ServerRunning: serverRunning,
+			TargetURL:     rawURL,
+			DevCommand:    resolvedCommand,
+			ServerRunning: t.isDevServerRunning(workDir),
 		}
 		return marshalResult(result)
 	}
+	serverRunning = t.isDevServerRunning(workDir)
 
 	// Iterate: take screenshot(s), compare, retry if hot-reload is still settling.
 	var lastResult FrontendVerifyResult
@@ -155,11 +190,13 @@ func (t *FrontendVerifyTool) ExecuteJSON(ctx context.Context, params map[string]
 			}
 		}
 
-		imgData, path, err := t.captureScreenshot(ctx, rawURL)
+		imgData, path, screenshotURI, err := t.captureScreenshot(ctx, rawURL)
 		if err != nil {
 			lastResult = FrontendVerifyResult{
 				Match:         false,
 				Feedback:      fmt.Sprintf("screenshot failed: %v", err),
+				TargetURL:     rawURL,
+				DevCommand:    resolvedCommand,
 				ServerRunning: serverRunning,
 			}
 			continue
@@ -167,6 +204,9 @@ func (t *FrontendVerifyTool) ExecuteJSON(ctx context.Context, params map[string]
 
 		lastResult = FrontendVerifyResult{
 			ScreenshotPath: path,
+			ScreenshotURI:  screenshotURI,
+			TargetURL:      rawURL,
+			DevCommand:     resolvedCommand,
 			ServerRunning:  serverRunning,
 		}
 
@@ -206,7 +246,7 @@ func (t *FrontendVerifyTool) ensureDevServer(ctx context.Context, command, workD
 	key := workDir
 	if proc, ok := t.devServers[key]; ok {
 		// Already running — check if process is still alive.
-		if proc.cmd.ProcessState == nil {
+		if proc.running() {
 			logger.Debugf("frontend_verify: dev server already running for %s", key)
 			return nil
 		}
@@ -229,9 +269,32 @@ func (t *FrontendVerifyTool) ensureDevServer(ctx context.Context, command, workD
 		return fmt.Errorf("failed to start dev server command %q: %w", command, err)
 	}
 
-	t.devServers[key] = &devServerProc{cmd: cmd, cancel: cancel}
+	proc := &devServerProc{cmd: cmd, cancel: cancel, done: make(chan error, 1)}
+	go func() {
+		proc.done <- cmd.Wait()
+	}()
+
+	t.devServers[key] = proc
 	logger.Debugf("frontend_verify: started dev server pid=%d for workDir=%q", cmd.Process.Pid, workDir)
 	return nil
+}
+
+func (p *devServerProc) running() bool {
+	if p == nil {
+		return false
+	}
+	select {
+	case err := <-p.done:
+		p.mu.Lock()
+		p.exited = true
+		p.err = err
+		p.mu.Unlock()
+		return false
+	default:
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return !p.exited
 }
 
 // stopDevServer kills the dev server for workDir.
@@ -251,8 +314,8 @@ func (t *FrontendVerifyTool) stopDevServer(workDir string) {
 func (t *FrontendVerifyTool) isDevServerRunning(workDir string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	_, ok := t.devServers[workDir]
-	return ok
+	proc, ok := t.devServers[workDir]
+	return ok && proc.running()
 }
 
 // waitForURL polls the URL with HTTP GET until it responds or timeout.
@@ -280,17 +343,228 @@ func (t *FrontendVerifyTool) waitForURL(ctx context.Context, rawURL string, time
 	return fmt.Errorf("timed out waiting for %s: %w", rawURL, lastErr)
 }
 
+func validateFrontendVerifyURL(ctx context.Context, rawURL string) error {
+	if policy := NetworkPolicyFromContext(ctx); policy != nil {
+		if denial := CheckNetworkTarget("frontend_verify", rawURL, policy); denial != nil {
+			return denial
+		}
+		return nil
+	}
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed == nil || parsed.Hostname() == "" {
+		return fmt.Errorf("frontend_verify requires a full http or https URL")
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme: %s", scheme)
+	}
+	return nil
+}
+
+func parseFrontendVerifyBool(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "t", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveFrontendDevCommand(command, workDir string) (string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return "", nil
+	}
+	if isFrontendAutoCommand(command) {
+		return detectFrontendDevCommand(workDir)
+	}
+
+	exe := firstShellExecutable(command)
+	if exe == "" || isShellBuiltin(exe) || containsShellControl(command) {
+		return command, nil
+	}
+	if _, err := exec.LookPath(exe); err == nil {
+		return command, nil
+	}
+	if isSupportedFrontendPackageManager(exe) {
+		fallback, err := detectFrontendDevCommand(workDir)
+		if err == nil {
+			logger.Debugf("frontend_verify: using detected dev command %q because %q is not in PATH", fallback, exe)
+			return fallback, nil
+		}
+		return "", fmt.Errorf("dev server command %q requires %q, but %q is not in PATH; %v", command, exe, exe, err)
+	}
+	return "", fmt.Errorf("dev server command executable %q is not in PATH; install it or pass command=auto in a frontend project with package.json", exe)
+}
+
+func isFrontendAutoCommand(command string) bool {
+	switch strings.ToLower(strings.TrimSpace(command)) {
+	case frontendVerifyAutoCommand, "detect", "auto-detect":
+		return true
+	default:
+		return false
+	}
+}
+
+func detectFrontendDevCommand(workDir string) (string, error) {
+	dir, err := frontendWorkDir(workDir)
+	if err != nil {
+		return "", err
+	}
+
+	scripts, err := frontendPackageScripts(dir)
+	if err != nil {
+		return "", err
+	}
+	script, ok := preferredFrontendDevScript(scripts)
+	if !ok {
+		return "", fmt.Errorf("no supported frontend dev command available in %s: package.json has no dev, start, serve, or preview script; pass a dev server command explicitly", dir)
+	}
+
+	for _, manager := range frontendPackageManagerOrder(dir) {
+		if _, err := exec.LookPath(manager); err == nil {
+			return frontendRunScriptCommand(manager, script), nil
+		}
+	}
+
+	return "", fmt.Errorf("no supported frontend dev command available in %s: package.json has a %q script, but none of npm, pnpm, yarn, or bun are available in PATH; install one of them or pass a dev server command explicitly", dir, script)
+}
+
+func frontendWorkDir(workDir string) (string, error) {
+	if strings.TrimSpace(workDir) == "" {
+		return os.Getwd()
+	}
+	return filepath.Abs(workDir)
+}
+
+func frontendPackageScripts(dir string) (map[string]string, error) {
+	path := filepath.Join(dir, "package.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("no supported frontend dev command available in %s: package.json not found; pass a dev server command explicitly", dir)
+		}
+		return nil, fmt.Errorf("read package.json: %w", err)
+	}
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, fmt.Errorf("parse package.json: %w", err)
+	}
+	return pkg.Scripts, nil
+}
+
+func preferredFrontendDevScript(scripts map[string]string) (string, bool) {
+	for _, name := range []string{"dev", "start", "serve", "preview"} {
+		if strings.TrimSpace(scripts[name]) != "" {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func frontendPackageManagerOrder(dir string) []string {
+	var order []string
+	add := func(name string) {
+		for _, existing := range order {
+			if existing == name {
+				return
+			}
+		}
+		order = append(order, name)
+	}
+	if fileExists(filepath.Join(dir, "bun.lock")) || fileExists(filepath.Join(dir, "bun.lockb")) {
+		add("bun")
+	}
+	if fileExists(filepath.Join(dir, "pnpm-lock.yaml")) {
+		add("pnpm")
+	}
+	if fileExists(filepath.Join(dir, "yarn.lock")) {
+		add("yarn")
+	}
+	if fileExists(filepath.Join(dir, "package-lock.json")) {
+		add("npm")
+	}
+	for _, name := range []string{"npm", "pnpm", "yarn", "bun"} {
+		add(name)
+	}
+	return order
+}
+
+func frontendRunScriptCommand(manager, script string) string {
+	switch manager {
+	case "npm":
+		if script == "start" {
+			return "npm start"
+		}
+		return "npm run " + script
+	case "yarn":
+		return "yarn " + script
+	default:
+		return manager + " run " + script
+	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func firstShellExecutable(command string) string {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return ""
+	}
+	i := 0
+	if fields[i] == "env" {
+		i++
+	}
+	for i < len(fields) && strings.Contains(fields[i], "=") && !strings.HasPrefix(fields[i], "=") {
+		i++
+	}
+	if i >= len(fields) {
+		return ""
+	}
+	return strings.Trim(fields[i], "'\"")
+}
+
+func isShellBuiltin(name string) bool {
+	switch name {
+	case "cd", "exec", "source", ".", "export", "ulimit":
+		return true
+	default:
+		return false
+	}
+}
+
+func containsShellControl(command string) bool {
+	return strings.ContainsAny(command, "|&;()<>")
+}
+
+func isSupportedFrontendPackageManager(name string) bool {
+	switch name {
+	case "npm", "pnpm", "yarn", "bun":
+		return true
+	default:
+		return false
+	}
+}
+
 // captureScreenshot navigates to rawURL using the ephemeral browser profile and
 // captures a full-page screenshot, saving it to screenshotDir.
 // Localhost/loopback URLs are explicitly allowed for dev server use.
-func (t *FrontendVerifyTool) captureScreenshot(ctx context.Context, rawURL string) ([]byte, string, error) {
+func (t *FrontendVerifyTool) captureScreenshot(ctx context.Context, rawURL string) ([]byte, string, string, error) {
 	if err := t.manager.StartProfile(browser.ProfileEphemeral); err != nil {
-		return nil, "", fmt.Errorf("failed to start ephemeral browser: %w", err)
+		return nil, "", "", fmt.Errorf("failed to start ephemeral browser: %w", err)
 	}
 
 	tabCtx, cancel, err := t.manager.NewTabForProfile(browser.ProfileEphemeral)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create browser tab: %w", err)
+		return nil, "", "", fmt.Errorf("failed to create browser tab: %w", err)
 	}
 	defer cancel()
 
@@ -303,25 +577,49 @@ func (t *FrontendVerifyTool) captureScreenshot(ctx context.Context, rawURL strin
 		chromedp.WaitReady("body"),
 		chromedp.FullScreenshot(&buf, 90),
 	); err != nil {
-		return nil, "", fmt.Errorf("chromedp screenshot failed: %w", err)
+		return nil, "", "", fmt.Errorf("chromedp screenshot failed: %w", err)
 	}
 
-	dir := t.screenshotDir
-	if dir == "" {
-		homeDir, _ := os.UserHomeDir()
-		dir = filepath.Join(homeDir, ".ok-gobot", "screenshots")
+	path, err := t.newScreenshotPath(time.Now())
+	if err != nil {
+		return nil, "", "", err
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, "", fmt.Errorf("failed to create screenshot dir: %w", err)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, "", "", fmt.Errorf("failed to create screenshot dir: %w", err)
 	}
-
-	filename := fmt.Sprintf("frontend_verify_%s.png", time.Now().Format("20060102_150405"))
-	path := filepath.Join(dir, filename)
 	if err := os.WriteFile(path, buf, 0o644); err != nil {
-		return nil, "", fmt.Errorf("failed to save screenshot: %w", err)
+		return nil, "", "", fmt.Errorf("failed to save screenshot: %w", err)
 	}
 
-	return buf, path, nil
+	return buf, path, localFileURI(path), nil
+}
+
+func (t *FrontendVerifyTool) newScreenshotPath(now time.Time) (string, error) {
+	filename := fmt.Sprintf("frontend_verify_%s_%09d.png", now.Format("20060102_150405"), now.Nanosecond())
+	return artifactview.GeneratedLocalPath(t.screenshotRoots(), filename)
+}
+
+func (t *FrontendVerifyTool) screenshotRoots() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if strings.TrimSpace(t.screenshotDir) != "" {
+		return []string{t.screenshotDir}
+	}
+	return append([]string(nil), t.artifactRoots...)
+}
+
+// SetArtifactRoots configures the safe local roots used for generated screenshots.
+func (t *FrontendVerifyTool) SetArtifactRoots(roots []string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.artifactRoots = append([]string(nil), roots...)
+}
+
+func localFileURI(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	return (&url.URL{Scheme: "file", Path: path}).String()
 }
 
 type llmCompareResult struct {
@@ -432,11 +730,72 @@ func parseLLMCompareResult(raw string) (*llmCompareResult, error) {
 }
 
 func marshalResult(r FrontendVerifyResult) (string, error) {
+	r = completeFrontendVerifyResult(r)
 	b, err := json.Marshal(r)
 	if err != nil {
 		return "", fmt.Errorf("failed to encode result: %w", err)
 	}
 	return string(b), nil
+}
+
+func completeFrontendVerifyResult(r FrontendVerifyResult) FrontendVerifyResult {
+	if strings.TrimSpace(r.VerificationStatus) == "" {
+		if r.Match {
+			r.VerificationStatus = "passed"
+		} else {
+			r.VerificationStatus = "failed"
+		}
+	}
+	if strings.TrimSpace(r.TextReport) == "" {
+		r.TextReport = frontendVerifyTextReport(r)
+	}
+	return r
+}
+
+func frontendVerifyTextReport(r FrontendVerifyResult) string {
+	status := strings.TrimSpace(r.VerificationStatus)
+	if status == "" {
+		if r.Match {
+			status = "passed"
+		} else {
+			status = "failed"
+		}
+	}
+	target := strings.TrimSpace(r.TargetURL)
+	if target == "" {
+		target = "target URL"
+	}
+
+	feedback := compactFrontendVerifyText(r.Feedback)
+	if feedback == "" {
+		feedback = "verification completed"
+	}
+	if score := strings.TrimSpace(r.Score); score != "" {
+		feedback = "score " + score + "; " + feedback
+	}
+	if suggestions := compactFrontendVerifyText(r.Suggestions); suggestions != "" && !r.Match {
+		feedback += "; suggestions: " + suggestions
+	}
+
+	return truncateFrontendVerifyText(fmt.Sprintf("frontend_verify %s for %s: %s", status, target, feedback), 600)
+}
+
+func compactFrontendVerifyText(s string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(s)), " ")
+}
+
+func truncateFrontendVerifyText(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
 }
 
 func (t *FrontendVerifyTool) GetSchema() map[string]interface{} {
@@ -453,7 +812,11 @@ func (t *FrontendVerifyTool) GetSchema() map[string]interface{} {
 			},
 			"command": map[string]interface{}{
 				"type":        "string",
-				"description": "Shell command to start the dev server, e.g. 'bun run dev' or 'npm start'. Omit if server is already running.",
+				"description": "Shell command to start the dev server, e.g. 'npm run dev'. Use 'auto' to detect npm, pnpm, yarn, or bun from package.json. Omit if server is already running.",
+			},
+			"auto_start": map[string]interface{}{
+				"type":        "string",
+				"description": "Set to 'true' to auto-detect and start a package.json dev/start/serve/preview script when command is omitted.",
 			},
 			"work_dir": map[string]interface{}{
 				"type":        "string",

--- a/internal/tools/frontend_verify_test.go
+++ b/internal/tools/frontend_verify_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -106,6 +107,68 @@ func TestFrontendVerifyTool_URLTimeout(t *testing.T) {
 	}
 	if out.Feedback == "" {
 		t.Error("feedback should describe the timeout")
+	}
+	if out.TargetURL != "http://127.0.0.1:19876" || out.VerificationStatus != "failed" || out.TextReport == "" {
+		t.Fatalf("missing structured failure metadata: %+v", out)
+	}
+}
+
+func TestFrontendVerifyTool_ScreenshotPathUsesArtifactRoot(t *testing.T) {
+	root := t.TempDir()
+	tool := NewFrontendVerifyTool("", "", "", nil)
+	tool.SetArtifactRoots([]string{root})
+
+	path, err := tool.newScreenshotPath(time.Date(2026, 5, 2, 12, 0, 0, 123, time.UTC))
+	if err != nil {
+		t.Fatalf("newScreenshotPath failed: %v", err)
+	}
+	if !strings.HasPrefix(path, root+string(os.PathSeparator)) {
+		t.Fatalf("screenshot path %q is outside configured root %q", path, root)
+	}
+	if filepath.Base(path) != "frontend_verify_20260502_120000_000000123.png" {
+		t.Fatalf("unexpected screenshot filename: %q", path)
+	}
+}
+
+func TestResolveFrontendDevCommandFallsBackFromMissingBunToNPM(t *testing.T) {
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, "package.json"), []byte(`{"scripts":{"dev":"vite --host 127.0.0.1"}}`), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "npm"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake npm: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	command, err := resolveFrontendDevCommand("bun run dev", workDir)
+	if err != nil {
+		t.Fatalf("resolveFrontendDevCommand failed: %v", err)
+	}
+	if command != "npm run dev" {
+		t.Fatalf("command = %q, want npm run dev", command)
+	}
+}
+
+func TestFrontendVerifyTool_AutoCommandMissingPackageManager(t *testing.T) {
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, "package.json"), []byte(`{"scripts":{"dev":"vite --host 127.0.0.1"}}`), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	tool := NewFrontendVerifyTool("", "", "", nil)
+	_, err := tool.ExecuteJSON(context.Background(), map[string]string{
+		"url":      "http://127.0.0.1:5173",
+		"work_dir": workDir,
+		"command":  "auto",
+	})
+	if err == nil {
+		t.Fatal("expected missing package manager error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "no supported frontend dev command available") || !strings.Contains(msg, "npm, pnpm, yarn, or bun") {
+		t.Fatalf("error is not actionable: %v", err)
 	}
 }
 

--- a/internal/tools/network_policy_test.go
+++ b/internal/tools/network_policy_test.go
@@ -802,6 +802,7 @@ func TestApplyPolicy_NetworkAllowlistWrapsTools(t *testing.T) {
 	reg := NewRegistry()
 	reg.Register(&stubTool{name: "web_fetch"})
 	reg.Register(&stubTool{name: "browser"})
+	reg.Register(&stubTool{name: "frontend_verify"})
 	reg.Register(&stubTool{name: "search"})
 	reg.Register(&stubTool{name: "file"}) // not a network tool
 
@@ -832,6 +833,12 @@ func TestApplyPolicy_NetworkAllowlistWrapsTools(t *testing.T) {
 	_, err = result.Execute(context.Background(), "browser", "navigate", "https://evil.com")
 	if err == nil {
 		t.Error("browser navigate to evil.com should be denied")
+	}
+
+	// frontend_verify denied by the same allowlist.
+	_, err = result.Execute(context.Background(), "frontend_verify", "https://evil.com")
+	if err == nil {
+		t.Error("frontend_verify to evil.com should be denied")
 	}
 
 	// search denied with allowlist.

--- a/internal/tools/policy.go
+++ b/internal/tools/policy.go
@@ -29,13 +29,14 @@ type CapabilityPolicy struct {
 // capabilitiesForTool maps tool names to the capabilities that govern them.
 // A tool requires ALL listed capabilities to be allowed.
 var capabilitiesForTool = map[string][]string{
-	"local":        {"shell"},
-	"ssh":          {"shell"},
-	"web_fetch":    {"network"},
-	"search":       {"network"},
-	"browser":      {"network"},
-	"browser_task": {"network", "spawn"},
-	"cron":         {"cron"},
+	"local":           {"shell"},
+	"ssh":             {"shell"},
+	"web_fetch":       {"network"},
+	"search":          {"network"},
+	"browser":         {"network"},
+	"frontend_verify": {"network"},
+	"browser_task":    {"network", "spawn"},
+	"cron":            {"cron"},
 }
 
 // CapabilityForTool returns the capabilities governing the named tool.
@@ -110,7 +111,7 @@ func wrapForPolicy(tool Tool, policy *CapabilityPolicy) Tool {
 	// Network-capable tools always get the policy context. Even with an empty
 	// allowlist, the policy controls internal network access and denial shape.
 	switch name {
-	case "web_fetch", "browser", "browser_task", "search":
+	case "web_fetch", "browser", "frontend_verify", "browser_task", "search":
 		tool = wrapToolWithNetworkPolicy(tool, policy)
 	}
 
@@ -579,6 +580,10 @@ func (g *networkPolicyGuard) checkExecArgs(args []string) *ToolDenial {
 				return CheckNetworkTarget(name, args[1], g.policy)
 			}
 		}
+	case "frontend_verify":
+		if len(args) > 0 {
+			return CheckNetworkTarget(name, args[0], g.policy)
+		}
 	case "search":
 		// Search engines make requests to their own APIs; we cannot guarantee
 		// that result URLs will stay within the allowlist. When an allowlist is
@@ -633,6 +638,10 @@ func (g *networkPolicyGuardWithJSON) checkJSONParams(params map[string]string) *
 			if u := params["url"]; u != "" {
 				return CheckNetworkTarget(name, u, g.policy)
 			}
+		}
+	case "frontend_verify":
+		if u := params["url"]; u != "" {
+			return CheckNetworkTarget(name, u, g.policy)
 		}
 	case "browser_task":
 		// browser_task delegates to a subagent that uses browser; the task is

--- a/internal/tools/policy_test.go
+++ b/internal/tools/policy_test.go
@@ -19,6 +19,7 @@ func TestCapabilityPolicy_DeniedCapability(t *testing.T) {
 		{"network denied blocks web_fetch", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "web_fetch", "network"},
 		{"network denied blocks search", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "search", "network"},
 		{"network denied blocks browser", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "browser", "network"},
+		{"network denied blocks frontend_verify", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true, Spawn: true}, "frontend_verify", "network"},
 		{"network denied blocks browser_task", CapabilityPolicy{Shell: true, Cron: true, MemoryWrite: true}, "browser_task", "network"},
 		{"spawn denied blocks browser_task", CapabilityPolicy{Shell: true, Network: true, Cron: true, MemoryWrite: true}, "browser_task", "spawn"},
 		{"cron denied blocks cron", CapabilityPolicy{Shell: true, Network: true, MemoryWrite: true, Spawn: true}, "cron", "cron"},

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -474,6 +474,7 @@ type ToolsConfig struct {
 	ChromePath           string // explicit path to Chrome/Chromium binary
 	BrowserProfile       string // user data directory for browser profiles
 	BrowserDebugURL      string // connect to existing browser CDP endpoint
+	ArtifactRoots        []string
 	CronScheduler        CronScheduler
 	MessageSender        MessageSender
 	Contacts             map[string]int64 // alias -> chatID for message tool allowlist
@@ -583,7 +584,11 @@ func LoadFromConfigWithOptions(basePath string, cfg *ToolsConfig) (*Registry, er
 	if cfg != nil {
 		aiClientForVerify = cfg.AIClient
 	}
-	registry.Register(NewFrontendVerifyTool(browserProfile, chromePath, browserDebugURL, aiClientForVerify))
+	frontendVerify := NewFrontendVerifyTool(browserProfile, chromePath, browserDebugURL, aiClientForVerify)
+	if cfg != nil {
+		frontendVerify.SetArtifactRoots(cfg.ArtifactRoots)
+	}
+	registry.Register(frontendVerify)
 
 	// Register optional tools based on config
 	if cfg != nil {


### PR DESCRIPTION
Implements #343

## Changes
- Write frontend_verify screenshots through configured safe artifact roots and return screenshot URI, target URL, verification status, dev command, and concise text report metadata.
- Add package-manager/dev-script detection with actionable failures and fallback away from unavailable bun where package.json allows it.
- Convert successful frontend_verify tool output into screenshot, URL, and text_report role-job artifacts while keeping browser/network allowlist enforcement.

## Testing
- bash .maestro/verify.sh (initial run hit a flaky internal/memory qmd temp-script text-file-busy failure; targeted rerun passed)
- go test ./internal/memory -run TestQMDBackendSourceFormatting -count=1
- git fetch origin && git rebase origin/main && go fmt ./... && go vet ./... && go test ./... && go build ./cmd/ok-gobot/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens `frontend_verify` for role-job demos by routing screenshots through configured safe artifact roots, adding package-manager auto-detection with fallback, enforcing the network allowlist on the tool, and enriching tool output with structured metadata (URL, verification status, text report).

- **P1 — `completeFrontendVerifyResult` marks screenshot-only runs as `"failed"`**: when `description` is omitted, the LLM comparison loop is skipped so `Match` stays `false`; `completeFrontendVerifyResult` therefore sets `VerificationStatus = "failed"` and generates a self-contradictory report (`"frontend_verify failed … : verification completed"`). Role-job consumers that gate on `verification_status` will treat a successful screenshot capture as a verification failure.
- **P2 — `file://` URI used as artifact `URI` in fallback path**: `extractToolArtifacts` falls back to `out.ScreenshotURI` (a `file://…` string) when `ScreenshotPath` is absent; downstream path-resolution helpers likely expect a bare filesystem path in the `URI` field.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without addressing the screenshot-only verification status bug.

One P1 defect on a core changed path: screenshot-only mode produces incorrect `verification_status: "failed"` metadata, which can mislead role-job consumers. Score is pulled below the P1 ceiling of 4 because the affected code path (`completeFrontendVerifyResult`) is central to the stated goal of the PR.

`internal/tools/frontend_verify.go` (`completeFrontendVerifyResult`) and `internal/rolejob/runner_test.go` (missing screenshot-only test coverage).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/tools/frontend_verify.go | Adds package-manager auto-detection, artifact-root-based screenshot paths, URL/scheme validation, and structured result metadata — but screenshot-only mode (no description) gets `verification_status: "failed"` incorrectly because `Match` is never set true without LLM comparison. |
| internal/rolejob/runner.go | Expands `extractToolArtifacts` to emit URL and text-report artifacts alongside screenshots; fallback from `ScreenshotPath` to `ScreenshotURI` (a `file://` URI) may not be handled correctly by downstream path-resolution helpers. |
| internal/artifacts/display.go | Adds `GeneratedLocalPath` with path-traversal validation; uses existing `NormalizeRoots`/`DefaultRoots` fallback chain correctly. |
| internal/bot/bot.go | Propagates artifact roots to `FrontendVerifyTool` after-the-fact via unwrapping; correct but tightly coupled to the wrapper chain implementation detail. |
| internal/rolejob/runner_test.go | Tests screenshot, URL, and text-report artifact emission for the LLM-comparison case; screenshot-only mode (no description) is not covered, leaving the `verification_status: "failed"` regression untested. |
| internal/tools/frontend_verify_test.go | Good new coverage for artifact-root path containment, bun-fallback-to-npm, and missing package manager error; all additions are well-targeted. |
| internal/tools/policy.go | Correctly registers `frontend_verify` as a network-capability tool and adds URL allowlist/scheme checks in both `checkExecArgs` and `checkJSONParams`. |
| internal/tools/tools.go | Adds `ArtifactRoots` to `ToolsConfig` and passes it to `FrontendVerifyTool` at construction time. |
| internal/cli/roles.go | Threads `cfg.Artifacts.Roots` into `ToolsConfig.ArtifactRoots`; straightforward wiring. |
| internal/artifacts/display_test.go | Tests path traversal rejection and root containment for `GeneratedLocalPath`; adequate coverage of the security-sensitive function. |
| internal/tools/network_policy_test.go | Adds a test asserting `frontend_verify` is blocked by the network allowlist; straightforward and correct. |
| internal/tools/policy_test.go | Adds a capability-denial test for `frontend_verify`; correct and minimal. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `internal/tools/frontend_verify.go`, line 813-825 ([link](https://github.com/befeast/ok-gobot/blob/9c36e3d0b1b3fad8957166f539ed076f6fb4da64/internal/tools/frontend_verify.go#L813-L825)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Screenshot-only mode always produces `verification_status: "failed"`**

   When `description` is empty (screenshot-only mode), `Match` is never set to `true`, so `completeFrontendVerifyResult` unconditionally assigns `VerificationStatus = "failed"`. The text report then reads e.g. `"frontend_verify failed for http://…: verification completed"` — contradictory and incorrect. Any downstream role-job consumer that keys off `verification_status` will incorrectly treat a successful screenshot capture as a failed verification.

   The `else` branch should distinguish between "verified and did not match" (where `Feedback` or `Score` was set by the LLM) and "no verification was attempted":

   ```go
   func completeFrontendVerifyResult(r FrontendVerifyResult) FrontendVerifyResult {
   	if strings.TrimSpace(r.VerificationStatus) == "" {
   		if r.Match {
   			r.VerificationStatus = "passed"
   		} else if strings.TrimSpace(r.Feedback) != "" || strings.TrimSpace(r.Score) != "" {
   			r.VerificationStatus = "failed"
   		} else {
   			r.VerificationStatus = "screenshot_only"
   		}
   	}
   	if strings.TrimSpace(r.TextReport) == "" {
   		r.TextReport = frontendVerifyTextReport(r)
   	}
   	return r
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tools/frontend_verify.go
   Line: 813-825

   Comment:
   **Screenshot-only mode always produces `verification_status: "failed"`**

   When `description` is empty (screenshot-only mode), `Match` is never set to `true`, so `completeFrontendVerifyResult` unconditionally assigns `VerificationStatus = "failed"`. The text report then reads e.g. `"frontend_verify failed for http://…: verification completed"` — contradictory and incorrect. Any downstream role-job consumer that keys off `verification_status` will incorrectly treat a successful screenshot capture as a failed verification.

   The `else` branch should distinguish between "verified and did not match" (where `Feedback` or `Score` was set by the LLM) and "no verification was attempted":

   ```go
   func completeFrontendVerifyResult(r FrontendVerifyResult) FrontendVerifyResult {
   	if strings.TrimSpace(r.VerificationStatus) == "" {
   		if r.Match {
   			r.VerificationStatus = "passed"
   		} else if strings.TrimSpace(r.Feedback) != "" || strings.TrimSpace(r.Score) != "" {
   			r.VerificationStatus = "failed"
   		} else {
   			r.VerificationStatus = "screenshot_only"
   		}
   	}
   	if strings.TrimSpace(r.TextReport) == "" {
   		r.TextReport = frontendVerifyTextReport(r)
   	}
   	return r
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `internal/rolejob/runner.go`, line 168-172 ([link](https://github.com/befeast/ok-gobot/blob/9c36e3d0b1b3fad8957166f539ed076f6fb4da64/internal/rolejob/runner.go#L168-L172)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`file://` URI as artifact `URI` may break downstream path resolution**

   When `out.ScreenshotPath` is empty (e.g., output from an external or future format that only emits `screenshot_uri`), the fallback sets the artifact `URI` to the `file://…` string returned by `localFileURI`. Downstream callers such as `artifacts.ContentPath` that derive a filesystem path by inspecting the `URI` field are likely to receive a URI string where they expect a bare absolute path, causing the artifact to be unresolvable.

   Consider stripping the `file://` scheme before storing, or storing the path and URI in separate fields of the artifact spec.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/rolejob/runner.go
   Line: 168-172

   Comment:
   **`file://` URI as artifact `URI` may break downstream path resolution**

   When `out.ScreenshotPath` is empty (e.g., output from an external or future format that only emits `screenshot_uri`), the fallback sets the artifact `URI` to the `file://…` string returned by `localFileURI`. Downstream callers such as `artifacts.ContentPath` that derive a filesystem path by inspecting the `URI` field are likely to receive a URI string where they expect a bare absolute path, causing the artifact to be unresolvable.

   Consider stripping the `file://` scheme before storing, or storing the path and URI in separate fields of the artifact spec.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/tools/frontend_verify.go:813-825
**Screenshot-only mode always produces `verification_status: "failed"`**

When `description` is empty (screenshot-only mode), `Match` is never set to `true`, so `completeFrontendVerifyResult` unconditionally assigns `VerificationStatus = "failed"`. The text report then reads e.g. `"frontend_verify failed for http://…: verification completed"` — contradictory and incorrect. Any downstream role-job consumer that keys off `verification_status` will incorrectly treat a successful screenshot capture as a failed verification.

The `else` branch should distinguish between "verified and did not match" (where `Feedback` or `Score` was set by the LLM) and "no verification was attempted":

```go
func completeFrontendVerifyResult(r FrontendVerifyResult) FrontendVerifyResult {
	if strings.TrimSpace(r.VerificationStatus) == "" {
		if r.Match {
			r.VerificationStatus = "passed"
		} else if strings.TrimSpace(r.Feedback) != "" || strings.TrimSpace(r.Score) != "" {
			r.VerificationStatus = "failed"
		} else {
			r.VerificationStatus = "screenshot_only"
		}
	}
	if strings.TrimSpace(r.TextReport) == "" {
		r.TextReport = frontendVerifyTextReport(r)
	}
	return r
}
```

### Issue 2 of 2
internal/rolejob/runner.go:168-172
**`file://` URI as artifact `URI` may break downstream path resolution**

When `out.ScreenshotPath` is empty (e.g., output from an external or future format that only emits `screenshot_uri`), the fallback sets the artifact `URI` to the `file://…` string returned by `localFileURI`. Downstream callers such as `artifacts.ContentPath` that derive a filesystem path by inspecting the `URI` field are likely to receive a URI string where they expect a bare absolute path, causing the artifact to be unresolvable.

Consider stripping the `file://` scheme before storing, or storing the path and URI in separate fields of the artifact spec.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden frontend verify artifacts (#..."](https://github.com/befeast/ok-gobot/commit/9c36e3d0b1b3fad8957166f539ed076f6fb4da64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30545900)</sub>

<!-- /greptile_comment -->