### PR TITLE
feat: surface role model and budgets in roles show/list (#397)

### DIFF
--- a/internal/bot/role_commands.go
+++ b/internal/bot/role_commands.go
@@ -85,7 +85,11 @@ func (b *Bot) handleRolesCommand(c telebot.Context) error {
 		if worker == "" {
 			worker = "default"
 		}
-		sb.WriteString(fmt.Sprintf("*%s* — worker: %s%s\n", m.Name, worker, schedule))
+		model := ""
+		if m.Model != "" {
+			model = fmt.Sprintf(", model: `%s`", m.Model)
+		}
+		sb.WriteString(fmt.Sprintf("*%s* — worker: %s%s%s\n", m.Name, worker, model, schedule))
 	}
 	sb.WriteString("\nUse `/role <name>` for details or `/role_run <name> [input]` to run.")
 
@@ -111,12 +115,30 @@ func (b *Bot) handleRoleCommand(c telebot.Context) error {
 		worker = "(default)"
 	}
 	sb.WriteString(fmt.Sprintf("Worker: `%s`\n", worker))
+	if m.Model != "" {
+		sb.WriteString(fmt.Sprintf("Model: `%s`\n", m.Model))
+	}
 	sb.WriteString(fmt.Sprintf("Approval: `%s`\n", m.Approval))
 	if m.Schedule != "" {
 		sb.WriteString(fmt.Sprintf("Schedule: `%s`\n", m.Schedule))
 	}
 	if len(m.Tools) > 0 {
 		sb.WriteString(fmt.Sprintf("Tools: `%s`\n", strings.Join(m.Tools, ", ")))
+	}
+	if m.MaxToolCalls > 0 {
+		sb.WriteString(fmt.Sprintf("Max tool calls: `%d`\n", m.MaxToolCalls))
+	}
+	if m.MaxDuration > 0 {
+		sb.WriteString(fmt.Sprintf("Max duration: `%s`\n", m.MaxDuration))
+	}
+	if m.MaxTokens > 0 {
+		sb.WriteString(fmt.Sprintf("Max tokens: `%d`\n", m.MaxTokens))
+	}
+	if m.MaxCostUSD > 0 {
+		sb.WriteString(fmt.Sprintf("Max cost USD: `%g`\n", m.MaxCostUSD))
+	}
+	if m.MemoryPolicy != "" {
+		sb.WriteString(fmt.Sprintf("Memory policy: `%s`\n", m.MemoryPolicy))
 	}
 	if m.SourcePath != "" {
 		sb.WriteString("Source: disk\n")

--- a/internal/bot/role_commands_test.go
+++ b/internal/bot/role_commands_test.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -108,6 +109,86 @@ func TestFindBotRole_NotFound(t *testing.T) {
 	_, err := b.findBotRole("nonexistent-role-xyz")
 	if err == nil {
 		t.Fatal("expected error for nonexistent role")
+	}
+}
+
+func TestHandleRoleCommand_RendersModelAndBudgets(t *testing.T) {
+	rolesDir := filepath.Join(t.TempDir(), "roles")
+	if err := os.MkdirAll(rolesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rolesDir, "audited.md"), []byte(`---
+worker: standard
+model: claude-sonnet-4-6
+max_tool_calls: 7
+max_cost_usd: 0.42
+memory_policy: read_only
+---
+# Audited
+Test role with budgets.
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	bot := &Bot{rolesPath: rolesDir}
+	ctx := &fakeContext{
+		msg: &telebot.Message{
+			Payload: "audited",
+			Chat:    &telebot.Chat{ID: 1, Type: telebot.ChatPrivate},
+			Sender:  &telebot.User{ID: 1},
+		},
+	}
+
+	if err := bot.handleRoleCommand(ctx); err != nil {
+		t.Fatalf("handleRoleCommand error = %v", err)
+	}
+	if len(ctx.sent) != 1 {
+		t.Fatalf("expected 1 message, got %d: %#v", len(ctx.sent), ctx.sent)
+	}
+	out := ctx.sent[0]
+	for _, want := range []string{
+		"Model: `claude-sonnet-4-6`",
+		"Max tool calls: `7`",
+		"Max cost USD: `0.42`",
+		"Memory policy: `read_only`",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output: %q", want, out)
+		}
+	}
+}
+
+func TestHandleRolesCommand_IncludesModelWhenSet(t *testing.T) {
+	rolesDir := filepath.Join(t.TempDir(), "roles")
+	if err := os.MkdirAll(rolesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rolesDir, "tiered.md"), []byte(`---
+worker: standard
+model: claude-opus-4-7
+---
+# Tiered
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	bot := &Bot{rolesPath: rolesDir}
+	ctx := &fakeContext{
+		msg: &telebot.Message{
+			Chat:   &telebot.Chat{ID: 1, Type: telebot.ChatPrivate},
+			Sender: &telebot.User{ID: 1},
+		},
+	}
+
+	if err := bot.handleRolesCommand(ctx); err != nil {
+		t.Fatalf("handleRolesCommand error = %v", err)
+	}
+	if len(ctx.sent) != 1 {
+		t.Fatalf("expected 1 message, got %d: %#v", len(ctx.sent), ctx.sent)
+	}
+	out := ctx.sent[0]
+	if !strings.Contains(out, "model: `claude-opus-4-7`") {
+		t.Errorf("expected model 'claude-opus-4-7' in output: %q", out)
 	}
 }
 

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -110,7 +110,7 @@ func newRolesListCommand(cfg *config.Config) *cobra.Command {
 			}
 
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "NAME\tWORKER\tSCHEDULE\tTOOLS\tAPPROVAL\tSOURCE")
+			fmt.Fprintln(w, "NAME\tWORKER\tMODEL\tSCHEDULE\tTOOLS\tAPPROVAL\tSOURCE")
 			for _, m := range roles {
 				source := "bundled"
 				if m.SourcePath != "" {
@@ -131,8 +131,12 @@ func newRolesListCommand(cfg *config.Config) *cobra.Command {
 				if worker == "" {
 					worker = "(default)"
 				}
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-					m.Name, worker, schedule, toolsStr, m.Approval, source)
+				model := m.Model
+				if model == "" {
+					model = "-"
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					m.Name, worker, model, schedule, toolsStr, m.Approval, source)
 			}
 			return w.Flush()
 		},
@@ -164,12 +168,30 @@ func newRolesShowCommand(cfg *config.Config) *cobra.Command {
 				worker = "(default)"
 			}
 			fmt.Fprintf(out, "Worker:    %s\n", worker)
+			if m.Model != "" {
+				fmt.Fprintf(out, "Model:     %s\n", m.Model)
+			}
 			fmt.Fprintf(out, "Approval:  %s\n", m.Approval)
 			if m.Schedule != "" {
 				fmt.Fprintf(out, "Schedule:  %s\n", m.Schedule)
 			}
 			if len(m.Tools) > 0 {
 				fmt.Fprintf(out, "Tools:     %s\n", strings.Join(m.Tools, ", "))
+			}
+			if m.MaxToolCalls > 0 {
+				fmt.Fprintf(out, "MaxToolCalls: %d\n", m.MaxToolCalls)
+			}
+			if m.MaxDuration > 0 {
+				fmt.Fprintf(out, "MaxDuration:  %s\n", m.MaxDuration)
+			}
+			if m.MaxTokens > 0 {
+				fmt.Fprintf(out, "MaxTokens:    %d\n", m.MaxTokens)
+			}
+			if m.MaxCostUSD > 0 {
+				fmt.Fprintf(out, "MaxCostUSD:   %g\n", m.MaxCostUSD)
+			}
+			if m.MemoryPolicy != "" {
+				fmt.Fprintf(out, "MemoryPolicy: %s\n", m.MemoryPolicy)
 			}
 			if m.SourcePath != "" {
 				fmt.Fprintf(out, "Source:    %s\n", m.SourcePath)

--- a/internal/cli/roles_test.go
+++ b/internal/cli/roles_test.go
@@ -98,6 +98,128 @@ func TestRolesShow(t *testing.T) {
 	}
 }
 
+func TestRolesShow_BudgetsAndModel(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+
+	rolesDir := filepath.Join(t.TempDir(), "roles")
+	if err := os.MkdirAll(rolesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rolesDir, "audited.md"), []byte(`---
+worker: standard
+model: claude-sonnet-4-6
+max_tool_calls: 7
+max_duration: 90s
+max_tokens: 12000
+max_cost_usd: 0.42
+memory_policy: read_only
+---
+# Audited
+Test budgets render.
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg.RolesPath = rolesDir
+
+	cmd := newRolesCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"show", "audited"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	output := out.String()
+	for _, want := range []string{
+		"Model:     claude-sonnet-4-6",
+		"MaxToolCalls: 7",
+		"MaxDuration:  1m30s",
+		"MaxTokens:    12000",
+		"MaxCostUSD:   0.42",
+		"MemoryPolicy: read_only",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in output: %q", want, output)
+		}
+	}
+}
+
+func TestRolesShow_OmitsZeroBudgets(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+
+	rolesDir := filepath.Join(t.TempDir(), "roles")
+	if err := os.MkdirAll(rolesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rolesDir, "minimal.md"), []byte(`---
+worker: cheap
+---
+# Minimal
+No budgets.
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg.RolesPath = rolesDir
+
+	cmd := newRolesCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"show", "minimal"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	output := out.String()
+	for _, unwanted := range []string{"Model:", "MaxToolCalls:", "MaxDuration:", "MaxTokens:", "MaxCostUSD:", "MemoryPolicy:"} {
+		if strings.Contains(output, unwanted) {
+			t.Errorf("did not expect %q in output: %q", unwanted, output)
+		}
+	}
+}
+
+func TestRolesList_IncludesModelColumn(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+
+	rolesDir := filepath.Join(t.TempDir(), "roles")
+	if err := os.MkdirAll(rolesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rolesDir, "tiered.md"), []byte(`---
+worker: standard
+model: claude-opus-4-7
+---
+# Tiered
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg.RolesPath = rolesDir
+
+	cmd := newRolesCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"list"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "MODEL") {
+		t.Errorf("expected MODEL column header in output: %q", output)
+	}
+	if !strings.Contains(output, "claude-opus-4-7") {
+		t.Errorf("expected model value 'claude-opus-4-7' in output: %q", output)
+	}
+}
+
 func TestRolesShow_NotFound(t *testing.T) {
 	t.Parallel()
 	_, cfg := newTestStore(t)


### PR DESCRIPTION
Implements #397

## Changes
- `roles list`: adds a `MODEL` column showing each role's model (or `-` when unset).
- `roles show <name>`: renders `Model` and any non-zero budget/policy fields (`MaxToolCalls`, `MaxDuration`, `MaxTokens`, `MaxCostUSD`, `MemoryPolicy`), matching the existing optional-field style.
- `/roles` (Telegram): appends `model: <value>` when a role sets `Model`.
- `/role <name>` (Telegram): renders the same model + budget/policy fields, length-safe.
- Tests added for the new render paths in `internal/cli/roles_test.go` and `internal/bot/role_commands_test.go` (model column, budget render, zero-budget omission).

No enforcement, scheduling, or write-path changes.

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./cmd/ok-gobot/`
- `go test ./internal/cli/... ./internal/bot/... ./internal/role/...`
- `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces existing role manifest fields — `Model`, `MaxToolCalls`, `MaxDuration`, `MaxTokens`, `MaxCostUSD`, and `MemoryPolicy` — in both the CLI (`roles list` / `roles show`) and Telegram (`/roles` / `/role`) commands. It is a read-only, display-only change with no enforcement, scheduling, or write-path modifications.

- **`roles list`** gains a `MODEL` column (showing `-` when unset); **`roles show`** renders model and non-zero budget fields using the same optional-field guard pattern already used for `Schedule` and `Tools`.
- **`/roles`** appends `, model: \`value\`` inline; **`/role <name>`** adds the same fields before the prompt block, which is already truncated at 500 chars for Telegram's message limit.
- Tests cover positive rendering, zero-value omission, and the new column header across both the CLI and bot layers.

<h3>Confidence Score: 5/5</h3>

All changes are display-only and touch no write paths, enforcement logic, or scheduling; safe to merge.

Every new code path follows the existing optional-field pattern already used for Schedule and Tools. The MODEL column addition is straightforward tabwriter work. Budget fields are guarded by non-zero checks so roles without budgets are unaffected. Tests cover the positive, negative (zero-omit), and column-header cases for both CLI and Telegram surfaces.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cli/roles.go | Adds MODEL column to roles list and renders model + budget fields in roles show; logic is consistent with existing optional-field pattern |
| internal/bot/role_commands.go | Surfaces model in /roles list and adds model + budget fields to /role detail; prompt truncation and optional-field guards look correct |
| internal/cli/roles_test.go | New tests cover budget render, zero-budget omission, and MODEL column; all three cases are well isolated and parallel-safe |
| internal/bot/role_commands_test.go | Bot-side tests verify model and budget fields appear in Telegram output; coverage matches the CLI test patterns |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: surface role model and budgets in ..."](https://github.com/befeast/ok-gobot/commit/40e58371f61909a038756b407eb0f65340749f81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35343478)</sub>

<!-- /greptile_comment -->