### PR TITLE
ci: add govulncheck workflow (report-only) (#395)

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,51 @@
+name: govulncheck
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      # TODO(#395 follow-up): drop `continue-on-error` once existing advisories
+      # are triaged so govulncheck findings block the build.
+      - name: Run govulncheck
+        id: govulncheck
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          "$(go env GOPATH)/bin/govulncheck" ./... | tee govulncheck.out
+
+      - name: Summarize govulncheck findings
+        if: always()
+        run: |
+          {
+            echo "## govulncheck (report-only)"
+            echo ""
+            if [ -s govulncheck.out ]; then
+              echo '```'
+              cat govulncheck.out
+              echo '```'
+            else
+              echo "_no output captured_"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ ok-gobot/
 
 ## Security
 
-See [SECURITY.md](SECURITY.md) for the security policy, threat model, and hardening checklist.
+See [SECURITY.md](SECURITY.md) for the security policy, threat model, and hardening checklist. CI runs `gitleaks` (secret scan) and `govulncheck` (Go vulnerability scan, report-only) on every PR and push to `main`.
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,12 +108,12 @@ Run `ok-gobot doctor` to check for risky configurations. The doctor command warn
 ## Automated Security Checks
 
 - **gitleaks**: scans for leaked secrets on every PR and push to `main` (`.github/workflows/secret-scan.yml`).
+- **govulncheck**: scans Go dependencies and stdlib for known vulnerabilities on every PR and push to `main` (`.github/workflows/govulncheck.yml`). Currently report-only -- findings appear in CI logs and the job summary but do not block the build; enforcement is a planned follow-up once existing advisories are triaged.
 
 ### Recommended additions
 
 Operators should add the following CI jobs to their fork or deployment pipeline:
 
-- **govulncheck**: `go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...` -- checks Go dependencies for known vulnerabilities.
 - **CodeQL**: GitHub's built-in static analysis for Go -- enable via repository Settings > Code security > Code scanning.
 
 ## Prior Security Work


### PR DESCRIPTION
Implements #395 — first runnable step toward the security hygiene rollout in epic #282.

## Changes
- **New workflow** `.github/workflows/govulncheck.yml`: scans the whole module (`govulncheck ./...`) on every `pull_request` and `push` to `main`, plus `workflow_dispatch`.
  - Uses the repo's `go.mod` Go version via `actions/setup-go`, with the action pinned by SHA (matching the existing `secret-scan.yml` style).
  - Pins `govulncheck@v1.1.4`.
  - **Report-only on first landing**: the scan step is `continue-on-error: true` so this PR (and any pre-existing advisories) cannot fail the build. A `TODO(#395 follow-up)` marks removal of the flag as the next step once advisories are triaged.
  - Findings are tee'd to a file and surfaced in the job's `GITHUB_STEP_SUMMARY` so they are easy to see without digging through logs.
- **`SECURITY.md`**: moved `govulncheck` from "Recommended additions" into the "Automated Security Checks" section and noted it is currently report-only.
- **`README.md`**: one-line note in the `## Security` section that CI now runs both `gitleaks` and `govulncheck` (report-only).

Out of scope (per the issue's non-goals):
- Not fixing any advisories `govulncheck` reports — that's a separate triage task.
- Not making the step blocking yet.
- Not adding CodeQL — separate step-1 item.

## Testing
- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — pass (including `TestMemoryEvalGateWiring` which guards `.maestro/verify.sh` and `ci.yml`)
- `go build ./cmd/ok-gobot/` — pass

The workflow itself will execute on this PR via GitHub Actions, which is the real verification of the CI integration.

Refs #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `govulncheck` GitHub Actions workflow that scans Go dependencies for known vulnerabilities on every PR and push to `main`, intentionally running in report-only mode (`continue-on-error: true`) while existing advisories are triaged. Documentation in `README.md` and `SECURITY.md` is updated to reflect the new automated check.

- **`.github/workflows/govulncheck.yml`**: New workflow closely mirrors the existing `secret-scan.yml` style — SHA-pinned actions, same trigger set, `timeout-minutes: 10`, and `GOPATH`-relative binary invocation. Findings are tee'd to a file and written to `GITHUB_STEP_SUMMARY` for visibility.
- **`SECURITY.md` / `README.md`**: `govulncheck` is promoted from the \"Recommended additions\" list to the \"Automated Security Checks\" section with a note that enforcement is a planned follow-up.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the workflow is report-only and cannot block builds, and the documentation changes are accurate.

The workflow is well-structured and consistent with existing CI patterns. The one minor gap is that the step summary doesn't distinguish between 'govulncheck ran and found nothing' and 'govulncheck failed to produce output', which could mask a broken tool invocation in the report-only phase.

`.github/workflows/govulncheck.yml` — specifically the `Summarize govulncheck findings` step could be improved to surface tool execution status alongside output content.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/govulncheck.yml | New report-only govulncheck CI workflow; follows existing secret-scan.yml conventions with SHA-pinned actions, but the step summary doesn't distinguish between a clean scan and a tool execution failure. |
| README.md | One-line addition noting govulncheck in the Security section; accurate and consistent with the new workflow. |
| SECURITY.md | Moves govulncheck from "Recommended additions" to "Automated Security Checks" and accurately notes its report-only status; clean documentation update. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/govulncheck.yml:40-51
**Summary step doesn't surface tool-failure vs. clean-scan**

If the `Run govulncheck` step fails before writing any output (e.g., `go env GOPATH` resolves incorrectly, the binary crashes before emitting anything, or a future refactor removes `tee`), `govulncheck.out` will be empty or absent. The summary then shows `_no output captured_` — which is indistinguishable from a clean run with zero findings. Adding `steps.govulncheck.outcome` to the summary would make it immediately visible whether the scan ran successfully or errored out, which is especially useful for a report-only job where a silent failure would go unnoticed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add govulncheck workflow (report-onl..."](https://github.com/befeast/ok-gobot/commit/b109f6849b54278770cf8e1806219d45700a1335) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35284118)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->