### PR TITLE
ci: refresh main CI after Dependabot merges (#441)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - feat/**
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,12 +4,14 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
 jobs:
   dependabot-auto-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Fetch Dependabot metadata
@@ -22,3 +24,27 @@ jobs:
         run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Merges performed through GITHUB_TOKEN do not emit another push workflow.
+      # Dispatch CI explicitly after GitHub finishes the auto-merge so the
+      # source-main-ci health signal covers the actual commit on main.
+      - name: Run CI for the merged commit
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+
+          for _ in $(seq 1 60); do
+            state="$(gh pr view "$PR_URL" --json state --jq .state)"
+            if [ "$state" = "MERGED" ]; then
+              gh workflow run ci.yml --ref main
+              exit 0
+            fi
+
+            sleep 10
+          done
+
+          echo "Dependabot PR did not merge within 10 minutes" >&2
+          exit 1


### PR DESCRIPTION
Implements #441

## Changes
- make the CI workflow manually dispatchable
- wait for eligible Dependabot auto-merges to land, then dispatch CI on `main`
- grant the auto-merge workflow the scoped Actions permission needed for that dispatch

The repeated gate failures reported `source-main-ci` as failed while the other outcome checks passed. Dependabot merges performed through `GITHUB_TOKEN` were advancing `main` without emitting the CI push workflow, leaving the health source without a CI result for the current main commit.

## Testing
- `actionlint .github/workflows/ci.yml .github/workflows/dependabot-auto-merge.yml`
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./cmd/ok-gobot/`
- `go run ./cmd/ok-gobot memory eval`
- `/home/god/.maestro/bin/ok-gobot-outcome-verifier.sh` (passed; runtime healthy, failure streak 0)

The next eligible Dependabot merge remains the end-to-end runtime verification that the dispatched CI result refreshes `source-main-ci`; this PR intentionally does not auto-close the issue.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores main-branch CI after Dependabot auto-merges. The main changes are:

- Adds manual dispatch support to the CI workflow.
- Grants the auto-merge workflow permission to dispatch Actions.
- Polls eligible Dependabot PRs and dispatches CI after merge.

<h3>Confidence Score: 4/5</h3>

The post-merge dispatch path can miss delayed merges, run more than once, or test a different main-branch commit.

- Auto-merge can complete after the polling run has already failed.
- Overlapping pull-request event runs can each dispatch CI.
- Dispatching the mutable `main` ref does not bind CI to the observed merge commit.

.github/workflows/dependabot-auto-merge.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the delayed-merge verification by running the workflow's extracted post-merge shell with a deterministic gh test double that returns OPEN for all 60 polling checks, causing the shell to exit with status 1 and produce zero gh workflow run dispatches.
- Demonstrated that overlapping runs can produce duplicate dispatches by executing two concurrent instances of the same post-merge polling shell; both returned MERGED and each invoked gh workflow run ci.yml --ref main.
- Validated that the dispatch uses the mutable main ref by executing the anchored command through a local gh test double, showing the main ref was used and the newer main SHA resolved in a local simulation with no authenticated GitHub CLI session.
- Confirmed that the overall test and verification run passes, and that changes touch only the CI workflow files, as shown by the head-memory, test, and tooling checks.

<a href="https://app.greptile.com/trex/runs/15448224/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the manual dispatch trigger required by the auto-merge workflow. |
| .github/workflows/dependabot-auto-merge.yml | Adds dispatch permission and post-merge polling, but delayed merges, repeated events, and mutable-ref dispatch can produce missing, duplicate, or misattributed CI runs. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.github/workflows/dependabot-auto-merge.yml:38-49
**Delayed Merge Loses CI Dispatch**

When required checks or merge conditions take longer than ten minutes, this run exits while the auto-merge request remains active. If the PR merges later through `GITHUB_TOKEN`, no run remains to dispatch CI, so `main` advances without the `source-main-ci` result this change is meant to restore.

### Issue 2 of 3
.github/workflows/dependabot-auto-merge.yml:31-42
**Repeated Events Duplicate Dispatches**

The workflow accepts the default set of `pull_request` actions and has no per-PR concurrency or idempotency guard. If one Dependabot PR starts overlapping runs, such as on `opened` and `synchronize`, every surviving run sees `MERGED` and dispatches a separate CI run for the same merge.

### Issue 3 of 3
.github/workflows/dependabot-auto-merge.yml:42
**Dispatch Uses Mutable Main Ref**

If another commit lands after this PR merges but before the dispatch request resolves `main`, CI runs against the newer branch tip rather than the Dependabot merge commit. The intended commit can therefore remain without its own CI result, while the health signal reflects a different SHA.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: refresh main checks after Dependabot..."](https://github.com/befeast/ok-gobot/commit/f6bb233d967cce40fc2c1c11265f336f1a218183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46386749)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->