### PR TITLE
feat: scheduled roles use the durable role runner (#347)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -480,6 +480,13 @@ func (a *App) Start(ctx context.Context) error {
 	a.bot = b
 	a.bot.SetArtifactRoots(a.config.Artifacts.Roots)
 
+	// Wire the bot's agent runtime into the cron scheduler so scheduled role
+	// tasks reuse the same durable role runner as manual /role_run invocations.
+	if a.scheduler != nil {
+		a.scheduler.SetRoleAgentSubmitter(a.bot.RoleAgentSubmitter())
+		a.scheduler.SetArtifactRoots(a.config.Artifacts.Roots)
+	}
+
 	// Wire Active Memory pre-reply recall (DM-only, opt-in).
 	activeCfg := agent.ActiveMemoryConfig{
 		Enabled:      a.config.Memory.Active.Enabled,

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -993,6 +993,13 @@ func (b *Bot) SubagentHub() *runtime.Hub {
 	return b.subagentHub
 }
 
+// RoleAgentSubmitter returns the agent runtime used to execute role jobs.
+// The cron scheduler wires this in so scheduled role tasks share the same
+// durable role runner used by manual /role_run invocations.
+func (b *Bot) RoleAgentSubmitter() *agent.RuntimeHub {
+	return b.hub
+}
+
 // SetTaskObserver wires an observer that is notified after each agent run.
 // The observer must implement agent.TaskObserver.
 func (b *Bot) SetTaskObserver(obs agent.TaskObserver) {

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -13,6 +13,7 @@ import (
 
 	"ok-gobot/internal/delegation"
 	"ok-gobot/internal/role"
+	"ok-gobot/internal/rolejob"
 	"ok-gobot/internal/runtime"
 	"ok-gobot/internal/storage"
 )
@@ -33,16 +34,18 @@ type ReportDeliverer func(chatID int64, report JobReport)
 
 // Scheduler manages cron jobs.
 type Scheduler struct {
-	cron       *cron.Cron
-	store      *storage.Store
-	executor   JobExecutor
-	notifier   ExecResultNotifier
-	deliverer  ReportDeliverer
-	jobService *runtime.JobService
-	manifests  map[string]*role.Manifest // role name → manifest (budget lookup)
-	jobs       map[int64]cron.EntryID
-	mu         sync.RWMutex
-	running    bool
+	cron               *cron.Cron
+	store              *storage.Store
+	executor           JobExecutor
+	notifier           ExecResultNotifier
+	deliverer          ReportDeliverer
+	jobService         *runtime.JobService
+	roleAgentSubmitter rolejob.AgentSubmitter
+	artifactRoots      []string
+	manifests          map[string]*role.Manifest // role name → manifest (budget lookup)
+	jobs               map[int64]cron.EntryID
+	mu                 sync.RWMutex
+	running            bool
 }
 
 // NewScheduler creates a new cron scheduler.
@@ -68,6 +71,25 @@ func (s *Scheduler) SetJobService(js *runtime.JobService) {
 // SetReportDeliverer sets the callback for standardized report delivery.
 func (s *Scheduler) SetReportDeliverer(d ReportDeliverer) {
 	s.deliverer = d
+}
+
+// SetRoleAgentSubmitter wires the agent runtime used to execute scheduled role
+// jobs. When set, role-tagged cron tasks run through the same durable role job
+// runner used by manual /role_run invocations, persisting real worker output
+// and artifacts instead of a stub "completed task" summary.
+func (s *Scheduler) SetRoleAgentSubmitter(sub rolejob.AgentSubmitter) {
+	s.mu.Lock()
+	s.roleAgentSubmitter = sub
+	s.mu.Unlock()
+}
+
+// SetArtifactRoots configures the allow-listed roots for role-job artifacts.
+// Scheduled role runs pass these to the role runner so file:// references
+// resolved from tool output get validated against the operator's policy.
+func (s *Scheduler) SetArtifactRoots(roots []string) {
+	s.mu.Lock()
+	s.artifactRoots = append([]string(nil), roots...)
+	s.mu.Unlock()
 }
 
 // Start begins the scheduler.
@@ -168,24 +190,40 @@ func (s *Scheduler) scheduleJob(job storage.CronJob) error {
 // fireDurable creates a durable runtime.Job for the cron fire and delivers a
 // standardized report on completion.
 func (s *Scheduler) fireDurable(cronJob storage.CronJob, timeout time.Duration) {
+	var (
+		roleName     string
+		roleManifest *role.Manifest
+		roleSubmit   rolejob.AgentSubmitter
+		artifactDirs []string
+	)
+	if name := roleNameFromTask(cronJob.Task); name != "" {
+		roleName = name
+		s.mu.RLock()
+		roleManifest = s.manifests[name]
+		roleSubmit = s.roleAgentSubmitter
+		artifactDirs = append([]string(nil), s.artifactRoots...)
+		s.mu.RUnlock()
+	}
+
+	// Preferred path: role manifest + agent runtime available → reuse the
+	// durable role job runner that powers /role_run.
+	if roleManifest != nil && roleSubmit != nil {
+		s.fireRoleDurable(cronJob, timeout, roleName, roleManifest, roleSubmit, artifactDirs)
+		return
+	}
+
 	kind := "cron_exec"
 	if cronJob.Type != "exec" {
 		kind = "cron_llm"
 	}
 
-	// Look up manifest to populate budget fields for role jobs.
+	// Look up manifest to populate budget fields for role jobs even when the
+	// dedicated runner is not wired in.
 	var maxToolCalls int
-	var roleName string
-	if name := roleNameFromTask(cronJob.Task); name != "" {
-		roleName = name
-		s.mu.RLock()
-		m := s.manifests[name]
-		s.mu.RUnlock()
-		if m != nil {
-			maxToolCalls = m.MaxToolCalls
-			if m.MaxDuration > 0 {
-				timeout = m.MaxDuration
-			}
+	if roleManifest != nil {
+		maxToolCalls = roleManifest.MaxToolCalls
+		if roleManifest.MaxDuration > 0 {
+			timeout = roleManifest.MaxDuration
 		}
 	}
 
@@ -214,11 +252,53 @@ func (s *Scheduler) fireDurable(cronJob storage.CronJob, timeout time.Duration) 
 	}
 
 	// Wait for the durable job to reach a terminal state, then deliver the report.
-	go s.waitAndDeliver(cronJob, job.JobID, start)
+	go s.waitAndDeliver(cronJob, job.JobID, start, roleManifest)
+}
+
+// fireRoleDurable runs a scheduled role through the shared rolejob.AgentJobRunner
+// so the worker output, artifacts, and budget fields match a manual /role_run.
+func (s *Scheduler) fireRoleDurable(cronJob storage.CronJob, timeout time.Duration, roleName string, manifest *role.Manifest, submitter rolejob.AgentSubmitter, artifactRoots []string) {
+	opts := rolejob.Options{
+		SessionKey:    fmt.Sprintf("cron:role:%s:%d", roleName, cronJob.ID),
+		Worker:        manifest.Worker,
+		ChatID:        cronJob.ChatID,
+		ArtifactRoots: artifactRoots,
+	}
+	// Only forward an explicit cron job timeout so manifest MaxDuration
+	// still wins over the scheduler-wide default of 15m.
+	if cronJob.TimeoutSeconds > 0 {
+		opts.Timeout = timeout
+	}
+	spec, err := rolejob.JobSpec(manifest, opts)
+	if err != nil {
+		log.Printf("Cron job %d: rolejob.JobSpec failed: %v", cronJob.ID, err)
+		s.fireLegacy(cronJob, timeout)
+		return
+	}
+	spec.Kind = "cron_role"
+	spec.Worker = strings.TrimSpace(spec.Worker)
+	if spec.Worker == "" {
+		spec.Worker = "cron_scheduler"
+	}
+	spec.Description = fmt.Sprintf("schedule #%d: role:%s", cronJob.ID, roleName)
+
+	runner := rolejob.AgentJobRunner(submitter, manifest, "", opts)
+
+	start := time.Now()
+	job, err := s.jobService.StartDetached(context.Background(), spec, runner)
+	if err != nil {
+		log.Printf("Cron job %d: failed to create durable role job: %v", cronJob.ID, err)
+		s.fireLegacy(cronJob, timeout)
+		return
+	}
+
+	go s.waitAndDeliver(cronJob, job.JobID, start, manifest)
 }
 
 // waitAndDeliver polls for the durable job to complete and delivers a report.
-func (s *Scheduler) waitAndDeliver(cronJob storage.CronJob, jobID string, start time.Time) {
+// manifest is non-nil when the cron task originates from a role; the report
+// template is then applied so scheduled role deliveries match manual runs.
+func (s *Scheduler) waitAndDeliver(cronJob storage.CronJob, jobID string, start time.Time, manifest *role.Manifest) {
 	var finished *storage.Job
 	for {
 		j, err := s.store.GetJob(jobID)
@@ -233,6 +313,11 @@ func (s *Scheduler) waitAndDeliver(cronJob storage.CronJob, jobID string, start 
 		time.Sleep(500 * time.Millisecond)
 	}
 
+	summary := finished.Summary
+	if rendered := renderRoleReport(manifest, finished); rendered != "" {
+		summary = rendered
+	}
+
 	report := JobReport{
 		CronJobID:   cronJob.ID,
 		Expression:  cronJob.Expression,
@@ -240,7 +325,7 @@ func (s *Scheduler) waitAndDeliver(cronJob storage.CronJob, jobID string, start 
 		JobType:     cronJob.Type,
 		Status:      finished.Status,
 		LimitReason: finished.LimitReason,
-		Summary:     finished.Summary,
+		Summary:     summary,
 		Error:       finished.Error,
 		Duration:    time.Since(start),
 		JobID:       finished.JobID,
@@ -249,8 +334,43 @@ func (s *Scheduler) waitAndDeliver(cronJob storage.CronJob, jobID string, start 
 	if cronJob.Type == "" {
 		report.JobType = "llm"
 	}
+	if manifest != nil {
+		report.JobType = "role"
+	}
 
 	s.deliver(cronJob.ChatID, report)
+}
+
+// renderRoleReport applies the manifest's report_template to a finished role job.
+// Returns "" when there is no template, no manifest, or the job did not succeed.
+// Template render errors are logged but do not break delivery; the raw worker
+// summary remains the fallback.
+func renderRoleReport(manifest *role.Manifest, finished *storage.Job) string {
+	if manifest == nil || finished == nil {
+		return ""
+	}
+	if manifest.ReportTemplate == "" {
+		return ""
+	}
+	if finished.Status != string(runtime.JobStatusSucceeded) {
+		return ""
+	}
+
+	summary := strings.TrimSpace(finished.Summary)
+	data := map[string]string{
+		"Summary": summary,
+		"Body":    summary,
+		"Title":   manifest.Name,
+		"Date":    time.Now().UTC().Format("2006-01-02"),
+		"JobID":   finished.JobID,
+		"Role":    manifest.Name,
+	}
+	rendered, err := manifest.RenderReport(data)
+	if err != nil {
+		log.Printf("[roles] render report template for %q failed: %v", manifest.Name, err)
+		return ""
+	}
+	return strings.TrimSpace(rendered)
 }
 
 // fireLegacy executes the cron job directly without durable job tracking.

--- a/internal/cron/scheduler_role_test.go
+++ b/internal/cron/scheduler_role_test.go
@@ -1,0 +1,254 @@
+package cron
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/role"
+	"ok-gobot/internal/runtime"
+	"ok-gobot/internal/storage"
+)
+
+// fakeAgentHub captures Submit/Cancel calls and replies with a configurable
+// final RunEventDone payload so the scheduler can exercise the rolejob path
+// without booting a real LLM runtime.
+type fakeAgentHub struct {
+	mu       sync.Mutex
+	requests []agent.RunRequest
+	content  string
+}
+
+func (h *fakeAgentHub) Submit(req agent.RunRequest) <-chan agent.RunEvent {
+	h.mu.Lock()
+	h.requests = append(h.requests, req)
+	content := h.content
+	h.mu.Unlock()
+
+	ch := make(chan agent.RunEvent, 1)
+	ch <- agent.RunEvent{Type: agent.RunEventDone, Result: &agent.AgentResponse{Message: content}, ProfileName: "test"}
+	close(ch)
+	return ch
+}
+
+func (h *fakeAgentHub) Cancel(agent.SessionKey) {}
+
+func (h *fakeAgentHub) lastRequest(t *testing.T) agent.RunRequest {
+	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.requests) == 0 {
+		t.Fatal("expected at least one agent submission")
+	}
+	return h.requests[len(h.requests)-1]
+}
+
+func TestSchedulerScheduledRoleUsesRoleRunner(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	jobService := runtime.NewJobService(store)
+
+	var (
+		mu        sync.Mutex
+		delivered []JobReport
+	)
+
+	sched := NewScheduler(store, nil)
+	sched.SetJobService(jobService)
+	sched.SetReportDeliverer(func(_ int64, report JobReport) {
+		mu.Lock()
+		delivered = append(delivered, report)
+		mu.Unlock()
+	})
+
+	hub := &fakeAgentHub{content: "real worker result with concrete details"}
+	sched.SetRoleAgentSubmitter(hub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := sched.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer sched.Stop()
+
+	manifests := []*role.Manifest{
+		{
+			Name:           "scheduled-role",
+			Schedule:       "* * * * * *",
+			Prompt:         "Run scheduled work.",
+			Worker:         "standard",
+			MaxToolCalls:   9,
+			MaxDuration:    90 * time.Second,
+			ReportTemplate: "🛎️ {{.Title}}\n{{.Summary}}\nDate: {{.Date}}",
+		},
+	}
+	if err := sched.RegisterRoleJobs(manifests, 4242); err != nil {
+		t.Fatalf("RegisterRoleJobs failed: %v", err)
+	}
+
+	deadline := time.Now().Add(cronTestWait)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(delivered)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	mu.Lock()
+	reports := append([]JobReport(nil), delivered...)
+	mu.Unlock()
+	if len(reports) == 0 {
+		t.Fatal("expected at least one report delivery")
+	}
+
+	rep := reports[0]
+	if rep.Status != "succeeded" {
+		t.Fatalf("Status = %q, want succeeded", rep.Status)
+	}
+	if rep.JobType != "role" {
+		t.Fatalf("JobType = %q, want role", rep.JobType)
+	}
+	if !strings.Contains(rep.Summary, "real worker result with concrete details") {
+		t.Errorf("Summary should embed worker output; got %q", rep.Summary)
+	}
+	if !strings.Contains(rep.Summary, "🛎️") {
+		t.Errorf("Summary should be rendered through the report template; got %q", rep.Summary)
+	}
+	if strings.Contains(rep.Summary, "completed task") {
+		t.Errorf("Summary should not be the legacy stub; got %q", rep.Summary)
+	}
+
+	if rep.JobID == "" {
+		t.Fatal("expected JobID on report")
+	}
+	job, err := store.GetJob(rep.JobID)
+	if err != nil {
+		t.Fatalf("GetJob failed: %v", err)
+	}
+	if job == nil {
+		t.Fatal("expected durable job to be persisted")
+	}
+	if job.Kind != "cron_role" {
+		t.Errorf("job.Kind = %q, want cron_role", job.Kind)
+	}
+	if job.RoleName != "scheduled-role" {
+		t.Errorf("job.RoleName = %q, want scheduled-role", job.RoleName)
+	}
+	if job.Worker != "standard" {
+		t.Errorf("job.Worker = %q, want standard", job.Worker)
+	}
+	if job.MaxToolCalls != 9 {
+		t.Errorf("job.MaxToolCalls = %d, want 9", job.MaxToolCalls)
+	}
+	if job.TimeoutSeconds != 90 {
+		t.Errorf("job.TimeoutSeconds = %d, want 90", job.TimeoutSeconds)
+	}
+	if !strings.Contains(job.Summary, "real worker result with concrete details") {
+		t.Errorf("persisted summary should be the worker output; got %q", job.Summary)
+	}
+	if strings.HasPrefix(job.Summary, "completed task") {
+		t.Errorf("persisted summary should not be the stub %q", job.Summary)
+	}
+
+	req := hub.lastRequest(t)
+	if !strings.Contains(req.Content, "Run scheduled work.") {
+		t.Errorf("agent submission should embed the manifest prompt; got %q", req.Content)
+	}
+	if req.Job == nil || req.Job.MaxToolCalls != 9 {
+		t.Errorf("agent submission should carry budget fields; got %+v", req.Job)
+	}
+}
+
+func TestSchedulerScheduledRoleFallsBackWithoutAgentSubmitter(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	jobService := runtime.NewJobService(store)
+
+	var (
+		mu        sync.Mutex
+		delivered []JobReport
+	)
+
+	sched := NewScheduler(store, nil)
+	sched.SetJobService(jobService)
+	sched.SetReportDeliverer(func(_ int64, report JobReport) {
+		mu.Lock()
+		delivered = append(delivered, report)
+		mu.Unlock()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := sched.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer sched.Stop()
+
+	manifests := []*role.Manifest{
+		{Name: "legacy-role", Schedule: "* * * * * *", Prompt: "stub", MaxToolCalls: 3},
+	}
+	if err := sched.RegisterRoleJobs(manifests, 7); err != nil {
+		t.Fatalf("RegisterRoleJobs failed: %v", err)
+	}
+
+	deadline := time.Now().Add(cronTestWait)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(delivered)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	mu.Lock()
+	reports := append([]JobReport(nil), delivered...)
+	mu.Unlock()
+
+	if len(reports) == 0 {
+		t.Fatal("expected at least one report delivery")
+	}
+	rep := reports[0]
+	job, err := store.GetJob(rep.JobID)
+	if err != nil {
+		t.Fatalf("GetJob failed: %v", err)
+	}
+	if job == nil {
+		t.Fatal("expected durable job to be persisted")
+	}
+	// Without a role agent submitter the scheduler keeps the legacy LLM kind
+	// so existing cron exec/LLM tooling and tests are not perturbed.
+	if job.Kind != "cron_llm" {
+		t.Errorf("expected cron_llm fallback kind; got %q", job.Kind)
+	}
+}
+
+func TestRenderRoleReportSkipsForNonSuccess(t *testing.T) {
+	t.Parallel()
+
+	m := &role.Manifest{Name: "monitor", ReportTemplate: "👀 {{.Summary}}"}
+	finished := &storage.Job{Status: string(runtime.JobStatusFailed), Summary: "boom"}
+	if got := renderRoleReport(m, finished); got != "" {
+		t.Errorf("renderRoleReport on failed job = %q, want empty", got)
+	}
+
+	finished.Status = string(runtime.JobStatusSucceeded)
+	finished.Summary = "all good"
+	got := renderRoleReport(m, finished)
+	if !strings.Contains(got, "all good") || !strings.Contains(got, "👀") {
+		t.Errorf("renderRoleReport on success = %q, want template applied", got)
+	}
+}


### PR DESCRIPTION
Implements #347

## Changes
- Scheduled cron jobs registered from a role manifest now route through `rolejob.AgentJobRunner`, the same durable runner used by manual `/role_run` invocations.
- Persisted `storage.Job` records carry the real worker output as the summary (no more `completed task: …` stub), plus role metadata: `Kind=cron_role`, `RoleName`, `Worker`, `MaxToolCalls`, `TimeoutSeconds`.
- Manifest budget fields (`max_tool_calls`, `max_duration`, worker/model tier, tool allowlist, memory policy) flow into both the durable job spec and the agent delegation, matching manual runs.
- Tool artifacts produced during scheduled runs are persisted via the existing rolejob path so they surface in `/job <id>`, the API, and Mission Control.
- The cron `JobReport` now renders the manifest's `report_template` (`Summary`, `Body`, `Title`, `Date`, `JobID`, `Role`) when the run succeeds; raw worker output remains the fallback.
- `cron.Scheduler` adds `SetRoleAgentSubmitter` / `SetArtifactRoots`; `app.Start` wires the bot's existing agent runtime into the scheduler after bot creation.
- A new accessor `Bot.RoleAgentSubmitter()` exposes the legacy agent hub used by `/role_run` so the scheduler shares the same runtime.

Non-role cron LLM tasks and exec jobs keep their previous behavior. When the agent runtime is not wired in, the scheduler falls back to the prior `cron_llm` path so existing cron-exec tests and tooling are unchanged.

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...` (all packages green, including `internal/cron`, `internal/rolejob`, `internal/cli`, `internal/role`, `internal/bot`)
- `go build ./cmd/ok-gobot/`
- New `internal/cron/scheduler_role_test.go` covers: scheduled role using the durable runner with manifest budgets + template rendering + persisted real summary; legacy fallback preserving `cron_llm` when no agent runtime is wired in; `renderRoleReport` skip on non-success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes scheduled role cron jobs through `rolejob.AgentJobRunner` — the same durable runner used by manual `/role_run` invocations — so worker output, artifacts, budget enforcement, and report-template rendering all behave consistently between scheduled and interactive role runs.

- `Scheduler.fireRoleDurable` is the new preferred path when a role manifest and agent submitter are both available; the legacy `cron_llm` path is preserved as a fallback when only the manifest is present, and `fireLegacy` is the last resort when neither is available.
- `waitAndDeliver` now accepts a `*role.Manifest` parameter so `renderRoleReport` can apply the manifest's `report_template` on successful role runs; the `Date` field in the template data is set to `time.Now()` at render time, which can differ from the job schedule or start time for long-running roles.
- `Bot.RoleAgentSubmitter()` exposes the existing `b.hub` field; `app.Start` wires it into the scheduler after bot creation, with an intentional fallback window for the first fires between registration and wiring.

<h3>Confidence Score: 4/5</h3>

The change is well-structured and all three fallback layers behave correctly; safe to merge with minor edge-case caveats.

The logic is sound and tests cover the primary paths. The Date template variable uses render time rather than job start time, and the fireLegacy fallback from fireRoleDurable silently drops manifest budget constraints on storage errors — both are edge-case issues that would not affect typical operation.

internal/cron/scheduler.go — specifically the renderRoleReport date population and the fireLegacy fallback path in fireRoleDurable.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cron/scheduler.go | Core change: adds fireRoleDurable path routing scheduled role jobs through rolejob.AgentJobRunner; extends waitAndDeliver and renderRoleReport for template rendering; locking is correct; minor date-accuracy issue in renderRoleReport. |
| internal/bot/bot.go | Adds RoleAgentSubmitter() accessor exposing the existing b.hub field; minimal and safe addition. |
| internal/app/app.go | Wires SetRoleAgentSubmitter and SetArtifactRoots into the scheduler after bot creation; correct placement post-bot-init; startup ordering leaves a narrow fallback window that is handled by design. |
| internal/cron/scheduler_role_test.go | New test file covering the durable role runner path, legacy fallback, and template rendering; uses fakeAgentHub that sends a single RunEventDone, which matches AgentJobRunner's single-select design. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/cron/scheduler.go:362-367
**`Date` field reflects render time, not job start time**

`time.Now().UTC()` is evaluated when `waitAndDeliver` calls `renderRoleReport` — after the job has already completed. For a role that runs near midnight (e.g., scheduled at 23:55 with a 10-minute max duration), the `{{.Date}}` variable in the report template would show the next day. The `start` timestamp is already available in `waitAndDeliver` as a parameter and would be more representative of when the work actually ran. Consider passing `start.UTC()` into the data map (or threading `start` into `renderRoleReport`) so the date matches the scheduling intent rather than the delivery moment.

### Issue 2 of 3
internal/cron/scheduler.go:272-277
**`rolejob.JobSpec` error branch is unreachable here**

`rolejob.JobSpec` only returns an error when `m == nil`. `fireRoleDurable` is only called from `fireDurable` after the `roleManifest != nil && roleSubmit != nil` guard, so `manifest` is guaranteed non-nil by the time this error check runs. The `fireLegacy` fallback in the error branch can never be triggered. It is harmless, but auditors scanning the fallback path could misread it as a live safety net. A comment like `// manifest is non-nil here; this guard is defensive` would make the intent explicit.

### Issue 3 of 3
internal/cron/scheduler.go:288-293
**Fallback to `fireLegacy` on `StartDetached` failure silently drops manifest budget**

When `StartDetached` fails (e.g., a database error creating the job record), `fireLegacy` is invoked with the original `timeout` but without the manifest's budget fields — the executor ultimately receives a `nil` budget, so `MaxToolCalls`, tool allowlists, and `MemoryPolicy` are not enforced. In practice this is a rare error path, but if the storage layer flaps the role could run unconstrained. The `fireDurable` fallback path (when `roleSubmit == nil`) does apply budget via `runLLM`'s manifest lookup, so there is an inconsistency between the two fallback behaviours worth noting.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: run scheduled roles through the du..."](https://github.com/befeast/ok-gobot/commit/a37cebb7062de9231dabf793f1f08ed9709d4725) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32537280)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->