### PR TITLE
docs: add Magic Demo acceptance harness and operator docs (#348)

### DIFF
--- a/.maestro/verify.sh
+++ b/.maestro/verify.sh
@@ -4,54 +4,43 @@
 set -e
 
 echo '=== Project Test Suite ==='
+go vet ./...
 go test ./...
 go run ./cmd/ok-gobot memory eval
-make test
+go build ./cmd/ok-gobot/
 
 echo '=== Requirement Verification ==='
-echo 'Requirement 1: Add internal/role/prebuilt/prototype-builder.md.'
+echo 'Requirement 1: Document the exact local prerequisites for the demo environment.'
 go test ./...
 
-echo 'Requirement 2: Suggested tools: file, patch, local, frontend_verify, message.'
-go test ./internal/tools/...
-
-echo 'Requirement 3: The role should create or modify a minimal runnable frontend in the assigned wor...'
-go test ./internal/bot/...
-
-echo 'Requirement 4: The role should run or prepare a local dev server.'
+echo 'Requirement 2: Document the Telegram command sequence: /roles, /role_run prototype-builder Buil...'
 go test ./internal/rolejob/...
 
-echo 'Requirement 5: The role should call frontend_verify for browser proof.'
-go test ./internal/tools/...
+echo 'Requirement 3: Add a focused integration or smoke test using fakes where possible: role job sta...'
+go test ./internal/rolejob/...
 
-echo 'Requirement 6: The role should produce a short final report with screenshot or artifact referen...'
+echo 'Requirement 4: Add troubleshooting notes for missing package managers, browser startup, artifac...'
 go test ./internal/artifacts/...
 
-echo 'Requirement 7: Dangerous shell behavior must still respect policy and approval settings.'
+echo 'Requirement 5: Update README/docs feature matrix if needed.'
+go test ./...
+
+echo 'Requirement 6: A maintainer can run the demo from docs without reading source code.'
 go test ./internal/agent/...
 
-echo 'Requirement 8: Add tests proving the role loads as bundled and exposes expected metadata.'
-go test ./internal/role/...
+echo 'Requirement 7: The demo does not require committing generated frontend artifacts into ok-gobot.'
+go test ./internal/artifacts/...
 
-echo 'Requirement 9: ok-gobot roles list shows prototype-builder as bundled.'
-go test ./internal/cli/...
-
-echo 'Requirement 10: /roles shows prototype-builder with a useful short description or quick command.'
-go test ./internal/bot/...
-
-echo 'Requirement 11: ok-gobot roles show prototype-builder displays tools, worker tier, approval mode...'
-go test ./internal/tools/...
-
-echo 'Requirement 12: Manual acceptance target: /role_run prototype-builder Build a blue 3D rocket lau...'
-go test ./internal/rolejob/...
-
-echo 'Requirement 13: go test ./... passes.'
+echo 'Requirement 8: The smoke or integration coverage proves the end-to-end control path with fakes.'
 go test ./internal/agent/...
 
-echo 'Requirement 14: Do not make this role scheduled by default.'
-go test ./internal/bot/...
-
-echo 'Requirement 15: Do not bypass approval or policy for dangerous local commands.'
+echo 'Requirement 9: go test ./... passes.'
 go test ./internal/agent/...
+
+echo 'Requirement 10: Do not add video or Remotion generation in this wave.'
+go test ./internal/videosummary/...
+
+echo 'Requirement 11: Do not claim fully autonomous self-improvement; keep skill install explicit.'
+go test ./internal/bootstrap/...
 
 echo 'All verifications passed.'

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Known gaps:
 Native workflow parity currently exists only for explicitly implemented flows,
 such as `/video_summary <youtube_url>` and `/youtube_karaoke <youtube_url>`.
 
+End-to-end "AI employee from Telegram" walkthrough: [docs/MAGIC-DEMO.md](docs/MAGIC-DEMO.md).
+
 Competitive landscape: [docs/COMPETITORS.md](docs/COMPETITORS.md).
 
 ## Why Go?
@@ -222,6 +224,7 @@ Core commands are registered with BotFather for slash autocomplete. `/commands` 
 | `/jobs` | List recent durable jobs |
 | `/job <id>` | Show job details |
 | `/job_cancel <id>` | Cancel a durable job (admin) |
+| `/skill_suggest <job-id>` | Draft a skill from a successful job (admin) |
 | `/estop [on|off|status]` | Emergency-stop dangerous tool families (admin) |
 | `/activate` | Group: respond to all messages |
 | `/standby` | Group: respond only to mentions |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -134,6 +134,15 @@ Skills are tracked by utility score. The skill router selects relevant skills pe
 ### Skill Versioning
 Skills support version history with rollback. Each modification creates a versioned snapshot that can be restored.
 
+### Skill Suggestion From Jobs
+Distill a reviewable `SKILL.md` draft from a successful durable job. The draft
+is written under `<soul>/skill-drafts/<id>/<skill-name>/`, runs the same static
+safety audit installs run, and is never installed automatically — an admin must
+explicitly approve installation via `ok-gobot skills install <draft-dir>`.
+
+**Commands:** `/skill_suggest <job-id>` (Telegram, admin-only)
+**Files:** `internal/bootstrap/skill_suggest.go`, `internal/bot/skill_suggest.go`
+
 ---
 
 ## Intelligence and Feedback Loops
@@ -418,6 +427,7 @@ Beyond the core commands (`/start`, `/help`, `/status`, `/clear`, `/model`, `/ag
 | `/jobs` | List recent durable jobs |
 | `/job <id>` | Show job details |
 | `/job_cancel <id>` | Cancel a durable job (admin) |
+| `/skill_suggest <job-id>` | Draft a reviewable skill from a successful job (admin) |
 | `/btw` | Side query during active task |
 | `/estop` | Toggle dangerous tool families on/off/status (admin for on/off) |
 | `/restart` | Restart the bot process (admin only) |

--- a/docs/MAGIC-DEMO.md
+++ b/docs/MAGIC-DEMO.md
@@ -1,0 +1,274 @@
+# Magic Demo: ok-gobot as an AI Employee from Telegram
+
+The Magic Demo is the smallest end-to-end walkthrough that proves an operator
+can drive ok-gobot like an AI employee from Telegram: register a role, dispatch
+real work, watch a durable job complete, inspect the proof artifacts, and turn
+a successful run into a reviewable skill draft.
+
+This document is the operator-facing playbook for that flow. A maintainer should
+be able to follow it without reading source code. Where the demo depends on a
+role manifest that is not yet bundled, the manifest is supplied inline so the
+demo is reproducible today.
+
+> **Scope.** The demo intentionally stops at "skill draft saved". Skill install
+> is always explicit and admin-gated — ok-gobot never self-installs the draft.
+> The demo does not try to prove autonomous self-improvement and does not
+> generate any video or Remotion artifacts.
+
+## What the demo proves
+
+- A role manifest visible from `/roles` becomes a durable job when an operator
+  runs `/role_run`.
+- The role-job runner executes the role through the standard agent runtime,
+  produces a result, and writes proof artifacts to durable storage.
+- The final status, summary, and artifacts are visible from Telegram via
+  `/job <id>` and from CLI via `ok-gobot jobs inspect <id>`.
+- A successful job can be distilled into a reviewable SKILL.md draft via
+  `/skill_suggest <id>`. The draft is audited but never installed automatically.
+
+## Local prerequisites
+
+The demo runs against a normal ok-gobot install. Before starting, confirm:
+
+| Requirement | Why | How to verify |
+|---|---|---|
+| Go 1.24+ with CGO enabled | Build/`go test ./...` for the smoke harness | `go version` |
+| C compiler (`gcc`, Xcode CLT, or MinGW-w64) | Required for the SQLite driver | `cc --version` |
+| `ok-gobot` binary on PATH | Driving CLI checks like `roles list`, `jobs inspect` | `ok-gobot version` |
+| Telegram bot token from BotFather | Sending `/role_run` and `/job` | `ok-gobot config get telegram.token` |
+| `auth.admin_id` set to your Telegram user ID | `/role_run` and `/skill_suggest` are admin-only | `ok-gobot config get auth.admin_id` |
+| Configured AI provider key or OAuth | Lets the role actually call a worker | `ok-gobot doctor` |
+| Google Chrome / Chromium on PATH | `frontend_verify` and `browser` tool need a real browser | `ok-gobot doctor` (Chrome check) |
+| Writable artifact root | Proof files must land somewhere ok-gobot can read back | `ls ~/.ok-gobot/screenshots ~/.ok-gobot/artifacts` |
+| Optional: `node`/`npm` or `bun` on PATH | Only required if the demo role builds a real frontend prototype locally | `node --version && npm --version` |
+
+Run `ok-gobot doctor` first. The command validates config, the Telegram token,
+the AI provider, the storage path, and optional dependencies. Resolve any red
+items before continuing.
+
+### Artifact root configuration
+
+Local file previews (Mission Control, role-job notifications, and the
+artifact preview endpoint) are restricted to a configured allowlist of roots.
+Defaults are `~/.ok-gobot/screenshots` and `~/.ok-gobot/artifacts`. To add
+project-specific roots, edit `config.yaml`:
+
+```yaml
+artifacts:
+  roots:
+    - "~/.ok-gobot/screenshots"
+    - "~/.ok-gobot/artifacts"
+    - "~/proof-artifacts"
+```
+
+Paths outside these roots are redacted from API responses, hidden from
+Telegram final notifications, and rejected by `frontend_verify`'s screenshot
+writer. The demo does not require committing any frontend build output into the
+ok-gobot repo — proof lives under the operator's artifact roots, not in source
+control.
+
+### Network allowlist
+
+If your agent profile uses `capabilities.network_allowlist`, make sure the
+hosts the demo role needs (for example, `127.0.0.1`, `localhost`,
+`api.openai.com`, `openrouter.ai`, or any image CDN you want to screenshot)
+are listed. Denials look like:
+
+```
+network access to <host> is blocked by the agent's network_allowlist
+```
+
+The remediation is to add the host (or `allow_internal_networks: true` for
+loopback prototypes) to the agent's capability policy.
+
+## Step 0 — Confirm the `prototype-builder` role is registered
+
+`prototype-builder` ships bundled
+(`internal/role/prebuilt/prototype-builder.md`). No manual install step is
+required: `/roles` and `ok-gobot roles list` both surface it as soon as the
+bot starts. The bundled manifest uses `worker: standard`, tools `file`,
+`patch`, `local`, `frontend_verify`, `message`, `max_tool_calls: 25`, and
+`approval: auto`, so dangerous shell commands continue to flow through the
+existing policy/approval gate.
+
+Customise it by copying the bundled manifest into your `roles_path` (your
+copy shadows the bundled version; the bundled template is never modified):
+
+```bash
+cp internal/role/prebuilt/prototype-builder.md ~/ok-gobot-roles/
+```
+
+Typical edits worth making for the demo:
+
+- tighten `tools` to the minimum your operator workspace needs;
+- lower `max_tool_calls` to bound cost;
+- set an explicit `max_duration` if you want shorter timeboxes;
+- adjust the `report_template` to match how your team scans Telegram updates.
+
+## Step 1 — `/roles`
+
+Send `/roles` from your admin Telegram chat. Expected output (other roles
+omitted for brevity):
+
+```
+Available Roles:
+
+prototype-builder — worker: standard
+researcher — worker: standard
+...
+```
+
+The bot lists every manifest from `roles_path` plus the bundled defaults.
+
+## Step 2 — `/role_run prototype-builder Build a blue 3D rocket launch simulator`
+
+Dispatch the role with a concrete brief:
+
+```
+/role_run prototype-builder Build a blue 3D rocket launch simulator
+```
+
+The bot replies with a job acknowledgement that includes the new job ID and
+worker tier:
+
+```
+Role job started: `job-2026...`
+Role: `prototype-builder`
+Worker tier: `standard`
+Use `/job job-2026...` to inspect.
+```
+
+Behind the scenes the bot calls `rolejob.AgentJobRunner`, which:
+
+- Builds the agent task from the role prompt plus your input.
+- Submits a run through the agent `RuntimeHub` under an isolated session key.
+- Streams tool events and persists `frontend_verify` screenshots and text
+  reports as job artifacts.
+- Records a terminal status (`succeeded`, `failed`, `timed_out`, or
+  `cancelled`) and a bounded summary.
+
+## Step 3 — `/job JOB_ID`
+
+Inspect the job at any time:
+
+```
+/job job-2026...
+```
+
+While running you'll see the 🏃 icon, attempt count, and (if available) recent
+evidence events. On completion the bot updates the same chat with a final
+notification containing the bounded summary and proof-artifact hints. Hints
+that point at unsafe paths are redacted to "hidden" rather than leaked.
+
+You can also inspect from the CLI:
+
+```bash
+ok-gobot jobs inspect <job-id>
+ok-gobot jobs tail   <job-id>
+```
+
+## Step 4 — `/skill_suggest JOB_ID`
+
+When the job succeeded and produced useful artifacts, distill a reusable
+skill draft:
+
+```
+/skill_suggest job-2026...
+```
+
+The bot writes a `SKILL.md` under
+`<soul>/skill-drafts/<draft-id>/<skill-name>/`, runs a static safety audit,
+and replies with one of:
+
+- `✅ Skill draft saved` — audit clean. Next step is human review.
+- `⚠️ Skill draft saved but audit failed` — the draft is still on disk so you
+  can edit and re-audit it.
+
+Install is always a deliberate second step:
+
+```bash
+ok-gobot skills audit <soul>/skill-drafts/<draft-id>/<skill-name>
+ok-gobot skills install <soul>/skill-drafts/<draft-id>/<skill-name>
+```
+
+The bot never installs a suggested skill on its own.
+
+## Troubleshooting
+
+### `Role "prototype-builder" not found`
+
+`roles_path` is unset or the manifest didn't load.
+
+- Check `ok-gobot config get roles_path`.
+- Run `ok-gobot roles list` — if `prototype-builder` is missing, the file
+  failed to parse. Look at startup logs for `[roles] skipping invalid manifest`
+  entries.
+- Reload after editing: `/reload` (admin only) or restart the bot.
+
+### Browser/`frontend_verify` errors
+
+- "chrome not found" / "exec: chromedp": install Chrome or Chromium. The
+  `ok-gobot doctor` Chrome/Chromium check lists the locations it searches.
+- "context deadline exceeded" while screenshotting: the role hit its
+  `max_duration` (5 minutes by default). Either raise the manifest's
+  `max_duration` or narrow the brief.
+- "screenshot path is outside artifact_roots": add the destination directory
+  to `artifacts.roots` in `config.yaml`. `frontend_verify` refuses to write
+  proofs into unconfigured roots so they remain previewable.
+
+### Missing package managers
+
+The bundled `prototype-builder` manifest above intentionally avoids global
+installs. If your variant needs `npm`/`bun`/`pnpm` and the role logs
+"command not found", install the tool on the host or revise the role brief
+to use only what the workspace already has. ok-gobot does not auto-install
+package managers.
+
+### Network allowlist blocks
+
+Errors that mention "blocked by the agent's network_allowlist" point at the
+agent capability policy. Either:
+
+- Add the host(s) to `capabilities.network_allowlist`, or
+- Set `capabilities.allow_internal_networks: true` for `127.0.0.1`/`localhost`
+  prototypes only.
+
+Both edits are per-agent in `config.yaml`.
+
+### Empty proof in `/job` output
+
+The runner only records `frontend_verify` artifacts when the tool returns a
+parseable JSON payload containing a screenshot path or text report. If your
+role uses a different verification tool, persist the artifact yourself via
+the role's worker output rather than relying on automatic extraction.
+
+### `/skill_suggest` says "require succeeded jobs"
+
+`/skill_suggest` only operates on terminal `succeeded` jobs to avoid
+distilling failures into reusable patterns. Re-run the role with a narrower
+brief and try again on the new job ID.
+
+## Acceptance harness
+
+A focused smoke test exercises the end-to-end control path with fakes:
+
+```bash
+go test ./internal/rolejob/ -run MagicDemo
+```
+
+The harness wires a fake agent runtime that mirrors what
+`/role_run prototype-builder` triggers in production:
+
+1. Dispatches a role job via `rolejob.AgentJobRunner`.
+2. Returns a final result with a `frontend_verify` tool event that includes a
+   real screenshot file under a temporary artifact root.
+3. Waits for the durable job to reach `succeeded`, then asserts the summary,
+   the screenshot/text/url artifacts, and the lifecycle event trail are all
+   visible.
+4. Hands the finished job to `bootstrap.SuggestSkillFromJob` to confirm the
+   skill-distillation step succeeds and writes an audited draft to disk —
+   without installing it.
+
+The harness uses fakes for the agent runtime and storage so it can prove the
+control surface without booting a Telegram client, a real LLM, or a real
+browser. CI runs the same test as part of `go test ./...`.

--- a/internal/rolejob/magic_demo_smoke_test.go
+++ b/internal/rolejob/magic_demo_smoke_test.go
@@ -1,0 +1,203 @@
+package rolejob
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"ok-gobot/internal/agent"
+	"ok-gobot/internal/bootstrap"
+	"ok-gobot/internal/role"
+	jobruntime "ok-gobot/internal/runtime"
+	"ok-gobot/internal/storage"
+)
+
+// TestMagicDemoSmoke_ProvesEndToEndControlPath exercises the same control path
+// the Magic Demo walkthrough drives from Telegram (/role_run → /job →
+// /skill_suggest), but with fakes for the agent runtime so it can run as part
+// of `go test ./...` without a Telegram client, a real LLM, or a real browser.
+//
+// The harness asserts the four things the Magic Demo doc promises:
+//
+//  1. The role job starts and reaches a terminal `succeeded` status.
+//  2. The runner produces a bounded summary that surfaces the worker result.
+//  3. Proof artifacts (screenshot, URL, text report) persist to durable
+//     storage and stay rooted under the configured artifact root.
+//  4. A successful job can be distilled into a reviewable skill draft without
+//     installing it.
+func TestMagicDemoSmoke_ProvesEndToEndControlPath(t *testing.T) {
+	t.Parallel()
+
+	store := newRoleJobTestStore(t)
+	defer store.Close() //nolint:errcheck
+
+	const adminChatID = int64(99)
+	const sessionKey = "dm:99"
+	if err := store.SaveSessionRoute(storage.SessionRoute{SessionKey: sessionKey, Channel: "telegram", ChatID: adminChatID}); err != nil {
+		t.Fatalf("SaveSessionRoute failed: %v", err)
+	}
+
+	artifactRoot := t.TempDir()
+	screenshotPath := filepath.Join(artifactRoot, "rocket-launch.png")
+	if err := os.WriteFile(screenshotPath, []byte("\x89PNG fake"), 0o644); err != nil {
+		t.Fatalf("write proof screenshot: %v", err)
+	}
+	screenshotURI := (&url.URL{Scheme: "file", Path: screenshotPath}).String()
+
+	const previewURL = "http://127.0.0.1:5173"
+	const textReport = "frontend_verify: rocket simulator renders blue 3D launchpad as briefed"
+	frontendVerifyPayload := `{` +
+		`"match":true,` +
+		`"status":"passed",` +
+		`"url":"` + previewURL + `",` +
+		`"text_report":"` + textReport + `",` +
+		`"screenshot_uri":"` + screenshotURI + `"` +
+		`}`
+	frontendVerifyEvent := agent.ToolEvent{
+		ToolName:   "frontend_verify",
+		Type:       agent.ToolEventFinished,
+		Output:     frontendVerifyPayload,
+		FullOutput: frontendVerifyPayload,
+	}
+
+	const finalSummary = "Built blue 3D rocket launch simulator at ./prototype.\n" +
+		"Preview: http://127.0.0.1:5173\n" +
+		"Verified visually with frontend_verify."
+
+	manifest := &role.Manifest{
+		Name:         "prototype-builder",
+		Prompt:       "Build the requested frontend prototype and verify it visually.",
+		Worker:       "standard",
+		Tools:        []string{"local", "file", "patch", "frontend_verify"},
+		MaxToolCalls: 12,
+		MaxDuration:  5 * time.Minute,
+	}
+	const brief = "Build a blue 3D rocket launch simulator"
+
+	hub := &fakeAgentHub{
+		content: finalSummary,
+		events:  []agent.ToolEvent{frontendVerifyEvent},
+	}
+	opts := Options{
+		SessionKey:         sessionKey,
+		DeliverySessionKey: sessionKey,
+		ChatID:             adminChatID,
+		ArtifactRoots:      []string{artifactRoot},
+	}
+
+	spec, err := JobSpec(manifest, opts)
+	if err != nil {
+		t.Fatalf("JobSpec failed: %v", err)
+	}
+	if spec.RoleName != "prototype-builder" {
+		t.Fatalf("spec.RoleName = %q, want prototype-builder", spec.RoleName)
+	}
+
+	svc := jobruntime.NewJobService(store)
+	svc.SetArtifactRoots([]string{artifactRoot})
+
+	job, err := svc.StartDetached(context.Background(), spec, AgentJobRunner(hub, manifest, brief, opts))
+	if err != nil {
+		t.Fatalf("StartDetached failed: %v", err)
+	}
+
+	// 1. Job reaches a terminal succeeded status, mirroring the ✅ icon shown
+	//    by /job in the demo doc.
+	finished := waitForRoleJobStatus(t, store, job.JobID, string(jobruntime.JobStatusSucceeded))
+	if finished.Status != string(jobruntime.JobStatusSucceeded) {
+		t.Fatalf("final status = %q, want succeeded", finished.Status)
+	}
+
+	// 2. The summary stored on the durable job is the worker's real output, not
+	//    a stub. This is what the Telegram final notification surfaces.
+	if !strings.Contains(finished.Summary, "Built blue 3D rocket launch simulator") {
+		t.Fatalf("Summary = %q, want worker result", finished.Summary)
+	}
+	if finished.RoleName != "prototype-builder" || finished.Worker != "standard" {
+		t.Fatalf("Job metadata = (role=%q, worker=%q), want (prototype-builder, standard)", finished.RoleName, finished.Worker)
+	}
+
+	// The runner submitted exactly one agent request with both the manifest
+	// prompt and the operator brief — the same payload /role_run constructs.
+	req := hub.firstRequest(t)
+	if !strings.Contains(req.Content, manifest.Prompt) || !strings.Contains(req.Content, "User input: "+brief) {
+		t.Fatalf("agent request content = %q, want manifest prompt + brief", req.Content)
+	}
+	if string(req.SessionKey) == sessionKey {
+		t.Fatalf("runtime session key should be isolated from delivery session key %q", sessionKey)
+	}
+
+	// 3. Proof artifacts persist to storage and stay within the configured
+	//    artifact root. /job <id> serializes these for the operator.
+	artifacts, err := store.ListJobArtifacts(job.JobID, 10)
+	if err != nil {
+		t.Fatalf("ListJobArtifacts failed: %v", err)
+	}
+
+	var (
+		gotScreenshot bool
+		gotURL        bool
+		gotReport     bool
+	)
+	for _, a := range artifacts {
+		switch a.ArtifactType {
+		case jobruntime.JobArtifactTypeScreenshot:
+			gotScreenshot = true
+			if a.URI != screenshotPath {
+				t.Fatalf("screenshot artifact URI = %q, want safe path %q", a.URI, screenshotPath)
+			}
+		case jobruntime.JobArtifactTypeURL:
+			if a.URI == previewURL {
+				gotURL = true
+			}
+		case jobruntime.JobArtifactTypeTextReport:
+			if strings.Contains(a.Content, textReport) {
+				gotReport = true
+			}
+		}
+	}
+	if !gotScreenshot || !gotURL || !gotReport {
+		t.Fatalf("missing one of (screenshot=%t url=%t report=%t): %+v", gotScreenshot, gotURL, gotReport, artifacts)
+	}
+
+	// Lifecycle events expose the runner's `running role …` progress message
+	// which /job replays as the latest evidence line.
+	events, err := store.ListJobEvents(job.JobID, 20)
+	if err != nil {
+		t.Fatalf("ListJobEvents failed: %v", err)
+	}
+	sawProgress := false
+	for _, e := range events {
+		if e.EventType == string(jobruntime.JobEventProgress) && strings.Contains(e.Message, "running role prototype-builder") {
+			sawProgress = true
+			break
+		}
+	}
+	if !sawProgress {
+		t.Fatalf("missing role progress event: %+v", events)
+	}
+
+	// 4. /skill_suggest turns the succeeded job into a reviewable draft that is
+	//    audited but not installed.
+	soul := t.TempDir()
+	suggestion, err := bootstrap.SuggestSkillFromJob(soul, store, finished.JobID)
+	if err != nil {
+		t.Fatalf("SuggestSkillFromJob failed: %v", err)
+	}
+	if suggestion == nil {
+		t.Fatal("SuggestSkillFromJob returned no suggestion")
+	}
+	if suggestion.Unsafe {
+		t.Fatalf("draft unexpectedly flagged unsafe: %+v", suggestion.AuditFindings)
+	}
+	if _, err := os.Stat(suggestion.SkillFile); err != nil {
+		t.Fatalf("draft SKILL.md missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(soul, "skills")); !os.IsNotExist(err) {
+		t.Fatalf("skill_suggest must not install into <soul>/skills: %v", err)
+	}
+}


### PR DESCRIPTION
Implements #348

## Changes

- **docs/MAGIC-DEMO.md** — operator-facing Magic Demo walkthrough. Covers local prerequisites (Go toolchain, Telegram, AI provider, Chrome, artifact roots, network allowlist), the Telegram command sequence (`/roles`, `/role_run prototype-builder Build a blue 3D rocket launch simulator`, `/job <id>`, `/skill_suggest <id>`), proof-artifact inspection, and a troubleshooting matrix covering missing browsers, package managers, allowlist denials, and artifact-root mismatches.
- **internal/rolejob/magic_demo_smoke_test.go** — focused integration test that runs the same control path with fakes. Proves the role job reaches `succeeded`, the bounded summary surfaces the worker result, `frontend_verify` produces screenshot/url/text-report artifacts under a temp artifact root, lifecycle progress events are emitted, and `bootstrap.SuggestSkillFromJob` produces a reviewable draft on disk without installing it.
- **README.md** — link to the Magic Demo doc; add `/skill_suggest` to the Telegram command table.
- **docs/FEATURES.md** — document the skill-suggestion-from-jobs feature and add `/skill_suggest` to the command list.
- **.maestro/verify.sh** — resolve rebase conflict with the bundled-role merge; restore `go vet ./...`, the `go run ./cmd/ok-gobot memory eval` gate (enforced by `TestMemoryEvalGateWiring`), and `go build ./cmd/ok-gobot/` in the project test suite block.

## Scope notes

- No bundled-role changes here — the `prototype-builder` manifest landed in #344/#400 immediately before this PR, so the demo doc points at the already-bundled role.
- No video or Remotion work, as the issue's non-goals call out.
- Skill install remains explicit and admin-gated; the smoke test asserts `/skill_suggest` never writes to `<soul>/skills/`.

## Testing

- `go fmt ./...`
- `go vet ./...`
- `go test ./...` — full suite passes, including the new `TestMagicDemoSmoke_ProvesEndToEndControlPath`.
- `go build ./cmd/ok-gobot/`
- `go test ./internal/rolejob/ -run MagicDemo`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the Magic Demo acceptance harness for the "AI employee from Telegram" flow: a new smoke test in `internal/rolejob/` exercises the full control path (role job → durable storage → skill draft) with fakes, and new operator docs in `docs/MAGIC-DEMO.md` cover prerequisites, the Telegram command sequence, proof-artifact inspection, and a troubleshooting matrix.

- `magic_demo_smoke_test.go` wires a fake `AgentHub` to prove the job reaches `succeeded`, that screenshot/URL/text-report artifacts persist under the configured artifact root, lifecycle progress events are emitted, and `bootstrap.SuggestSkillFromJob` writes a draft without installing it — matching the four guarantees documented in MAGIC-DEMO.md.
- `README.md` and `docs/FEATURES.md` receive the `/skill_suggest` command entry; `.maestro/verify.sh` replaces the old `make test` invocation with explicit `go vet`, `go build`, and `go test` calls aligned to the new requirement set.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are docs, a new smoke test, and a CI script update with no production code paths modified.

The smoke test closely mirrors the patterns in the existing runner_test.go and the runtime layer is unchanged. The one finding is that err != nil is checked before suggestion.Unsafe in the skill-draft assertion, which means an audit failure would surface a less informative message rather than the detailed AuditFindings slice — a diagnostic gap, not a broken guarantee.

internal/rolejob/magic_demo_smoke_test.go — the error-handling order in the SuggestSkillFromJob block is worth a quick look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/rolejob/magic_demo_smoke_test.go | New smoke test proving end-to-end control path (role job → artifact → skill draft) with fakes; one minor diagnostic gap in the SuggestSkillFromJob error check. |
| docs/MAGIC-DEMO.md | New operator walkthrough; prerequisites, command sequence, troubleshooting matrix, and acceptance-harness section are accurate and consistent with the codebase. |
| .maestro/verify.sh | Replaces make test with explicit go vet/build commands and updates requirement labels to match the new PR scope; no logic issues. |
| README.md | Adds MAGIC-DEMO.md link and /skill_suggest row to the command table; straightforward docs change. |
| docs/FEATURES.md | Adds Skill Suggestion From Jobs section and /skill_suggest command row; accurate and consistent with implementation. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/rolejob/magic_demo_smoke_test.go:186-196
When `SuggestSkillFromJob` flags a draft as unsafe it returns `(result, ErrSkillSuggestionUnsafe)` — a non-nil error together with a non-nil `*SkillSuggestion`. The current `err != nil → t.Fatalf` guard fires first, so the richer `suggestion.AuditFindings` diagnostic is swallowed. If the auto-generated SKILL.md ever trips the safety audit, the failure message will just be "SuggestSkillFromJob failed: skill draft failed safety audit: N error(s)" instead of the detailed `AuditFindings` slice. Unwrapping `ErrSkillSuggestionUnsafe` explicitly lets the unsafe-findings branch run.

```suggestion
	soul := t.TempDir()
	suggestion, err := bootstrap.SuggestSkillFromJob(soul, store, finished.JobID)
	if err != nil && !errors.Is(err, bootstrap.ErrSkillSuggestionUnsafe) {
		t.Fatalf("SuggestSkillFromJob unexpected error: %v", err)
	}
	if suggestion == nil {
		t.Fatal("SuggestSkillFromJob returned no suggestion")
	}
	if suggestion.Unsafe {
		t.Fatalf("draft unexpectedly flagged unsafe: %+v", suggestion.AuditFindings)
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Magic Demo acceptance harness ..."](https://github.com/befeast/ok-gobot/commit/372c59bb01e5485f7bc94f5486bab5cc40d1d889) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35339136)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->