### PR TITLE
fix(bot): make rate-limiter timing tests deterministic (#449)

### DIFF
--- a/internal/bot/ratelimit.go
+++ b/internal/bot/ratelimit.go
@@ -11,6 +11,9 @@ type RateLimiter struct {
 	window      time.Duration
 	mu          sync.Mutex
 	requests    map[int64][]time.Time
+	// now returns the current time. Defaults to time.Now but can be overridden
+	// in tests for deterministic, non-flaky timing behavior.
+	now func() time.Time
 }
 
 // NewRateLimiter creates a new rate limiter
@@ -27,6 +30,7 @@ func NewRateLimiter(maxRequests int, window time.Duration) *RateLimiter {
 		maxRequests: maxRequests,
 		window:      window,
 		requests:    make(map[int64][]time.Time),
+		now:         time.Now,
 	}
 }
 
@@ -36,7 +40,7 @@ func (r *RateLimiter) Allow(chatID int64) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	now := time.Now()
+	now := r.now()
 
 	// Get request history for this chat
 	history := r.requests[chatID]
@@ -69,7 +73,7 @@ func (r *RateLimiter) RemainingCooldown(chatID int64) time.Duration {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	now := time.Now()
+	now := r.now()
 	history := r.requests[chatID]
 
 	if len(history) == 0 {
@@ -107,7 +111,7 @@ func (r *RateLimiter) GetRequestCount(chatID int64) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	now := time.Now()
+	now := r.now()
 	history := r.requests[chatID]
 	cutoff := now.Add(-r.window)
 

--- a/internal/bot/ratelimit_test.go
+++ b/internal/bot/ratelimit_test.go
@@ -6,6 +6,26 @@ import (
 	"time"
 )
 
+// fakeClock is a controllable time source for deterministic rate-limiter tests.
+// It removes the dependency on real wall-clock sleeps, which made the timing
+// tests flaky under CPU load (the sleeps could overshoot the window).
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time { return c.now }
+
+func (c *fakeClock) Advance(d time.Duration) { c.now = c.now.Add(d) }
+
+// newTestLimiter builds a RateLimiter wired to a fakeClock so tests can advance
+// time explicitly instead of sleeping.
+func newTestLimiter(maxRequests int, window time.Duration) (*RateLimiter, *fakeClock) {
+	limiter := NewRateLimiter(maxRequests, window)
+	clock := &fakeClock{now: time.Unix(0, 0)}
+	limiter.now = clock.Now
+	return limiter, clock
+}
+
 func TestRateLimiter_Allow_UnderLimit(t *testing.T) {
 	limiter := NewRateLimiter(3, 1*time.Second)
 
@@ -36,7 +56,7 @@ func TestRateLimiter_Allow_ExceedLimit(t *testing.T) {
 }
 
 func TestRateLimiter_Allow_WindowExpiry(t *testing.T) {
-	limiter := NewRateLimiter(2, 200*time.Millisecond)
+	limiter, clock := newTestLimiter(2, 200*time.Millisecond)
 
 	chatID := int64(123)
 
@@ -48,8 +68,8 @@ func TestRateLimiter_Allow_WindowExpiry(t *testing.T) {
 		t.Error("Request should be denied when limit reached")
 	}
 
-	// Wait for window to expire
-	time.Sleep(250 * time.Millisecond)
+	// Advance past the window so the earlier requests expire
+	clock.Advance(250 * time.Millisecond)
 
 	// Should be allowed again
 	if !limiter.Allow(chatID) {
@@ -78,7 +98,7 @@ func TestRateLimiter_MultipleChatsSeparate(t *testing.T) {
 }
 
 func TestRateLimiter_RemainingCooldown(t *testing.T) {
-	limiter := NewRateLimiter(2, 500*time.Millisecond)
+	limiter, clock := newTestLimiter(2, 500*time.Millisecond)
 
 	chatID := int64(123)
 
@@ -97,22 +117,22 @@ func TestRateLimiter_RemainingCooldown(t *testing.T) {
 		t.Errorf("Expected cooldown between 0 and 500ms, got %v", cooldown)
 	}
 
-	// Wait and check again
-	time.Sleep(250 * time.Millisecond)
+	// Advance and check again
+	clock.Advance(250 * time.Millisecond)
 	cooldown = limiter.RemainingCooldown(chatID)
 	if cooldown <= 0 || cooldown > 300*time.Millisecond {
 		t.Errorf("Expected reduced cooldown, got %v", cooldown)
 	}
 
-	// Wait for full expiry
-	time.Sleep(300 * time.Millisecond)
+	// Advance past full expiry
+	clock.Advance(300 * time.Millisecond)
 	if cooldown := limiter.RemainingCooldown(chatID); cooldown != 0 {
 		t.Errorf("Expected 0 cooldown after expiry, got %v", cooldown)
 	}
 }
 
 func TestRateLimiter_GetRequestCount(t *testing.T) {
-	limiter := NewRateLimiter(5, 500*time.Millisecond)
+	limiter, clock := newTestLimiter(5, 500*time.Millisecond)
 
 	chatID := int64(123)
 
@@ -128,7 +148,7 @@ func TestRateLimiter_GetRequestCount(t *testing.T) {
 		t.Errorf("Expected 3 requests, got %d", count)
 	}
 
-	time.Sleep(550 * time.Millisecond)
+	clock.Advance(550 * time.Millisecond)
 
 	if count := limiter.GetRequestCount(chatID); count != 0 {
 		t.Errorf("Expected 0 requests after expiry, got %d", count)
@@ -217,24 +237,24 @@ func TestRateLimiter_ConcurrentAccess(t *testing.T) {
 }
 
 func TestRateLimiter_SlidingWindow(t *testing.T) {
-	limiter := NewRateLimiter(3, 300*time.Millisecond)
+	limiter, clock := newTestLimiter(3, 300*time.Millisecond)
 
 	chatID := int64(123)
 
 	// Use all 3 requests
 	limiter.Allow(chatID) // t=0
-	time.Sleep(100 * time.Millisecond)
+	clock.Advance(100 * time.Millisecond)
 	limiter.Allow(chatID) // t=100
-	time.Sleep(100 * time.Millisecond)
+	clock.Advance(100 * time.Millisecond)
 	limiter.Allow(chatID) // t=200
 
-	// Should be denied
+	// Should be denied — all three requests are still within the 300ms window
 	if limiter.Allow(chatID) {
 		t.Error("Should be denied at t=200")
 	}
 
-	// Wait for first request to expire (at t=300)
-	time.Sleep(150 * time.Millisecond) // Now at t=350
+	// Advance so the first request (t=0) expires at t=300
+	clock.Advance(150 * time.Millisecond) // Now at t=350
 
 	// Should be allowed (first request expired)
 	if !limiter.Allow(chatID) {


### PR DESCRIPTION
Implements #449

## Root cause
The scheduled `healthcheck_command` gate failed 2 consecutive runs (fingerprint `658f0089bedb2248`, reason class `failing`). Reproduced locally: `TestRateLimiter_SlidingWindow` in `internal/bot/ratelimit_test.go` is a **flaky, wall-clock-dependent test**.

It builds a 300ms-window limiter and issues requests separated by real `time.Sleep(100ms)` calls, then asserts the 4th request is denied. Under CPU load on the scheduled gate runner (the full suite + `make test` run concurrently), the sleeps overshoot 300ms, so the oldest request expires early and the 4th is *allowed* — flipping the assertion and failing the gate. `TestRateLimiter_Allow_WindowExpiry`, `TestRateLimiter_RemainingCooldown`, and `TestRateLimiter_GetRequestCount` shared the same risk.

Confirmed: the test passes in isolation but fails reliably when run under saturating CPU load.

## Changes
- `internal/bot/ratelimit.go`: inject a clock into `RateLimiter` (`now func() time.Time`, defaulting to `time.Now`), following the existing `reliability.Runner.Clock` pattern. All `time.Now()` call sites now use `r.now()`. No behavior change in production.
- `internal/bot/ratelimit_test.go`: add a `fakeClock` helper and drive the four timing tests with it, advancing time explicitly instead of sleeping. Tests are now deterministic and run ~10x faster (no real sleeps).

## Testing
- `go vet ./...` — clean
- `go test ./...` — pass
- `go build ./cmd/ok-gobot/` — pass
- `make test` — pass
- Ran `go test -run TestRateLimiter -count=40 ./internal/bot/` under saturating CPU load (24 busy loops on 12 cores): **passes** where the old sleep-based test failed reliably under the same load.

## Verification note
This repairs the flaky gate by removing wall-clock dependence from the tests. The gate's own failing-streak state should clear once it observes green scheduled runs; that runtime confirmation happens on the Maestro side after merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the rate limiter timing tests deterministic. The main changes are:

- Adds an injectable clock to `RateLimiter`.
- Keeps production behavior on `time.Now` by default.
- Replaces wall-clock sleeps in timing-sensitive tests with a fake clock.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped, preserves the production default clock, and consistently updates the affected time reads and tests.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the targeted RateLimiter command and confirmed the test completed with exit code 0 and a final PASS.
- Reran the internal/bot package tests and verified the run finished with exit code 0.
- Performed a narrow vet pass on the internal code and confirmed exit code 0.
- Executed the Gobot build rerun and confirmed exit code 0.

<a href="https://app.greptile.com/trex/runs/15615002/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/bot/ratelimit.go | Adds an injectable clock to `RateLimiter` and consistently uses it for window calculations without changing production defaults. |
| internal/bot/ratelimit_test.go | Replaces wall-clock sleeps in timing-sensitive rate limiter tests with a deterministic fake clock. |

<sub>Reviews (1): Last reviewed commit: ["fix(bot): make rate-limiter timing tests..."](https://github.com/befeast/ok-gobot/commit/7f8a96696b9638477d5f33de9c55d58251d326d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46744134)</sub>

<!-- /greptile_comment -->