### PR TITLE
feat: support trusted workspace skills (#388)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -188,6 +188,12 @@ runtime:
 session:
   dm_scope: "main"  # main or per_user
 
+# Skill compatibility settings
+skills:
+  # Enable only for trusted mounted OpenClaw workspaces under soul_path/skills.
+  # Installs remain markdown-only and scripts are not executed automatically.
+  trust_workspace_scripts: false
+
 # Maestro issue intake (read-only dry-run/status checks; workers are not started automatically)
 maestro:
   repo: ""                 # Optional owner/name; empty lets gh infer from the current repo

--- a/config.schema.json
+++ b/config.schema.json
@@ -590,6 +590,19 @@
       },
       "type": "object"
     },
+    "skills": {
+      "additionalProperties": false,
+      "default": {},
+      "description": "Skill discovery and workspace compatibility settings.",
+      "properties": {
+        "trust_workspace_scripts": {
+          "default": false,
+          "description": "Allow script-bearing skills already rooted under soul_path/skills to be treated as trusted OpenClaw workspace skills. Does not change the strict markdown-only install audit and does not execute scripts automatically. Env override: OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "soul_path": {
       "default": "~/ok-gobot-soul",
       "description": "Default personality directory (deprecated; prefer agents[*].soul_path).",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,9 +56,12 @@ allowlists.
 
 ### 2.3 Skills
 
-Skills are markdown-only knowledge bases installable via CLI (`ok-gobot skills install`).
-A static safety audit runs before installation. Skills are tracked by utility score
-and selected by a skill router per query.
+Skills installed via CLI (`ok-gobot skills install`) remain markdown-only knowledge
+bases. A static safety audit runs before installation. Script-bearing skills already
+mounted under `soul_path/skills` can be surfaced as trusted OpenClaw workspace
+skills only when `skills.trust_workspace_scripts` or
+`OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS` is explicitly enabled. Runtime routing
+labels every discovered skill as `native`, `trusted_workspace`, or `blocked`.
 
 **Files:** `internal/bootstrap/skills.go`
 
@@ -381,6 +384,18 @@ single source of truth for configuration keys, types, defaults, and descriptions
           "type": "integer",
           "default": 50,
           "description": "Number of open issues inspected by maestro dry-run/status commands."
+        }
+      }
+    },
+    "skills": {
+      "type": "object",
+      "default": {},
+      "description": "Skill discovery and workspace compatibility settings.",
+      "properties": {
+        "trust_workspace_scripts": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow script-bearing skills already rooted under soul_path/skills to be treated as trusted OpenClaw workspace skills. Does not change the strict markdown-only install audit and does not execute scripts automatically. Env override: OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS."
         }
       }
     },

--- a/internal/agent/personality.go
+++ b/internal/agent/personality.go
@@ -23,21 +23,29 @@ type Personality struct {
 	Files         map[string]string
 	Skills        []SkillEntry
 	loader        *bootstrap.Loader
+	loaderOptions bootstrap.LoaderOptions
 	scoreProvider SkillScoreProvider
 }
 
 // NewPersonality creates a new personality loader.
 func NewPersonality(basePath string) (*Personality, error) {
-	loader, err := bootstrap.NewLoader(basePath)
+	return NewPersonalityWithOptions(basePath, bootstrap.LoaderOptions{})
+}
+
+// NewPersonalityWithOptions creates a personality loader with explicit
+// workspace skill compatibility options.
+func NewPersonalityWithOptions(basePath string, opts bootstrap.LoaderOptions) (*Personality, error) {
+	loader, err := bootstrap.NewLoaderWithOptions(basePath, opts)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Personality{
-		BasePath: loader.BasePath,
-		Files:    cloneFiles(loader.Files),
-		Skills:   cloneSkills(loader.Skills),
-		loader:   loader,
+		BasePath:      loader.BasePath,
+		Files:         cloneFiles(loader.Files),
+		Skills:        cloneSkills(loader.Skills),
+		loader:        loader,
+		loaderOptions: opts,
 	}, nil
 }
 
@@ -124,7 +132,7 @@ func (p *Personality) Reload() error {
 	defer p.mu.Unlock()
 
 	if p.loader == nil {
-		loader, err := bootstrap.NewLoader(p.BasePath)
+		loader, err := bootstrap.NewLoaderWithOptions(p.BasePath, p.loaderOptions)
 		if err != nil {
 			return err
 		}
@@ -186,6 +194,7 @@ func (p *Personality) loaderSnapshotLocked() *bootstrap.Loader {
 		BasePath: basePath,
 		Files:    files,
 		Skills:   skills,
+		Options:  p.loaderOptions,
 	}
 }
 

--- a/internal/agent/personality_test.go
+++ b/internal/agent/personality_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"ok-gobot/internal/bootstrap"
 	"ok-gobot/internal/memory"
 	"ok-gobot/internal/tools"
 )
@@ -114,9 +115,24 @@ func TestBuildSystemPrompt_OrdersSkillsAfterAgentsAndMentionsMemoryTools(t *test
 		},
 		Skills: []SkillEntry{
 			{
-				Name:        "repo-inspector",
-				Description: "Inspect repository quickly",
-				Path:        "/tmp/skills/repo-inspector/SKILL.md",
+				Name:          "repo-inspector",
+				Description:   "Inspect repository quickly",
+				Path:          "/tmp/skills/repo-inspector/SKILL.md",
+				Compatibility: bootstrap.SkillCompatibilityNative,
+			},
+			{
+				Name:          "video-summary",
+				Description:   "Summarize videos with helper assets",
+				Path:          "/tmp/skills/video-summary/SKILL.md",
+				Compatibility: bootstrap.SkillCompatibilityTrustedWorkspace,
+				ScriptAssets:  []string{"scripts/summary.py"},
+			},
+			{
+				Name:                "unsafe-downloaded",
+				Description:         "Has untrusted scripts",
+				Path:                "/tmp/skills/unsafe-downloaded/SKILL.md",
+				Compatibility:       bootstrap.SkillCompatibilityBlocked,
+				CompatibilityReason: "script assets require trust",
 			},
 		},
 	}
