### PR TITLE
fix: preserve scheduler timeout and budget on role cron fallbacks (#347)

### DIFF
--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -264,13 +264,18 @@ func (s *Scheduler) fireRoleDurable(cronJob storage.CronJob, timeout time.Durati
 		ChatID:        cronJob.ChatID,
 		ArtifactRoots: artifactRoots,
 	}
-	// Only forward an explicit cron job timeout so manifest MaxDuration
-	// still wins over the scheduler-wide default of 15m.
-	if cronJob.TimeoutSeconds > 0 {
-		opts.Timeout = timeout
+	// Resolve timeout with scheduler-aware precedence:
+	//   explicit cron timeout_seconds > manifest max_duration > scheduler default (15m).
+	// Falling through to rolejob.JobSpec without setting opts.Timeout would let it
+	// use its own 5m DefaultTimeout, silently shortening pre-existing schedules.
+	opts.Timeout = timeout
+	if cronJob.TimeoutSeconds == 0 && manifest.MaxDuration > 0 {
+		opts.Timeout = manifest.MaxDuration
 	}
 	spec, err := rolejob.JobSpec(manifest, opts)
 	if err != nil {
+		// manifest is non-nil here (guarded by the fireDurable caller); this
+		// branch is defensive in case rolejob.JobSpec gains other failure modes.
 		log.Printf("Cron job %d: rolejob.JobSpec failed: %v", cronJob.ID, err)
 		s.fireLegacy(cronJob, timeout)
 		return
@@ -314,7 +319,7 @@ func (s *Scheduler) waitAndDeliver(cronJob storage.CronJob, jobID string, start 
 	}
 
 	summary := finished.Summary
-	if rendered := renderRoleReport(manifest, finished); rendered != "" {
+	if rendered := renderRoleReport(manifest, finished, start); rendered != "" {
 		summary = rendered
 	}
 
@@ -344,8 +349,10 @@ func (s *Scheduler) waitAndDeliver(cronJob storage.CronJob, jobID string, start 
 // renderRoleReport applies the manifest's report_template to a finished role job.
 // Returns "" when there is no template, no manifest, or the job did not succeed.
 // Template render errors are logged but do not break delivery; the raw worker
-// summary remains the fallback.
-func renderRoleReport(manifest *role.Manifest, finished *storage.Job) string {
+// summary remains the fallback. start should be the job start time so that the
+// {{.Date}} field reflects when the work ran, not when the report is rendered
+// (matters for jobs that straddle midnight).
+func renderRoleReport(manifest *role.Manifest, finished *storage.Job, start time.Time) string {
 	if manifest == nil || finished == nil {
 		return ""
 	}
@@ -356,12 +363,16 @@ func renderRoleReport(manifest *role.Manifest, finished *storage.Job) string {
 		return ""
 	}
 
+	dateRef := start
+	if dateRef.IsZero() {
+		dateRef = time.Now()
+	}
 	summary := strings.TrimSpace(finished.Summary)
 	data := map[string]string{
 		"Summary": summary,
 		"Body":    summary,
 		"Title":   manifest.Name,
-		"Date":    time.Now().UTC().Format("2006-01-02"),
+		"Date":    dateRef.UTC().Format("2006-01-02"),
 		"JobID":   finished.JobID,
 		"Role":    manifest.Name,
 	}
@@ -373,7 +384,11 @@ func renderRoleReport(manifest *role.Manifest, finished *storage.Job) string {
 	return strings.TrimSpace(rendered)
 }
 
-// fireLegacy executes the cron job directly without durable job tracking.
+// fireLegacy executes the cron job directly without durable job tracking. When
+// the task originates from a registered role manifest the manifest's delegation
+// budget (MaxToolCalls, MemoryPolicy, tool allowlist, etc.) is forwarded to the
+// executor so role constraints are still enforced if the durable-runner path
+// fails (e.g. StartDetached errors) and we fall through to here.
 func (s *Scheduler) fireLegacy(cronJob storage.CronJob, timeout time.Duration) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -382,7 +397,17 @@ func (s *Scheduler) fireLegacy(cronJob storage.CronJob, timeout time.Duration) {
 		s.executeExecJob(ctx, cronJob)
 	} else {
 		if s.executor != nil {
-			if err := s.executor(ctx, cronJob, nil); err != nil {
+			var budget *delegation.Job
+			if name := roleNameFromTask(cronJob.Task); name != "" {
+				s.mu.RLock()
+				m := s.manifests[name]
+				s.mu.RUnlock()
+				if m != nil {
+					j := m.ToDelegationJob()
+					budget = &j
+				}
+			}
+			if err := s.executor(ctx, cronJob, budget); err != nil {
 				log.Printf("Cron job %d failed: %v", cronJob.ID, err)
 			}
 		}

--- a/internal/cron/scheduler_role_test.go
+++ b/internal/cron/scheduler_role_test.go
@@ -241,14 +241,29 @@ func TestRenderRoleReportSkipsForNonSuccess(t *testing.T) {
 
 	m := &role.Manifest{Name: "monitor", ReportTemplate: "👀 {{.Summary}}"}
 	finished := &storage.Job{Status: string(runtime.JobStatusFailed), Summary: "boom"}
-	if got := renderRoleReport(m, finished); got != "" {
+	if got := renderRoleReport(m, finished, time.Now()); got != "" {
 		t.Errorf("renderRoleReport on failed job = %q, want empty", got)
 	}
 
 	finished.Status = string(runtime.JobStatusSucceeded)
 	finished.Summary = "all good"
-	got := renderRoleReport(m, finished)
+	got := renderRoleReport(m, finished, time.Now())
 	if !strings.Contains(got, "all good") || !strings.Contains(got, "👀") {
 		t.Errorf("renderRoleReport on success = %q, want template applied", got)
+	}
+}
+
+// TestRenderRoleReportUsesStartTimeForDate guards against a regression where
+// {{.Date}} reflected the render time, not the job start time. For a job that
+// began on day D and finished after midnight, the date should still be D.
+func TestRenderRoleReportUsesStartTimeForDate(t *testing.T) {
+	t.Parallel()
+
+	m := &role.Manifest{Name: "midnight", ReportTemplate: "{{.Date}}"}
+	finished := &storage.Job{Status: string(runtime.JobStatusSucceeded), Summary: "done"}
+	start := time.Date(2030, 1, 15, 23, 55, 0, 0, time.UTC)
+	got := renderRoleReport(m, finished, start)
+	if got != "2030-01-15" {
+		t.Errorf("renderRoleReport with start=%v = %q, want 2030-01-15", start, got)
 	}
 }


### PR DESCRIPTION
Refs #347. Follow-up to PR #393 addressing review feedback on the
scheduled role runner.

## Changes
- `fireRoleDurable` now resolves timeout with explicit precedence
  (cron `timeout_seconds` > manifest `max_duration` > scheduler default
  15m). Without this, a role declaring neither override silently
  inherited `rolejob.DefaultTimeout` (5m), shortening pre-existing
  schedules. (Codex P1.)
- `renderRoleReport` takes the job `start` time so the `{{.Date}}`
  field reflects when the work ran, not when the report renders —
  matters for jobs that cross midnight. (Greptile P2.)
- `fireLegacy` looks up the role manifest and forwards its delegation
  budget so `MaxToolCalls`, `MemoryPolicy`, and tool allowlists stay
  enforced when the durable path falls back (e.g. `StartDetached`
  errors). (Greptile P2.)
- Documented the defensive `rolejob.JobSpec` error branch — `manifest`
  is non-nil at that point. (Greptile P2.)

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...` — all packages pass; new
  `TestRenderRoleReportUsesStartTimeForDate` guards against the date
  regression.
- `go build ./cmd/ok-gobot/`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a targeted follow-up to #393, hardening three aspects of the scheduled role runner: timeout precedence in `fireRoleDurable`, the `{{.Date}}` field in `renderRoleReport`, and delegation-budget forwarding in `fireLegacy`.

- **Timeout precedence** (`fireRoleDurable`): always sets `opts.Timeout` so the scheduler default (15 m) is used when neither `timeout_seconds` nor `max_duration` is specified, and prefers `manifest.MaxDuration` over the scheduler default when the cron entry has no explicit override. However, the resolved value is only written to `opts.Timeout`; both `fireLegacy` fallback sites inside `fireRoleDurable` still pass the original `timeout` variable, so a manifest with `max_duration` longer than 15 m would get a shorter hard-timeout on the error-recovery path.
- **Date fix** (`renderRoleReport`): receives the job `start` time instead of calling `time.Now()`, so `{{.Date}}` reflects the day the work began even for jobs that cross midnight. A new test (`TestRenderRoleReportUsesStartTimeForDate`) guards against regression.
- **Budget forwarding** (`fireLegacy`): looks up the role manifest and converts it to a `delegation.Job`, forwarding `MaxToolCalls`, `MemoryPolicy`, and tool allowlists to the executor when the durable runner falls through.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the date fix and budget-forwarding changes; the timeout fix is incomplete for the error-recovery path inside fireRoleDurable.

The timeout variable passed to both fireLegacy fallbacks inside fireRoleDurable is the pre-resolution scheduler default, so a role with max_duration longer than 15 m would have its legacy fallback silently capped at 15 m, directly undermining the main intent of the PR.

internal/cron/scheduler.go — specifically the opts.Timeout assignment block and the two fireLegacy(cronJob, timeout) calls that follow it in fireRoleDurable.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cron/scheduler.go | Fixes timeout precedence, date field, and delegation budget for role-cron paths, but the resolved manifest.MaxDuration is not propagated to the fireLegacy fallback inside fireRoleDurable. |
| internal/cron/scheduler_role_test.go | Adds TestRenderRoleReportUsesStartTimeForDate to guard the midnight date regression; existing tests updated for the new start-time signature. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/cron/scheduler.go:271-274
When `rolejob.JobSpec` fails (or `StartDetached` fails) and execution falls back to `fireLegacy`, the context hard-timeout used by the legacy executor is the original scheduler `timeout` (15 m by default), not the resolved `opts.Timeout`. If a manifest declares `max_duration: 30m` and `TimeoutSeconds` is 0, the fallback runs with a 15 m context rather than 30 m — defeating the precedence the PR intends to establish. Assigning back to `timeout` ensures both the durable and the fallback paths honour the same resolved value.

```suggestion
	opts.Timeout = timeout
	if cronJob.TimeoutSeconds == 0 && manifest.MaxDuration > 0 {
		opts.Timeout = manifest.MaxDuration
		timeout = manifest.MaxDuration // keep fallback path consistent
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve scheduler timeout and budg..."](https://github.com/befeast/ok-gobot/commit/b26a51061ae79aee9f6e0cad7664851a228c19b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32537873)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->