### PR TITLE
chore: run Dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     groups:
       gomod-minor-patch:
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 5
     groups:
       github-actions-minor-patch:


### PR DESCRIPTION
Switch Dependabot schedule weekly→daily across this repo's ecosystems. Patch/minor auto-merge; major stays manual. Refs #761

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes Dependabot to check for updates every day.

- Switches Go module updates from weekly to daily.
- Switches GitHub Actions updates from weekly to daily.
- Keeps the existing update grouping and open PR limits.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is limited to Dependabot scheduling configuration.

Only .github/dependabot.yml is changed, and the update cadence adjustment is straightforward with no runtime application impact.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the before-state log trex-artifacts/dependabot-schedule-01-before.log showed schedule.interval: weekly for gomod and github-actions with a validation exit code of 0.
- Validated the after-state log trex-artifacts/dependabot-schedule-02-after.log showed schedule.interval: daily for gomod and github-actions, maintained minor/patch grouping, no major update-type, and a validation exit code of 0.

<a href="https://app.greptile.com/trex/runs/12386296/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: run Dependabot daily instead of w..."](https://github.com/befeast/ok-gobot/commit/43cfffb4daa9ac974f24e3c43677b8921754dc63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40018974)</sub>

<!-- /greptile_comment -->