@@ -150,6 +166,11 @@ func TestBuildSystemPrompt_OrdersSkillsAfterAgentsAndMentionsMemoryTools(t *test
 	}
 	if !strings.Contains(prompt, "memory_get") {
 		t.Fatalf("prompt should instruct proactive use of memory_get")
+	}
+	for _, want := range []string{"status: native", "status: trusted_workspace", "status: blocked", "Only route to native or trusted_workspace skills"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
 	}
 }
 

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"ok-gobot/internal/bootstrap"
 	"ok-gobot/internal/config"
 	"ok-gobot/internal/tools"
 )
@@ -25,6 +26,12 @@ type AgentRegistry struct {
 
 // NewAgentRegistry creates a new agent registry from configuration
 func NewAgentRegistry(configs []config.AgentConfig, globalModel string, globalSoulPath string) (*AgentRegistry, error) {
+	return NewAgentRegistryWithOptions(configs, globalModel, globalSoulPath, bootstrap.LoaderOptions{})
+}
+
+// NewAgentRegistryWithOptions creates an agent registry with explicit bootstrap
+// loader options, including trusted workspace skill compatibility.
+func NewAgentRegistryWithOptions(configs []config.AgentConfig, globalModel string, globalSoulPath string, loaderOptions bootstrap.LoaderOptions) (*AgentRegistry, error) {
 	registry := &AgentRegistry{
 		agents:       make(map[string]*AgentProfile),
 		defaultAgent: "default",
@@ -33,7 +40,7 @@ func NewAgentRegistry(configs []config.AgentConfig, globalModel string, globalSo
 	// If no agents configured, create a default agent
 	if len(configs) == 0 {
 		log.Println("🤖 No agents configured, creating default agent")
-		personality, err := NewPersonality(globalSoulPath)
+		personality, err := NewPersonalityWithOptions(globalSoulPath, loaderOptions)
 		if err != nil {
 			log.Printf("⚠️ Failed to load default personality: %v", err)
 			personality = &Personality{}
@@ -59,7 +66,7 @@ func NewAgentRegistry(configs []config.AgentConfig, globalModel string, globalSo
 		}
 
 		log.Printf("🤖 Loading agent '%s' from %s...", cfg.Name, cfg.SoulPath)
-		personality, err := NewPersonality(cfg.SoulPath)
+		personality, err := NewPersonalityWithOptions(cfg.SoulPath, loaderOptions)
 		if err != nil {
 			log.Printf("⚠️ Failed to load personality for agent '%s': %v", cfg.Name, err)
 			personality = &Personality{}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -208,8 +208,9 @@ func (a *App) Start(ctx context.Context) error {
 
 	// Load personality from configured directory
 	soulPath := a.config.GetSoulPath()
+	loaderOptions := bootstrap.LoaderOptions{TrustWorkspaceScripts: a.config.TrustWorkspaceScripts()}
 	log.Printf("🧠 Loading personality from %s...", soulPath)
-	personality, err := agent.NewPersonality(soulPath)
+	personality, err := agent.NewPersonalityWithOptions(soulPath, loaderOptions)
 	if err != nil {
 		log.Printf("⚠️ Failed to load personality: %v", err)
 		// Continue - NewPersonality already handles missing files gracefully
@@ -224,7 +225,7 @@ func (a *App) Start(ctx context.Context) error {
 	var agentRegistry *agent.AgentRegistry
 	if len(a.config.Agents) > 0 {
 		log.Printf("🤖 Initializing agent registry with %d agents...", len(a.config.Agents))
-		agentRegistry, err = agent.NewAgentRegistry(a.config.Agents, a.config.AI.Model, soulPath)
+		agentRegistry, err = agent.NewAgentRegistryWithOptions(a.config.Agents, a.config.AI.Model, soulPath, loaderOptions)
 		if err != nil {
 			return fmt.Errorf("failed to initialize agent registry: %w", err)
 		}

--- a/internal/bootstrap/loader.go
+++ b/internal/bootstrap/loader.go
@@ -49,10 +49,30 @@ var filesToLoad = []string{
 
 // SkillEntry represents a discovered skill.
 type SkillEntry struct {
-	Name         string
-	Description  string
-	Path         string
-	UtilityScore int
+	Name                string
+	Description         string
+	Path                string
+	UtilityScore        int
+	Compatibility       SkillCompatibility
+	CompatibilityReason string
+	ScriptAssets        []string
+}
+
+// SkillCompatibility explains how a discovered skill may be used.
+type SkillCompatibility string
+
+const (
+	SkillCompatibilityNative           SkillCompatibility = "native"
+	SkillCompatibilityTrustedWorkspace SkillCompatibility = "trusted_workspace"
+	SkillCompatibilityBlocked          SkillCompatibility = "blocked"
+)
+
+// LoaderOptions controls workspace loading behavior.
+type LoaderOptions struct {
+	// TrustWorkspaceScripts allows script-bearing skills already mounted under
+	// <basePath>/skills to be routed as trusted workspace skills. Installs still
+	// use the strict markdown-only audit path.
+	TrustWorkspaceScripts bool
 }
 
 // Loader loads and exposes bootstrap context files.
@@ -60,6 +80,7 @@ type Loader struct {
 	BasePath string
 	Files    map[string]string
 	Skills   []SkillEntry
+	Options  LoaderOptions
 	now      func() time.Time
 }
 
@@ -68,7 +89,16 @@ func NewLoader(basePath string) (*Loader, error) {
 	return newLoader(basePath, time.Now)
 }
 
+// NewLoaderWithOptions creates a loader with explicit workspace skill options.
+func NewLoaderWithOptions(basePath string, opts LoaderOptions) (*Loader, error) {
+	return newLoaderWithOptions(basePath, time.Now, opts)
+}
+
 func newLoader(basePath string, now func() time.Time) (*Loader, error) {
+	return newLoaderWithOptions(basePath, now, LoaderOptions{})
+}
+
+func newLoaderWithOptions(basePath string, now func() time.Time, opts LoaderOptions) (*Loader, error) {
 	if now == nil {
 		now = time.Now
 	}
@@ -79,6 +109,7 @@ func newLoader(basePath string, now func() time.Time) (*Loader, error) {
 	l := &Loader{
 		BasePath: ExpandPath(basePath),
 		Files:    make(map[string]string),
+		Options:  opts,
 		now:      now,
 	}
 
@@ -421,7 +452,21 @@ func (l *Loader) SkillsSummary() string {
 	var summary strings.Builder
 	for _, skill := range sorted {
 		dir := filepath.Dir(skill.Path)
-		summary.WriteString(fmt.Sprintf("- %s (SKILL.md: %s, baseDir: %s, score: %d): %s\n", skill.Name, skill.Path, dir, skill.UtilityScore, skill.Description))
+		status := skill.Compatibility
+		if status == "" {
+			status = SkillCompatibilityNative
+		}
+		line := fmt.Sprintf("- %s (status: %s, SKILL.md: %s, baseDir: %s, score: %d): %s", skill.Name, status, skill.Path, dir, skill.UtilityScore, skill.Description)
+		if status == SkillCompatibilityTrustedWorkspace && len(skill.ScriptAssets) > 0 {
+			line += fmt.Sprintf(" Script assets: %s. Do not execute scripts unless the user explicitly asks within the trusted workspace boundary.", strings.Join(skill.ScriptAssets, ", "))
+		}
+		if status == SkillCompatibilityBlocked {
+			line += " Blocked: visible for diagnosis only; do not route to this skill."
+			if skill.CompatibilityReason != "" {
+				line += " Reason: " + skill.CompatibilityReason + "."
+			}
+		}
+		summary.WriteString(line + "\n")
 	}
 
 	return summary.String()
@@ -458,59 +503,11 @@ func (l *Loader) HasFile(filename string) bool {
 }
 
 func (l *Loader) discoverSkills() error {
-	skillsPath := filepath.Join(l.BasePath, "skills")
-	if _, err := os.Stat(skillsPath); os.IsNotExist(err) {
-		return nil
-	}
-
-	entries, err := os.ReadDir(skillsPath)
+	skills, err := ListSkillsWithOptions(l.BasePath, l.Options)
 	if err != nil {
-		return fmt.Errorf("failed to read skills directory: %w", err)
+		return err
 	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		skillName := entry.Name()
-		skillFilePath := filepath.Join(skillsPath, skillName, "SKILL.md")
-		content, err := os.ReadFile(skillFilePath)
-		if err != nil {
-			continue
-		}
-
-		description := ""
-		lines := strings.Split(string(content), "\n")
-		inFrontmatter := false
-		for _, line := range lines {
-			trimmed := strings.TrimSpace(line)
-			if trimmed == "---" {
-				inFrontmatter = !inFrontmatter
-				continue
-			}
-			if inFrontmatter {
-				if strings.HasPrefix(trimmed, "description:") {
-					description = strings.TrimSpace(strings.TrimPrefix(trimmed, "description:"))
-				}
-				continue
-			}
-			if trimmed != "" && !strings.HasPrefix(trimmed, "#") && description == "" {
-				description = trimmed
-				break
-			}
-		}
-
-		if description == "" {
-			description = "No description available"
-		}
-
-		l.Skills = append(l.Skills, SkillEntry{
-			Name:        skillName,
-			Description: description,
-			Path:        skillFilePath,
-		})
-	}
+	l.Skills = skills
 
 	return nil
 }

--- a/internal/bootstrap/prompt.go
+++ b/internal/bootstrap/prompt.go
@@ -44,9 +44,11 @@ func BuildPrompt(loader *Loader, registry *tools.Registry, opts PromptOptions) s
 		if skillsSummary != "" {
 			prompt.WriteString("\n## Skills\n\n")
 			prompt.WriteString("Before replying: scan the available skills below.\n")
+			prompt.WriteString("- Skills show status: native, trusted_workspace, or blocked. Only route to native or trusted_workspace skills.\n")
 			prompt.WriteString("- If exactly one skill clearly applies: read its SKILL.md with the `file` tool, then follow it.\n")
 			prompt.WriteString("- If multiple could apply: choose the most specific one, then read/follow it.\n")
 			prompt.WriteString("- If none clearly apply: do not read any SKILL.md.\n")
+			prompt.WriteString("- Blocked skills are visible for diagnostics only; do not read or follow them.\n")
 			prompt.WriteString("- In SKILL.md, replace `{baseDir}` with the skill's directory path.\n\n")
 			prompt.WriteString("Available skills:\n")
 			prompt.WriteString(skillsSummary)

--- a/internal/bootstrap/skills.go
+++ b/internal/bootstrap/skills.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -165,8 +166,185 @@ func AuditHasErrors(findings []AuditFinding) bool {
 	return false
 }
 
+// SkillAuditResult captures strict audit findings plus workspace compatibility
+// classification used for already-mounted skills.
+type SkillAuditResult struct {
+	Findings            []AuditFinding
+	Compatibility       SkillCompatibility
+	CompatibilityReason string
+	ScriptAssets        []string
+}
+
+// AuditSkillForWorkspace audits a skill and classifies how runtime/listing
+// should treat it. It never changes the strict AuditSkill behavior used by
+// installs: script assets are only downgraded for skills already rooted under
+// basePath/skills and only when trusted workspace compatibility is enabled.
+func AuditSkillForWorkspace(basePath, skillPath string, opts LoaderOptions) (SkillAuditResult, error) {
+	findings, err := AuditSkill(skillPath)
+	if err != nil {
+		return SkillAuditResult{}, err
+	}
+
+	scriptAssets, err := ScriptAssetPaths(skillPath)
+	if err != nil {
+		return SkillAuditResult{}, err
+	}
+
+	result := SkillAuditResult{
+		Findings:            findings,
+		Compatibility:       SkillCompatibilityNative,
+		CompatibilityReason: "markdown-only skill",
+		ScriptAssets:        scriptAssets,
+	}
+
+	if len(scriptAssets) == 0 {
+		if AuditHasErrors(findings) {
+			result.Compatibility = SkillCompatibilityBlocked
+			result.CompatibilityReason = "strict audit errors"
+		}
+		return result, nil
+	}
+
+	if !opts.TrustWorkspaceScripts {
+		result.Compatibility = SkillCompatibilityBlocked
+		result.CompatibilityReason = "script assets require skills.trust_workspace_scripts or OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS"
+		return result, nil
+	}
+
+	insideWorkspace, workspaceRoot, err := SkillPathWithinWorkspace(basePath, skillPath)
+	if err != nil {
+		result.Compatibility = SkillCompatibilityBlocked
+		result.CompatibilityReason = fmt.Sprintf("workspace root check failed: %v", err)
+		return result, nil
+	}
+	if !insideWorkspace {
+		result.Compatibility = SkillCompatibilityBlocked
+		result.CompatibilityReason = fmt.Sprintf("script assets are outside configured workspace skills root %s", workspaceRoot)
+		return result, nil
+	}
+
+	result.Findings = downgradeWorkspaceScriptFindings(findings, scriptAssets)
+	if AuditHasErrors(result.Findings) {
+		result.Compatibility = SkillCompatibilityBlocked
+		result.CompatibilityReason = "trusted workspace mode does not allow non-script audit errors"
+		return result, nil
+	}
+
+	result.Compatibility = SkillCompatibilityTrustedWorkspace
+	result.CompatibilityReason = fmt.Sprintf("script assets trusted under workspace root %s; ok-gobot does not execute them automatically", workspaceRoot)
+	return result, nil
+}
+
+// ScriptAssetPaths returns script/executable asset paths relative to skillPath.
+func ScriptAssetPaths(skillPath string) ([]string, error) {
+	skillPath, err := filepath.Abs(skillPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	var assets []string
+	err = filepath.Walk(skillPath, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			if info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		linfo, err := os.Lstat(path)
+		if err != nil {
+			return nil
+		}
+		if linfo.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(info.Name()))
+		if !scriptExtensions[ext] {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(skillPath, path)
+		if err != nil {
+			return err
+		}
+		assets = append(assets, relPath)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk skill directory: %w", err)
+	}
+	sort.Strings(assets)
+	return assets, nil
+}
+
+// SkillPathWithinWorkspace verifies that skillPath resolves under basePath/skills.
+func SkillPathWithinWorkspace(basePath, skillPath string) (bool, string, error) {
+	basePath = ExpandPath(basePath)
+	workspaceRoot := filepath.Join(basePath, "skills")
+
+	absRoot, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return false, workspaceRoot, fmt.Errorf("failed to resolve workspace skills root: %w", err)
+	}
+	absSkill, err := filepath.Abs(skillPath)
+	if err != nil {
+		return false, absRoot, fmt.Errorf("failed to resolve skill path: %w", err)
+	}
+
+	root, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		return false, absRoot, fmt.Errorf("failed to resolve workspace skills root symlinks: %w", err)
+	}
+	skill, err := filepath.EvalSymlinks(absSkill)
+	if err != nil {
+		return false, root, fmt.Errorf("failed to resolve skill path symlinks: %w", err)
+	}
+
+	rel, err := filepath.Rel(root, skill)
+	if err != nil {
+		return false, root, fmt.Errorf("failed to compare skill path with workspace root: %w", err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return false, root, nil
+	}
+	return true, root, nil
+}
+
+func downgradeWorkspaceScriptFindings(findings []AuditFinding, scriptAssets []string) []AuditFinding {
+	scriptSet := make(map[string]struct{}, len(scriptAssets))
+	for _, asset := range scriptAssets {
+		scriptSet[asset] = struct{}{}
+	}
+
+	out := make([]AuditFinding, len(findings))
+	copy(out, findings)
+	for i := range out {
+		if out[i].Severity != SeverityError {
+			continue
+		}
+		if _, ok := scriptSet[out[i].Path]; !ok {
+			continue
+		}
+		if !strings.Contains(out[i].Message, "script or executable file") {
+			continue
+		}
+		out[i].Severity = SeverityWarning
+		out[i].Message = "script asset allowed by trusted workspace compatibility; ok-gobot does not execute skill scripts automatically"
+	}
+	return out
+}
+
 // ListSkills returns all installed skills in the workspace.
 func ListSkills(basePath string) ([]SkillEntry, error) {
+	return ListSkillsWithOptions(basePath, LoaderOptions{})
+}
+
+// ListSkillsWithOptions returns installed skills with compatibility metadata.
+func ListSkillsWithOptions(basePath string, opts LoaderOptions) ([]SkillEntry, error) {
 	basePath = ExpandPath(basePath)
 	skillsDir := filepath.Join(basePath, "skills")
 
@@ -196,10 +374,20 @@ func ListSkills(basePath string) ([]SkillEntry, error) {
 		}
 
 		description := parseSkillDescription(string(content))
+		audit, err := AuditSkillForWorkspace(basePath, filepath.Join(skillsDir, entry.Name()), opts)
+		if err != nil {
+			audit = SkillAuditResult{
+				Compatibility:       SkillCompatibilityBlocked,
+				CompatibilityReason: fmt.Sprintf("audit failed: %v", err),
+			}
+		}
 		skills = append(skills, SkillEntry{
-			Name:        entry.Name(),
-			Description: description,
-			Path:        skillFile,
+			Name:                entry.Name(),
+			Description:         description,
+			Path:                skillFile,
+			Compatibility:       audit.Compatibility,
+			CompatibilityReason: audit.CompatibilityReason,
+			ScriptAssets:        audit.ScriptAssets,
 		})
 	}
 

--- a/internal/bootstrap/skills_test.go
+++ b/internal/bootstrap/skills_test.go
@@ -218,6 +218,68 @@ func TestListSkills_FindsInstalledSkills(t *testing.T) {
 	}
 }
 
+func TestListSkills_ReportsScriptBearingWorkspaceCompatibility(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "skills", "video-summary", "SKILL.md"), "---\ndescription: summarize videos\n---\n# Video")
+	writeTestFile(t, filepath.Join(dir, "skills", "video-summary", "scripts", "summarize.py"), "print('ok')")
+
+	blocked, err := ListSkills(dir)
+	if err != nil {
+		t.Fatalf("ListSkills() error = %v", err)
+	}
+	if len(blocked) != 1 {
+		t.Fatalf("skills = %d, want 1", len(blocked))
+	}
+	if blocked[0].Compatibility != SkillCompatibilityBlocked {
+		t.Fatalf("compatibility = %q, want %q", blocked[0].Compatibility, SkillCompatibilityBlocked)
+	}
+	if len(blocked[0].ScriptAssets) != 1 || blocked[0].ScriptAssets[0] != filepath.Join("scripts", "summarize.py") {
+		t.Fatalf("script assets = %#v", blocked[0].ScriptAssets)
+	}
+
+	trusted, err := ListSkillsWithOptions(dir, LoaderOptions{TrustWorkspaceScripts: true})
+	if err != nil {
+		t.Fatalf("ListSkillsWithOptions() error = %v", err)
+	}
+	if trusted[0].Compatibility != SkillCompatibilityTrustedWorkspace {
+		t.Fatalf("compatibility = %q, want %q", trusted[0].Compatibility, SkillCompatibilityTrustedWorkspace)
+	}
+}
+
+func TestAuditSkillForWorkspace_DowngradesTrustedScriptAssetsOnlyInsideWorkspace(t *testing.T) {
+	t.Parallel()
+	workspace := t.TempDir()
+	skillDir := filepath.Join(workspace, "skills", "youtube-karaoke")
+	writeTestFile(t, filepath.Join(skillDir, "SKILL.md"), "# Karaoke")
+	writeTestFile(t, filepath.Join(skillDir, "scripts", "sync.sh"), "#!/bin/sh\necho ok")
+
+	audit, err := AuditSkillForWorkspace(workspace, skillDir, LoaderOptions{TrustWorkspaceScripts: true})
+	if err != nil {
+		t.Fatalf("AuditSkillForWorkspace() error = %v", err)
+	}
+	if audit.Compatibility != SkillCompatibilityTrustedWorkspace {
+		t.Fatalf("compatibility = %q, want %q", audit.Compatibility, SkillCompatibilityTrustedWorkspace)
+	}
+	if AuditHasErrors(audit.Findings) {
+		t.Fatalf("trusted workspace script assets should be warnings only: %v", audit.Findings)
+	}
+
+	outside := t.TempDir()
+	writeTestFile(t, filepath.Join(outside, "SKILL.md"), "# Outside")
+	writeTestFile(t, filepath.Join(outside, "scripts", "run.py"), "print('outside')")
+	audit, err = AuditSkillForWorkspace(workspace, outside, LoaderOptions{TrustWorkspaceScripts: true})
+	if err != nil {
+		t.Fatalf("AuditSkillForWorkspace(outside) error = %v", err)
+	}
+	if audit.Compatibility != SkillCompatibilityBlocked {
+		t.Fatalf("outside compatibility = %q, want %q", audit.Compatibility, SkillCompatibilityBlocked)
+	}
+	if !AuditHasErrors(audit.Findings) {
+		t.Fatalf("outside script assets must remain strict errors: %v", audit.Findings)
+	}
+}
+
 func TestInstallSkill_FromLocalPath(t *testing.T) {
 	t.Parallel()
 	workspace := t.TempDir()
@@ -264,6 +326,23 @@ func TestInstallSkill_RejectsUnsafe(t *testing.T) {
 	entries, _ := os.ReadDir(skillsDir)
 	if len(entries) > 0 {
 		t.Fatalf("unsafe skill should not be installed, found: %v", entries)
+	}
+}
+
+func TestInstallSkill_RejectsScriptAssetsEvenWhenWorkspaceTrustExists(t *testing.T) {
+	t.Parallel()
+	workspace := t.TempDir()
+	source := t.TempDir()
+
+	writeTestFile(t, filepath.Join(source, "SKILL.md"), "# Script skill")
+	writeTestFile(t, filepath.Join(source, "scripts", "helper.py"), "print('not installable')")
+
+	_, findings, err := InstallSkill(workspace, source)
+	if err == nil {
+		t.Fatal("expected script-bearing skill install to fail")
+	}
+	if !AuditHasErrors(findings) {
+		t.Fatalf("expected strict audit errors, got %v", findings)
 	}
 }
 

--- a/internal/bot/status.go
+++ b/internal/bot/status.go
@@ -156,6 +156,9 @@ func (b *Bot) buildStatusStringForScope(chatID, userID int64, chatType string) s
 		memoryToolStatus = "on"
 	}
 	sb.WriteString(fmt.Sprintf("🧠 Memory: mode=`%s` · tools=%s\n", memoryMode, memoryToolStatus))
+	if line := skillCompatibilityStatusLine(b.personality.Loader()); line != "" {
+		sb.WriteString(line + "\n")
+	}
 
 	// Estop state
 	estopEnabled, err := b.store.IsEmergencyStopEnabled()
@@ -243,4 +246,23 @@ func valueOrStatus(value, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func skillCompatibilityStatusLine(loader *bootstrap.Loader) string {
+	if loader == nil || len(loader.Skills) == 0 {
+		return ""
+	}
+	counts := map[bootstrap.SkillCompatibility]int{
+		bootstrap.SkillCompatibilityNative:           0,
+		bootstrap.SkillCompatibilityTrustedWorkspace: 0,
+		bootstrap.SkillCompatibilityBlocked:          0,
+	}
+	for _, skill := range loader.Skills {
+		status := skill.Compatibility
+		if status == "" {
+			status = bootstrap.SkillCompatibilityNative
+		}
+		counts[status]++
+	}
+	return fmt.Sprintf("🧩 Skills: native=%d · trusted_workspace=%d · blocked=%d", counts[bootstrap.SkillCompatibilityNative], counts[bootstrap.SkillCompatibilityTrustedWorkspace], counts[bootstrap.SkillCompatibilityBlocked])
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -78,6 +79,7 @@ func newConfigShowCommand(cfg *config.Config) *cobra.Command {
 			}
 			fmt.Printf("\nAgent Personality:\n")
 			fmt.Printf("  Soul Path: %s\n", cfg.GetSoulPath())
+			fmt.Printf("  Trusted Workspace Scripts: %t\n", cfg.TrustWorkspaceScripts())
 			fmt.Printf("\nStorage:\n")
 			fmt.Printf("  Path: %s\n", cfg.StoragePath)
 		},
@@ -107,6 +109,12 @@ func newConfigSetCommand(cfg *config.Config) *cobra.Command {
 				cfg.AI.BaseURL = value
 			case "soul_path":
 				cfg.SoulPath = value
+			case "skills.trust_workspace_scripts":
+				enabled, err := strconv.ParseBool(value)
+				if err != nil {
+					return fmt.Errorf("invalid boolean value for %s: %w", key, err)
+				}
+				cfg.Skills.TrustWorkspaceScripts = enabled
 			case "log_level":
 				cfg.LogLevel = value
 			// Legacy support
@@ -217,6 +225,11 @@ ai:
 # Path to directory containing SOUL.md, IDENTITY.md, USER.md, etc.
 # Can also be set via OKGOBOT_SOUL_PATH environment variable
 soul_path: %q
+
+# Skill compatibility
+# Set true only for trusted mounted OpenClaw workspaces under soul_path/skills.
+skills:
+  trust_workspace_scripts: false
 
 # Storage Configuration
 storage_path: "~/.ok-gobot/ok-gobot.db"

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -11,6 +11,7 @@ import (
 
 	"ok-gobot/internal/agent"
 	"ok-gobot/internal/ai"
+	"ok-gobot/internal/bootstrap"
 	"ok-gobot/internal/config"
 	"ok-gobot/internal/role"
 	"ok-gobot/internal/rolejob"
@@ -289,7 +290,8 @@ func newRoleRunSubmitter(cfg *config.Config, store *storage.Store) (rolejob.Agen
 	}
 
 	soulPath := cfg.GetSoulPath()
-	personality, err := agent.NewPersonality(soulPath)
+	loaderOptions := bootstrap.LoaderOptions{TrustWorkspaceScripts: cfg.TrustWorkspaceScripts()}
+	personality, err := agent.NewPersonalityWithOptions(soulPath, loaderOptions)
 	if err != nil {
 		personality = &agent.Personality{}
 	}
@@ -297,7 +299,7 @@ func newRoleRunSubmitter(cfg *config.Config, store *storage.Store) (rolejob.Agen
 
 	var agentRegistry *agent.AgentRegistry
 	if len(cfg.Agents) > 0 {
-		agentRegistry, err = agent.NewAgentRegistry(cfg.Agents, cfg.AI.Model, soulPath)
+		agentRegistry, err = agent.NewAgentRegistryWithOptions(cfg.Agents, cfg.AI.Model, soulPath, loaderOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -75,7 +75,7 @@ func newSkillsListCommand(cfg *config.Config) *cobra.Command {
 
 			// Load discovered skills from the soul directory.
 			soulPath := cfg.GetSoulPath()
-			loader, err := bootstrap.NewLoader(soulPath)
+			loader, err := bootstrap.NewLoaderWithOptions(soulPath, skillLoaderOptions(cfg))
 			if err != nil {
 				return fmt.Errorf("failed to load skills: %w", err)
 			}
@@ -110,13 +110,13 @@ func newSkillsListCommand(cfg *config.Config) *cobra.Command {
 			}
 
 			w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "SKILL\tSCORE\tUSES\tSUCCESSES\tFAILURES\tDESCRIPTION")
+			fmt.Fprintln(w, "SKILL\tSTATUS\tSCORE\tUSES\tSUCCESSES\tFAILURES\tDESCRIPTION")
 
 			for _, skill := range loader.Skills {
 				shown[skill.Name] = struct{}{}
 				ss := dbByName[skill.Name]
-				fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t%s\n",
-					skill.Name, skill.UtilityScore, ss.Uses, ss.Successes, ss.Failures,
+				fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%d\t%s\n",
+					skill.Name, formatSkillCompatibility(skill), skill.UtilityScore, ss.Uses, ss.Successes, ss.Failures,
 					truncate(skill.Description, 50))
 			}
 
@@ -125,7 +125,7 @@ func newSkillsListCommand(cfg *config.Config) *cobra.Command {
 				if _, ok := shown[ss.Name]; ok {
 					continue
 				}
-				fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t(not on disk)\n",
+				fmt.Fprintf(w, "%s\tmissing\t%d\t%d\t%d\t%d\t(not on disk)\n",
 					ss.Name, ss.Score, ss.Uses, ss.Successes, ss.Failures)
 			}
 
@@ -207,7 +207,11 @@ Checks for:
   - Symlinks (may escape the skill sandbox)
   - Script or executable files (.sh, .py, .exe, etc.)
   - Pipe-to-shell patterns (curl|bash, wget|sh, etc.)
-  - Markdown links escaping the skill directory (../)`,
+  - Markdown links escaping the skill directory (../)
+
+Installed skills under the configured workspace are also classified as native,
+trusted_workspace, or blocked. Trusted workspace script compatibility must be
+enabled explicitly and does not change install-time markdown-only checks.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := args[0]
@@ -221,9 +225,18 @@ Checks for:
 				}
 			}
 
-			findings, err := bootstrap.AuditSkill(target)
+			audit, err := bootstrap.AuditSkillForWorkspace(cfg.GetSoulPath(), target, skillLoaderOptions(cfg))
 			if err != nil {
 				return fmt.Errorf("audit failed: %w", err)
+			}
+			findings := audit.Findings
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Compatibility: %s\n", audit.Compatibility)
+			if audit.CompatibilityReason != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "Reason: %s\n", audit.CompatibilityReason)
+			}
+			if len(audit.ScriptAssets) > 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "Script assets: %s\n", strings.Join(audit.ScriptAssets, ", "))
 			}
 
 			if len(findings) == 0 {
@@ -232,7 +245,7 @@ Checks for:
 			}
 
 			hasErrors := bootstrap.AuditHasErrors(findings)
-			fmt.Fprintf(cmd.OutOrStdout(), "Audit findings (%d):\n\n", len(findings))
+			fmt.Fprintf(cmd.OutOrStdout(), "\nAudit findings (%d):\n\n", len(findings))
 			for _, f := range findings {
 				fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", f)
 			}
@@ -321,6 +334,21 @@ func countErrors(findings []bootstrap.AuditFinding) int {
 		}
 	}
 	return n
+}
+
+func skillLoaderOptions(cfg *config.Config) bootstrap.LoaderOptions {
+	if cfg == nil {
+		return bootstrap.LoaderOptions{}
+	}
+	return bootstrap.LoaderOptions{TrustWorkspaceScripts: cfg.TrustWorkspaceScripts()}
+}
+
+func formatSkillCompatibility(skill bootstrap.SkillEntry) string {
+	status := skill.Compatibility
+	if status == "" {
+		status = bootstrap.SkillCompatibilityNative
+	}
+	return string(status)
 }
 
 func printSkillSuggestion(out interface{ Write([]byte) (int, error) }, suggestion *bootstrap.SkillSuggestion) {

--- a/internal/cli/skills_test.go
+++ b/internal/cli/skills_test.go
@@ -54,6 +54,41 @@ func TestSkillsListCommand_ShowsInstalledSkills(t *testing.T) {
 	}
 }
 
+func TestSkillsListCommand_ShowsWorkspaceCompatibilityStatus(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeSkillFile(t, filepath.Join(dir, "skills", "youtube-karaoke", "SKILL.md"), "# Karaoke")
+	writeSkillFile(t, filepath.Join(dir, "skills", "youtube-karaoke", "scripts", "karaoke.sh"), "#!/bin/sh\necho ok")
+
+	cfg := &config.Config{SoulPath: dir}
+	cmd := newSkillsCommand(cfg)
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"list"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "youtube-karaoke") || !strings.Contains(out.String(), "blocked") {
+		t.Fatalf("expected blocked compatibility status in output: %q", out.String())
+	}
+
+	trustedCfg := &config.Config{SoulPath: dir, Skills: config.SkillsConfig{TrustWorkspaceScripts: true}}
+	trustedCmd := newSkillsCommand(trustedCfg)
+	out.Reset()
+	trustedCmd.SetOut(&out)
+	trustedCmd.SetErr(&out)
+	trustedCmd.SetArgs([]string{"list"})
+	if err := trustedCmd.Execute(); err != nil {
+		t.Fatalf("trusted Execute() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "trusted_workspace") {
+		t.Fatalf("expected trusted_workspace status in output: %q", out.String())
+	}
+}
+
 func TestSkillsInstallCommand_LocalPath(t *testing.T) {
 	t.Parallel()
 	workspace := t.TempDir()
@@ -199,6 +234,30 @@ func TestSkillsAuditCommand_ReportsErrors(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "script or executable") {
 		t.Fatalf("expected script finding in output: %q", out.String())
+	}
+}
+
+func TestSkillsAuditCommand_ExplainsTrustedWorkspaceScripts(t *testing.T) {
+	t.Parallel()
+	workspace := t.TempDir()
+	writeSkillFile(t, filepath.Join(workspace, "skills", "video-summary", "SKILL.md"), "# Video")
+	writeSkillFile(t, filepath.Join(workspace, "skills", "video-summary", "scripts", "summary.py"), "print('summary')")
+
+	cfg := &config.Config{SoulPath: workspace, Skills: config.SkillsConfig{TrustWorkspaceScripts: true}}
+	cmd := newSkillsCommand(cfg)
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"audit", "video-summary"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v; output=%q", err, out.String())
+	}
+	for _, want := range []string{"Compatibility: trusted_workspace", "Script assets:", "warnings only"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q: %q", want, out.String())
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -904,12 +905,17 @@ func (c *Config) GetSoulPath() string {
 
 // TrustWorkspaceScripts reports whether script-bearing skills mounted under
 // soul_path/skills may be treated as trusted workspace skills. The environment
-// variable takes precedence so operators can enable compatibility for mounted
-// OpenClaw workspaces without editing config files.
+// variable takes precedence when it contains a valid boolean so operators can
+// enable compatibility for mounted OpenClaw workspaces without editing config
+// files.
 func (c *Config) TrustWorkspaceScripts() bool {
 	if env := strings.TrimSpace(os.Getenv("OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS")); env != "" {
 		v, err := strconv.ParseBool(env)
-		return err == nil && v
+		if err != nil {
+			log.Printf("warning: OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS=%q is not a valid boolean; ignoring and using config value", env)
+		} else {
+			return v
+		}
 	}
 	if c == nil {
 		return false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -81,6 +82,14 @@ type ArtifactConfig struct {
 	Roots []string `mapstructure:"roots"` // Local roots safe for Mission Control/API artifact previews
 }
 
+// SkillsConfig holds skill discovery and compatibility settings.
+type SkillsConfig struct {
+	// TrustWorkspaceScripts allows script-bearing skills already mounted under
+	// soul_path/skills to appear as trusted workspace skills. It does not change
+	// the strict markdown-only install audit and does not execute scripts.
+	TrustWorkspaceScripts bool `mapstructure:"trust_workspace_scripts"`
+}
+
 // SessionConfig holds session-key derivation behavior.
 type SessionConfig struct {
 	// DMScope controls how DM session keys are created:
@@ -125,6 +134,7 @@ type Config struct {
 	Control      ControlConfig     `mapstructure:"control"`
 	Browser      BrowserConfig     `mapstructure:"browser"`
 	Artifacts    ArtifactConfig    `mapstructure:"artifacts"`
+	Skills       SkillsConfig      `mapstructure:"skills"`
 	Runtime      RuntimeConfig     `mapstructure:"runtime"`
 	Session      SessionConfig     `mapstructure:"session"`
 	Groups       GroupsConfig      `mapstructure:"groups"`
@@ -405,6 +415,7 @@ func Load() (*Config, error) {
 	v.SetDefault("api.api_key", "")
 	v.SetDefault("api.webhook_chat", int64(0))
 	v.SetDefault("artifacts.roots", []string{})
+	v.SetDefault("skills.trust_workspace_scripts", false)
 	v.SetDefault("tts.provider", "openai")
 	v.SetDefault("tts.default_voice", "")
 	v.SetDefault("stt.base_url", "")
@@ -547,6 +558,7 @@ func LoadFrom(configPath string) (*Config, error) {
 	v.SetDefault("api.api_key", "")
 	v.SetDefault("api.webhook_chat", int64(0))
 	v.SetDefault("artifacts.roots", []string{})
+	v.SetDefault("skills.trust_workspace_scripts", false)
 	v.SetDefault("tts.provider", "openai")
 	v.SetDefault("tts.default_voice", "")
 	v.SetDefault("stt.base_url", "")
@@ -805,6 +817,7 @@ func (c *Config) Save() error {
 	v.Set("api.api_key", c.API.APIKey)
 	v.Set("api.webhook_chat", c.API.WebhookChat)
 	v.Set("artifacts.roots", c.Artifacts.Roots)
+	v.Set("skills.trust_workspace_scripts", c.Skills.TrustWorkspaceScripts)
 	v.Set("tts.provider", c.TTS.Provider)
 	v.Set("tts.default_voice", c.TTS.DefaultVoice)
 	v.Set("memory.enabled", c.Memory.Enabled)
@@ -887,6 +900,21 @@ func (c *Config) GetSoulPath() string {
 		return expandPath(envPath)
 	}
 	return c.SoulPath
+}
+
+// TrustWorkspaceScripts reports whether script-bearing skills mounted under
+// soul_path/skills may be treated as trusted workspace skills. The environment
+// variable takes precedence so operators can enable compatibility for mounted
+// OpenClaw workspaces without editing config files.
+func (c *Config) TrustWorkspaceScripts() bool {
+	if env := strings.TrimSpace(os.Getenv("OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS")); env != "" {
+		v, err := strconv.ParseBool(env)
+		return err == nil && v
+	}
+	if c == nil {
+		return false
+	}
+	return c.Skills.TrustWorkspaceScripts
 }
 
 // expandPath expands ~ to home directory

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -678,3 +678,43 @@ func TestNormalizeMemoryMode(t *testing.T) {
 		t.Errorf("unknown values should be returned verbatim so Validate can reject them, got %q", got)
 	}
 }
+
+func TestLoadFromSkillsTrustWorkspaceScripts(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `telegram:
+  token: "test-token"
+ai:
+  api_key: "test-key"
+  model: "test-model"
+  provider: "openrouter"
+storage_path: "/tmp/test.db"
+skills:
+  trust_workspace_scripts: true
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if !cfg.TrustWorkspaceScripts() {
+		t.Fatal("TrustWorkspaceScripts() = false, want true")
+	}
+}
+
+func TestTrustWorkspaceScriptsEnvOverride(t *testing.T) {
+	t.Setenv("OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS", "true")
+	cfg := &Config{}
+	if !cfg.TrustWorkspaceScripts() {
+		t.Fatal("env should enable trusted workspace scripts")
+	}
+
+	t.Setenv("OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS", "false")
+	cfg.Skills.TrustWorkspaceScripts = true
+	if cfg.TrustWorkspaceScripts() {
+		t.Fatal("env=false should override config=true")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -717,4 +717,9 @@ func TestTrustWorkspaceScriptsEnvOverride(t *testing.T) {
 	if cfg.TrustWorkspaceScripts() {
 		t.Fatal("env=false should override config=true")
 	}
+
+	t.Setenv("OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS", "enable")
+	if !cfg.TrustWorkspaceScripts() {
+		t.Fatal("invalid env should fall back to config=true")
+	}
 }


### PR DESCRIPTION
Implements #388

## Changes
- Adds workspace skill compatibility classification: native, trusted_workspace, and blocked.
- Allows script-bearing skills only when they are already under the configured workspace skills root and `skills.trust_workspace_scripts` or `OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS` is explicitly enabled.
- Keeps install-time audits strict and updates list/audit/runtime prompt/status surfaces plus config docs/schema.

## Testing
- go fmt ./...
- go vet ./...
- go test ./...
- go build ./cmd/ok-gobot/
- .maestro/verify.sh

## Runtime Verification
- Smoke LXC verification for the mounted kobi skills still needs to be run by an operator on forge/LXC 202.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces workspace skill compatibility classification (`native`, `trusted_workspace`, `blocked`) so script-bearing skills already mounted under `soul_path/skills` can be surfaced to the router without changing the strict markdown-only install audit. The feature is opt-in via `skills.trust_workspace_scripts` or `OKGOBOT_SKILLS_TRUST_WORKSPACE_SCRIPTS`, symlink-containment is enforced with `filepath.EvalSymlinks`, and invalid env values now log a warning and fall back to the config file value.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic errors found; the trust boundary is correctly enforced at every layer.

All changed code paths were traced end-to-end. Relative-path matching between AuditSkill findings and ScriptAssetPaths is consistent (both compute paths relative to filepath.Abs of the same skillPath). Symlink escape is blocked by EvalSymlinks before the containment check. Non-script audit errors (symlinks, pipe-to-shell) survive the downgrade step and still block trusted workspace skills. The env-var silent-ignore issue flagged in a previous review has been addressed with a warning log. Test coverage is thorough across all new classification paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/bootstrap/skills.go | Core workspace compatibility logic: AuditSkillForWorkspace, ScriptAssetPaths, SkillPathWithinWorkspace, and downgradeWorkspaceScriptFindings all look correct; relative-path matching between AuditSkill findings and ScriptAssetPaths is consistent, and symlink containment check via EvalSymlinks is properly implemented. |
| internal/config/config.go | Adds SkillsConfig struct, TrustWorkspaceScripts() method with env-var override; invalid env values now log a warning and fall back to the config value, addressing the previous review thread. |
| internal/bootstrap/loader.go | Adds LoaderOptions and NewLoaderWithOptions, delegates discoverSkills to ListSkillsWithOptions; SkillsSummary correctly handles empty Compatibility with a native fallback. |
| internal/agent/personality.go | Threads LoaderOptions through NewPersonalityWithOptions and Reload correctly; loaderSnapshotLocked now propagates Options so the snapshot stays consistent. |
| internal/cli/skills.go | Audit command now shows compatibility, reason, and script assets; list command gains STATUS column; skillLoaderOptions helper ensures consistent option plumbing across all CLI entry points. |
| internal/bot/status.go | skillCompatibilityStatusLine correctly counts native/trusted_workspace/blocked skills and handles empty Compatibility as native; nil/empty-skills guard prevents panics. |
| internal/agent/registry.go | NewAgentRegistryWithOptions cleanly propagates LoaderOptions to every agent personality; backward-compatible no-arg constructor preserved. |
| internal/app/app.go | Correctly wires TrustWorkspaceScripts config into loaderOptions before building personality and agent registry. |
| internal/bootstrap/skills_test.go | New tests cover blocked default, trusted_workspace upgrade, outside-workspace rejection, and install-time strict audit; comprehensive coverage of the new classification paths. |
| internal/cli/skills_test.go | Tests verify CLI list output shows blocked/trusted_workspace columns and audit output shows compatibility details; coverage is good. |
| internal/config/config_test.go | Tests for config file loading and env-var override (including invalid env fallback) are complete. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: preserve trusted workspace config o..."](https://github.com/befeast/ok-gobot/commit/fa25c43a8f43569bd0dd4460b5f3e0b0e0fa0398) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30552955)</sub>

<!-- /greptile_comment -->