### PR TITLE
feat(reliability): bounded retry-with-backoff for gh CLI calls (#399)

### DIFF
--- a/internal/reliability/github.go
+++ b/internal/reliability/github.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"ok-gobot/internal/evidence"
 )
@@ -16,6 +17,8 @@ const (
 	defaultGitHubEvidenceLimit = 200
 	defaultGitHubPRSearchLimit = 100
 	githubPRJSONFields         = "number,title,url,state,isDraft,mergeStateStatus,headRefName,baseRefName,reviewDecision,statusCheckRollup,reviews,closingIssuesReferences"
+	defaultGHCLIMaxAttempts    = 3
+	defaultGHCLIBaseBackoff    = 200 * time.Millisecond
 )
 
 // GitHubClient is the read-only GitHub surface used by the reliability provider.
@@ -70,13 +73,20 @@ type GitHubIssueReference struct {
 // GHCLIClient reads GitHub state through the gh CLI. It only uses view/list/auth
 // commands and never invokes mutating GitHub operations.
 type GHCLIClient struct {
-	Dir    string
-	Binary string
+	Dir         string
+	Binary      string
+	MaxAttempts int
+	BaseBackoff time.Duration
 }
 
 // NewGHCLIClient returns a read-only GitHub CLI client rooted at dir.
 func NewGHCLIClient(dir string) *GHCLIClient {
-	return &GHCLIClient{Dir: dir, Binary: "gh"}
+	return &GHCLIClient{
+		Dir:         dir,
+		Binary:      "gh",
+		MaxAttempts: defaultGHCLIMaxAttempts,
+		BaseBackoff: defaultGHCLIBaseBackoff,
+	}
 }
 
 // CheckAuth verifies that gh can read GitHub state before a benchmark starts.
@@ -177,19 +187,49 @@ func (c *GHCLIClient) run(ctx context.Context, args ...string) ([]byte, error) {
 	if binary == "" {
 		binary = "gh"
 	}
-	cmd := exec.CommandContext(ctx, binary, args...)
-	if c.Dir != "" {
-		cmd.Dir = c.Dir
+	attempts := c.MaxAttempts
+	if attempts <= 0 {
+		attempts = defaultGHCLIMaxAttempts
 	}
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		msg := strings.TrimSpace(string(out))
-		if msg == "" {
-			return nil, err
+	backoff := c.BaseBackoff
+	if backoff <= 0 {
+		backoff = defaultGHCLIBaseBackoff
+	}
+
+	var (
+		out     []byte
+		err     error
+		lastMsg string
+	)
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
 		}
-		return nil, fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, msg)
+		cmd := exec.CommandContext(ctx, binary, args...)
+		if c.Dir != "" {
+			cmd.Dir = c.Dir
+		}
+		out, err = cmd.CombinedOutput()
+		if err == nil {
+			return out, nil
+		}
+		lastMsg = strings.TrimSpace(string(out))
+		if attempt == attempts {
+			break
+		}
+		sleep := backoff << (attempt - 1)
+		timer := time.NewTimer(sleep)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
 	}
-	return out, nil
+	if lastMsg == "" {
+		return nil, err
+	}
+	return nil, fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, lastMsg)
 }
 
 type ghRawPullRequest struct {

--- a/internal/reliability/github_test.go
+++ b/internal/reliability/github_test.go
@@ -2,8 +2,13 @@ package reliability
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"ok-gobot/internal/evidence"
 )
