### PR TITLE
chore: enable Dependabot auto-merge (patch/minor)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      gomod-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+# Auto-enable merge for Dependabot patch/minor updates once CI passes. Major
+# updates are left for manual review. Standard GitHub pattern.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch and minor updates
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fleet-wide rollout: Dependabot auto-merge workflow (auto-merge on green CI for patch/minor; major manual) + Dependabot config for this repo's ecosystems (gomod github-actions). `allow_auto_merge` enabled.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Dependabot update automation for the repository. The main changes are:

- New Dependabot config for root Go modules.
- New Dependabot config for GitHub Actions workflows.
- New workflow to enable squash auto-merge for Dependabot patch and minor PRs.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until T-Rex findings are addressed.

- The Dependabot configuration for Go modules and GitHub Actions matches the intended ecosystems and update grouping.
- The auto-merge workflow attempts to enable merging for patch and minor updates, but the command path does not enforce that CI has completed successfully before merge eligibility can take effect.
- The workflow also depends on a token permission model that may remain read-only for Dependabot pull request runs, preventing auto-merge from being enabled.

T-Rex reproduced 2 failing behaviors at runtime; the change needs fixes before it is safe to merge.

.github/workflows/dependabot-auto-merge.yml

Files exercised by T-Rex runtime checks

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Compared dependabot contract checks from before and after; the before log shows the base state with no matching Dependabot config and all contract checks failing, while the after log shows passes for gomod root weekly limited minor/patch grouping, github-actions root weekly limited minor/patch grouping, and workflow patch/minor-but-not-major semver checks, with no remaining contract defects.
- - Investigated auto-merge behavior around CI gating; the before capture shows the workflow command from line 22 and a pending CI marker with a MOCK\_GH\_INVOKED: gh pr merge --auto --squash ...; the after capture shows a control CI gate that skips gh pr merge while CI remains pending, and a harness script was generated to reproduce both captures.
- - Verified Dependabot token permissions for patch PRs; with a token that has pull-requests:write, the patch PR path succeeds, while with a read-only token the merge command fails with GraphQL: Resource not accessible by integration or HTTP 403 Forbidden: GITHUB\_TOKEN lacks pull-requests:write; a harness script captures both runs.

<a href="https://app.greptile.com/trex/runs/12365895/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Auto-Merge Can Precede CI**

   - **Bug**
     - The Dependabot auto-merge workflow enables auto-merge immediately for semver patch/minor PRs without first waiting for or querying CI status. In repositories without required status checks or equivalent branch rules, this can allow a broken dependency update to merge before `go build ./...` and `go test ./...` complete.
   - **Cause**
     - The `pull_request` workflow runs the patch/minor branch directly after metadata fetch and invokes `gh pr merge --auto --squash` at line 22. There is no preceding CI/status-check gate in the job.
   - **Fix**
     - Add an explicit gate before enabling auto-merge, such as waiting for required CI checks to finish successfully, moving the merge enablement to a `workflow_run` triggered after CI success, or enforcing required status checks/rulesets on the protected branch so GitHub cannot complete the merge before CI is green.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Dependabot pull_request token can remain read-only, preventing auto-merge enablement**

   - **Bug**
     - The workflow runs on `pull_request` for Dependabot-authored PRs and uses `secrets.GITHUB_TOKEN` for both Dependabot metadata and `gh pr merge --auto --squash`. In the reproduced read-only token condition, the semver patch Dependabot PR path reaches the merge step but cannot enable auto-merge because the token lacks `pull-requests:write`. The command fails with a 403-style permission error, so patch/minor Dependabot PRs are not auto-merge enabled.
   - **Cause**
     - The workflow relies on the `pull_request` event's `GITHUB_TOKEN` being writable for Dependabot PRs. In repositories/settings where Dependabot-triggered `pull_request` workflows receive a read-only token despite requested workflow permissions, the requested `pull-requests: write` permission is not available to the command path.
   - **Fix**
     - Use a trusted execution/token model for this automation, such as `pull_request_target` with safe checkout practices and strict Dependabot/update-type gating, or a GitHub App/PAT secret with the required pull request write permission. Ensure the merge command only runs after validating the PR author and Dependabot metadata without executing untrusted PR code.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/dependabot-auto-merge.yml:22
**Auto-Merge Can Precede CI**

When a Dependabot PR opens, this job runs in parallel with the `ci.yml` pull request checks and calls `gh pr merge --auto` immediately. If required status checks are not enforced in repository rules, the PR can merge before `go build ./...` and `go test ./...` finish, so a broken dependency update can land on `main` without green CI.

### Issue 2 of 2
.github/workflows/dependabot-auto-merge.yml:4
**Dependabot Token Stays Read-Only**

This workflow uses the `pull_request` event for Dependabot PRs, but Dependabot-triggered pull request workflows can receive a read-only `GITHUB_TOKEN` despite the requested write permissions. In that repo setting, metadata fetch or `gh pr merge --auto` fails with a permission error, and patch/minor Dependabot PRs never get auto-merge enabled.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: enable Dependabot auto-merge for ..."](https://github.com/befeast/ok-gobot/commit/6ba737efe35a8a60deda0d80b03c2bb85e365665) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39975394)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->