### PR TITLE
feat: add memory search CLI subcommand (#398)

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -373,17 +373,34 @@ memory save Meeting scheduled for Friday at 3pm
 #### Search Memories
 
 ```
-memory search <query> [--limit=<n>] [--person=<name>]
+memory search <query> [--limit=<n>] [--expand] [--json]
 ```
 
 Example:
 ```
-memory search What programming languages does the user prefer? --limit=5
-memory search upcoming meetings
-memory search release decisions --person=Anton
+ok-gobot memory search What programming languages does the user prefer? --limit=5
+ok-gobot memory search upcoming meetings
+ok-gobot memory search release decisions --expand
+ok-gobot memory search release decisions --json
 ```
 
-Returns the most semantically similar memories with similarity scores.
+Runs one read-only hybrid (BM25 + vector) retrieval and prints the raw ranked
+`[]MemoryResult` — rank, source file, header path, line range, per-result
+scores (`hybrid`, `similarity`, `lexical`, `vector`, `bm25`), and a snippet.
+Use this to debug retrieval quality without going through `memory pack`'s
+budgeting and citation assembly.
+
+Flags:
+
+- `--limit <n>` caps the number of ranked hits (default `memory.DefaultSearchTopK`).
+- `--expand` returns the full branch (file + header path) for each match
+  instead of only the matched chunk — useful when a top hit lacks surrounding
+  context.
+- `--json` prints `[]MemoryResult` as JSON for piping or scripts.
+
+> `--person=<name>` is documented in older READMEs but is **not yet implemented**.
+> Identity-scoped recall is tracked separately and will surface here once the
+> CLI grows scope flags; until then this command runs an unscoped query.
 
 #### List Recent Memories
 

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -24,6 +25,7 @@ func newMemoryCommand(cfg *config.Config) *cobra.Command {
 	cmd.AddCommand(newMemoryIndexCommand(cfg))
 	cmd.AddCommand(newMemoryCurateCommand(cfg))
 	cmd.AddCommand(newMemoryPackCommand(cfg))
+	cmd.AddCommand(newMemorySearchCommand(cfg))
 	cmd.AddCommand(newMemoryEvalCommand())
 	return cmd
 }
@@ -210,6 +212,116 @@ func newMemoryPackCommand(cfg *config.Config) *cobra.Command {
 	cmd.Flags().IntVar(&budget, "budget", memory.DefaultContextPackMaxChars, "maximum rendered context pack characters")
 	cmd.Flags().IntVar(&limit, "limit", memory.DefaultContextPackMaxItems, "maximum cited memory snippets")
 	return cmd
+}
+
+// newMemorySearchCommand wires the read-only `memory search <query>` CLI
+// subcommand. It runs one retrieval against the existing MemoryManager and
+// prints the ranked []MemoryResult — no writes, no MEMORY.md edits, no chat.
+// Backends, embedder, and fallback are constructed the same way as
+// newMemoryPackCommand so users see what `pack` actually retrieves.
+func newMemorySearchCommand(cfg *config.Config) *cobra.Command {
+	var limit int
+	var expand bool
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Show raw ranked memory retrieval results for a query",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cfg.Memory.Enabled {
+				return fmt.Errorf("memory.enabled is false; enable memory before searching")
+			}
+
+			store, memStore, err := openMemoryStore(cfg)
+			if err != nil {
+				return err
+			}
+			defer store.Close() //nolint:errcheck
+
+			apiKey := cfg.Memory.EmbeddingsAPIKey
+			if apiKey == "" {
+				apiKey = cfg.AI.APIKey
+			}
+			// Hold the embedder as the interface type so an unconfigured client
+			// remains a true nil interface (not a typed-nil) and the builtin
+			// backend's `if client != nil` check correctly falls back to the
+			// lexical-only path instead of panicking on GetEmbedding.
+			var embedder memory.EmbeddingQueryClient
+			if memory.EmbeddingProviderConfigured(cfg.Memory.EmbeddingsBaseURL, apiKey) {
+				embedder = memory.NewEmbeddingClient(
+					cfg.Memory.EmbeddingsBaseURL,
+					apiKey,
+					cfg.Memory.EmbeddingsModel,
+				)
+			}
+
+			var options []memory.MemoryManagerOption
+			if backend := memoryBackendName(cfg); backend == "qmd" || backend == "auto" {
+				qmdBackend := memory.NewQMDBackend(cliQMDConfig(cfg.Memory.QMD))
+				builtin := memory.NewBuiltinBackend(embedder, memStore)
+				cooldown := cliDurationOrDefault(cfg.Memory.QMD.FallbackCooldown, time.Minute)
+				options = append(options, memory.WithBackend(memory.NewFallbackBackend(qmdBackend, builtin, cooldown)))
+			}
+			manager := memory.NewMemoryManager(embedder, memStore, options...)
+
+			query := strings.Join(args, " ")
+			topK := limit
+			if topK <= 0 {
+				topK = memory.DefaultSearchTopK
+			}
+
+			var results []memory.MemoryResult
+			if expand {
+				results, err = manager.SearchExpanded(cmd.Context(), query, topK)
+			} else {
+				results, err = manager.Search(cmd.Context(), query, topK)
+			}
+			if err != nil {
+				return fmt.Errorf("memory search: %w", err)
+			}
+
+			out := cmd.OutOrStdout()
+			if asJSON {
+				if results == nil {
+					results = []memory.MemoryResult{}
+				}
+				enc := json.NewEncoder(out)
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(results); err != nil {
+					return fmt.Errorf("encode json: %w", err)
+				}
+				return nil
+			}
+
+			if len(results) == 0 {
+				fmt.Fprintf(out, "No memory matches for query %q.\n", query)
+				return nil
+			}
+
+			fmt.Fprintf(out, "Query: %s\n", query)
+			fmt.Fprintf(out, "Results: %d (top_k=%d, expand=%v)\n", len(results), topK, expand)
+			for i, r := range results {
+				fmt.Fprintf(out, "\n#%d %s :: %s (lines %d-%d)\n", i+1, r.SourceFile, r.HeaderPath, r.StartLine, r.EndLine)
+				fmt.Fprintf(out, "  scores: hybrid=%.4f similarity=%.4f lexical=%.4f vector=%.4f bm25=%.4f\n",
+					r.HybridScore, r.Similarity, r.LexicalScore, r.VectorScore, r.BM25)
+				fmt.Fprintf(out, "  %s\n", snippet(r.Content, 200))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", memory.DefaultSearchTopK, "maximum ranked results to return")
+	cmd.Flags().BoolVar(&expand, "expand", false, "expand each match to the full branch (file + header path)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "print results as a JSON array of MemoryResult")
+	return cmd
+}
+
+// snippet returns a single-line preview of content trimmed to max runes.
+func snippet(content string, max int) string {
+	collapsed := strings.Join(strings.Fields(content), " ")
+	if max > 0 && len(collapsed) > max {
+		return collapsed[:max] + "…"
+	}
+	return collapsed
 }
 
 func newMemoryEvalCommand() *cobra.Command {

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,7 +122,7 @@ func TestMemoryCommandIncludesPackDebugCommand(t *testing.T) {
 	_, cfg := newTestStore(t)
 
 	cmd := newMemoryCommand(cfg)
-	want := map[string]bool{"pack": false, "eval": false}
+	want := map[string]bool{"pack": false, "eval": false, "search": false}
 	for _, sub := range cmd.Commands() {
 		if _, ok := want[sub.Name()]; ok {
 			want[sub.Name()] = true
@@ -256,6 +257,81 @@ func TestMemoryStatusReportsConfigError(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Extra paths: configuration error") {
 		t.Fatalf("expected config error in output: %q", out.String())
+	}
+}
+
+func TestMemorySearchReturnsRankedResultsAndJSON(t *testing.T) {
+	t.Parallel()
+	store, cfg := newTestStore(t)
+	cfg.Memory.Enabled = true
+	cfg.SoulPath = t.TempDir()
+	writeCLITestFile(t, filepath.Join(cfg.SoulPath, "MEMORY.md"), "# Memory\n\nThe user prefers Go for backend services.\n")
+	writeCLITestFile(t, filepath.Join(cfg.SoulPath, "memory", "2026-04-29.md"), "# Daily\n\nWeather is sunny today.\n")
+
+	memStore, err := memory.NewMemoryStore(store.DB())
+	if err != nil {
+		t.Fatalf("NewMemoryStore failed: %v", err)
+	}
+	if _, _, err := runMemoryIndex(context.Background(), cfg, memStore, &stubCLIEmbedder{}, true); err != nil {
+		t.Fatalf("runMemoryIndex failed: %v", err)
+	}
+
+	t.Run("text output lists ranked hits", func(t *testing.T) {
+		cmd := newMemoryCommand(cfg)
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"search", "Go", "backend"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute error = %v\n%s", err, out.String())
+		}
+		output := out.String()
+		for _, want := range []string{"Query: Go backend", "Results:", "#1 ", "scores:", "MEMORY.md"} {
+			if !strings.Contains(output, want) {
+				t.Fatalf("expected %q in output: %q", want, output)
+			}
+		}
+	})
+
+	t.Run("--json prints a MemoryResult array", func(t *testing.T) {
+		cmd := newMemoryCommand(cfg)
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"search", "Go", "backend", "--json", "--limit", "3"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute error = %v\n%s", err, out.String())
+		}
+		var got []memory.MemoryResult
+		if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+			t.Fatalf("Unmarshal: %v\n%s", err, out.String())
+		}
+		if len(got) == 0 {
+			t.Fatalf("expected at least one result, got 0; output=%q", out.String())
+		}
+		for _, r := range got {
+			if r.SourceFile == "" || r.Content == "" {
+				t.Fatalf("missing fields in result: %+v", r)
+			}
+		}
+	})
+}
+
+func TestMemorySearchRequiresMemoryEnabled(t *testing.T) {
+	t.Parallel()
+	_, cfg := newTestStore(t)
+	cfg.Memory.Enabled = false
+	cfg.SoulPath = t.TempDir()
+
+	cmd := newMemoryCommand(cfg)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"search", "anything"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "memory.enabled is false") {
+		t.Fatalf("expected memory.enabled error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Implements #398

## Changes

- `internal/cli/memory.go`: add `newMemorySearchCommand` and register it on the `memory` command tree. The command is read-only — it opens the store, builds the same builtin/QMD-auto fallback wiring as `memory pack`, runs one hybrid retrieval, and prints the raw ranked `[]MemoryResult` (rank, source file, header path, line range, hybrid/similarity/lexical/vector/BM25 scores, snippet). Supports `--limit <n>` (default `memory.DefaultSearchTopK`), `--expand` (uses `SearchExpanded`), and `--json` (prints `[]MemoryResult` JSON). Returns the same `memory.enabled is false` error as `pack` when memory is disabled.
- The embedder is held as the `EmbeddingQueryClient` interface so an unconfigured embedder remains a true nil interface — the builtin backend then falls back to the lexical-only path instead of panicking on a typed-nil `GetEmbedding` call (acceptance criterion: must not panic when embeddings are unconfigured).
- `internal/cli/memory_test.go`: add `TestMemorySearchReturnsRankedResultsAndJSON` (asserts ranked text output + `--json` decodes back into `[]memory.MemoryResult`) and `TestMemorySearchRequiresMemoryEnabled` (asserts the disabled-memory error). Extend the registration check to include `search`.
- `docs/MEMORY.md`: reconcile the documented flags with what ships (`--limit`, `--expand`, `--json`) and note `--person` as not-yet-implemented rather than leaving the docs as a false promise.

No changes to `memory pack`, `eval`, `index`, or `curate`, no retrieval or scoring changes, no writes to MEMORY.md/daily notes/index from this command, and no Telegram/MCP/Mission Control surface changes.

## Testing

```
go fmt ./...
go vet ./...
go build ./cmd/ok-gobot/
go test ./...
```

All pass. New tests:

```
go test -run TestMemorySearch -v ./internal/cli/
=== PASS  TestMemorySearchRequiresMemoryEnabled
=== PASS  TestMemorySearchReturnsRankedResultsAndJSON
    === PASS  text_output_lists_ranked_hits
    === PASS  --json_prints_a_MemoryResult_array
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a read-only `memory search <query>` CLI subcommand that runs a single hybrid (BM25 + vector) retrieval and prints the ranked `[]MemoryResult` — useful for debugging what `memory pack` actually retrieves without going through budgeting and citation assembly. It also reconciles the `docs/MEMORY.md` flags section with what is actually shipped.

- **`internal/cli/memory.go`**: Adds `newMemorySearchCommand` with `--limit`, `--expand`, and `--json` flags. Correctly holds the embedder as the `EmbeddingQueryClient` interface (not the concrete `*EmbeddingClient`) so an unconfigured embedder stays a true nil interface and the builtin backend falls back to lexical-only instead of panicking. Adds a `snippet()` helper for single-line previews.
- **`internal/cli/memory_test.go`**: Adds two new tests covering ranked text output, `--json` decode, and the disabled-memory error path; extends the subcommand registration check.
- **`docs/MEMORY.md`**: Replaces the obsolete `--person` flag with a "not-yet-implemented" notice and documents the three flags that are actually present.

<h3>Confidence Score: 3/5</h3>

The new subcommand is read-only and well-isolated, but the snippet helper slices at a byte boundary rather than a rune boundary, which can produce invalid UTF-8 output when memory content contains non-ASCII characters.

The snippet() function uses len(collapsed) (byte count) and collapsed[:max] (byte slice) despite its comment claiming rune-based truncation. Any multi-byte UTF-8 character that straddles the max boundary will be split, producing garbled or invalid output in the terminal. Memory notes commonly contain accented characters, emoji, or other non-ASCII text, so this is a realistic failure path for the new command's primary display loop.

internal/cli/memory.go — the snippet() helper needs rune-safe truncation

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cli/memory.go | Adds newMemorySearchCommand (read-only hybrid retrieval CLI). The typed-nil embedder fix is correct, but snippet() uses byte-length slicing despite its "runes" comment, which can corrupt multi-byte UTF-8 output. |
| internal/cli/memory_test.go | Adds TestMemorySearchReturnsRankedResultsAndJSON and TestMemorySearchRequiresMemoryEnabled; extends subcommand registration check to include "search". Tests look correct and cover the key paths. |
| docs/MEMORY.md | Reconciles documented flags with shipped implementation; replaces --person with a "not-yet-implemented" notice and documents --limit, --expand, --json correctly. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/cli/memory.go:318-325
The `snippet` function comment says "trimmed to max **runes**", but `len(collapsed)` returns a byte count and `collapsed[:max]` slices at a byte boundary. For memory content that contains multi-byte UTF-8 characters (accented letters, CJK text, emoji), this can produce invalid UTF-8 by cutting a character in half. In practice the terminal may display a replacement character (�) or garble the last few visible characters of the snippet.

```suggestion
// snippet returns a single-line preview of content trimmed to max runes.
func snippet(content string, max int) string {
	collapsed := strings.Join(strings.Fields(content), " ")
	runes := []rune(collapsed)
	if max > 0 && len(runes) > max {
		return string(runes[:max]) + "…"
	}
	return collapsed
}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add memory search CLI subcommand (..."](https://github.com/befeast/ok-gobot/commit/7b115a2e8ff3e4ada74083e275c62c273f46e6f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35347815)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->