@@ -192,6 +197,149 @@ func assertGitHubResult(t *testing.T, report Report, id string, outcome Outcome,
 	if result.DataSource == "" {
 		t.Fatalf("%s missing data source", id)
 	}
+}
+
+func TestGHCLIClientRunRetries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell script not supported on windows")
+	}
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		failTimes     int
+		maxAttempts   int
+		wantErr       bool
+		wantCalls     int
+		wantStderrIn  string
+		cancelCtxFunc func(ctx context.Context, cancel context.CancelFunc)
+	}{
+		{name: "success-first-try", failTimes: 0, maxAttempts: 3, wantCalls: 1},
+		{name: "transient-then-success", failTimes: 2, maxAttempts: 3, wantCalls: 3},
+		{name: "all-attempts-fail", failTimes: 10, maxAttempts: 3, wantErr: true, wantCalls: 3, wantStderrIn: "boom"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			binary, counter := writeFakeGH(t, dir, tc.failTimes)
+
+			client := &GHCLIClient{Binary: binary, MaxAttempts: tc.maxAttempts, BaseBackoff: time.Millisecond}
+			out, err := client.run(context.Background(), "pr", "view", "1")
+
+			calls := readCounter(t, counter)
+			if calls != tc.wantCalls {
+				t.Fatalf("calls = %d, want %d", calls, tc.wantCalls)
+			}
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (out=%q)", out)
+				}
+				msg := err.Error()
+				if !strings.HasPrefix(msg, "gh pr view 1: ") {
+					t.Fatalf("error missing preserved prefix: %q", msg)
+				}
+				if tc.wantStderrIn != "" && !strings.Contains(msg, tc.wantStderrIn) {
+					t.Fatalf("error missing last stderr %q: %q", tc.wantStderrIn, msg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(string(out), "ok") {
+				t.Fatalf("unexpected output: %q", out)
+			}
+		})
+	}
+}
+
+func TestGHCLIClientRunHonorsCancelledContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell script not supported on windows")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	binary, counter := writeFakeGH(t, dir, 0)
+	client := &GHCLIClient{Binary: binary, MaxAttempts: 3, BaseBackoff: time.Millisecond}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	out, err := client.run(ctx, "pr", "view", "1")
+	if err == nil {
+		t.Fatalf("expected context error, got nil (out=%q)", out)
+	}
+	if err != context.Canceled {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if calls := readCounter(t, counter); calls != 0 {
+		t.Fatalf("binary was called %d times after cancel; expected 0", calls)
+	}
+}
+
+func TestNewGHCLIClientAppliesDefaults(t *testing.T) {
+	t.Parallel()
+	c := NewGHCLIClient("/tmp")
+	if c.MaxAttempts != defaultGHCLIMaxAttempts {
+		t.Fatalf("MaxAttempts = %d, want %d", c.MaxAttempts, defaultGHCLIMaxAttempts)
+	}
+	if c.BaseBackoff != defaultGHCLIBaseBackoff {
+		t.Fatalf("BaseBackoff = %v, want %v", c.BaseBackoff, defaultGHCLIBaseBackoff)
+	}
+	if c.Binary != "gh" {
+		t.Fatalf("Binary = %q, want %q", c.Binary, "gh")
+	}
+}
+
+// writeFakeGH writes a small shell script that fails the first failTimes calls
+// (printing "boom" to stdout/stderr with exit 1) then succeeds (printing "ok").
+// It uses counterPath to track the number of invocations atomically across runs.
+func writeFakeGH(t *testing.T, dir string, failTimes int) (binary, counterPath string) {
+	t.Helper()
+	counterPath = filepath.Join(dir, "calls.count")
+	binary = filepath.Join(dir, "fake-gh.sh")
+	script := fmt.Sprintf(`#!/bin/sh
+counter='%s'
+n=0
+if [ -f "$counter" ]; then
+  n=$(cat "$counter")
+fi
+n=$((n + 1))
+printf '%%s' "$n" > "$counter"
+if [ "$n" -le %d ]; then
+  echo "boom" 1>&2
+  exit 1
+fi
+echo "ok"
+`, counterPath, failTimes)
+	if err := os.WriteFile(binary, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	return binary, counterPath
+}
+
+func readCounter(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read counter: %v", err)
+	}
+	raw := strings.TrimSpace(string(data))
+	if raw == "" {
+		return 0
+	}
+	n := 0
+	if _, err := fmt.Sscanf(raw, "%d", &n); err != nil {
+		t.Fatalf("parse counter %q: %v", raw, err)
+	}
+	return n
 }
 
 func hasEvidenceLink(result ScenarioResult, linkType string) bool {


### PR DESCRIPTION
Refs #399

## Summary
- `GHCLIClient` gains `MaxAttempts` and `BaseBackoff` fields (defaults: 3 attempts, 200ms base) set in `NewGHCLIClient`.
- `run()` now retries on non-nil command errors with exponential backoff (`BaseBackoff << (attempt-1)`), honoring `ctx` between and during sleeps. Pre-cancelled context returns immediately without consuming attempts.
- Error format on final failure is preserved: `gh <args>: <err>: <stderr>`.
- Happy path: exactly one exec, zero added latency.

## Why
Per epic #352, the reliability harness needs to detect and retry transient failures with evidence. Until now the harness itself read GitHub state through a single-shot `gh` invocation, making the grader less reliable than the agent it grades. `gh pr view` / `gh pr list` / `gh auth status` are read-only and idempotent, so bounded retry is safe.

## Testing
Table-driven tests in `internal/reliability/github_test.go` drive `run()` via the existing `Binary` seam, pointing it at a small fake shell script in `t.TempDir()` that fails N times then succeeds (counter file). Coverage:
- `success-first-try` — single exec, no sleep
- `transient-then-success` — recovers after 2 failures within 3 attempts
- `all-attempts-fail` — exhausts attempts; returned error keeps prefix and surfaces last stderr
- `cancelled-context` — returns `context.Canceled` immediately; fake binary called 0 times
- `NewGHCLIClient` applies defaults

Commands run:
- `go vet ./internal/reliability/...` — clean
- `go test ./internal/reliability/...` — pass
- `go build ./cmd/ok-gobot/` — pass

## Out of scope (per issue)
- No retry for AI provider clients (has its own `failover.go`).
- No mutating GitHub operations.
- No shared retry package, no YAML/schema knobs.
- No `Retry-After` parsing or rate-limit-specific classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds bounded retry-with-exponential-backoff to `GHCLIClient.run()`, exposing `MaxAttempts` (default 3) and `BaseBackoff` (default 200 ms) as exported fields and wiring them through `NewGHCLIClient`. Context cancellation is honoured at the top of each attempt loop and during the inter-attempt sleep.

- `run()` now loops up to `MaxAttempts` times, sleeping `BaseBackoff << (attempt-1)` between failures and returning immediately on context cancellation; happy-path cost is zero.
- Table-driven tests use a POSIX shell fake binary (counter file) to drive success, transient-then-success, full-exhaustion, and pre-cancelled-context scenarios.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the current default configuration; the only behavioural gap is in callers that set a very large MaxAttempts value.

The retry logic is correct and well-tested for the intended defaults. The left-shift backoff formula silently drops to zero delay once attempt numbers exceed ~37, which is unreachable with the default MaxAttempts of 3 but becomes a real issue if a caller raises the limit significantly. The dead cancelCtxFunc field in the test struct is cosmetic but could mislead future contributors.

internal/reliability/github.go — specifically the backoff << (attempt-1) expression in run().

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/reliability/github.go | Adds retry-with-exponential-backoff to `run()`: public `MaxAttempts`/`BaseBackoff` fields with sane defaults; context is honoured between retries. The bit-shift formula `backoff << (attempt-1)` can silently overflow `time.Duration` for `MaxAttempts` > ~37, eliminating backoff at high attempt counts. |
| internal/reliability/github_test.go | Table-driven tests cover success, transient failure, exhaustion, and pre-cancelled context via a POSIX shell fake binary; coverage is solid. The struct has an unused `cancelCtxFunc` field that is never set or read in the loop. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/reliability/github.go:220
**Backoff overflows for large `MaxAttempts` values**

`backoff << (attempt - 1)` left-shifts a `time.Duration` (int64 nanoseconds). With the default 200 ms base (`200_000_000` ns), the value overflows `int64` at attempt ≈ 37. Past that point `time.NewTimer` receives a negative duration and fires immediately, silently eliminating the intended backoff for all remaining attempts. Since `MaxAttempts` is an exported field with no upper-bound guard in `run()`, any caller that sets it above ~36 will see rapid-fire retries instead of exponential back-off. A multiplication with a capped exponent (e.g. `min(attempt-1, 30)`) or replacing the shift with `backoff * (1 << ...)` plus an explicit cap avoids the overflow.

### Issue 2 of 2
internal/reliability/github_test.go:205-216
**Dead `cancelCtxFunc` field in table test struct**

The `cancelCtxFunc func(ctx context.Context, cancel context.CancelFunc)` field is declared in the test case struct but is never populated in any of the three test cases, and the loop body always calls `client.run(context.Background(), ...)`, ignoring it entirely. The cancelled-context scenario is instead covered by a separate function. If the field was meant to enable cancellation-variant rows in this table, it should be wired up; otherwise it should be removed to avoid misleading future contributors into thinking in-loop cancellation is already tested here.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(reliability): bounded retry-with-ba..."](https://github.com/befeast/ok-gobot/commit/98d4af7dc75b38897f2325543d7aff1beb66b491) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35350019)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->